### PR TITLE
fix: VueJS infinite query parameters reactivity when `hasInfiniteQueryParam`

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -931,7 +931,7 @@ const generateQueryImplementation = ({
           )
             return param.destructured;
           return param.name === 'params'
-            ? `{...params, ${queryParam}: pageParam || ${
+            ? `{...${isVue(outputClient) ? `unref(params)` : 'params'}, ${queryParam}: pageParam || ${
                 isVue(outputClient)
                   ? `unref(params)?.['${queryParam}']`
                   : `params?.['${queryParam}']`


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

UPD:

Samples updated here: https://github.com/soartec-lab/orval/blob/eecc2622a211d52f27804294a228cf1cd4eda659/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts

## Description

Fix https://github.com/anymaniax/orval/issues/1378 for detailed issue description


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

- 
