### PR TITLE
fix: import react deps when tags have mutator

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -815,6 +815,7 @@ export type ClientDependenciesBuilder = (
   hasParamsSerializerOptions: boolean,
   packageJson?: PackageJson,
   httpClient?: OutputHttpClient,
+  hasTagsMutator?: boolean,
 ) => GeneratorDependency[];
 
 export type ClientMockGeneratorImplementation = {
@@ -1051,6 +1052,7 @@ export type GeneratorClientImports = (data: {
   hasSchemaDir: boolean;
   isAllowSyntheticDefaultImports: boolean;
   hasGlobalMutator: boolean;
+  hasTagsMutator: boolean;
   hasParamsSerializerOptions: boolean;
   packageJson?: PackageJson;
   output: NormalizedOutputOptions;

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -68,7 +68,9 @@ export const writeSingleMode = async ({
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
       hasGlobalMutator: !!output.override.mutator,
-      hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
+      hasTagsMutator: Object.values(output.override.tags).some(
+        (tag) => !!tag.mutator,
+      ),
       hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
       packageJson: output.packageJson,
       output,

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -68,6 +68,7 @@ export const writeSingleMode = async ({
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
       hasGlobalMutator: !!output.override.mutator,
+      hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
       hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
       packageJson: output.packageJson,
       output,

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -60,7 +60,9 @@ export const writeSplitMode = async ({
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
       hasGlobalMutator: !!output.override.mutator,
-      hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
+      hasTagsMutator: Object.values(output.override.tags).some(
+        (tag) => !!tag.mutator,
+      ),
       hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
       packageJson: output.packageJson,
       output,

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -60,6 +60,7 @@ export const writeSplitMode = async ({
       hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
       hasGlobalMutator: !!output.override.mutator,
+      hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
       hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
       packageJson: output.packageJson,
       output,

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -74,6 +74,7 @@ export const writeSplitTagsMode = async ({
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
           hasGlobalMutator: !!output.override.mutator,
+          hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
           hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
           packageJson: output.packageJson,
           output,

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -74,7 +74,9 @@ export const writeSplitTagsMode = async ({
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
           hasGlobalMutator: !!output.override.mutator,
-          hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
+          hasTagsMutator: Object.values(output.override.tags).some(
+            (tag) => !!tag.mutator,
+          ),
           hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
           packageJson: output.packageJson,
           output,

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -73,7 +73,9 @@ export const writeTagsMode = async ({
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
           hasGlobalMutator: !!output.override.mutator,
-          hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
+          hasTagsMutator: Object.values(output.override.tags).some(
+            (tag) => !!tag.mutator,
+          ),
           hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
           packageJson: output.packageJson,
           output,

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -73,6 +73,7 @@ export const writeTagsMode = async ({
           hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
           hasGlobalMutator: !!output.override.mutator,
+          hasTagsMutator: Object.values(output.override.tags).some(tag => !!tag.mutator),
           hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
           packageJson: output.packageJson,
           output,

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -65,6 +65,7 @@ export const generateClientImports: GeneratorClientImports = ({
   hasSchemaDir,
   isAllowSyntheticDefaultImports,
   hasGlobalMutator,
+  hasTagsMutator,
   hasParamsSerializerOptions,
   packageJson,
   output,
@@ -79,6 +80,7 @@ export const generateClientImports: GeneratorClientImports = ({
             hasParamsSerializerOptions,
             packageJson,
             output.httpClient,
+            hasTagsMutator,
           ),
           ...imports,
         ]

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -209,6 +209,7 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
   hasParamsSerializerOptions,
   packageJson,
   httpClient,
+  hasTagsMutator,
 ) => {
   const hasReactQuery =
     packageJson?.dependencies?.['react-query'] ??
@@ -220,7 +221,7 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
     packageJson?.peerDependencies?.['@tanstack/react-query'];
 
   return [
-    ...(hasGlobalMutator ? REACT_DEPENDENCIES : []),
+    ...(hasGlobalMutator || hasTagsMutator ? REACT_DEPENDENCIES : []),
     ...(!hasGlobalMutator && httpClient === OutputHttpClient.AXIOS
       ? AXIOS_DEPENDENCIES
       : []),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,23 +1165,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.0.1, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.1.0, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.0.1, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.1.0, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.0.1, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.1.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1219,62 +1219,62 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.0.1, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.1.0, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.0.1, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.1.0, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.0.1"
-    "@orval/zod": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
+    "@orval/zod": "npm:7.1.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.0.1, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.1.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
     lodash.get: "npm:^4.4.2"
     lodash.omit: "npm:^4.5.0"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.0.1, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.1.0, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.0.1"
-    "@orval/fetch": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
+    "@orval/fetch": "npm:7.1.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.0.1, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.1.0, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.0.1"
-    "@orval/fetch": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
+    "@orval/fetch": "npm:7.1.0"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.0.1, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.1.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.0.1"
+    "@orval/core": "npm:7.1.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -7177,15 +7177,15 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@orval/angular": "npm:7.0.1"
-    "@orval/axios": "npm:7.0.1"
-    "@orval/core": "npm:7.0.1"
-    "@orval/fetch": "npm:7.0.1"
-    "@orval/hono": "npm:7.0.1"
-    "@orval/mock": "npm:7.0.1"
-    "@orval/query": "npm:7.0.1"
-    "@orval/swr": "npm:7.0.1"
-    "@orval/zod": "npm:7.0.1"
+    "@orval/angular": "npm:7.1.0"
+    "@orval/axios": "npm:7.1.0"
+    "@orval/core": "npm:7.1.0"
+    "@orval/fetch": "npm:7.1.0"
+    "@orval/hono": "npm:7.1.0"
+    "@orval/mock": "npm:7.1.0"
+    "@orval/query": "npm:7.1.0"
+    "@orval/swr": "npm:7.1.0"
+    "@orval/zod": "npm:7.1.0"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

close #1612

Current behavior: When `output.override.mutator` is set (i.e`hasGlobalMutator` is true), the React dependencies (like useCallback) are imported. However, in this issue(#1612), the mutator is set in `output.override.tags.foo`, and this case wasn't covered properly.

Update: I've now made sure that even when the mutator is set in `output.override.tags.foo`, the React dependencies will be imported as expected.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1.Following the steps in this issue, set up the orval.config.ts file and provide api.yaml as the input. Then, check the output to confirm that `useCallback` is being imported.
