### PR TITLE
fix: format to index of `hono`

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -199,14 +199,17 @@ const getHandlerFix = ({
 const getVerbOptionGroupByTag = (
   verbOptions: Record<string, GeneratorVerbOptions>,
 ) => {
-  return Object.values(verbOptions).reduce((acc, value) => {
-    const tag = value.tags[0];
-    if (!acc[tag]) {
-      acc[tag] = [];
-    }
-    acc[tag].push(value);
-    return acc;
-  }, {} as Record<string, GeneratorVerbOptions[]>);
+  return Object.values(verbOptions).reduce(
+    (acc, value) => {
+      const tag = value.tags[0];
+      if (!acc[tag]) {
+        acc[tag] = [];
+      }
+      acc[tag].push(value);
+      return acc;
+    },
+    {} as Record<string, GeneratorVerbOptions[]>,
+  );
 };
 
 const generateHandlers = async (


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I fixed the following commit because there was a formatting error and CI was failing.

https://github.com/anymaniax/orval/commit/db7de2f9a67fce04c8b0e7ca1ec03162acf49ec0 

## Related commit

https://github.com/anymaniax/orval/commit/db7de2f9a67fce04c8b0e7ca1ec03162acf49ec0

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none
