### PR TITLE
fix(fetch): properly append array values to `normalizedParams` object

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -52,7 +52,11 @@ ${
     if (value === null) {
       normalizedParams.append(key, 'null');
     } else if (value !== undefined) {
-      normalizedParams.append(key, value.toString());
+      if (value instanceof Array) {
+        value.forEach((v) => normalizedParams.append(key, v.toString()));
+      } else {
+        normalizedParams.append(key, value.toString());
+      }
     }
   });`
     : ''


### PR DESCRIPTION
## Status

**WIP**

## Description

related https://github.com/orval-labs/orval/issues/1285

I experienced a problem with array values.
For example I want to send this: `Foo: [0, 1]` this will be added by [this line of code](https://github.com/orval-labs/orval/blob/master/packages/fetch/src/index.ts#L55) to the URLSearchParams instance, which in turn will by stringified to `Foo=0,1` and appended to the API url in generated code.

Shouldn't this be done according to [this example in the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/append#examples)? Resulting in `Foo=0&Foo=1` as stringified value.

This PR addresses that. Let me know if I need to anything else within this PR.

Thanks @soartec-lab for the great work on the fetch client 🎉

## Related PRs

List related PRs against other branches:
* https://github.com/orval-labs/orval/issues/1387

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
