### PR TITLE
fix(core): generate schemas when filters.schemas undefined

### DIFF
--- a/packages/core/src/generators/schema-definition.test.ts
+++ b/packages/core/src/generators/schema-definition.test.ts
@@ -95,4 +95,35 @@ describe('generateSchemasDefinition', () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('AnotherSchemaSuffix');
   });
+
+  it('should generate schemas when filters.schemas is undefined with other filters', () => {
+    const schemas: SchemasObject = {
+      TestSchema: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+      AnotherSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+    };
+
+    const filters: InputFiltersOption = {
+      tags: ['TestTag'],
+    };
+
+    const result = generateSchemasDefinition(
+      schemas,
+      context,
+      'Suffix',
+      filters,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('TestSchemaSuffix');
+    expect(result[1].name).toBe('AnotherSchemaSuffix');
+  });
 });

--- a/packages/core/src/generators/schema-definition.ts
+++ b/packages/core/src/generators/schema-definition.ts
@@ -35,8 +35,8 @@ export const generateSchemasDefinition = (
   const transformedSchemas = resolveDiscriminators(schemas, context);
 
   let generateSchemas = Object.entries(transformedSchemas);
-  if (filters) {
-    const schemasFilters = filters.schemas || [];
+  if (filters?.schemas) {
+    const schemasFilters = filters.schemas;
     const mode = filters.mode || 'include';
 
     generateSchemas = generateSchemas.filter(([schemaName]) => {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

READY

## Description

Fixes #1736.  Fixes a regression between 7.2.0 and 7.3.0 that prevents  schema generation when `filters` is populated in the config but `filters.schemas` is not.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| [melloware:1736](https://github.com/melloware/orval/tree/1736) | #1740 |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```bash
yarn install
yarn run build
yarn run test
```
Tests will succeed
Undo changes in `schemas-generation.ts` and rebuild
Tests will fail
