### PR TITLE
feat(core): take servers fields into account

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -296,6 +296,163 @@ module.exports = {
 };
 ```
 
+### baseUrl
+
+Type: `String | Object`.
+
+Default Value: `''`.
+
+Allows you to set the baesUrl used for all API calls. This can either be a constant string or be configured to read from the `servers` field
+in the specification.
+
+Example using constant:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      baseUrl: 'https://api.example.com', // prepend https://api.example.com to all api calls
+    },
+  },
+};
+```
+
+#### getBaseUrlFromSpecification
+
+Type: `boolean`
+
+Set to `true` to make Orval read the url from the `servers` fields in the specification. If a path has defined a `servers` field,
+that url will be used, otherwise the url from the whole specification's `servers` field will be used.
+If set to `false`, a constant `baseUrl` must be set.
+
+Example:
+
+```yaml
+servers:
+  - url: https://api.example.com
+paths:
+  /pets:
+    servers:
+      - url: https://pets.example.com
+```
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      baseUrl: {
+        getBaseUrlFromSpecification: true,
+        // prepend url defined in specification, in this example: 'https://api.example.com'
+        // for all calls, except for calls to /pets, which will instead use 'https://pets.example.com' as base url.
+      },
+    },
+  },
+};
+```
+
+#### variables
+
+Type: `Dictionary`.
+
+Only valid when `getBaseUrlFromSpecification` is `true`.
+Used to substitute variables in urls.
+If the variable in the specification is an enum, and the provided value in the configuration is not one of the
+allowed values, an error will occur when generating.
+If a variable that is substituted is not configured, the default value defined in the specification will be used.
+
+Example:
+
+```yaml
+servers:
+  - url: https://{environment}.example.com/v1
+    variables:
+      environment:
+        default: api
+        enum:
+          - api
+          - api.dev
+          - api.staging
+```
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      baseUrl: {
+        getBaseUrlFromSpecification: true,
+        variables: {
+          environment: 'api.dev',
+        },
+      },
+    },
+  },
+};
+```
+
+#### index
+
+Type: `Number`.
+
+Only valid when `getBaseUrlFromSpecification` is `true`.
+Since the `servers` field allows for multiple urls to be defined, you can decide which index of urls to pick here.
+If this is not defined, the first url will be used.
+If the defined index is out of range of the array, the last url in the array will be selected.
+
+Example:
+
+```yaml
+servers:
+  - url: https://api.example.com/v1
+  - url: https://api.dev.example.com/v1
+```
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      baseUrl: {
+        getBaseUrlFromSpecification: true,
+        index: 1,
+      },
+    },
+  },
+};
+```
+
+#### baseUrl
+
+Type: `String`.
+
+Only valid when `getBaseUrlFromSpecification` is `false`.
+Behaves the same as setting the baseUrl as a string directly.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      baseUrl: {
+        getBaseUrlFromSpecification: false,
+        baseUrl: 'https://api.example.com', // The same as setting petstore.output.baseUrl: 'https://api.example.com'
+      },
+    },
+  },
+};
+```
+
+Gives the same result as:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      baseUrl: 'https://api.example.com',
+    },
+  },
+};
+```
+
 ### mock
 
 Type: `Boolean | Object | Function`.

--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -1,5 +1,7 @@
+import { ServerObject } from 'openapi3-ts/oas30';
 import { describe, expect, it, test } from 'vitest';
-import { getRoute, getRouteAsArray } from './route';
+import { BaseUrlFromConstant, BaseUrlFromSpec } from '../types';
+import { getFullRoute, getRoute, getRouteAsArray } from './route';
 
 describe('getRoute getter', () => {
   [
@@ -16,6 +18,150 @@ describe('getRoute getter', () => {
   ].forEach(([input, expected]) => {
     it(`should process ${input} to ${expected}`, () => {
       expect(getRoute(input)).toBe(expected);
+    });
+  });
+});
+
+describe('getFullRoute getter', () => {
+  (
+    [
+      [
+        '/path',
+        [{ url: 'url' }],
+        { getBaseUrlFromSpecification: true },
+        'url/path',
+      ],
+      [
+        '/path',
+        [
+          {
+            url: '{environment}.example.com',
+            variables: {
+              environment: {
+                default: 'dev',
+              },
+            },
+          },
+        ],
+        { getBaseUrlFromSpecification: true },
+        'dev.example.com/path',
+      ],
+      [
+        '/path',
+        [
+          {
+            url: '{environment}.example.com',
+            variables: {
+              environment: {
+                default: 'dev',
+              },
+            },
+          },
+        ],
+        {
+          getBaseUrlFromSpecification: true,
+          variables: { environment: 'prod' },
+        },
+        'prod.example.com/path',
+      ],
+      [
+        '/path',
+        [
+          {
+            url: '{region}.{environment}.example.com',
+            variables: {
+              environment: {
+                default: 'dev',
+              },
+              region: {
+                default: 'us',
+                enum: ['us', 'eu'],
+              },
+            },
+          },
+        ],
+        {
+          getBaseUrlFromSpecification: true,
+          variables: { environment: 'prod' },
+        },
+        'us.prod.example.com/path',
+      ],
+      [
+        '/path',
+        [
+          {
+            url: '{region}.{environment}.example.com',
+            variables: {
+              environment: {
+                default: 'dev',
+              },
+              region: {
+                default: 'us',
+                enum: ['us', 'eu'],
+              },
+            },
+          },
+        ],
+        {
+          getBaseUrlFromSpecification: true,
+          variables: { environment: 'prod', region: 'eu' },
+        },
+        'eu.prod.example.com/path',
+      ],
+    ] as [string, ServerObject[] | undefined, BaseUrlFromSpec, string][]
+  ).forEach(([path, servers, config, expected]) => {
+    it(`should make path ${path} with config ${JSON.stringify(config)} and servers ${JSON.stringify(servers)} be ${expected}`, () => {
+      expect(getFullRoute(path, servers, config)).toBe(expected);
+    });
+  });
+  (
+    [
+      [
+        '/path',
+        [{ url: 'url' }],
+        { getBaseUrlFromSpecification: false, baseUrl: 'api.example.com' },
+        'api.example.com/path',
+      ],
+      [
+        '/path',
+        undefined,
+        { getBaseUrlFromSpecification: false, baseUrl: 'api.example.com' },
+        'api.example.com/path',
+      ],
+    ] as [string, ServerObject[] | undefined, BaseUrlFromConstant, string][]
+  ).forEach(([path, servers, config, expected]) => {
+    it(`should make path ${path} with config ${JSON.stringify(config)} and servers ${JSON.stringify(servers)} be ${expected}`, () => {
+      expect(getFullRoute(path, servers, config)).toBe(expected);
+    });
+  });
+  (
+    [
+      [
+        '/path',
+        undefined,
+        { getBaseUrlFromSpecification: true },
+        "Orval is configured to use baseUrl from the specifications 'servers' field, but there exist no servers in the specification.",
+      ],
+      [
+        '/path',
+        [
+          {
+            url: '{region}.example.com',
+            variables: {
+              region: {
+                default: 'us',
+                enum: ['us', 'eu'],
+              },
+            },
+          },
+        ],
+        { getBaseUrlFromSpecification: true, variables: { region: 'euwest' } },
+        `Invalid variable value 'euwest' for variable 'region' when resolving {region}.example.com. Valid values are: us, eu.`,
+      ],
+    ] as [string, ServerObject[] | undefined, BaseUrlFromSpec, string][]
+  ).forEach(([path, servers, config, error]) => {
+    it(`should throw '${error}' when path ${path} with config ${JSON.stringify(config)} and servers ${JSON.stringify(servers)} is evaluated`, () => {
+      expect(() => getFullRoute(path, servers, config)).toThrow(error);
     });
   });
 });

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -1,5 +1,12 @@
 import { camel, sanitize } from '../utils';
 import { TEMPLATE_TAG_REGEX } from '../constants';
+import {
+  BaseUrlFromConstant,
+  BaseUrlFromSpec,
+  ContextSpecs,
+  NormalizedOutputOptions,
+} from '../types';
+import { PathItemObject, ServerObject } from 'openapi3-ts/oas31';
 
 const TEMPLATE_TAG_IN_PATH_REGEX = /\/([\w]+)(?:\$\{)/g; // all dynamic parts of path
 
@@ -39,6 +46,60 @@ export const getRoute = (route: string) => {
 
     return `${acc}/${getRoutePath(path)}`;
   }, '');
+};
+
+export const getFullRoute = (
+  route: string,
+  servers: ServerObject[] | undefined,
+  baseUrl: string | BaseUrlFromConstant | BaseUrlFromSpec | undefined,
+): string => {
+  const getBaseUrl = (): string => {
+    if (!baseUrl) return '';
+    if (typeof baseUrl === 'string') return baseUrl;
+    if (baseUrl.getBaseUrlFromSpecification) {
+      if (!servers) {
+        throw new Error(
+          "Orval is configured to use baseUrl from the specifications 'servers' field, but there exist no servers in the specification.",
+        );
+      }
+      const server = servers.at(
+        Math.min(baseUrl.index ?? 0, servers.length - 1),
+      );
+      if (!server) return '';
+      if (!server.variables) return server.url;
+
+      let url = server.url;
+      const variables = baseUrl.variables;
+      for (const variableKey of Object.keys(server.variables)) {
+        const variable = server.variables[variableKey];
+        if (!variables?.[variableKey]) {
+          url = url.replaceAll(`{${variableKey}}`, String(variable.default));
+        } else {
+          if (
+            variable.enum &&
+            !variable.enum.some((e) => e == variables[variableKey])
+          ) {
+            throw new Error(
+              `Invalid variable value '${variables[variableKey]}' for variable '${variableKey}' when resolving ${server.url}. Valid values are: ${variable.enum.join(', ')}.`,
+            );
+          }
+          url = url.replaceAll(`{${variableKey}}`, variables[variableKey]);
+        }
+      }
+      return url;
+    }
+    return baseUrl.baseUrl;
+  };
+
+  let fullRoute = route;
+  const base = getBaseUrl();
+  if (base) {
+    if (base.endsWith('/') && route.startsWith('/')) {
+      fullRoute = route.slice(1);
+    }
+    fullRoute = `${base}${fullRoute}`;
+  }
+  return fullRoute;
 };
 
 // Creates a mixed use array with path variables and string from template string route

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,7 +59,7 @@ export type NormalizedOutputOptions = {
   packageJson?: PackageJson;
   headers: boolean;
   indexFiles: boolean;
-  baseUrl?: string;
+  baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional: boolean;
   urlEncodeParameters: boolean;
   unionAddMissingProperties: boolean;
@@ -164,6 +164,22 @@ export type OutputClientFunc = (
   clients: GeneratorClients,
 ) => ClientGeneratorsBuilder;
 
+export type BaseUrlFromSpec = {
+  getBaseUrlFromSpecification: true;
+  variables?: {
+    [variable: string]: string;
+  };
+  index?: number;
+  baseUrl?: never;
+};
+
+export type BaseUrlFromConstant = {
+  getBaseUrlFromSpecification: false;
+  variables?: never;
+  index?: never;
+  baseUrl: string;
+};
+
 export type OutputOptions = {
   workspace?: string;
   target?: string;
@@ -184,7 +200,7 @@ export type OutputOptions = {
   packageJson?: string;
   headers?: boolean;
   indexFiles?: boolean;
-  baseUrl?: string;
+  baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional?: boolean;
   urlEncodeParameters?: boolean;
   unionAddMissingProperties?: boolean;

--- a/packages/orval/src/api.ts
+++ b/packages/orval/src/api.ts
@@ -13,6 +13,7 @@ import {
   resolveRef,
 } from '@orval/core';
 import { generateMockImports } from '@orval/mock';
+import { ServerObject } from 'openapi3-ts/dist/oas31';
 import { PathItemObject } from 'openapi3-ts/oas30';
 import {
   generateClientFooter,
@@ -98,11 +99,55 @@ export const getApiBuilder = async ({
       );
 
       let fullRoute = route;
-      if (output.baseUrl) {
-        if (output.baseUrl.endsWith('/') && route.startsWith('/')) {
+      const getBaseUrl = (): string => {
+        if (!output.baseUrl) return '';
+        if (typeof output.baseUrl === 'string') return output.baseUrl;
+        if (output.baseUrl.getBaseUrlFromSpecification) {
+          const servers =
+            verbs.servers ?? context.specs[context.specKey].servers;
+          if (!servers) {
+            throw new Error(
+              "Orval is configured to use baseUrl from the specifications 'servers' field, but there exist no servers in the specification.",
+            );
+          }
+          const server = servers.at(
+            Math.min(output.baseUrl.index ?? 0, servers.length - 1),
+          );
+          if (!server) return '';
+          if (!server.variables) return server.url;
+
+          let url = server.url;
+          const variables = output.baseUrl.variables;
+          for (const variableKey of Object.keys(server.variables)) {
+            const variable = server.variables[variableKey];
+            if (!variables?.[variableKey]) {
+              url = url.replaceAll(
+                `{${variableKey}}`,
+                String(variable.default),
+              );
+            } else {
+              if (
+                variable.enum &&
+                !variable.enum.some((e) => e == variables[variableKey])
+              ) {
+                throw new Error(
+                  `Invalid variable value '${variables[variableKey]}' for variable '${variableKey}' when resolving ${server.url}. Valid values are: ${variable.enum.join(', ')}.`,
+                );
+              }
+              url = url.replaceAll(`{${variableKey}}`, variables[variableKey]);
+            }
+          }
+          return url;
+        }
+        return output.baseUrl.baseUrl;
+      };
+
+      const baseUrl = getBaseUrl();
+      if (baseUrl) {
+        if (baseUrl.endsWith('/') && route.startsWith('/')) {
           fullRoute = route.slice(1);
         }
-        fullRoute = `${output.baseUrl}${fullRoute}`;
+        fullRoute = `${baseUrl}${fullRoute}`;
       }
       const pathOperations = await generateOperations(
         output.client,

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
       httpClient: 'fetch',
       override: {
         fetch: {
-          includeHttpStatusReturnType: false,
+          includeHttpResponseReturnType: false,
         },
       },
     },
@@ -283,6 +283,36 @@ export default defineConfig({
       override: {
         transformer: '../transformers/add-version.js',
       },
+    },
+  },
+  baseUrlFromSpec: {
+    output: {
+      target: '../generated/swr/baseUrlFromSpec/endpoints.ts',
+      schemas: '../generated/swr/baseUrlFromSpec/model',
+      client: 'swr',
+      baseUrl: {
+        getBaseUrlFromSpecification: true,
+        variables: {
+          environment: 'api.dev',
+        },
+      },
+    },
+    input: {
+      target: '../specifications/url-paths.yaml',
+    },
+  },
+  baseUrlNotFromSpec: {
+    output: {
+      target: '../generated/swr/baseUrlNotFromSpec/endpoints.ts',
+      schemas: '../generated/swr/baseUrlNotFromSpec/model',
+      client: 'swr',
+      baseUrl: {
+        getBaseUrlFromSpecification: false,
+        baseUrl: 'https://api.example.com',
+      },
+    },
+    input: {
+      target: '../specifications/url-paths.yaml',
     },
   },
 });

--- a/tests/specifications/url-paths.yaml
+++ b/tests/specifications/url-paths.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: https://{environment}.example.com/v1
+    variables:
+      environment:
+        default: api
+        enum:
+          - api
+          - api.dev
+          - api.staging
+
+paths:
+  /pets:
+    servers:
+      - url: https://pets.example.com
+        description: Override base path for all operations with the /pets path
+    post:
+      operationId: createPet
+      requestBody:
+        $ref: '#/components/requestBodies/RequiredPetBody'
+      responses:
+        '204':
+          description: Ok
+
+  /ping:
+    servers:
+      - url: https://{region}.echo.{environment}.example.com
+        variables:
+          region:
+            default: eu
+          environment:
+            default: api
+            enum:
+              - api
+              - api.dev
+              - api.staging
+    get:
+      operationId: getEcho
+      responses:
+        '200':
+          description: Ok
+
+components:
+  requestBodies:
+    RequiredPetBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+  schemas:
+    Pet:
+      type: object
+    Cookie:
+      type: object


### PR DESCRIPTION
## Status

**READY**

## Description

Fix #1689 
This allows the user to specify whether or not they want to use the servers field as specified in the openapi spec.
The user can still use the old way of defining the baseUrl as a string for backwards compatibility. 
If the servers field contains a variable to be substituted, Orval tries to substitute it using the value that the user has defined in the configuration file. If the user has not defined that variable, the default value is used.

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Define output.baseUrl in your config as 
```ts
baseUrl: {
  getBaseUrlFromSpecification: true
}
```
2. Define servers in your specification, e.g.
```yaml
servers:
  - url: https://api.example.com
```
3. Generate
4. Notice that the url in the generated getUrl functions (e.g. `getCreatePetUrl`) returns `'https://api.example.com/pets'`