### PR TITLE
fix(fetch): `fetch` client can now override `headers` with `options`

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -142,7 +142,7 @@ ${
   const ignoreContentTypes = ['multipart/form-data'];
   const fetchHeadersOption =
     body.contentType && !ignoreContentTypes.includes(body.contentType)
-      ? `headers: { 'Content-Type': '${body.contentType}' }`
+      ? `headers: { 'Content-Type': '${body.contentType}', ...options?.headers }`
       : '';
   const requestBodyParams = generateBodyOptions(
     body,

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -65,7 +65,7 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
   const data = await res.json();
@@ -92,7 +92,7 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
   const data = await res.json();

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -91,7 +91,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -115,7 +115,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
 };

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -100,7 +100,7 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBody),
   });
   const data = await res.json();

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -222,7 +222,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -304,7 +304,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
 };

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -172,7 +172,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -254,7 +254,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
 };

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -137,7 +137,7 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
   const data = await res.json();
@@ -205,7 +205,7 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
   const data = await res.json();

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -174,7 +174,7 @@ export const createPets = async (
   return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -256,7 +256,7 @@ export const updatePets = async (
   return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1622 

The `fetch` client could not override `header` with `options`, so i fixed it.

### Before

The `fetch` client could not override `headers` with `options` because `headers` implement after `...options` so `headers` is always fixed.

```
return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
  ...options,
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify(createPetsBodyItem),
});

```

### After

`headers` implement contains `...options?.headers` 

```
return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
  ...options,
  method: 'POST',
  headers: { 'Content-Type': 'application/json', ...options?.headers },
  body: JSON.stringify(createPetsBodyItem),
});
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check by using sample app.