### PR TITLE
fix: faker bigint support

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -122,7 +122,7 @@ export const getMockScalar = ({
     case 'number':
     case 'integer': {
       let value = getNullable(
-        `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`,
+        `${getNumberType(type, item.format, context.output.override.useBigInt)}({min: ${item.minimum}, max: ${item.maximum}})`,
         item.nullable,
       );
       let numberImports: GeneratorImport[] = [];
@@ -326,4 +326,24 @@ function getItemType(item: MockSchemaObject) {
   const type = Array.from(uniqTypes.values()).at(0);
   if (!type) return;
   return ['string', 'number'].includes(type) ? type : undefined;
+}
+
+/**
+ * Checks type and format and returns the correct faker number function
+ *
+ * Will default to int if no specific type is found
+ */
+function getNumberType(type?: string, format?: string, useBigInt?: boolean) {
+  switch (type) {
+    case 'integer':
+      return format == 'int64' && useBigInt === true
+        ? 'faker.number.bigInt'
+        : 'faker.number.int';
+    case 'number':
+      return format == 'double' || format == 'float'
+        ? 'faker.number.float'
+        : 'faker.number.int';
+    default:
+      return 'faker.number.int';
+  }
 }

--- a/tests/configs/mock.config.ts
+++ b/tests/configs/mock.config.ts
@@ -147,14 +147,15 @@ export default defineConfig({
       mock: true,
     },
   },
-  useDates: {
+  formats: {
     input: '../specifications/format.yaml',
     output: {
-      target: '../generated/mock/useDates/endpoints.ts',
-      schemas: '../generated/mock/useDates/model',
+      target: '../generated/mock/formats/endpoints.ts',
+      schemas: '../generated/mock/formats/model',
       mock: true,
       override: {
         useDates: true,
+        useBigInt: true,
       },
     },
   },

--- a/tests/specifications/format.yaml
+++ b/tests/specifications/format.yaml
@@ -41,9 +41,27 @@ components:
         - birthDate
         - createdAt
       properties:
+        id:
+          type: integer
+          format: int64
         birthDate:
           type: string
           format: date
         createdAt:
           type: string
           format: date-time
+        age:
+          type: integer
+        legCount:
+          type: number
+        weight:
+          type: number
+          format: double
+        height:
+          type: number
+          format: float
+        chipNumbers:
+          type: array
+          items:
+            type: integer
+            format: int64


### PR DESCRIPTION
## Status

**READY**

## Description

Fix https://github.com/orval-labs/orval/issues/1472
If orval config uses override useBigInt, faker will be generated with faker.number.bigInt. I also added support for format double/float, to use faker.number.float. if useBigInt is not set, it will default back to faker.number.int

I appended the existing `tests/specifications/format.yaml`, and changed the name in `tests/configs/mock.config.ts` from **useDates**, to **formats**, to better reflect its content with the new test scenarios

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Running locally against `tests/configs/mock.config.ts`, the config **formats** tests to generate the new number type/format combinations
