### PR TITLE
Sanitize JS Doc strings

### DIFF
--- a/packages/core/src/utils/doc.ts
+++ b/packages/core/src/utils/doc.ts
@@ -86,7 +86,7 @@ export function jsDoc(
   function tryAppendStringDocLine(key: string, value?: string) {
     if (value) {
       appendPrefix();
-      doc += ` @${key} ${value}`;
+      doc += ` @${key} ${value.replace(regex, replacement)}`;
     }
   }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix #1703 

if the `pattern` contains `*/` then orval produces TS files which have error due invalid comment parsing, these changes ensure to properly escape all JS doc strings .
 

