### PR TITLE
fix: generate zod constants for oneOf schemas

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -404,9 +404,19 @@ export const parseZodValidationSchemaDefinition = (
 
     if (fn === 'oneOf' || fn === 'anyOf') {
       return args.reduce(
-        (acc: string, { functions }: { functions: [string, any][] }) => {
+        (
+          acc: string,
+          {
+            functions,
+            consts: argConsts,
+          }: { functions: [string, any][]; consts: string[] },
+        ) => {
           const value = functions.map(parseProperty).join('');
           const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
+
+          if (argConsts.length) {
+            consts += argConsts.join('');
+          }
 
           if (!acc) {
             acc += valueWithZod;


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

close #1594

This PR adds the capability to generate Zod constants when handling oneOf schemas in the OpenAPI specification.

### before
```ts
/**
 * Generated by orval v7.1.0 🍺
 * Do not edit manually.
 * Swagger Petstore
 * OpenAPI spec version: 1.0.0
 */
import { z as zod } from "zod";

/**
 * @summary Create a pet
 */
export const createPetsBodyPasswordMin = 8;

export const createPetsBody = zod.object({
  login: zod
    .string()
    .min(createPetsBodyLoginMinOne)
    .max(createPetsBodyLoginMaxOne)
    .or(zod.string().email()),
  password: zod.string().min(createPetsBodyPasswordMin),
  remember: zod.boolean(),
});
```

### after
```ts
/**
 * Generated by orval v7.1.0 🍺
 * Do not edit manually.
 * Swagger Petstore
 * OpenAPI spec version: 1.0.0
 */
import { z as zod } from "zod";

/**
 * @summary Create a pet
 */
export const createPetsBodyLoginMinOne = 18; // generated!
export const createPetsBodyLoginMaxOne = 18; // generated!
export const createPetsBodyPasswordMin = 8;

export const createPetsBody = zod.object({
  login: zod
    .string()
    .min(createPetsBodyLoginMinOne)
    .max(createPetsBodyLoginMaxOne)
    .or(zod.string().email()),
  password: zod.string().min(createPetsBodyPasswordMin),
  remember: zod.boolean(),
});
```

## Related PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Update orval.config.js with the OpenAPI spec and client configuration.
2. Ensure the oneOf schema definitions generate the correct constants for validation rules.
3. Verify that the generated constants match the values specified in the OpenAPI schema.


```js
// orval.config.js
import { defineConfig } from "orval";

export default defineConfig({
  petstore: {
    input: "./petstore.yaml",
    output: {
      client: "zod",
      target: "./src/generated/zod.ts",
      override: {},
    },
  },
});
```

```yaml
// petstore.yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    post:
      summary: Create a pet
      operationId: createPets
      requestBody:
        required: true
        content:
          application/json:
            schema:
              required:
                - login
                - password
                - remember
              properties:
                login:
                  description: ""
                  oneOf:
                    - type: string
                      maxLength: 18
                      minLength: 18
                    - type: string
                      format: email
                password:
                  type: string
                  minLength: 8
                remember:
                  type: boolean
                  example: false
              type: object
            example:
              login: "+7 (982) 556-29-77"
              password: t9NB5Z4H8Q_V
              remember: false
      responses:
        "201":
          description: Null response
```


