### PR TITLE
fix(msw): Incorrect Import Generated for Enum in Mock Files

### DIFF
--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -89,7 +89,7 @@ export const resolveMockValue = ({
 
     const newSchema = {
       ...schemaRef,
-      name: originalName,
+      name: pascal(originalName),
       path: schema.path,
       isRef: true,
     };

--- a/samples/vue-query/vue-query-basic/petstore.yaml
+++ b/samples/vue-query/vue-query-basic/petstore.yaml
@@ -116,6 +116,12 @@ paths:
           description: Success
 components:
   schemas:
+    Domain.Status.Enum:
+      type: string
+      enum:
+        - new
+        - sold
+        - uknown
     Pet:
       type: object
       required:
@@ -129,6 +135,8 @@ components:
           type: string
         tag:
           type: string
+        status:
+          $ref: '#/components/schemas/Domain.Status.Enum'
         email:
           type: string
           format: email


### PR DESCRIPTION
## Status
fix #1620

**WIP** 

## Description

Fixes the issue mention in #1620. It now imports like this `import { DomainStatusEnum } from '.././model';` instead of `import { Domain.Status.Enum } from '.././model';`

## Todos
It is realy difficult to check if I didn't broken anything after the change. When i ran  generate api  on vue-query sample it looked good and only added the  new correct import statments. Thats why i marked it as WIP. If you have tips to test it better please let me know.


