### PR TITLE
fix(swr): fix to use Array as  key for `useMutation`

### DIFF
--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -418,7 +418,7 @@ const generateSwrHook = (
     const swrKeyFn = `
 export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       queryParams ? ', ...(params ? [params]: [])' : ''
-    }${body.implementation ? `, ${body.implementation}` : ''}] as const;
+    }] as const;
 \n`;
 
     const swrKeyLoaderFnName = camel(

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -458,7 +458,8 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       props.filter(
         (prop) =>
           prop.type === GetterPropType.PARAM ||
-          prop.type === GetterPropType.NAMED_PATH_PARAMS,
+          prop.type === GetterPropType.NAMED_PATH_PARAMS ||
+          prop.type === GetterPropType.QUERY_PARAM,
       ),
       'implementation',
     );
@@ -506,7 +507,8 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       .filter(
         (prop) =>
           prop.type === GetterPropType.PARAM ||
-          prop.type === GetterPropType.NAMED_PATH_PARAMS,
+          prop.type === GetterPropType.NAMED_PATH_PARAMS ||
+          prop.type === GetterPropType.QUERY_PARAM,
       )
       .map((prop) => {
         if (prop.type === GetterPropType.NAMED_PATH_PARAMS) {
@@ -518,7 +520,10 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       .join(',');
 
     const swrKeyFnName = camel(`get-${operationName}-mutation-key`);
-    const swrMutationKeyFn = `export const ${swrKeyFnName} = (${queryKeyProps}) => \`${route}\` as const;\n`;
+    const swrMutationKeyFn = `export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
+      queryParams ? ', ...(params ? [params]: [])' : ''
+    }] as const;
+`;
 
     const swrMutationFetcherName = camel(
       `get-${operationName}-mutation-fetcher`,

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -137,7 +137,7 @@ const generateSwrMutationArguments = ({
   swrBodyType: string;
   httpClient: OutputHttpClient;
 }) => {
-  const definition = `SWRMutationConfiguration<Awaited<ReturnType<typeof ${operationName}>>, TError, string, ${swrBodyType}, Awaited<ReturnType<typeof ${operationName}>>> & { swrKey?: string }`;
+  const definition = `SWRMutationConfiguration<Awaited<ReturnType<typeof ${operationName}>>, TError, Key, ${swrBodyType}, Awaited<ReturnType<typeof ${operationName}>>> & { swrKey?: string }`;
 
   if (!isRequestOptions) {
     return `swrOptions?: ${definition}`;
@@ -419,7 +419,7 @@ const generateSwrHook = (
 export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       queryParams ? ', ...(params ? [params]: [])' : ''
     }] as const;
-\n`;
+`;
 
     const swrKeyLoaderFnName = camel(
       `get-${operationName}-infinite-key-loader`,
@@ -558,7 +558,7 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
 
     const swrMutationFetcherFn = `
 export const ${swrMutationFetcherName} = (${swrProps} ${swrMutationFetcherOptions}) => {
-  return (_: string, ${swrMutationFetcherArg}: { arg: ${swrBodyType} }): ${swrMutationFetcherType} => {
+  return (_: Key, ${swrMutationFetcherArg}: { arg: ${swrBodyType} }): ${swrMutationFetcherType} => {
     return ${operationName}(${httpFnProperties}${
       swrMutationFetcherOptions.length
         ? (httpFnProperties.length ? ', ' : '') + 'options'

--- a/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -89,12 +89,12 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationFetcher = (version: number = 1) => {
-  return (_: string, { arg }: { arg: CreatePetsBody }): Promise<Pet> => {
+  return (_: Key, { arg }: { arg: CreatePetsBody }): Promise<Pet> => {
     return createPets(arg, version);
   };
 };
 export const getCreatePetsMutationKey = (version: number = 1) =>
-  `/v${version}/pets` as const;
+  [`/v${version}/pets`] as const;
 
 export type CreatePetsMutationResult = NonNullable<
   Awaited<ReturnType<typeof createPets>>
@@ -110,7 +110,7 @@ export const useCreatePets = <TError = Error>(
     swr?: SWRMutationConfiguration<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      string,
+      Key,
       CreatePetsBody,
       Awaited<ReturnType<typeof createPets>>
     > & { swrKey?: string };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1487

the `useMutation` key should use same key as `useSWR`.
https://github.com/vercel/swr/blob/1585a3e37d90ad0df8097b099db38f1afb43c95d/src/mutation/types.ts#L236-L241

So, i fixed the get key function to return Array and hooks use Array as key for `useMutation`.
And, and, update the using url type in http fetcher from `string` to `Key`

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none