### PR TITLE
fix(msw): `ref` in `allOf` expands the object

### DIFF
--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -116,6 +116,14 @@ export const combineSchemasMock = ({
       currentValue = `${currentValue ? `${currentValue},` : ''}${itemResolvedValue.value}`;
     }
 
+    if (
+      resolvedValue.type === undefined &&
+      currentValue &&
+      separator === 'allOf'
+    ) {
+      currentValue = `...${currentValue}`;
+    }
+
     const isObjectBounds =
       !combine ||
       (['oneOf', 'anyOf'].includes(combine.separator) && separator === 'allOf');

--- a/tests/specifications/all-of.yaml
+++ b/tests/specifications/all-of.yaml
@@ -27,6 +27,22 @@ paths:
                   - type: object
                     required:
                       - color
+  /rested-ref-in-all-of-pets:
+    get:
+      operationId: getNestedRefInAllOfPets
+      tags:
+        - pets
+      description: |-
+        Nested ref in allOf pets.
+      responses:
+        '200':
+          description: User
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PetRef'
+                  - $ref: '#/components/schemas/PetDetail'
 
 components:
   schemas:
@@ -48,3 +64,5 @@ components:
       properties:
         tag:
           type: string
+    PetRef:
+      $ref: '#/components/schemas/Pet'


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

fix #1119 

Fixed a syntax error that occurred when using `ref` in an item referenced by `allOf`.
The reference with `ref` is not necessarily an object, but there are few cases where `allOf` refers to an item other than an object, so this covers many cases.

### Before

`ref` objects will cause an syntax error.

```ts
export const getGetNestedRefInAllOfPetsResponseMock = (): GetNestedRefInAllOfPets200 => ({{id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample()},tag: faker.word.sample()})
```

### After

`ref` objects are expanded so no error occurs.

```ts
export const getGetNestedRefInAllOfPetsResponseMock = (): GetNestedRefInAllOfPets200 => ({...{id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample()},tag: faker.word.sample()})
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

i added test case