### PR TITLE
Fix `useInfinteQuery` typo in documentation

### DIFF
--- a/docs/src/pages/guides/react-query.md
+++ b/docs/src/pages/guides/react-query.md
@@ -70,7 +70,7 @@ export const useShowPetById = <
 
 ### How use other query
 
-With the following example Orval will generate a useQuery and useInfinteQuery with a nextId queryparam. You can also override the config for each one with the options props.
+With the following example Orval will generate a useQuery and useInfiniteQuery with a nextId queryparam. You can also override the config for each one with the options props.
 
 ```js
 module.exports = {

--- a/docs/src/pages/guides/svelte-query.md
+++ b/docs/src/pages/guides/svelte-query.md
@@ -73,7 +73,7 @@ export const useShowPetById = <
 
 ### How use other query
 
-With the following example Orval will generate a useQuery and useInfinteQuery with a nextId queryparam. You can also override the config for each one with the options props.
+With the following example Orval will generate a useQuery and useInfiniteQuery with a nextId queryparam. You can also override the config for each one with the options props.
 
 ```js
 module.exports = {

--- a/docs/src/pages/guides/vue-query.md
+++ b/docs/src/pages/guides/vue-query.md
@@ -73,7 +73,7 @@ export const useShowPetById = <
 
 ### How use other query
 
-With the following example Orval will generate a useQuery and useInfinteQuery with a nextId queryparam. You can also override the config for each one with the options props.
+With the following example Orval will generate a useQuery and useInfiniteQuery with a nextId queryparam. You can also override the config for each one with the options props.
 
 ```js
 module.exports = {


### PR DESCRIPTION
## Status

<!--- **READY** --->

**READY**

## Description

There is a typo in the documentation. `useInfinteQuery` -> `useInfiniteQuery`
