### PR TITLE
fix: add nullable condition to multipart formdata for openapi3.1

### DIFF
--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -437,7 +437,7 @@ const resolveSchemaPropertiesToFormData = ({
       const isRequired =
         schema.required?.includes(key) && !isRequestBodyOptional;
 
-      if (property.nullable) {
+      if (property.nullable || property.type?.includes('null')) {
         if (isRequired) {
           return acc + `if(${valueKey} !== null) {\n ${formDataValue} }\n`;
         }


### PR DESCRIPTION
## Status

READY

## Description

OpenAPI 3.1 introduces support for jsonschema's 'null' type, however, 
there is a problem in multipart/formdata where the generated code does not correctly determine null.
Specifically, the expected output from the following yaml is different.

https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-7.6.1

input.yaml
```yaml
openapi: '3.1.0'
info:
  version: 1.0.0
  title: Swagger Petstore
paths:
  /pets:
    post:
      summary: Create a pet
      operationId: createPets
      tags:
        - pets
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                name:
                  type: [ string, 'null' ]
      responses:
        '204':
          description: Created Pet
```

* Expected

```ts
if(createPetsBody.name !== undefined && createPetsBody.name !== null) {
 formData.append('name', createPetsBody.name)
 }
```

* Generated

```ts
if(createPetsBody.name !== undefined) {
 formData.append('name', createPetsBody.name)
 }
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
