### PR TITLE
fix: faker recursive reference pascal sanitation

### DIFF
--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -4,6 +4,7 @@ import {
   isReference,
   isSchema,
   MockOptions,
+  pascal,
 } from '@orval/core';
 import omit from 'lodash.omit';
 import { MockDefinition, MockSchemaObject } from '../../types';
@@ -69,7 +70,7 @@ export const combineSchemasMock = ({
   const value = (item[separator] ?? []).reduce((acc, val, index, arr) => {
     if (
       '$ref' in val &&
-      existingReferencedProperties.includes(val.$ref.split('/').pop()!)
+      existingReferencedProperties.includes(pascal(val.$ref.split('/').pop()!))
     ) {
       if (arr.length === 1) {
         return 'undefined';

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -5,6 +5,7 @@ import {
   isBoolean,
   isReference,
   MockOptions,
+  pascal,
 } from '@orval/core';
 import { ReferenceObject, SchemaObject } from 'openapi3-ts/oas30';
 import { resolveMockValue } from '../resolvers/value';
@@ -120,7 +121,9 @@ export const getMockObject = ({
         // Fixes issue #910
         if (
           '$ref' in prop &&
-          existingReferencedProperties.includes(prop.$ref.split('/').pop()!)
+          existingReferencedProperties.includes(
+            pascal(prop.$ref.split('/').pop()!),
+          )
         ) {
           return undefined;
         }

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -6,6 +6,7 @@ import {
   isRootKey,
   mergeDeep,
   MockOptions,
+  pascal,
 } from '@orval/core';
 import { MockDefinition, MockSchemaObject } from '../../types';
 import { DEFAULT_FORMAT_MOCK } from '../constants';
@@ -172,7 +173,9 @@ export const getMockScalar = ({
 
       if (
         '$ref' in item.items &&
-        existingReferencedProperties.includes(item.items.$ref.split('/').pop()!)
+        existingReferencedProperties.includes(
+          pascal(item.items.$ref.split('/').pop()!),
+        )
       ) {
         return { value: '[]', imports: [], name: item.name };
       }


### PR DESCRIPTION
## Status

**READY**

## Description

Fixed bug when faker attempted to create mocked data, the schema had recursive references, where the name of the schema was changed when sanitized to pascal case. The bug was fixed with the change in ```packages\mock\src\faker\getters\scalar.ts:176```, but I found two checks to ```existingReferencedProperties``` in ```packages\mock\src\faker\getters\object.ts``` and ```packages\mock\src\faker\getters\combine.ts```, so I thought I would proactively fix them too

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Here is a simplified, obfuscated version of the json that caused the issue. The sanitation changed ```Foo.Bar.MainMenuItemDTO``` to ```FooBarMainMenuItemDTO```, causing it to miss the check in ```existingReferencedProperties```

I ran this json in the react query sample to confirm the bug, and the fix

```json
{
  "swagger": "2.0",
  "info": {
    "version": "v1",
    "title": "Foo Bar Api"
  },
  "host": "localhost:443",
  "basePath": "/",
  "schemes": ["https"],
  "paths": {
    "/api/foo/bar": {
      "get": {
        "tags": ["Foo"],
        "operationId": "Foo_Bar",
        "consumes": [],
        "produces": ["application/json"],
        "parameters": [],
        "responses": {
          "200": {
            "description": "OK",
            "schema": {
              "type": "array",
              "items": {
                "$ref": "#/definitions/Foo.Bar.MainMenuItemDTO"
              }
            }
          }
        },
        "deprecated": false
      }
    }
  },
  "definitions": {
    "Foo.Bar.MainMenuItemDTO": {
      "type": "object",
      "properties": {
        "id": {
          "type": "string"
        },
        "children": {
          "type": "array",
          "items": {
            "$ref": "#/definitions/Foo.Bar.MainMenuItemDTO"
          }
        }
      }
    }
  }
}
```
