### PR TITLE
docs: add custom client with `angular` client to guide

### DIFF
--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -57,3 +57,55 @@ export type BodyType<BodyData> = CamelCase<BodyType>;
 ```
 
 Or, Please refer to the using custom fetch with Next.js sample app [here](https://github.com/orval-labs/orval/blob/master/samples/next-app-with-fetch/custom-fetch.ts).
+
+#### Angular
+
+Even if you use the `angular` client, you can add mutator functions to your configuration to set up your preferred HTTP client.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      ...
+      override: {
+        mutator: 'src/api/mutator/response-type.ts'
+      }
+    }
+    ...
+  },
+};
+```
+
+```ts
+// response-type.ts
+
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+const responseType = <Result>(
+  {
+    url,
+    method,
+    params,
+    data,
+  }: {
+    url: string;
+    method: string;
+    params?: any;
+    data?: any;
+    headers?: any;
+  },
+  http: HttpClient,
+): Observable<Result> =>
+  http.request<Result>(method, url, {
+    params,
+    body: data,
+    responseType: 'json',
+  });
+
+export default responseType;
+```
+
+Please also refer to sample app for more details.
+
+https://github.com/orval-labs/orval/tree/master/samples/angular-app


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

fix #1460

I add custom client with `angular` client to guide.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none