### PR TITLE
fix(msw): broken mock when `allof` with not has `properties` object

### DIFF
--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -152,7 +152,23 @@ export const combineSchemasMock = ({
         return `${acc}${currentValue}${!combine ? '])' : ''}`;
       }
 
+      if (currentValue === '{}') {
+        currentValue = '';
+
+        if (acc.toString().endsWith(',')) {
+          acc = acc.toString().slice(0, -1);
+        }
+      }
+
       return `${acc}${currentValue}${isObjectBounds ? '}' : ''}`;
+    }
+
+    if (currentValue === '{}') {
+      currentValue = '';
+
+      if (acc.toString().endsWith(',')) {
+        acc = acc.toString().slice(0, -1);
+      }
     }
 
     if (!currentValue) {

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -105,6 +105,14 @@ export default defineConfig({
       mock: true,
     },
   },
+  'all-of': {
+    input: '../specifications/all-of.yaml',
+    output: {
+      schemas: '../generated/default/all-of/model',
+      target: '../generated/default/all-of/endpoints.ts',
+      mock: true,
+    },
+  },
   'deeply-nested-refs': {
     input: '../specifications/deeply-nested-refs.yaml',
     output: {

--- a/tests/specifications/all-of.yaml
+++ b/tests/specifications/all-of.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: AnyOf Schema
+  license:
+    name: MIT
+paths:
+  /not-has-properties-with-all-of-pets:
+    get:
+      operationId: getNotHasPropertiesWithAllOfPets
+      tags:
+        - pets
+      description: |-
+        Not has properties with allOf pets.
+      responses:
+        '200':
+          description: User
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Pet'
+                  - $ref: '#/components/schemas/PetDetail'
+                  - type: object
+                    required:
+                      - category
+                  - type: object
+                    required:
+                      - color
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    PetDetail:
+      type: object
+      required:
+        - tag
+      properties:
+        tag:
+          type: string


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1101 

when i have not implemented `properties` in `OpenAPI` like a bellow, generated `msw` mock will be broken.

```yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: AnyOf Schema
  license:
    name: MIT
paths:
  /not-has-properties-with-all-of-pets:
    get:
      operationId: getNotHasPropertiesWithAllOfPets
      tags:
        - pets
      description: |-
        Not has properties with allOf pets.
      responses:
        '200':
          description: User
          content:
            application/json:
              schema:
                allOf:
                  - $ref: '#/components/schemas/Pet'
                  - $ref: '#/components/schemas/PetDetail'
                  - type: object
                    required:
                      - category
                  - type: object
                    required:
                      - color

components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
    PetDetail:
      type: object
      required:
        - tag
      properties:
        tag:
          type: string
```

The object can't be converted because there are no `properties` in that schema.
Currently `orval` is producing `{}` which results in a syntax error.
So if the generated mock object contains `{}` remove it.


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

you can check by using the yaml mentioned above or see tests