### PR TITLE
Exclude content type header if multipart/form-data in fetch client

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -94,10 +94,11 @@ ${
     ? `${stringify(override?.requestOptions)?.slice(1, -1)?.trim()}`
     : '';
   const fetchMethodOption = `method: '${verb.toUpperCase()}'`;
-  const ignoreContentTypes = ['multipart/form-data']
-  const fetchHeadersOption = body.contentType && ignoreContentTypes.includes(body.contentType)
-    ? `headers: { 'Content-Type': '${body.contentType}' }`
-    : '';
+  const ignoreContentTypes = ['multipart/form-data'];
+  const fetchHeadersOption =
+    body.contentType && !ignoreContentTypes.includes(body.contentType)
+      ? `headers: { 'Content-Type': '${body.contentType}' }`
+      : '';
   const requestBodyParams = generateBodyOptions(
     body,
     isFormData,

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -94,7 +94,7 @@ ${
     ? `${stringify(override?.requestOptions)?.slice(1, -1)?.trim()}`
     : '';
   const fetchMethodOption = `method: '${verb.toUpperCase()}'`;
-  const fetchHeadersOption = body.contentType
+  const fetchHeadersOption = body.contentType && !isFormData
     ? `headers: { 'Content-Type': '${body.contentType}' }`
     : '';
   const requestBodyParams = generateBodyOptions(

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -94,7 +94,8 @@ ${
     ? `${stringify(override?.requestOptions)?.slice(1, -1)?.trim()}`
     : '';
   const fetchMethodOption = `method: '${verb.toUpperCase()}'`;
-  const fetchHeadersOption = body.contentType && !isFormData
+  const ignoreContentTypes = ['multipart/form-data']
+  const fetchHeadersOption = body.contentType && ignoreContentTypes.includes(body.contentType)
     ? `headers: { 'Content-Type': '${body.contentType}' }`
     : '';
   const requestBodyParams = generateBodyOptions(


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Excludes form data content header in fetch client. 
Fix #1531

## Related PRs

https://github.com/orval-labs/orval/pull/1529

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Generate fetch client using multipart/form-data openapi spec
