### PR TITLE
fix: relative hono handler imports when using tag mode

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -62,8 +62,12 @@ export const getHonoHeader: ClientHeaderBuilder = ({
         clientImplementation.includes(`${verbOption.operationName}Handlers`),
       )
       .map((verbOption) => {
+        const isTagMode =
+          output.mode === 'tags' || output.mode === 'tags-split';
+        const tag = kebab(verbOption.tags[0] ?? 'default');
+
         const handlersPath = upath.relativeSafe(
-          targetInfo.dirname ?? '',
+          upath.join(targetInfo.dirname ?? '', isTagMode ? tag : ''),
           upath.join(
             handlerFileInfo.dirname ?? '',
             `./${verbOption.operationName}`,
@@ -151,7 +155,7 @@ const getHonoHandlers = ({
   return `
 export const ${handlerName} = factory.createHandlers(
 ${currentValidator}async (c: ${contextTypeName}) => {
-  
+
   },
 );`;
 };
@@ -861,7 +865,7 @@ export const zValidator =
       }
     } else {
       await next();
-      
+
       if (
         c.res.status !== 200 ||
        !c.res.headers.get('Content-Type')?.includes('application/json')
@@ -877,7 +881,7 @@ export const zValidator =
       } catch {
         const message = 'Malformed JSON in response';
         c.res = new Response(message, { status: 400 });
-        
+
         return;
       }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #1573 

## Description

The logic to account for the tag in the relative path already existed [during the generation of the handlers](https://github.com/orval-labs/orval/blob/master/packages/hono/src/index.ts#L221). 
I simply reused it when creating the imports for the handlers in the hono routes.

