### PR TITLE
chore(test): add test for case where tags have hook mutator and client is react-query

### DIFF
--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -235,6 +235,26 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  tagHookMutator: {
+    output: {
+      target: '../generated/react-query/tag-hook-mutator/endpoints.ts',
+      schemas: '../generated/react-query/tag-hook-mutator/model',
+      client: 'react-query',
+      override: {
+        tags: {
+          pets: {
+            mutator: {
+              path: '../mutators/use-custom-instance.ts',
+              name: 'useCustomInstance',
+            },
+          },
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   formData: {
     output: {
       target: '../generated/react-query/form-data/endpoints.ts',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

As @soartec-lab mentioned in PR #1614, I have added a test for tags.mutator.
This test expects that `useCallback` is imported when a hook mutator is provided.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
|fix/import-react-deps-when-tags-have-mutator | [link](https://github.com/orval-labs/orval/pull/1614) |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. cd tests
2. yarn generate:react-query
3. check if  `🎉 tagHookMutator - Your OpenAPI spec has been converted into ready to use orval!` displays
