### PR TITLE
fix(query): remove `Promise` from error type in query clients

### DIFF
--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -334,10 +334,9 @@ export const getQueryErrorType = (
         }>`
       : response.definition.errors || 'unknown';
   } else {
-    const errorType =
-      httpClient === OutputHttpClient.AXIOS ? 'AxiosError' : 'Promise';
-
-    return `${errorType}<${response.definition.errors || 'unknown'}>`;
+    return httpClient === OutputHttpClient.AXIOS
+      ? `AxiosError<${response.definition.errors || 'unknown'}>`
+      : `${response.definition.errors || 'unknown'}`;
   }
 };
 


### PR DESCRIPTION
## Status

<!--- **READY** --->

**READY/WIP/HOLD**

## Description

fix #1534

I removed unnecessary `Promise` from error response types when using query client.
Because the `error` variable doesn't need a `Promise` and there is no need to use `await`.

https://tanstack.com/query/latest/docs/framework/react/reference/useQuery

### Before
const { data, error} = useCreatePets()
// const error: Ref<null> | Ref<Promise<Error>>

### After

const { data, error} = useCreatePets()
// const error: Ref<null> | Ref<Error>

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

you can check `error` variable type in sample app

```diff
// samples/vue-query/custom-fetch/src/components/HelloWorld.vue

- const { data } = useListPets();
+ const { data, error } = useListPets();
```
