### PR TITLE
Fix custom client example to include a question mark before query parameters

### DIFF
--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -36,13 +36,16 @@ export const customInstance = async <T>({
   data?: BodyType<unknown>;
   responseType?: string;
 }): Promise<T> => {
-  const response = await fetch(
-    `${baseURL}${url}` + new URLSearchParams(params),
-    {
-      method,
-      ...(data ? { body: JSON.stringify(data) } : {}),
-    },
-  );
+  let targetUrl = `${baseURL}${url}`;
+
+  if (params) {
+    targetUrl += '?' + new URLSearchParams(params);
+  }
+
+  const response = await fetch(targetUrl, {
+    method,
+    ...(data ? { body: JSON.stringify(data) } : {}),
+  });
 
   return response.json();
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix the custom fetch client example to include a question mark before any query parameters. 

Closes https://github.com/orval-labs/orval/issues/1666 
Closes  https://github.com/orval-labs/orval/issues/482
