### PR TITLE
fix(msw): fix break `msw` when `anyof` included `allof`

### DIFF
--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -117,7 +117,8 @@ export const combineSchemasMock = ({
     }
 
     const isObjectBounds =
-      !combine || (combine.separator === 'oneOf' && separator === 'allOf');
+      !combine ||
+      (['oneOf', 'anyOf'].includes(combine.separator) && separator === 'allOf');
 
     if (!index && isObjectBounds) {
       if (

--- a/tests/specifications/any-of.yaml
+++ b/tests/specifications/any-of.yaml
@@ -22,9 +22,49 @@ paths:
       responses:
         '204':
           description: Ok
+  /any-of-included-all-of-pet:
+    get:
+      summary: Gets anyOf included allOf pets
+      operationId: getAnyOfIncludedAllOfPets
+      responses:
+        '200':
+          description: Pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
 components:
   schemas:
     A:
       type: string
       enum:
         - A
+    Pet:
+      anyOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+    Cat:
+      type: object
+      required:
+        - color
+      properties:
+        color:
+          type: string
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/DogType'
+        - $ref: '#/components/schemas/DogDetail'
+    DogType:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+    DogDetail:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1508 
Previously, an `allOf` object was maked only if `oneOf` contained `allOf`, and `msw` would break when `anyOf` contained `allOf`. Therefore, i have fixed it so that `anyOf` now generates an `Allof` object just like `oneOf`.

### Before

`type: faker.word.sample(),name: faker.word.sample()` is not `object` so syntax error.

```ts
export const getGetAnyOfIncludedAllOfPetsResponseMock = (): Pet => (faker.helpers.arrayElement([{color: faker.word.sample()},type: faker.word.sample(),name: faker.word.sample()]))
```

### After

`{type: faker.word.sample(),name: faker.word.sample()}` is `object` so there is no syntax error.

```ts
export const getGetAnyOfIncludedAllOfPetsResponseMock = (): Pet => (faker.helpers.arrayElement([{color: faker.word.sample()},{type: faker.word.sample(),name: faker.word.sample()}]))
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

you can check by i added test case