### PR TITLE
fix: change --apply to --write in biome check command

### DIFF
--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -187,7 +187,7 @@ export const writeSpecs = async (
 
   if (output.biome) {
     try {
-      await execa('biome', ['check', '--apply', ...paths]);
+      await execa('biome', ['check', '--write', ...paths]);
     } catch (e: any) {
       const message =
         e.exitCode === 1


### PR DESCRIPTION
## Status
**READY**

## Description

Setting biome: true and running the `orval` command results in an error asking to change `--apply` to `--write`.

```bash
DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ! The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.
```

## Related PRs

List related PRs against other branches:

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. You define biome to true in `orval.config.ts` like a bellow, then execute `orval` and make sure biome executes together.

```ts
import { defineConfig } from 'orval';

export default defineConfig({
  petstoreFile: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      client: 'swr',
      target: 'src/gen/endpoints',
      schemas: 'src/gen/model',
      biome: true,
    },
  },
});
```
