### PR TITLE
fix(msw): do not use spread objects if `nullable` object schema in `oneOf`

### DIFF
--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -134,7 +134,13 @@ export const resolveMockValue = ({
         const func = `export const ${funcName} = (${args}): ${newSchema.name} => ({...${value}, ...${overrideVarName}});`;
         splitMockImplementations?.push(func);
       }
-      scalar.value = `{...${funcName}()}`;
+
+      if (newSchema.nullable) {
+        scalar.value = `${funcName}()`;
+      } else {
+        scalar.value = `{...${funcName}()}`;
+      }
+
       scalar.imports.push({
         name: newSchema.name,
         specKey: isRootKey(specKey, context.target) ? undefined : specKey,

--- a/tests/specifications/one-of.yaml
+++ b/tests/specifications/one-of.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: AnyOf Schema
+  license:
+    name: MIT
+
+paths:
+  /one-of-with-nullable-object:
+    get:
+      operationId: getOneOfWithNullableObject
+      tags:
+        - pets
+      description: |-
+        oneOf with nullable object.
+      responses:
+        '200':
+          description: Pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+
+components:
+  schemas:
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+    Dog:
+      type: object
+      nullable: true
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Cat:
+      type: object
+      required:
+        - id
+        - category
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          type: string


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Suppose I have a schema `nullable` object in `oneOf` as below.

```yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: AnyOf Schema
  license:
    name: MIT

paths:
  /one-of-with-nullable-object:
    get:
      operationId: getOneOfWithNullableObject
      tags:
        - pets
      description: |-
        oneOf with nullable object.
      responses:
        '200':
          description: Pet
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'

components:
  schemas:
    Pet:
      oneOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'
    Dog:
      type: object
      nullable: true
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
    Cat:
      type: object
      required:
        - id
        - category
      properties:
        id:
          type: integer
          format: int64
        category:
          type: string
```

In this case, the `mock` defined function cannot be spread and will result in a syntax error.
Therefore, I modified it to avoid it in the case of `nullable`.

### Before

`Dog` is `nullable` so occur syntax error 

```ts
export const getGetOneOfObjectOrIntegerPetsResponseMock = (): Pet => (faker.helpers.arrayElement([{...getGetOneOfObjectOrIntegerPetsResponseDogMock()},{...getGetOneOfObjectOrIntegerPetsResponseCatMock()}]))
```

### After

`mock` of `Doc` doesn't use spread.

```ts
export const getGetOneOfObjectOrIntegerPetsResponseMock = (): Pet => (faker.helpers.arrayElement([getGetOneOfObjectOrIntegerPetsResponseDogMock(),{...getGetOneOfObjectOrIntegerPetsResponseCatMock()}]))
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check by i added test case.