### PR TITLE
feat: TData generic for mutation hooks

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -481,9 +481,7 @@ const getQueryOptionsDefinition = ({
         > , 'initialData'
       >`
         : '';
-    const optionType = `${prefix}${pascal(
-      type,
-    )}Options<TData, TError, TData${
+    const optionType = `${prefix}${pascal(type)}Options<TData, TError, TData${
       hasQueryV5 &&
       (type === QueryType.INFINITE || type === QueryType.SUSPENSE_INFINITE) &&
       queryParam &&
@@ -1322,7 +1320,7 @@ const generateQueryHook = async (
       mutator?.isHook
         ? `ReturnType<typeof use${pascal(operationName)}Hook>`
         : `typeof ${operationName}`
-    }>>`
+    }>>`;
 
     const mutationOptionsFn = `export const ${mutationOptionsFnName} = <TData = ${TData}, TError = ${errorType},
     TContext = unknown>(${mutationArguments}) => {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Right now we have an opportunity to override the type of `data` that is returned by the generated `useQuery` hooks using `TData` generic. It would be great to have the same opportunity with the `useMutation` hooks.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can use samples tests
