### PR TITLE
Fix small typo in the docs

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -37,7 +37,7 @@ module.exports = {
 };
 ```
 
-if you want you can provide a function to extend or create you custom client generator and this function receive a [[GeneratorClients](https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L156)](https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L156) in argument and should return a [ClientGeneratorsBuilder](https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L652).
+If you want you can provide a function to extend or create you custom client generator and this function receive a [GeneratorClients](https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L156) in argument and should return a [ClientGeneratorsBuilder](https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L652).
 
 ### httpClient
 


### PR DESCRIPTION
## Status

**READY**

## Description

Small change to fix issue in the markdown format of the URL. 

Converts this
<img width="883" alt="Screenshot 2024-10-01 at 20 37 50" src="https://github.com/user-attachments/assets/962d6be0-bb13-467a-b070-af2893a109b6">
 to 
<img width="1029" alt="Screenshot 2024-10-01 at 20 38 57" src="https://github.com/user-attachments/assets/00e329f5-2465-419a-87bd-6affd7b94bbc">


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
