### PR TITLE
fix: add additional response type possibility

### DIFF
--- a/src/core/generators/msw.ts
+++ b/src/core/generators/msw.ts
@@ -97,6 +97,7 @@ export const generateMSW = async (
     value[0] === '[' ||
     value.startsWith('(function() {') ||
     value.startsWith('(()=>({') ||
+    value.startsWith('()=>(()=>[') ||
     value.startsWith('faker.helpers') ||
     value.startsWith('Array.from')
       ? 'json'


### PR DESCRIPTION
## Status
READY

## Description
Accounts for operation mock overrides that return an array like;
```
 output: { override: { operations: { operationId: { mock: { data: () => [...] } } } } }
```

Though would be nice to pass `responseType` as an additional param to `mock` here. quick fix.