### PR TITLE
chore: dereference whole API on importing to avoid extra definitions

### DIFF
--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -35,16 +35,8 @@ const resolveSpecs = async (
       }
     }
 
-    const data = (await SwaggerParser.resolve(path, options)).values();
-
-    if (isUrl) {
-      return data;
-    }
-
-    // normalizing slashes after SwaggerParser
-    return Object.fromEntries(
-      Object.entries(data).map(([key, value]) => [upath.resolve(key), value]),
-    );
+    const data = await SwaggerParser.dereference(path, options);
+    return { [path]: data };
   } catch {
     const file = await fs.readFile(path, 'utf8');
 


### PR DESCRIPTION
My solution to https://github.com/anymaniax/orval/issues/863  I'm not quite sure if this is a proper solution for the problem, but it works for me.

Basically, I'm dereferencing the whole API at the beginning so there are no extra schemas that could generate types.