### PR TITLE
feat(core): add mode include/exclude to input filters option

### DIFF
--- a/docs/src/pages/reference/configuration/input.md
+++ b/docs/src/pages/reference/configuration/input.md
@@ -71,6 +71,30 @@ Default Value: `{}`.
 
 If specified, Orval only generates the endpoints after applying the filter.
 
+#### mode
+
+Type: `String`.
+
+Valid values: `include`, `exclude`.
+
+Default Value: `include`.
+
+Combined with `tags` or `schemas`, this setting determines whether to include or exclude the specified items.
+For instance, the example below generates endpoints that do not contain the tag `pets`.
+
+```js
+module.exports = {
+  petstore: {
+    input: {
+      filters: {
+        mode: 'exclude',
+        tags: ['pets'],
+      },
+    },
+  },
+};
+```
+
 #### tags
 
 Type: Array of `string` or `RegExp`.

--- a/packages/core/src/generators/schema-definition.test.ts
+++ b/packages/core/src/generators/schema-definition.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type { ContextSpecs, InputFiltersOption, SchemasObject } from '../types';
+import { generateSchemasDefinition } from './schema-definition';
+
+describe('generateSchemasDefinition', () => {
+  const context: ContextSpecs = {
+    specKey: 'testSpec',
+    output: {
+      override: {
+        useNativeEnums: false,
+      },
+    },
+    target: 'typescript',
+    specs: {},
+  };
+
+  it('should return an empty array if schemas are empty', () => {
+    const result = generateSchemasDefinition({}, context, 'Suffix');
+    expect(result).toEqual([]);
+  });
+
+  it('should generate schemas without filters', () => {
+    const schemas: SchemasObject = {
+      TestSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+    };
+
+    const result = generateSchemasDefinition(schemas, context, 'Suffix');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('TestSchemaSuffix');
+  });
+
+  it('should generate schemas with include filters', () => {
+    const schemas: SchemasObject = {
+      TestSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+      AnotherSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+    };
+
+    const filters: InputFiltersOption = {
+      schemas: ['TestSchema'],
+      mode: 'include',
+    };
+
+    const result = generateSchemasDefinition(
+      schemas,
+      context,
+      'Suffix',
+      filters,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('TestSchemaSuffix');
+  });
+
+  it('should generate schemas with exclude filters', () => {
+    const schemas: SchemasObject = {
+      TestSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+      AnotherSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+    };
+
+    const filters: InputFiltersOption = {
+      schemas: ['TestSchema'],
+      mode: 'exclude',
+    };
+
+    const result = generateSchemasDefinition(
+      schemas,
+      context,
+      'Suffix',
+      filters,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('AnotherSchemaSuffix');
+  });
+});

--- a/packages/core/src/generators/schema-definition.ts
+++ b/packages/core/src/generators/schema-definition.ts
@@ -1,15 +1,19 @@
 import isEmpty from 'lodash.isempty';
-import { SchemaObject, SchemasObject } from 'openapi3-ts/oas30';
+import type { SchemaObject, SchemasObject } from 'openapi3-ts/oas30';
 import { getEnum, resolveDiscriminators } from '../getters';
 import { resolveRef, resolveValue } from '../resolvers';
-import { ContextSpecs, GeneratorSchema, InputFiltersOption } from '../types';
+import type {
+  ContextSpecs,
+  GeneratorSchema,
+  InputFiltersOption,
+} from '../types';
 import {
-  upath,
   isReference,
+  isString,
   jsDoc,
   pascal,
   sanitize,
-  isString,
+  upath,
 } from '../utils';
 import { generateInterface } from './interface';
 
@@ -22,19 +26,25 @@ export const generateSchemasDefinition = (
   schemas: SchemasObject = {},
   context: ContextSpecs,
   suffix: string,
-  schemasFilters?: InputFiltersOption['schemas'],
+  filters?: InputFiltersOption,
 ): GeneratorSchema[] => {
   if (isEmpty(schemas)) {
     return [];
   }
+
   const transformedSchemas = resolveDiscriminators(schemas, context);
 
   let generateSchemas = Object.entries(transformedSchemas);
-  if (schemasFilters) {
+  if (filters) {
+    const schemasFilters = filters.schemas || [];
+    const mode = filters.mode || 'include';
+
     generateSchemas = generateSchemas.filter(([schemaName]) => {
-      return schemasFilters.some((filter) =>
+      const isMatch = schemasFilters.some((filter) =>
         isString(filter) ? filter === schemaName : filter.test(schemaName),
       );
+
+      return mode === 'include' ? isMatch : !isMatch;
     });
   }
 

--- a/packages/core/src/generators/verbs-options.test.ts
+++ b/packages/core/src/generators/verbs-options.test.ts
@@ -1,5 +1,6 @@
-import { _filteredVerbs } from './verbs-options';
 import { describe, expect, it } from 'vitest';
+import type { NormalizedInputOptions } from '../types';
+import { _filteredVerbs } from './verbs-options';
 
 describe('_filteredVerbs', () => {
   it('should return all verbs if filters.tags is undefined', () => {
@@ -33,7 +34,7 @@ describe('_filteredVerbs', () => {
       },
     };
 
-    const filters = {
+    const filters: NormalizedInputOptions['filters'] = {
       tags: ['tag1'],
     };
 
@@ -42,7 +43,7 @@ describe('_filteredVerbs', () => {
     );
   });
 
-  it('should verbs that match the regex filter', () => {
+  it('should return verbs that match the regex filter', () => {
     const verbs = {
       get: {
         tags: ['tag1', 'tag2'],
@@ -54,12 +55,58 @@ describe('_filteredVerbs', () => {
       },
     };
 
-    const filters = {
+    const filters: NormalizedInputOptions['filters'] = {
       tags: [/tag1/],
     };
 
     expect(_filteredVerbs(verbs, filters)).toEqual(
       Object.entries({ get: verbs.get }),
     );
+  });
+
+  describe('filters.mode', () => {
+    it('should return verbs that match the tag filter', () => {
+      const verbs = {
+        get: {
+          tags: ['tag1', 'tag2'],
+          responses: {},
+        },
+        post: {
+          tags: ['tag3', 'tag4'],
+          responses: {},
+        },
+      };
+
+      const filters: NormalizedInputOptions['filters'] = {
+        tags: ['tag1'],
+        mode: 'include',
+      };
+
+      expect(_filteredVerbs(verbs, filters)).toEqual(
+        Object.entries({ get: verbs.get }),
+      );
+    });
+
+    it('should return verbs that do not match the tag filter', () => {
+      const verbs = {
+        get: {
+          tags: ['tag1', 'tag2'],
+          responses: {},
+        },
+        post: {
+          tags: ['tag3', 'tag4'],
+          responses: {},
+        },
+      };
+
+      const filters: NormalizedInputOptions['filters'] = {
+        tags: ['tag1'],
+        mode: 'exclude',
+      };
+
+      expect(_filteredVerbs(verbs, filters)).toEqual(
+        Object.entries({ post: verbs.post }),
+      );
+    });
   });
 });

--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ComponentsObject,
   OperationObject,
   ParameterObject,
@@ -14,7 +14,7 @@ import {
   getQueryParams,
   getResponse,
 } from '../getters';
-import {
+import type {
   ContextSpecs,
   GeneratorVerbOptions,
   GeneratorVerbsOptions,
@@ -259,15 +259,20 @@ export const _filteredVerbs = (
     return Object.entries(verbs);
   }
 
+  const filterTags = filters.tags || [];
+  const filterMode = filters.mode || 'include';
+
   return Object.entries(verbs).filter(
     ([_verb, operation]: [string, OperationObject]) => {
       const operationTags = operation.tags || [];
-      const filterTags = filters.tags || [];
-      return operationTags.some((tag) =>
+
+      const isMatch = operationTags.some((tag) =>
         filterTags.some((filterTag) =>
           filterTag instanceof RegExp ? filterTag.test(tag) : filterTag === tag,
         ),
       );
+
+      return filterMode === 'exclude' ? !isMatch : isMatch;
     },
   );
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
-import SwaggerParser from '@apidevtools/swagger-parser';
-import {
+import type SwaggerParser from '@apidevtools/swagger-parser';
+import type { allLocales } from '@faker-js/faker';
+import type {
   InfoObject,
   OpenAPIObject,
   OperationObject,
@@ -10,8 +11,7 @@ import {
   SchemaObject,
 } from 'openapi3-ts/oas30';
 // @ts-ignore // FIXME when running `yarn test` getting `orval:test: ../core/src/types.ts(12,34): error TS7016: Could not find a declaration file for module 'swagger2openapi'. '/home/maxim/orval/node_modules/swagger2openapi/index.js' implicitly has an 'any' type.`
-import swagger2openapi from 'swagger2openapi';
-import type { allLocales } from '@faker-js/faker';
+import type swagger2openapi from 'swagger2openapi';
 
 export interface Options {
   output?: string | OutputOptions;
@@ -193,6 +193,7 @@ export type SwaggerParserOptions = Omit<SwaggerParser.Options, 'validate'> & {
 };
 
 export type InputFiltersOption = {
+  mode?: 'include' | 'exclude';
   tags?: (string | RegExp)[];
   schemas?: (string | RegExp)[];
 };

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -123,7 +123,7 @@ const getApiSchemas = ({
         parsedSchemas,
         context,
         output.override.components.schemas.suffix,
-        input.filters?.schemas,
+        input.filters,
       );
 
       const responseDefinition = generateComponentDefinition(

--- a/samples/basic/petstore.yaml
+++ b/samples/basic/petstore.yaml
@@ -71,7 +71,7 @@ paths:
       summary: List all pets as nested array
       operationId: listPetsNestedArray
       tags:
-        - pets
+        - pets, pets-nested-array
       parameters:
         - name: limit
           in: query

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -16,6 +16,17 @@ export default defineConfig({
     },
     output: '../generated/default/petstore-filter/endpoints.ts',
   },
+  'petstore-filter-exlude-mode': {
+    input: {
+      target: '../specifications/petstore.yaml',
+      filters: {
+        mode: 'exclude',
+        tags: ['pets-nested-array'],
+        schemas: ['PetsNestedArray'],
+      },
+    },
+    output: '../generated/default/petstore-filter-exclude-mode/endpoints.ts',
+  },
   'petstore-transfomer': {
     output: {
       target: '../generated/default/petstore-transformer/endpoints.ts',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix https://github.com/orval-labs/orval/issues/1676

Extend the `filters` input option by introducing a `mode` optional parameter to specify if filtering should `include` or `exclude` tags or schemas.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| [yesyesufcurs:issues/739](https://github.com/yesyesufcurs/orval/tree/issues/739) | [link](https://github.com/anymaniax/orval/pull/810) |


## Todos

- [X] Tests
- [X] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Add a tag that should be filtered out to orval.config:

````js
output: {
	mode: :"exclude"
    tags: ["pets"]
},
````
Only endpoints that do not contain the tag "pets" will be generated.
