### PR TITLE
fix(msw): fix broken mocks when using 'allOf' within 'anyOf' and using a shared schema

### DIFF
--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -94,12 +94,25 @@ export const resolveMockValue = ({
       isRef: true,
     };
 
+    const newSeparator = newSchema.allOf
+      ? 'allOf'
+      : newSchema.oneOf
+        ? 'oneOf'
+        : 'anyOf';
+
     const scalar = getMockScalar({
       item: newSchema,
       mockOptions,
       operationId,
       tags,
-      combine,
+      combine: combine
+        ? {
+            separator:
+              combine.separator === 'anyOf' ? newSeparator : combine.separator,
+            includedProperties:
+              newSeparator === 'allOf' ? [] : combine.includedProperties,
+          }
+        : undefined,
       context: {
         ...context,
         specKey,
@@ -145,6 +158,10 @@ export const resolveMockValue = ({
         name: newSchema.name,
         specKey: isRootKey(specKey, context.target) ? undefined : specKey,
       });
+    }
+
+    if (scalar.value && newSchema.allOf && combine?.separator === 'anyOf') {
+      scalar.value = `{${scalar.value}}`;
     }
 
     return {

--- a/tests/specifications/any-of.yaml
+++ b/tests/specifications/any-of.yaml
@@ -33,6 +33,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
+  /any-of-included-all-of-and-shared-schema-pet:
+    get:
+      summary: Gets anyOf included allOf and shared schema pets
+      operationId: getAnyOfIncludedAllOfAndSharedSchemaPets
+      responses:
+        '200':
+          description: Pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatDetail'
 components:
   schemas:
     A:
@@ -68,3 +79,21 @@ components:
       properties:
         name:
           type: string
+    CatDetail:
+      type: object
+      required:
+        - detail
+      properties:
+        detail:
+          anyOf:
+            - $ref: '#/components/schemas/Cat'
+            - $ref: '#/components/schemas/CatExpandDetail'
+    CatExpandDetail:
+      allOf:
+        - $ref: '#/components/schemas/Cat'
+        - type: object
+          required:
+            - url
+          properties:
+            url:
+              type: string


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I fixed the syntax error when using `allOf` within `anyOf` and shared schema.

## Before

`TS1128: Declaration or statement expected.` occurred.

```ts
export const getGetPetsResponseMock = (
  overrideResponse: Partial< Pet > = {}
): Pet => ({
  detail: faker.helpers.arrayElement([
    { name: faker.word.sample() },
    { ,url: faker.word.sample()}
  ]),
  ...overrideResponse
})
```

## After

It's correct

```ts
export const getGetPetsResponseMock = (
  overrideResponse: Partial<Pet> = {},
): Pet => ({
  detail: faker.helpers.arrayElement([
    { name: faker.word.sample() },
    { name: faker.word.sample(), url: faker.word.sample() },
  ]),
  ...overrideResponse,
});
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check by i added test case or below:

```yaml
openapi: 3.0.3
info:
  version: 1.0.0
  title: Test
paths:
  /pet:
    get:
      operationId: get-pets
      responses:
        '200':
          description: 'success'
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
components:
  schemas:
    Pet:
      type: object
      required:
        - detail
      properties:
        detail:
          anyOf:
            - $ref: '#/components/schemas/Color'
            - $ref: '#/components/schemas/Detail'
    Color:
      type: object
      required:
        - name
      properties:
        name:
          type: string
    Detail:
      allOf:
        - $ref: '#/components/schemas/Color'
        - type: object
          required:
            - url
          properties:
            url:
              type: string
```