### PR TITLE
mock strings fields as 20 char strings

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -250,7 +250,7 @@ export const getMockScalar = ({
     }
 
     case 'string': {
-      let value = 'faker.word.sample()';
+      let value = 'faker.string.alpha(20)';
       let imports: GeneratorImport[] = [];
 
       if (item.enum) {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

With faker.string.alpha(20), you get a 20-character string using random letters from the alphabet. The chances of getting an identical string are astronomically low, given the vast number of possible combinations.

On the other hand, faker.word.sample() picks a word from a predefined list of words. The uniqueness of this function is limited to the size of that list. So, while it’s great for generating realistic and coherent words, it doesn’t offer the same level of uniqueness as generating a random string of 20 characters.

In summary:

faker.string.alpha(20): Super unique because of the high number of possible combinations.

faker.word.sample(): Limited uniqueness, depending on the list size. Ideal if you want sensible words rather than random strings.

Resolves https://github.com/orval-labs/orval/issues/1680

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
