### PR TITLE
fix(core): fixes #878 - header parameter as ref not generated properly

### DIFF
--- a/packages/core/src/generators/parameter-definition.test.ts
+++ b/packages/core/src/generators/parameter-definition.test.ts
@@ -1,0 +1,88 @@
+import { ComponentsObject } from 'openapi3-ts/oas30';
+import { describe, expect, it } from 'vitest';
+import { ContextSpecs } from '../types';
+import { generateParameterDefinition } from './parameter-definition';
+
+describe('generateParameterDefinition', () => {
+  const context: ContextSpecs = {
+    specKey: 'testSpec',
+    output: {
+      override: {
+        useNativeEnums: false,
+        components: {
+          schemas: { itemSuffix: 'Parameter' },
+        },
+      },
+    },
+    target: 'typescript',
+    specs: {},
+  };
+
+  it('should return an empty array if parameters are empty', () => {
+    const result = generateParameterDefinition({}, context, 'Suffix');
+    expect(result).toEqual([]);
+  });
+
+  it('should generate parameter definitions for query parameters', () => {
+    const parameters: ComponentsObject['parameters'] = {
+      PetNames: {
+        name: 'names',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const result = generateParameterDefinition(
+      parameters,
+      context,
+      'Parameter',
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('PetNamesParameter');
+    expect(result[0].model).toBe('export type PetNamesParameter = string[];\n');
+  });
+
+  it('should generate parameter definitions for header parameters', () => {
+    const parameters: ComponentsObject['parameters'] = {
+      XUserId: {
+        name: 'X-User-Id',
+        in: 'header',
+        schema: {
+          type: 'string',
+        },
+      },
+    };
+    const result = generateParameterDefinition(
+      parameters,
+      context,
+      'Parameter',
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('XUserIdParameter');
+    expect(result[0].model).toBe('export type XUserIdParameter = string;\n');
+  });
+
+  it('should generate parameter definitions for header parameters', () => {
+    const parameters: ComponentsObject['parameters'] = {
+      XUserId: {
+        name: 'X-User-Id',
+        in: 'header',
+        schema: {
+          type: 'string',
+        },
+      },
+    };
+    const result = generateParameterDefinition(
+      parameters,
+      context,
+      'Parameter',
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('XUserIdParameter');
+    expect(result[0].model).toBe('export type XUserIdParameter = string;\n');
+  });
+});

--- a/packages/core/src/generators/parameter-definition.ts
+++ b/packages/core/src/generators/parameter-definition.ts
@@ -22,7 +22,7 @@ export const generateParameterDefinition = (
         context,
       );
 
-      if (schema.in !== 'query') {
+      if (schema.in !== 'query' && schema.in !== 'header') {
         return acc;
       }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This should fix issue #878 (header parameter as ref not generated properly).

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Reproduction can be found in the related issue.

If more is needed from my side, just let me know. :slightly_smiling_face: 