### PR TITLE
fix: Always async resolver function

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -116,9 +116,7 @@ const generateDefinition = (
   const infoParam = 'info';
   const handlerImplementation = `
 export const ${handlerName} = (overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => Promise<${returnType}> | ${returnType})) => {
-  return http.${verb}('${route}', ${
-    (isReturnHttpResponse && !isTextPlain) || delay !== false ? 'async' : ''
-  } (${infoParam}) => {${
+  return http.${verb}('${route}', async (${infoParam}) => {${
     delay !== false
       ? `await delay(${isFunction(delay) ? `(${delay})()` : delay});`
       : ''

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -367,6 +367,20 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  mockWithoutDelay: {
+    output: {
+      target: '../generated/react-query/mockWithoutDelay/endpoints.ts',
+      schemas: '../generated/react-query/mockWithoutDelay/model',
+      client: 'react-query',
+      mock: {
+        type: 'msw',
+        delay: false,
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   polymorphic: {
     output: {
       target: '../generated/react-query/polymorphic/endpoints.ts',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #1566

## Description

MSW resolver function has to be always async as Orlval is always adding async "override" function

in case `mock.delay = false` Orval failed to add `async` keyword

I also added extra test case to catch the case
🙏 Please do check if I missed anything for tests


🙏 Please release this fix soon as it's blocking us to use Orval v7 and it has couple fixes we're looking for