### PR TITLE
fix(angular): add request overloads based on observe property

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -27,6 +27,8 @@ const ANGULAR_DEPENDENCIES: GeneratorDependency[] = [
       { name: 'HttpHeaders' },
       { name: 'HttpParams' },
       { name: 'HttpContext' },
+      { name: 'HttpResponse', alias: 'AngularHttpResponse' }, // alias to prevent naming conflict with msw
+      { name: 'HttpEvent' },
     ],
     dependency: '@angular/common/http',
   },
@@ -212,7 +214,14 @@ const generateImplementation = (
     hasSignal: false,
   });
 
-  return ` ${operationName}<TData = ${dataType}>(\n    ${toObjectString(
+  const propsDefinition = toObjectString(props, 'definition');
+  const overloads = isRequestOptions
+    ? `${operationName}<TData = ${dataType}>(\n    ${propsDefinition} options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'body' }\n  ): Observable<TData>;
+    ${operationName}<TData = ${dataType}>(\n    ${propsDefinition} options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'response' }\n  ): Observable<AngularHttpResponse<TData>>;
+    ${operationName}<TData = ${dataType}>(\n    ${propsDefinition} options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'events' }\n  ): Observable<HttpEvent<TData>>;`
+    : '';
+
+  return ` ${overloads}${operationName}<TData = ${dataType}>(\n    ${toObjectString(
     props,
     'implementation',
   )} ${

--- a/samples/angular-app/src/api/endpoints/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.service.ts
@@ -7,8 +7,10 @@
 import { HttpClient } from '@angular/common/http';
 import type {
   HttpContext,
+  HttpEvent,
   HttpHeaders,
   HttpParams,
+  HttpResponse as AngularHttpResponse,
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -53,6 +55,21 @@ export class PetsService {
    */
   createPets<TData = void>(
     createPetsBody: CreatePetsBody,
+    version?: number,
+    options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'body' },
+  ): Observable<TData>;
+  createPets<TData = void>(
+    createPetsBody: CreatePetsBody,
+    version?: number,
+    options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'response' },
+  ): Observable<AngularHttpResponse<TData>>;
+  createPets<TData = void>(
+    createPetsBody: CreatePetsBody,
+    version?: number,
+    options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'events' },
+  ): Observable<HttpEvent<TData>>;
+  createPets<TData = void>(
+    createPetsBody: CreatePetsBody,
     version: number = 1,
     options?: HttpClientOptions,
   ): Observable<TData> {
@@ -61,6 +78,21 @@ export class PetsService {
   /**
    * @summary Info for a specific pet
    */
+  showPetById<TData = Pet>(
+    petId: string,
+    version?: number,
+    options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'body' },
+  ): Observable<TData>;
+  showPetById<TData = Pet>(
+    petId: string,
+    version?: number,
+    options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'response' },
+  ): Observable<AngularHttpResponse<TData>>;
+  showPetById<TData = Pet>(
+    petId: string,
+    version?: number,
+    options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'events' },
+  ): Observable<HttpEvent<TData>>;
   showPetById<TData = Pet>(
     petId: string,
     version: number = 1,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

READY

## Description

Fixes #1631 

- Updated `generateImplementation` to add function overloads when `isRequestOptions` is `true`.
- This ensures that when supplying `observe` to a request, it's return type will match what is returned by the `HttpClient`.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
