### PR TITLE
fix: Correctly set type for false or 0 constants

### DIFF
--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -52,7 +52,7 @@ export const getScalar = ({
       }
 
       const itemWithConst = item as SchemaWithConst;
-      if (itemWithConst.const) {
+      if (itemWithConst.const !== undefined) {
         value = itemWithConst.const;
       }
 
@@ -73,7 +73,7 @@ export const getScalar = ({
       let value = 'boolean';
 
       const itemWithConst = item as SchemaWithConst;
-      if (itemWithConst.const) {
+      if (itemWithConst.const !== undefined) {
         value = itemWithConst.const;
       }
 

--- a/tests/specifications/const.yaml
+++ b/tests/specifications/const.yaml
@@ -26,11 +26,15 @@ components:
       type: object
       required:
         - value
+        - valueFalse
         - valueNullable
       properties:
         value:
           type: boolean
           const: true
+        valueFalse:
+          type: boolean
+          const: false
         valueNullable:
           type:
             - boolean
@@ -40,11 +44,15 @@ components:
       type: object
       required:
         - value
+        - valueZero
         - valueNullable
       properties:
         value:
           type: number
           const: 1
+        valueZero:
+          type: number
+          const: 0
         valueNullable:
           type:
             - number


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #1647

I've expanded the `const` specification to include `false` and `0` constants. Before this change, the models were generated as:
```typescript
export interface BooleanConst {
  value: true;
  valueFalse: boolean;
  valueNullable: BooleanConstValueNullable;
}

export interface IntegerConst {
  value: 1;
  valueNullable: IntegerConstValueNullable;
  valueZero: number;
}
```

After this change, the models are generated as:
```typescript
export interface BooleanConst {
  value: true;
  valueFalse: false;
  valueNullable: BooleanConstValueNullable;
}

export interface IntegerConst {
  value: 1;
  valueNullable: IntegerConstValueNullable;
  valueZero: 0;
}
```

## Related PRs

[PR that introduced the problem](https://github.com/orval-labs/orval/pull/1512)

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git clone https://github.com/RinseV/orval.git
```

1. Install dependencies & build the package
2. Generate the default specification in the `tests` folder: `yarn generate:default`
3. The generated models will have the correct literal types
