### PR TITLE
fix(core): filters = {} treated as undefined

### DIFF
--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -133,7 +133,7 @@ export const normalizeOptions = async (
         parserDefaultOptions,
         inputOptions.parserOptions ?? {},
       ),
-      filters: inputOptions.filters,
+      filters: Object.keys(inputOptions.filters || {}).length === 0 ? undefined : inputOptions.filters,
     },
     output: {
       target: globalOptions.output


### PR DESCRIPTION
Fix #1736 fix(core): filters = {} treated as undefined