### PR TITLE
fix(core): make sure to add '| null' to enums with null in type array

### DIFF
--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -27,7 +27,10 @@ export const getScalar = ({
 }): ScalarValue => {
   // NOTE: Angular client does not support nullable types
   const isAngularClient = context.output.client === OutputClient.ANGULAR;
-  const nullable = item.nullable && !isAngularClient ? ' | null' : '';
+  const typeIncludesNull =
+    Array.isArray(item.type) && item.type.includes('null');
+  const nullable =
+    (typeIncludesNull || item.nullable) && !isAngularClient ? ' | null' : '';
 
   const enumItems = item.enum?.filter((enumItem) => enumItem !== null);
 

--- a/tests/specifications/null-type.yaml
+++ b/tests/specifications/null-type.yaml
@@ -76,6 +76,13 @@ components:
           type:
             - 'boolean'
             - 'null'
+    NullStringEnum:
+      type:
+        - string
+        - 'null'
+      enum:
+        - foo
+        - bar
     NullEnum:
       nullable: true
       enum:


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #1738

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

yarn generate:default
check tests/generated/default/null-type/model/nullStringEnum.ts
make sure `| null` is added as expected.
