### PR TITLE
Feat/add property include return type http status

### DIFF
--- a/docs/src/pages/guides/fetch-client.md
+++ b/docs/src/pages/guides/fetch-client.md
@@ -94,6 +94,54 @@ export const useListPets = <TError = Promise<Pets | Error>>(
 };
 ```
 
+#### return original defined return type
+
+When using `fetch` as an `httpClient`, by default the `fetch` response type includes http status.
+If use `swr` or queries, i will be accessing things like `data.data`, which will be noisy so if you want to return a defined return type instead of an automatically generated return type, set `override.fetch.includeHttpStatusReturnType` value to `false`.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      ...
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    ...
+  },
+};
+```
+
+```diff
+/**
+ * @summary List all pets
+ */
+- export type listPetsResponse = {
+-   data: Pets;
+-   status: number;
+- };
+
+export const listPets = async (
+  params?: ListPetsParams,
+  options?: RequestInit,
+- ): Promise<listPetsResponse> => {
++ ): Promise<Pet> => {
+  const res = await fetch(getListPetsUrl(params), {
+    ...options,
+    method: 'GET',
+  });
+  const data = await res.json();
+
+-  return { status: res.status, data };
++  return data as Pet;
+};
+```
+
+#### custom fetch client
+
 Also, if you want to use to the custom fetch client, you can set in the override option.
 
 ```js

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -670,6 +670,36 @@ module.exports = {
 };
 ```
 
+#### fetch
+
+Type: `Object`.
+
+Give options to the generated `fetch` client.
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      ...
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    ...
+  },
+};
+```
+
+##### includeHttpStatusReturnType
+
+Type: `Boolean`.
+Default: `true`
+
+When using `fetch` for `client` or `httpClient`, the `fetch` response type includes http status for easier processing by the application.
+If you want to return a defined return type instead of an automatically generated return type, set this value to `false`.
+
 #### query
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,6 +101,7 @@ export type NormalizedOverrideOutput = {
   angular: Required<AngularOptions>;
   swr: SwrOptions;
   zod: NormalizedZodOptions;
+  fetch: FetchOptions;
   operationName?: (
     operation: OperationObject,
     route: string,
@@ -141,6 +142,7 @@ export type NormalizedOperationOptions = {
     route: string,
     verb: Verbs,
   ) => string;
+  fetch?: FetchOptions;
   formData?: boolean | NormalizedMutator;
   formUrlEncoded?: boolean | NormalizedMutator;
   paramsSerializer?: NormalizedMutator;
@@ -356,6 +358,7 @@ export type OverrideOutput = {
     route: string,
     verb: Verbs,
   ) => string;
+  fetch?: FetchOptions;
   requestOptions?: Record<string, any> | boolean;
   useDates?: boolean;
   useTypeOverInterfaces?: boolean;
@@ -496,6 +499,10 @@ export type SwrOptions = {
   swrInfiniteOptions?: any;
 };
 
+export type FetchOptions = {
+  includeHttpStatusReturnType: boolean;
+};
+
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;
 
 type InputTransformer = string | InputTransformerFn;
@@ -520,6 +527,7 @@ export type OperationOptions = {
     route: string,
     verb: Verbs,
   ) => string;
+  fetch?: FetchOptions;
   formData?: boolean | Mutator;
   formUrlEncoded?: boolean | Mutator;
   paramsSerializer?: Mutator;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -303,6 +303,11 @@ export const normalizeOptions = async (
         angular: {
           provideIn: outputOptions.override?.angular?.provideIn ?? 'root',
         },
+        fetch: {
+          includeHttpStatusReturnType:
+            outputOptions.override?.fetch?.includeHttpStatusReturnType ?? true,
+          ...(outputOptions.override?.fetch ?? {}),
+        },
         useDates: outputOptions.override?.useDates || false,
         useDeprecatedOperations:
           outputOptions.override?.useDeprecatedOperations ?? true,

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -237,11 +237,16 @@ export const getSwrMutationFetcherOptionType = (
 export const getSwrMutationFetcherType = (
   response: GetterResponse,
   httpClient: OutputHttpClient,
+  includeHttpStatusReturnType: boolean,
   operationName: string,
   mutator?: GeneratorMutator,
 ) => {
   if (httpClient === OutputHttpClient.FETCH) {
-    const responseType = fetchResponseTypeName(operationName);
+    const responseType = fetchResponseTypeName(
+      includeHttpStatusReturnType,
+      response.definition.success,
+      operationName,
+    );
 
     return `Promise<${responseType}>`;
   } else if (mutator) {

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -532,6 +532,7 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
     const swrMutationFetcherType = getSwrMutationFetcherType(
       response,
       httpClient,
+      override.fetch.includeHttpStatusReturnType,
       operationName,
       mutator,
     );

--- a/samples/react-app-with-swr/fetch-client/orval.config.ts
+++ b/samples/react-app-with-swr/fetch-client/orval.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       client: 'swr',
       httpClient: 'fetch',
       mock: true,
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
     },
     input: {
       target: './petstore.yaml',

--- a/samples/react-app-with-swr/fetch-client/src/App.tsx
+++ b/samples/react-app-with-swr/fetch-client/src/App.tsx
@@ -14,8 +14,8 @@ function App() {
     <>
       <h1>SWR with fetch client</h1>
       <div>
-        {data?.data &&
-          data.data.map((pet: Pet, index: number) => (
+        {data &&
+          data.map((pet: Pet, index: number) => (
             <div key={index}>
               <p>id: {pet.id}</p>
               <p>name: {pet.name}</p>

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -19,11 +19,6 @@ import type {
 /**
  * @summary List all pets
  */
-export type listPetsResponse = {
-  data: Pets;
-  status: number;
-};
-
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -43,14 +38,14 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
-): Promise<listPetsResponse> => {
+): Promise<Pets> => {
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
   });
   const data = await res.json();
 
-  return { status: res.status, data };
+  return data as Pets;
 };
 
 export const getListPetsKey = (params?: ListPetsParams) =>
@@ -96,11 +91,6 @@ export const useListPets = <TError = Promise<Error>>(
 /**
  * @summary Create a pet
  */
-export type createPetsResponse = {
-  data: Pet;
-  status: number;
-};
-
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
@@ -108,7 +98,7 @@ export const getCreatePetsUrl = () => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
-): Promise<createPetsResponse> => {
+): Promise<Pet> => {
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
@@ -117,14 +107,11 @@ export const createPets = async (
   });
   const data = await res.json();
 
-  return { status: res.status, data };
+  return data as Pet;
 };
 
 export const getCreatePetsMutationFetcher = (options?: RequestInit) => {
-  return (
-    _: Key,
-    { arg }: { arg: CreatePetsBody },
-  ): Promise<createPetsResponse> => {
+  return (_: Key, { arg }: { arg: CreatePetsBody }): Promise<Pet> => {
     return createPets(arg, options);
   };
 };
@@ -165,11 +152,6 @@ export const useCreatePets = <TError = Promise<Error>>(options?: {
 /**
  * @summary Info for a specific pet
  */
-export type showPetByIdResponse = {
-  data: Pet;
-  status: number;
-};
-
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
@@ -177,14 +159,14 @@ export const getShowPetByIdUrl = (petId: string) => {
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
-): Promise<showPetByIdResponse> => {
+): Promise<Pet> => {
   const res = await fetch(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
   });
   const data = await res.json();
 
-  return { status: res.status, data };
+  return data as Pet;
 };
 
 export const getShowPetByIdKey = (petId: string) =>

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -76,6 +76,22 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  includeHttpStatusReturnType: {
+    output: {
+      target: '../generated/fetch/include-http-status-return-type/endpoints.ts',
+      schemas: '../generated/fetch/include-http-status-return-type/model',
+      mock: true,
+      client: 'fetch',
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   namedParameters: {
     output: {
       target: '../generated/fetch/named-parameters/endpoints.ts',

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -61,6 +61,25 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  httpClientFetchWithIncludeHttpStatusReturnType: {
+    output: {
+      target:
+        '../generated/react-query/http-client-fetch-with-include-http-status-return-type/endpoints.ts',
+      schemas:
+        '../generated/react-query/http-client-fetch-with-include-http-status-return-type/model',
+      mode: 'tags-split',
+      client: 'react-query',
+      httpClient: 'fetch',
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   mutator: {
     output: {
       target: '../generated/react-query/mutator/endpoints.ts',

--- a/tests/configs/svelte-query.config.ts
+++ b/tests/configs/svelte-query.config.ts
@@ -70,6 +70,25 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  httpClientFetchWithIncludeHttpStatusReturnType: {
+    output: {
+      target:
+        '../generated/svelte-query/http-client-fetch-with-include-http-status-return-type/endpoints.ts',
+      schemas:
+        '../generated/svelte-query/http-client-fetch-with-include-http-status-return-type/model',
+      mode: 'tags-split',
+      client: 'svelte-query',
+      httpClient: 'fetch',
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   mutator: {
     output: {
       target: '../generated/svelte-query/mutator/endpoints.ts',

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -63,6 +63,25 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  httpClientFetchWithIncludeHttpStatusReturnType: {
+    output: {
+      target:
+        '../generated/swr/http-client-fetch-with-include-http_status_return-type/endpoints.ts',
+      schemas:
+        '../generated/swr/http-client-fetch-with-include-http_status_return-type/model',
+      mode: 'tags-split',
+      client: 'swr',
+      httpClient: 'fetch',
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   mutator: {
     output: {
       target: '../generated/swr/mutator/endpoints.ts',

--- a/tests/configs/vue-query.config.ts
+++ b/tests/configs/vue-query.config.ts
@@ -70,6 +70,25 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  httpClientFetchWithIncludeHttpStatusReturnType: {
+    output: {
+      target:
+        '../generated/vue-query/http-client-fetch-with-include-http-status-return-type/endpoints.ts',
+      schemas:
+        '../generated/vue-query/http-client-fetch-with-include-http-status-return-type/model',
+      mode: 'tags-split',
+      client: 'vue-query',
+      httpClient: 'fetch',
+      override: {
+        fetch: {
+          includeHttpStatusReturnType: false,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   mutator: {
     output: {
       target: '../generated/vue-query/mutator/endpoints.ts',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1550

I added `override.fetch.includeHttpStatusReturnType` and switch return type by it in `fetch`.
The `fetch` client response type includes the http status to make it easier for applications to handle it.
However, if i use `swr` or queries, i will be accessing things like `data.data`, which will be noisy.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check with the test I added