### PR TITLE
fix(core): fixed error where a renamed enum was used by old name

### DIFF
--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -6,7 +6,7 @@ import {
   isReference,
   MockOptions,
   pascal,
-  PropertySorting,
+  PropertySortOrder,
 } from '@orval/core';
 import { ReferenceObject, SchemaObject } from 'openapi3-ts/oas30';
 import { resolveMockValue } from '../resolvers/value';
@@ -107,7 +107,7 @@ export const getMockObject = ({
     let includedProperties: string[] = [];
 
     const entries = Object.entries(item.properties);
-    if (context.output.propertySortOrder === PropertySorting.Alphabetical) {
+    if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
         return a[0].localeCompare(b[0]);
       });


### PR DESCRIPTION
## Status

**READY**

## Description

During development I renamed an enum, but apparently missed a place where it was used.

## Related PRs

Introduced in #1763 
