### PR TITLE
fix(jsdoc): replace all matches of comment terminations, not just the first

### DIFF
--- a/src/utils/doc.ts
+++ b/src/utils/doc.ts
@@ -1,3 +1,8 @@
+const search = '\\*/'; // Find '*/'
+const replacement = '*\\/'; // Replace With '*\/'
+
+const regex = new RegExp(search, 'g');
+
 export function jsDoc(
   {
     description,
@@ -13,7 +18,7 @@ export function jsDoc(
   // Ensure there aren't any comment terminations in doc
   const lines = (
     Array.isArray(description) ? description : [description || '']
-  ).map((line) => line.replaceAll('*/', '*\\/'));
+  ).map((line) => line.replace(regex, replacement));
 
   const count = [description, deprecated, summary].reduce(
     (acc, it) => (it ? acc + 1 : acc),
@@ -45,7 +50,7 @@ export function jsDoc(
     if (!oneLine) {
       doc += `\n${tryOneLine ? '  ' : ''} *`;
     }
-    doc += ` @summary ${summary.replaceAll('*/', '*\\/')}`;
+    doc += ` @summary ${summary.replace(regex, replacement)}`;
   }
 
   doc += !oneLine ? `\n ${tryOneLine ? '  ' : ''}` : ' ';


### PR DESCRIPTION
Looks like the previous solution was lacking because I used `String.prototype.replace` and not `.replaceAll`. Now all comment terminations are found and not just the first.