### PR TITLE
feat(fetch): add type to response data in `fetch` client

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -176,7 +176,7 @@ ${
   `
     : `const res = await fetch(${fetchFnOptions})
 
-  const data = await res.json()
+  const data:${response.definition.success}  = await res.json()
 
   ${override.fetch.includeHttpResponseReturnType ? 'return { status: res.status, data, headers: res.headers }' : `return data as ${responseTypeName}`}
 `;

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
@@ -58,16 +58,6 @@ export const PetCallingCode = {
 } as const;
 
 export interface Pet {
-  /**
-   * @minimum 0
-   * @maximum 30
-   * @exclusiveMinimum
-   * @exclusiveMaximum
-   */
-  age?: number;
-  callingCode?: PetCallingCode;
-  country?: PetCountry;
-  email?: string;
   id: number;
   /**
    * Name of pet
@@ -76,10 +66,20 @@ export interface Pet {
    */
   name: string;
   /**
+   * @minimum 0
+   * @maximum 30
+   * @exclusiveMinimum
+   * @exclusiveMaximum
+   */
+  age?: number;
+  /**
    * @nullable
    * @pattern ^\\d{3}-\\d{2}-\\d{4}$
    */
   tag?: string | null;
+  email?: string;
+  callingCode?: PetCallingCode;
+  country?: PetCountry;
 }
 
 /**

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -77,10 +77,14 @@ export const getListPetsResponseMock = (): PetsArray =>
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
+    id: faker.number.int({ min: undefined, max: undefined }),
+    name: 'jon',
     age: faker.helpers.arrayElement([
       faker.number.int({ min: 0, max: 30 }),
       undefined,
     ]),
+    tag: faker.helpers.arrayElement(['jon', null]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     callingCode: faker.helpers.arrayElement([
       faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
       undefined,
@@ -92,10 +96,6 @@ export const getListPetsResponseMock = (): PetsArray =>
       ] as const),
       undefined,
     ]),
-    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-    id: faker.number.int({ min: undefined, max: undefined }),
-    name: 'jon',
-    tag: faker.helpers.arrayElement(['jon', null]),
   }));
 
 export const getListPetsNestedArrayResponseMock = (
@@ -106,10 +106,14 @@ export const getListPetsNestedArrayResponseMock = (
       { length: faker.number.int({ min: 1, max: 10 }) },
       (_, i) => i + 1,
     ).map(() => ({
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: 'jon',
       age: faker.helpers.arrayElement([
         faker.number.int({ min: 0, max: 30 }),
         undefined,
       ]),
+      tag: faker.helpers.arrayElement(['jon', null]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -121,10 +125,6 @@ export const getListPetsNestedArrayResponseMock = (
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: 'jon',
-      tag: faker.helpers.arrayElement(['jon', null]),
     })),
     undefined,
   ]),

--- a/samples/basic/api/model/pet.ts
+++ b/samples/basic/api/model/pet.ts
@@ -8,16 +8,6 @@ import type { PetCallingCode } from './petCallingCode';
 import type { PetCountry } from './petCountry';
 
 export interface Pet {
-  /**
-   * @minimum 0
-   * @maximum 30
-   * @exclusiveMinimum
-   * @exclusiveMaximum
-   */
-  age?: number;
-  callingCode?: PetCallingCode;
-  country?: PetCountry;
-  email?: string;
   id: number;
   /**
    * Name of pet
@@ -26,8 +16,18 @@ export interface Pet {
    */
   name: string;
   /**
+   * @minimum 0
+   * @maximum 30
+   * @exclusiveMinimum
+   * @exclusiveMaximum
+   */
+  age?: number;
+  /**
    * @nullable
    * @pattern ^\\d{3}-\\d{2}-\\d{4}$
    */
   tag?: string | null;
+  email?: string;
+  callingCode?: PetCallingCode;
+  country?: PetCountry;
 }

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -43,7 +43,7 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data = await res.json();
+  const data: Pets = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -72,7 +72,7 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data = await res.json();
+  const data: Pet = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -101,7 +101,7 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data = await res.json();
+  const data: Pet = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -128,7 +128,7 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data = await res.json();
+  const data: Pet = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };

--- a/samples/hono/hono-with-zod/src/petstore.schemas.ts
+++ b/samples/hono/hono-with-zod/src/petstore.schemas.ts
@@ -44,8 +44,8 @@ export const DachshundBreed = {
 } as const;
 
 export interface Dachshund {
-  breed: DachshundBreed;
   length: number;
+  breed: DachshundBreed;
 }
 
 export type LabradoodleBreed =
@@ -57,8 +57,8 @@ export const LabradoodleBreed = {
 } as const;
 
 export interface Labradoodle {
-  breed: LabradoodleBreed;
   cuteness: number;
+  breed: LabradoodleBreed;
 }
 
 export type DogType = (typeof DogType)[keyof typeof DogType];
@@ -98,19 +98,19 @@ export const PetCallingCode = {
 export type Pet =
   | (Dog & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     })
   | (Cat & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     });

--- a/samples/next-app-with-fetch/app/gen/models/dachshund.ts
+++ b/samples/next-app-with-fetch/app/gen/models/dachshund.ts
@@ -7,6 +7,6 @@
 import type { DachshundBreed } from './dachshundBreed';
 
 export interface Dachshund {
-  breed: DachshundBreed;
   length: number;
+  breed: DachshundBreed;
 }

--- a/samples/next-app-with-fetch/app/gen/models/labradoodle.ts
+++ b/samples/next-app-with-fetch/app/gen/models/labradoodle.ts
@@ -7,6 +7,6 @@
 import type { LabradoodleBreed } from './labradoodleBreed';
 
 export interface Labradoodle {
-  breed: LabradoodleBreed;
   cuteness: number;
+  breed: LabradoodleBreed;
 }

--- a/samples/next-app-with-fetch/app/gen/models/pet.ts
+++ b/samples/next-app-with-fetch/app/gen/models/pet.ts
@@ -12,19 +12,19 @@ import type { PetCountry } from './petCountry';
 export type Pet =
   | (Dog & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     })
   | (Cat & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     });

--- a/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
@@ -12,8 +12,8 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -22,8 +22,8 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -74,6 +74,10 @@ export const getListPetsResponseMock = (): Pets =>
       {
         ...getListPetsResponseDogMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -85,14 +89,14 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
       {
         ...getListPetsResponseCatMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -104,10 +108,6 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
     ]),
   );
@@ -116,8 +116,8 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -126,8 +126,8 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -174,6 +174,10 @@ export const getCreatePetsResponseMock = (): Pet =>
     {
       ...getCreatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -185,14 +189,14 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getCreatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -204,10 +208,6 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -215,8 +215,8 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -225,8 +225,8 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -273,6 +273,10 @@ export const getUpdatePetsResponseMock = (): Pet =>
     {
       ...getUpdatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -284,14 +288,14 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getUpdatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -303,10 +307,6 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -314,8 +314,8 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -324,8 +324,8 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -372,6 +372,10 @@ export const getShowPetByIdResponseMock = (): Pet =>
     {
       ...getShowPetByIdResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -383,14 +387,14 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getShowPetByIdResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -402,10 +406,6 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -67,7 +67,7 @@ export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  return customFetch<Promise<listPetsResponse>>(getListPetsUrl(params), {
+  return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
     method: 'GET',
   });
@@ -90,7 +90,7 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
+  return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -115,7 +115,7 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
+  return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -140,7 +140,7 @@ export const showPetById = async (
   petId: string,
   options?: RequestInit,
 ): Promise<showPetByIdResponse> => {
-  return customFetch<Promise<showPetByIdResponse>>(getShowPetByIdUrl(petId), {
+  return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
   });

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -14,20 +14,20 @@ export const getListPetsResponseMock = (): Pets =>
     (_, i) => i + 1,
   ).map(() => ({
     '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     id: (() => faker.number.int({ min: 1, max: 99999 }))(),
     name: (() => faker.person.lastName())(),
     tag: (() => faker.person.lastName())(),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   }));
 
 export const getCreatePetsResponseMock = (
   overrideResponse: Partial<Pet> = {},
 ): Pet => ({
   '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   id: faker.number.int({ min: undefined, max: undefined }),
   name: (() => faker.person.lastName())(),
   tag: (() => faker.person.lastName())(),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   ...overrideResponse,
 });
 

--- a/samples/react-app-with-swr/basic/src/api/model/pet.ts
+++ b/samples/react-app-with-swr/basic/src/api/model/pet.ts
@@ -7,8 +7,8 @@
 
 export interface Pet {
   '@id'?: string;
-  email?: string;
   id: number;
   name: string;
   tag?: string;
+  email?: string;
 }

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.msw.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.msw.ts
@@ -14,20 +14,20 @@ export const getListPetsResponseMock = (): Pets =>
     (_, i) => i + 1,
   ).map(() => ({
     '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     id: faker.number.int({ min: undefined, max: undefined }),
     name: faker.string.alpha(20),
     tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   }));
 
 export const getCreatePetsResponseMock = (
   overrideResponse: Partial<Pet> = {},
 ): Pet => ({
   '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   id: faker.number.int({ min: undefined, max: undefined }),
   name: faker.string.alpha(20),
   tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   ...overrideResponse,
 });
 
@@ -35,10 +35,10 @@ export const getShowPetByIdResponseMock = (
   overrideResponse: Partial<Pet> = {},
 ): Pet => ({
   '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   id: faker.number.int({ min: undefined, max: undefined }),
   name: faker.string.alpha(20),
   tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   ...overrideResponse,
 });
 

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -41,7 +41,8 @@ export const listPets = async (
     ...options,
     method: 'GET',
   });
-  const data = await res.json();
+
+  const data: Pets = await res.json();
 
   return data as Pets;
 };
@@ -103,7 +104,8 @@ export const createPets = async (
     headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBody),
   });
-  const data = await res.json();
+
+  const data: Pet = await res.json();
 
   return data as Pet;
 };
@@ -162,7 +164,8 @@ export const showPetById = async (
     ...options,
     method: 'GET',
   });
-  const data = await res.json();
+
+  const data: Pet = await res.json();
 
   return data as Pet;
 };

--- a/samples/react-app-with-swr/fetch-client/src/api/models/pet.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/models/pet.ts
@@ -7,8 +7,8 @@
 
 export interface Pet {
   '@id'?: string;
-  email?: string;
   id: number;
   name: string;
   tag?: string;
+  email?: string;
 }

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -13,10 +13,14 @@ export const getListPetsResponseMock = (): PetsArray =>
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
+    id: (() => faker.number.int({ min: 1, max: 99999 }))(),
+    name: (() => faker.person.lastName())(),
     age: faker.helpers.arrayElement([
       faker.number.int({ min: 0, max: 30 }),
       undefined,
     ]),
+    tag: faker.helpers.arrayElement([(() => faker.person.lastName())(), null]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     callingCode: faker.helpers.arrayElement([
       faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
       undefined,
@@ -28,10 +32,6 @@ export const getListPetsResponseMock = (): PetsArray =>
       ] as const),
       undefined,
     ]),
-    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-    id: (() => faker.number.int({ min: 1, max: 99999 }))(),
-    name: (() => faker.person.lastName())(),
-    tag: faker.helpers.arrayElement([(() => faker.person.lastName())(), null]),
   }));
 
 export const getListPetsNestedArrayResponseMock = (
@@ -42,10 +42,17 @@ export const getListPetsNestedArrayResponseMock = (
       { length: faker.number.int({ min: 1, max: 10 }) },
       (_, i) => i + 1,
     ).map(() => ({
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: (() => faker.person.lastName())(),
       age: faker.helpers.arrayElement([
         faker.number.int({ min: 0, max: 30 }),
         undefined,
       ]),
+      tag: faker.helpers.arrayElement([
+        (() => faker.person.lastName())(),
+        null,
+      ]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -56,13 +63,6 @@ export const getListPetsNestedArrayResponseMock = (
           'Uruguay',
         ] as const),
         undefined,
-      ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: (() => faker.person.lastName())(),
-      tag: faker.helpers.arrayElement([
-        (() => faker.person.lastName())(),
-        null,
       ]),
     })),
     undefined,

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -83,10 +83,10 @@ export const getListPetsInfiniteQueryOptions = <
   options?: {
     query?: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -115,10 +115,10 @@ export const getListPetsInfiniteQueryOptions = <
     enabled: !!version,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData,
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     QueryKey,
     ListPetsParams['limit']
   > & { queryKey: DataTag<QueryKey, TData> };
@@ -141,21 +141,16 @@ export function useListPetsInfinite<
   options: {
     query: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
     > &
       Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPets>>,
-          TError,
-          TData,
-          QueryKey
-        >,
+        DefinedInitialDataOptions<TData, TError, TData, QueryKey>,
         'initialData'
       >;
   },
@@ -174,21 +169,16 @@ export function useListPetsInfinite<
   options?: {
     query?: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
     > &
       Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPets>>,
-          TError,
-          TData,
-          QueryKey
-        >,
+        UndefinedInitialDataOptions<TData, TError, TData, QueryKey>,
         'initialData'
       >;
   },
@@ -207,10 +197,10 @@ export function useListPetsInfinite<
   options?: {
     query?: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -235,10 +225,10 @@ export function useListPetsInfinite<
   options?: {
     query?: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -269,11 +259,7 @@ export const getListPetsQueryOptions = <
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -289,7 +275,7 @@ export const getListPetsQueryOptions = <
     queryFn,
     enabled: !!version,
     ...queryOptions,
-  } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
+  } as UseQueryOptions<TData, TError, TData> & {
     queryKey: DataTag<QueryKey, TData>;
   };
 };
@@ -306,17 +292,8 @@ export function useListPets<
   params: undefined | ListPetsParams,
   version: undefined | number,
   options: {
-    query: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPets>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<DefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
   },
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
@@ -328,17 +305,8 @@ export function useListPets<
   params?: ListPetsParams,
   version?: number,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPets>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 export function useListPets<
@@ -347,11 +315,7 @@ export function useListPets<
 >(
   params?: ListPetsParams,
   version?: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
  * @summary List all pets
@@ -363,11 +327,7 @@ export function useListPets<
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
@@ -386,15 +346,7 @@ export const getListPetsSuspenseQueryOptions = <
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseSuspenseQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -406,7 +358,7 @@ export const getListPetsSuspenseQueryOptions = <
   }) => listPets(params, version, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData> };
@@ -423,15 +375,7 @@ export function useListPetsSuspense<
 >(
   params: undefined | ListPetsParams,
   version: undefined | number,
-  options: {
-    query: Partial<
-      UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options: { query: Partial<UseSuspenseQueryOptions<TData, TError, TData>> },
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -441,15 +385,7 @@ export function useListPetsSuspense<
 >(
   params?: ListPetsParams,
   version?: number,
-  options?: {
-    query?: Partial<
-      UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseSuspenseQueryOptions<TData, TError, TData>> },
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -459,15 +395,7 @@ export function useListPetsSuspense<
 >(
   params?: ListPetsParams,
   version?: number,
-  options?: {
-    query?: Partial<
-      UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseSuspenseQueryOptions<TData, TError, TData>> },
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -481,15 +409,7 @@ export function useListPetsSuspense<
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseSuspenseQueryOptions<TData, TError, TData>> },
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 } {
@@ -521,10 +441,10 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
   options?: {
     query?: Partial<
       UseSuspenseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -552,10 +472,10 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
     queryFn,
     ...queryOptions,
   } as UseSuspenseInfiniteQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData,
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     QueryKey,
     ListPetsParams['limit']
   > & { queryKey: DataTag<QueryKey, TData> };
@@ -578,10 +498,10 @@ export function useListPetsSuspenseInfinite<
   options: {
     query: Partial<
       UseSuspenseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -602,10 +522,10 @@ export function useListPetsSuspenseInfinite<
   options?: {
     query?: Partial<
       UseSuspenseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -626,10 +546,10 @@ export function useListPetsSuspenseInfinite<
   options?: {
     query?: Partial<
       UseSuspenseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -654,10 +574,10 @@ export function useListPetsSuspenseInfinite<
   options?: {
     query?: Partial<
       UseSuspenseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -701,21 +621,17 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof createPets>>,
-  TError,
-  { data: CreatePetsBody; version?: number },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -734,7 +650,12 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: CreatePetsBody; version?: number },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -747,17 +668,18 @@ export type CreatePetsMutationError = ErrorType<Error>;
  * @summary Create a pet
  */
 export const useCreatePets = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
 }): UseMutationResult<
-  Awaited<ReturnType<typeof createPets>>,
+  TData,
   TError,
   { data: CreatePetsBody; version?: number },
   TContext
@@ -799,15 +721,7 @@ export const getListPetsNestedArrayQueryOptions = <
 >(
   params?: ListPetsNestedArrayParams,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listPetsNestedArray>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -823,11 +737,9 @@ export const getListPetsNestedArrayQueryOptions = <
     queryFn,
     enabled: !!version,
     ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof listPetsNestedArray>>,
-    TError,
-    TData
-  > & { queryKey: DataTag<QueryKey, TData> };
+  } as UseQueryOptions<TData, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
 };
 
 export type ListPetsNestedArrayQueryResult = NonNullable<
@@ -842,21 +754,8 @@ export function useListPetsNestedArray<
   params: undefined | ListPetsNestedArrayParams,
   version: undefined | number,
   options: {
-    query: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listPetsNestedArray>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPetsNestedArray>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<DefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
   },
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
@@ -868,21 +767,8 @@ export function useListPetsNestedArray<
   params?: ListPetsNestedArrayParams,
   version?: number,
   options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listPetsNestedArray>>,
-        TError,
-        TData
-      >
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPetsNestedArray>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 export function useListPetsNestedArray<
@@ -891,15 +777,7 @@ export function useListPetsNestedArray<
 >(
   params?: ListPetsNestedArrayParams,
   version?: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listPetsNestedArray>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
  * @summary List all pets as nested array
@@ -911,15 +789,7 @@ export function useListPetsNestedArray<
 >(
   params?: ListPetsNestedArrayParams,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof listPetsNestedArray>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getListPetsNestedArrayQueryOptions(
     params,
@@ -961,11 +831,7 @@ export const getShowPetByIdQueryOptions = <
 >(
   petId: string,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -981,11 +847,9 @@ export const getShowPetByIdQueryOptions = <
     queryFn,
     enabled: !!(version && petId),
     ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof showPetById>>,
-    TError,
-    TData
-  > & { queryKey: DataTag<QueryKey, TData> };
+  } as UseQueryOptions<TData, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -1000,17 +864,8 @@ export function useShowPetById<
   petId: string,
   version: undefined | number,
   options: {
-    query: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof showPetById>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<DefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
   },
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
@@ -1022,17 +877,8 @@ export function useShowPetById<
   petId: string,
   version?: number,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof showPetById>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 export function useShowPetById<
@@ -1041,11 +887,7 @@ export function useShowPetById<
 >(
   petId: string,
   version?: number,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
  * @summary Info for a specific pet
@@ -1057,11 +899,7 @@ export function useShowPetById<
 >(
   petId: string,
   version: number = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 

--- a/samples/react-query/basic/src/api/model/pet.ts
+++ b/samples/react-query/basic/src/api/model/pet.ts
@@ -8,16 +8,6 @@ import type { PetCallingCode } from './petCallingCode';
 import type { PetCountry } from './petCountry';
 
 export interface Pet {
-  /**
-   * @minimum 0
-   * @maximum 30
-   * @exclusiveMinimum
-   * @exclusiveMaximum
-   */
-  age?: number;
-  callingCode?: PetCallingCode;
-  country?: PetCountry;
-  email?: string;
   id: number;
   /**
    * Name of pet
@@ -26,8 +16,18 @@ export interface Pet {
    */
   name: string;
   /**
+   * @minimum 0
+   * @maximum 30
+   * @exclusiveMinimum
+   * @exclusiveMaximum
+   */
+  age?: number;
+  /**
    * @nullable
    * @pattern ^\\d{3}-\\d{2}-\\d{4}$
    */
   tag?: string | null;
+  email?: string;
+  callingCode?: PetCallingCode;
+  country?: PetCountry;
 }

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -13,10 +13,14 @@ export const getListPetsResponseMock = (): PetsArray =>
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
+    id: (() => faker.number.int({ min: 1, max: 99999 }))(),
+    name: (() => faker.person.lastName())(),
     age: faker.helpers.arrayElement([
       faker.number.int({ min: 0, max: 30 }),
       undefined,
     ]),
+    tag: faker.helpers.arrayElement([(() => faker.person.lastName())(), null]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     callingCode: faker.helpers.arrayElement([
       faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
       undefined,
@@ -28,10 +32,6 @@ export const getListPetsResponseMock = (): PetsArray =>
       ] as const),
       undefined,
     ]),
-    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-    id: (() => faker.number.int({ min: 1, max: 99999 }))(),
-    name: (() => faker.person.lastName())(),
-    tag: faker.helpers.arrayElement([(() => faker.person.lastName())(), null]),
   }));
 
 export const getListPetsNestedArrayResponseMock = (
@@ -42,10 +42,17 @@ export const getListPetsNestedArrayResponseMock = (
       { length: faker.number.int({ min: 1, max: 10 }) },
       (_, i) => i + 1,
     ).map(() => ({
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: (() => faker.person.lastName())(),
       age: faker.helpers.arrayElement([
         faker.number.int({ min: 0, max: 30 }),
         undefined,
       ]),
+      tag: faker.helpers.arrayElement([
+        (() => faker.person.lastName())(),
+        null,
+      ]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -56,13 +63,6 @@ export const getListPetsNestedArrayResponseMock = (
           'Uruguay',
         ] as const),
         undefined,
-      ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: (() => faker.person.lastName())(),
-      tag: faker.helpers.arrayElement([
-        (() => faker.person.lastName())(),
-        null,
       ]),
     })),
     undefined,

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -63,13 +63,7 @@ export const useListPetsQueryOptions = <
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<ReturnType<typeof useListPetsHook>>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: UseQueryOptions<TData, TError, TData> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -87,11 +81,7 @@ export const useListPetsQueryOptions = <
     queryFn,
     enabled: !!version,
     ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<ReturnType<typeof useListPetsHook>>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
+  } as UseQueryOptions<TData, TError, TData> & { queryKey: QueryKey };
 };
 
 export type ListPetsQueryResult = NonNullable<
@@ -109,13 +99,7 @@ export function useListPets<
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<ReturnType<typeof useListPetsHook>>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: UseQueryOptions<TData, TError, TData> },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useListPetsQueryOptions(params, version, options);
 
@@ -153,21 +137,17 @@ export const useCreatePetsHook = () => {
 };
 
 export const useCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
+    TData,
     TError,
     { data: BodyType<CreatePetsBody>; version?: number },
     TContext
   >;
-}): UseMutationOptions<
-  Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-  TError,
-  { data: BodyType<CreatePetsBody>; version?: number },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -188,7 +168,12 @@ export const useCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: BodyType<CreatePetsBody>; version?: number },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -201,17 +186,18 @@ export type CreatePetsMutationError = ErrorType<Error>;
  * @summary Create a pet
  */
 export const useCreatePets = <
+  TData = Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
+    TData,
     TError,
     { data: BodyType<CreatePetsBody>; version?: number },
     TContext
   >;
 }): UseMutationResult<
-  Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
+  TData,
   TError,
   { data: BodyType<CreatePetsBody>; version?: number },
   TContext
@@ -260,13 +246,7 @@ export const useListPetsNestedArrayQueryOptions = <
 >(
   params?: ListPetsNestedArrayParams,
   version: number = 1,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<ReturnType<typeof useListPetsNestedArrayHook>>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: UseQueryOptions<TData, TError, TData> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -284,11 +264,7 @@ export const useListPetsNestedArrayQueryOptions = <
     queryFn,
     enabled: !!version,
     ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<ReturnType<typeof useListPetsNestedArrayHook>>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
+  } as UseQueryOptions<TData, TError, TData> & { queryKey: QueryKey };
 };
 
 export type ListPetsNestedArrayQueryResult = NonNullable<
@@ -306,13 +282,7 @@ export function useListPetsNestedArray<
 >(
   params?: ListPetsNestedArrayParams,
   version: number = 1,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<ReturnType<typeof useListPetsNestedArrayHook>>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: UseQueryOptions<TData, TError, TData> },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useListPetsNestedArrayQueryOptions(
     params,
@@ -357,13 +327,7 @@ export const useShowPetByIdQueryOptions = <
 >(
   petId: string,
   version: number = 1,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: UseQueryOptions<TData, TError, TData> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -381,11 +345,7 @@ export const useShowPetByIdQueryOptions = <
     queryFn,
     enabled: !!(version && petId),
     ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
+  } as UseQueryOptions<TData, TError, TData> & { queryKey: QueryKey };
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -403,13 +363,7 @@ export function useShowPetById<
 >(
   petId: string,
   version: number = 1,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: UseQueryOptions<TData, TError, TData> },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = useShowPetByIdQueryOptions(petId, version, options);
 

--- a/samples/react-query/custom-client/src/api/model/pet.ts
+++ b/samples/react-query/custom-client/src/api/model/pet.ts
@@ -8,16 +8,6 @@ import type { PetCallingCode } from './petCallingCode';
 import type { PetCountry } from './petCountry';
 
 export interface Pet {
-  /**
-   * @minimum 0
-   * @maximum 30
-   * @exclusiveMinimum
-   * @exclusiveMaximum
-   */
-  age?: number;
-  callingCode?: PetCallingCode;
-  country?: PetCountry;
-  email?: string;
   id: number;
   /**
    * Name of pet
@@ -26,8 +16,18 @@ export interface Pet {
    */
   name: string;
   /**
+   * @minimum 0
+   * @maximum 30
+   * @exclusiveMinimum
+   * @exclusiveMaximum
+   */
+  age?: number;
+  /**
    * @nullable
    * @pattern ^\\d{3}-\\d{2}-\\d{4}$
    */
   tag?: string | null;
+  email?: string;
+  callingCode?: PetCallingCode;
+  country?: PetCountry;
 }

--- a/samples/react-query/custom-fetch/src/gen/models/dachshund.ts
+++ b/samples/react-query/custom-fetch/src/gen/models/dachshund.ts
@@ -7,6 +7,6 @@
 import type { DachshundBreed } from './dachshundBreed';
 
 export interface Dachshund {
-  breed: DachshundBreed;
   length: number;
+  breed: DachshundBreed;
 }

--- a/samples/react-query/custom-fetch/src/gen/models/labradoodle.ts
+++ b/samples/react-query/custom-fetch/src/gen/models/labradoodle.ts
@@ -7,6 +7,6 @@
 import type { LabradoodleBreed } from './labradoodleBreed';
 
 export interface Labradoodle {
-  breed: LabradoodleBreed;
   cuteness: number;
+  breed: LabradoodleBreed;
 }

--- a/samples/react-query/custom-fetch/src/gen/models/pet.ts
+++ b/samples/react-query/custom-fetch/src/gen/models/pet.ts
@@ -12,19 +12,19 @@ import type { PetCountry } from './petCountry';
 export type Pet =
   | (Dog & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     })
   | (Cat & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     });

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -12,8 +12,8 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -22,8 +22,8 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -74,6 +74,10 @@ export const getListPetsResponseMock = (): Pets =>
       {
         ...getListPetsResponseDogMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -85,14 +89,14 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
       {
         ...getListPetsResponseCatMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -104,10 +108,6 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
     ]),
   );
@@ -116,8 +116,8 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -126,8 +126,8 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -174,6 +174,10 @@ export const getCreatePetsResponseMock = (): Pet =>
     {
       ...getCreatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -185,14 +189,14 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getCreatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -204,10 +208,6 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -215,8 +215,8 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -225,8 +225,8 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -273,6 +273,10 @@ export const getUpdatePetsResponseMock = (): Pet =>
     {
       ...getUpdatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -284,14 +288,14 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getUpdatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -303,10 +307,6 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -314,8 +314,8 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -324,8 +324,8 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -372,6 +372,10 @@ export const getShowPetByIdResponseMock = (): Pet =>
     {
       ...getShowPetByIdResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -383,14 +387,14 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getShowPetByIdResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -402,10 +406,6 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -84,7 +84,7 @@ export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  return customFetch<Promise<listPetsResponse>>(getListPetsUrl(params), {
+  return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
     method: 'GET',
   });
@@ -100,9 +100,7 @@ export const getListPetsQueryOptions = <
 >(
   params?: ListPetsParams,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ) => {
@@ -115,7 +113,7 @@ export const getListPetsQueryOptions = <
   }) => listPets(params, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData> };
@@ -132,17 +130,8 @@ export function useListPets<
 >(
   params: undefined | ListPetsParams,
   options: {
-    query: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPets>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<DefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): DefinedUseQueryResult<TData, TError> & {
@@ -154,17 +143,8 @@ export function useListPets<
 >(
   params?: ListPetsParams,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof listPets>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
@@ -174,9 +154,7 @@ export function useListPets<
 >(
   params?: ListPetsParams,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
@@ -190,9 +168,7 @@ export function useListPets<
 >(
   params?: ListPetsParams,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
@@ -224,7 +200,7 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
+  return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -233,22 +209,18 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof createPets>>,
-  TError,
-  { data: CreatePetsBodyItem[] },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -267,7 +239,12 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: CreatePetsBodyItem[] },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -279,16 +256,20 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
+export const useCreatePets = <
+  TData = Awaited<ReturnType<typeof createPets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationResult<
-  Awaited<ReturnType<typeof createPets>>,
+  TData,
   TError,
   { data: CreatePetsBodyItem[] },
   TContext
@@ -314,7 +295,7 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
+  return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -323,22 +304,18 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof updatePets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updatePets>>,
+    TData,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof updatePets>>,
-  TError,
-  { data: NonReadonly<Pet> },
-  TContext
-> => {
+}) => {
   const mutationKey = ['updatePets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -357,7 +334,12 @@ export const getUpdatePetsMutationOptions = <
     return updatePets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: NonReadonly<Pet> },
+    TContext
+  >;
 };
 
 export type UpdatePetsMutationResult = NonNullable<
@@ -369,20 +351,19 @@ export type UpdatePetsMutationError = Error;
 /**
  * @summary Update a pet
  */
-export const useUpdatePets = <TError = Error, TContext = unknown>(options?: {
+export const useUpdatePets = <
+  TData = Awaited<ReturnType<typeof updatePets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updatePets>>,
+    TData,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof updatePets>>,
-  TError,
-  { data: NonReadonly<Pet> },
-  TContext
-> => {
+}): UseMutationResult<TData, TError, { data: NonReadonly<Pet> }, TContext> => {
   const mutationOptions = getUpdatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);
@@ -404,7 +385,7 @@ export const showPetById = async (
   petId: string,
   options?: RequestInit,
 ): Promise<showPetByIdResponse> => {
-  return customFetch<Promise<showPetByIdResponse>>(getShowPetByIdUrl(petId), {
+  return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
   });
@@ -420,9 +401,7 @@ export const getShowPetByIdQueryOptions = <
 >(
   petId: string,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ) => {
@@ -439,11 +418,9 @@ export const getShowPetByIdQueryOptions = <
     queryFn,
     enabled: !!petId,
     ...queryOptions,
-  } as UseQueryOptions<
-    Awaited<ReturnType<typeof showPetById>>,
-    TError,
-    TData
-  > & { queryKey: DataTag<QueryKey, TData> };
+  } as UseQueryOptions<TData, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -457,17 +434,8 @@ export function useShowPetById<
 >(
   petId: string,
   options: {
-    query: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    > &
-      Pick<
-        DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof showPetById>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<DefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): DefinedUseQueryResult<TData, TError> & {
@@ -479,17 +447,8 @@ export function useShowPetById<
 >(
   petId: string,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    > &
-      Pick<
-        UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof showPetById>>,
-          TError,
-          TData
-        >,
-        'initialData'
-      >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>> &
+      Pick<UndefinedInitialDataOptions<TData, TError, TData>, 'initialData'>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
@@ -499,9 +458,7 @@ export function useShowPetById<
 >(
   petId: string,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
@@ -515,9 +472,7 @@ export function useShowPetById<
 >(
   petId: string,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -52,13 +52,7 @@ export const getListPetsQueryOptions = <
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: CreateQueryOptions<TData, TError, TData> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -74,11 +68,7 @@ export const getListPetsQueryOptions = <
     queryFn,
     enabled: !!version,
     ...queryOptions,
-  } as CreateQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
+  } as CreateQueryOptions<TData, TError, TData> & { queryKey: QueryKey };
 };
 
 export type ListPetsQueryResult = NonNullable<
@@ -96,13 +86,7 @@ export function createListPets<
 >(
   params?: ListPetsParams,
   version: number = 1,
-  options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: CreateQueryOptions<TData, TError, TData> },
 ): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
@@ -134,21 +118,17 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
-}): CreateMutationOptions<
-  Awaited<ReturnType<typeof createPets>>,
-  TError,
-  { data: CreatePetsBody; version?: number },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -167,7 +147,12 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as CreateMutationOptions<
+    TData,
+    TError,
+    { data: CreatePetsBody; version?: number },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -179,15 +164,19 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
+export const createCreatePets = <
+  TData = Awaited<ReturnType<typeof createPets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
 }): CreateMutationResult<
-  Awaited<ReturnType<typeof createPets>>,
+  TData,
   TError,
   { data: CreatePetsBody; version?: number },
   TContext
@@ -222,13 +211,7 @@ export const getShowPetByIdQueryOptions = <
 >(
   petId: string,
   version: number = 1,
-  options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof showPetById>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: CreateQueryOptions<TData, TError, TData> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -244,11 +227,7 @@ export const getShowPetByIdQueryOptions = <
     queryFn,
     enabled: !!(version && petId),
     ...queryOptions,
-  } as CreateQueryOptions<
-    Awaited<ReturnType<typeof showPetById>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
+  } as CreateQueryOptions<TData, TError, TData> & { queryKey: QueryKey };
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -266,13 +245,7 @@ export function createShowPetById<
 >(
   petId: string,
   version: number = 1,
-  options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof showPetById>>,
-      TError,
-      TData
-    >;
-  },
+  options?: { query?: CreateQueryOptions<TData, TError, TData> },
 ): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 

--- a/samples/svelte-query/custom-fetch/src/gen/models/dachshund.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/models/dachshund.ts
@@ -7,6 +7,6 @@
 import type { DachshundBreed } from './dachshundBreed';
 
 export interface Dachshund {
-  breed: DachshundBreed;
   length: number;
+  breed: DachshundBreed;
 }

--- a/samples/svelte-query/custom-fetch/src/gen/models/labradoodle.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/models/labradoodle.ts
@@ -7,6 +7,6 @@
 import type { LabradoodleBreed } from './labradoodleBreed';
 
 export interface Labradoodle {
-  breed: LabradoodleBreed;
   cuteness: number;
+  breed: LabradoodleBreed;
 }

--- a/samples/svelte-query/custom-fetch/src/gen/models/pet.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/models/pet.ts
@@ -12,19 +12,19 @@ import type { PetCountry } from './petCountry';
 export type Pet =
   | (Dog & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     })
   | (Cat & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     });

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -12,8 +12,8 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -22,8 +22,8 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -74,6 +74,10 @@ export const getListPetsResponseMock = (): Pets =>
       {
         ...getListPetsResponseDogMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -85,14 +89,14 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
       {
         ...getListPetsResponseCatMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -104,10 +108,6 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
     ]),
   );
@@ -116,8 +116,8 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -126,8 +126,8 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -174,6 +174,10 @@ export const getCreatePetsResponseMock = (): Pet =>
     {
       ...getCreatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -185,14 +189,14 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getCreatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -204,10 +208,6 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -215,8 +215,8 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -225,8 +225,8 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -273,6 +273,10 @@ export const getUpdatePetsResponseMock = (): Pet =>
     {
       ...getUpdatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -284,14 +288,14 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getUpdatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -303,10 +307,6 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -314,8 +314,8 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -324,8 +324,8 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -372,6 +372,10 @@ export const getShowPetByIdResponseMock = (): Pet =>
     {
       ...getShowPetByIdResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -383,14 +387,14 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getShowPetByIdResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -402,10 +406,6 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -80,7 +80,7 @@ export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  return customFetch<Promise<listPetsResponse>>(getListPetsUrl(params), {
+  return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
     method: 'GET',
   });
@@ -96,11 +96,7 @@ export const getListPetsQueryOptions = <
 >(
   params?: ListPetsParams,
   options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
-    >;
+    query?: CreateQueryOptions<TData, TError, TData>;
     request?: SecondParameter<typeof customFetch>;
   },
 ) => {
@@ -113,7 +109,7 @@ export const getListPetsQueryOptions = <
   }) => listPets(params, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as CreateQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData
   > & { queryKey: QueryKey };
@@ -134,11 +130,7 @@ export function createListPets<
 >(
   params?: ListPetsParams,
   options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof listPets>>,
-      TError,
-      TData
-    >;
+    query?: CreateQueryOptions<TData, TError, TData>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {
@@ -171,7 +163,7 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
+  return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -180,22 +172,18 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): CreateMutationOptions<
-  Awaited<ReturnType<typeof createPets>>,
-  TError,
-  { data: CreatePetsBodyItem[] },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -214,7 +202,12 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as CreateMutationOptions<
+    TData,
+    TError,
+    { data: CreatePetsBodyItem[] },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -226,16 +219,20 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
+export const createCreatePets = <
+  TData = Awaited<ReturnType<typeof createPets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
-  Awaited<ReturnType<typeof createPets>>,
+  TData,
   TError,
   { data: CreatePetsBodyItem[] },
   TContext
@@ -261,7 +258,7 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
+  return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -270,22 +267,18 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof updatePets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof updatePets>>,
+    TData,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): CreateMutationOptions<
-  Awaited<ReturnType<typeof updatePets>>,
-  TError,
-  { data: NonReadonly<Pet> },
-  TContext
-> => {
+}) => {
   const mutationKey = ['updatePets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -304,7 +297,12 @@ export const getUpdatePetsMutationOptions = <
     return updatePets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as CreateMutationOptions<
+    TData,
+    TError,
+    { data: NonReadonly<Pet> },
+    TContext
+  >;
 };
 
 export type UpdatePetsMutationResult = NonNullable<
@@ -316,16 +314,20 @@ export type UpdatePetsMutationError = Error;
 /**
  * @summary Update a pet
  */
-export const createUpdatePets = <TError = Error, TContext = unknown>(options?: {
+export const createUpdatePets = <
+  TData = Awaited<ReturnType<typeof updatePets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof updatePets>>,
+    TData,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
-  Awaited<ReturnType<typeof updatePets>>,
+  TData,
   TError,
   { data: NonReadonly<Pet> },
   TContext
@@ -351,7 +353,7 @@ export const showPetById = async (
   petId: string,
   options?: RequestInit,
 ): Promise<showPetByIdResponse> => {
-  return customFetch<Promise<showPetByIdResponse>>(getShowPetByIdUrl(petId), {
+  return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
   });
@@ -367,11 +369,7 @@ export const getShowPetByIdQueryOptions = <
 >(
   petId: string,
   options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof showPetById>>,
-      TError,
-      TData
-    >;
+    query?: CreateQueryOptions<TData, TError, TData>;
     request?: SecondParameter<typeof customFetch>;
   },
 ) => {
@@ -388,11 +386,7 @@ export const getShowPetByIdQueryOptions = <
     queryFn,
     enabled: !!petId,
     ...queryOptions,
-  } as CreateQueryOptions<
-    Awaited<ReturnType<typeof showPetById>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
+  } as CreateQueryOptions<TData, TError, TData> & { queryKey: QueryKey };
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -410,11 +404,7 @@ export function createShowPetById<
 >(
   petId: string,
   options?: {
-    query?: CreateQueryOptions<
-      Awaited<ReturnType<typeof showPetById>>,
-      TError,
-      TData
-    >;
+    query?: CreateQueryOptions<TData, TError, TData>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): CreateQueryResult<TData, TError> & { queryKey: QueryKey } {

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.msw.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.msw.ts
@@ -12,8 +12,8 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -22,8 +22,8 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -74,6 +74,10 @@ export const getListPetsResponseMock = (): Pets =>
       {
         ...getListPetsResponseDogMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -85,14 +89,14 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
       {
         ...getListPetsResponseCatMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -104,10 +108,6 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
     ]),
   );
@@ -116,8 +116,8 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -126,8 +126,8 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -174,6 +174,10 @@ export const getCreatePetsResponseMock = (): Pet =>
     {
       ...getCreatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -185,14 +189,14 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getCreatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -204,10 +208,6 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -215,8 +215,8 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -225,8 +225,8 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -273,6 +273,10 @@ export const getUpdatePetsResponseMock = (): Pet =>
     {
       ...getUpdatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -284,14 +288,14 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getUpdatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -303,10 +307,6 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -314,8 +314,8 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -324,8 +324,8 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -372,6 +372,10 @@ export const getShowPetByIdResponseMock = (): Pet =>
     {
       ...getShowPetByIdResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -383,14 +387,14 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getShowPetByIdResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -402,10 +406,6 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -75,7 +75,8 @@ export const listPets = async (
     ...options,
     method: 'GET',
   });
-  const data = await res.json();
+
+  const data: Pets = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -142,7 +143,8 @@ export const createPets = async (
     headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(createPetsBodyItem),
   });
-  const data = await res.json();
+
+  const data: Pet = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -211,7 +213,8 @@ export const updatePets = async (
     headers: { 'Content-Type': 'application/json', ...options?.headers },
     body: JSON.stringify(pet),
   });
-  const data = await res.json();
+
+  const data: Pet = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -278,7 +281,8 @@ export const showPetById = async (
     ...options,
     method: 'GET',
   });
-  const data = await res.json();
+
+  const data: Pet = await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };

--- a/samples/swr-with-zod/src/gen/models/dachshund.ts
+++ b/samples/swr-with-zod/src/gen/models/dachshund.ts
@@ -7,6 +7,6 @@
 import type { DachshundBreed } from './dachshundBreed';
 
 export interface Dachshund {
-  breed: DachshundBreed;
   length: number;
+  breed: DachshundBreed;
 }

--- a/samples/swr-with-zod/src/gen/models/labradoodle.ts
+++ b/samples/swr-with-zod/src/gen/models/labradoodle.ts
@@ -7,6 +7,6 @@
 import type { LabradoodleBreed } from './labradoodleBreed';
 
 export interface Labradoodle {
-  breed: LabradoodleBreed;
   cuteness: number;
+  breed: LabradoodleBreed;
 }

--- a/samples/swr-with-zod/src/gen/models/pet.ts
+++ b/samples/swr-with-zod/src/gen/models/pet.ts
@@ -12,19 +12,19 @@ import type { PetCountry } from './petCountry';
 export type Pet =
   | (Dog & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     })
   | (Cat & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     });

--- a/samples/vue-query/custom-fetch/src/gen/models/dachshund.ts
+++ b/samples/vue-query/custom-fetch/src/gen/models/dachshund.ts
@@ -7,6 +7,6 @@
 import type { DachshundBreed } from './dachshundBreed';
 
 export interface Dachshund {
-  breed: DachshundBreed;
   length: number;
+  breed: DachshundBreed;
 }

--- a/samples/vue-query/custom-fetch/src/gen/models/labradoodle.ts
+++ b/samples/vue-query/custom-fetch/src/gen/models/labradoodle.ts
@@ -7,6 +7,6 @@
 import type { LabradoodleBreed } from './labradoodleBreed';
 
 export interface Labradoodle {
-  breed: LabradoodleBreed;
   cuteness: number;
+  breed: LabradoodleBreed;
 }

--- a/samples/vue-query/custom-fetch/src/gen/models/pet.ts
+++ b/samples/vue-query/custom-fetch/src/gen/models/pet.ts
@@ -12,19 +12,19 @@ import type { PetCountry } from './petCountry';
 export type Pet =
   | (Dog & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     })
   | (Cat & {
       '@id'?: string;
-      callingCode?: PetCallingCode;
-      country?: PetCountry;
-      email?: string;
       id: number;
       name: string;
       tag?: string;
+      email?: string;
+      callingCode?: PetCallingCode;
+      country?: PetCountry;
     });

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -12,8 +12,8 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -22,8 +22,8 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -74,6 +74,10 @@ export const getListPetsResponseMock = (): Pets =>
       {
         ...getListPetsResponseDogMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -85,14 +89,14 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
       {
         ...getListPetsResponseCatMock(),
         '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        id: faker.number.int({ min: undefined, max: undefined }),
+        name: faker.string.alpha(20),
+        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
         callingCode: faker.helpers.arrayElement([
           faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
           undefined,
@@ -104,10 +108,6 @@ export const getListPetsResponseMock = (): Pets =>
           ] as const),
           undefined,
         ]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
       },
     ]),
   );
@@ -116,8 +116,8 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -126,8 +126,8 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -174,6 +174,10 @@ export const getCreatePetsResponseMock = (): Pet =>
     {
       ...getCreatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -185,14 +189,14 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getCreatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -204,10 +208,6 @@ export const getCreatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -215,8 +215,8 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -225,8 +225,8 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -273,6 +273,10 @@ export const getUpdatePetsResponseMock = (): Pet =>
     {
       ...getUpdatePetsResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -284,14 +288,14 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getUpdatePetsResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -303,10 +307,6 @@ export const getUpdatePetsResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 
@@ -314,8 +314,8 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
     cuteness: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
 });
@@ -324,8 +324,8 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    breed: faker.helpers.arrayElement(['Dachshund'] as const),
     length: faker.number.int({ min: undefined, max: undefined }),
+    breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
 });
@@ -372,6 +372,10 @@ export const getShowPetByIdResponseMock = (): Pet =>
     {
       ...getShowPetByIdResponseDogMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -383,14 +387,14 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
     {
       ...getShowPetByIdResponseCatMock(),
       '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      id: faker.number.int({ min: undefined, max: undefined }),
+      name: faker.string.alpha(20),
+      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       callingCode: faker.helpers.arrayElement([
         faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
         undefined,
@@ -402,10 +406,6 @@ export const getShowPetByIdResponseMock = (): Pet =>
         ] as const),
         undefined,
       ]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
     },
   ]);
 

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -83,7 +83,7 @@ export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  return customFetch<Promise<listPetsResponse>>(getListPetsUrl(params), {
+  return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
     method: 'GET',
   });
@@ -104,9 +104,7 @@ export const getListPetsQueryOptions = <
 >(
   params?: MaybeRef<ListPetsParams>,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ) => {
@@ -119,7 +117,7 @@ export const getListPetsQueryOptions = <
   }) => listPets(unref(params), { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData
   >;
@@ -140,9 +138,7 @@ export function useListPets<
 >(
   params?: MaybeRef<ListPetsParams>,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryReturnType<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
@@ -174,7 +170,7 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  return customFetch<Promise<createPetsResponse>>(getCreatePetsUrl(), {
+  return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -183,22 +179,18 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof createPets>>,
-  TError,
-  { data: CreatePetsBodyItem[] },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -217,7 +209,12 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: CreatePetsBodyItem[] },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -229,16 +226,20 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
+export const useCreatePets = <
+  TData = Awaited<ReturnType<typeof createPets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationReturnType<
-  Awaited<ReturnType<typeof createPets>>,
+  TData,
   TError,
   { data: CreatePetsBodyItem[] },
   TContext
@@ -264,7 +265,7 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  return customFetch<Promise<updatePetsResponse>>(getUpdatePetsUrl(), {
+  return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -273,22 +274,18 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof updatePets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updatePets>>,
+    TData,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof updatePets>>,
-  TError,
-  { data: NonReadonly<Pet> },
-  TContext
-> => {
+}) => {
   const mutationKey = ['updatePets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -307,7 +304,12 @@ export const getUpdatePetsMutationOptions = <
     return updatePets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: NonReadonly<Pet> },
+    TContext
+  >;
 };
 
 export type UpdatePetsMutationResult = NonNullable<
@@ -319,16 +321,20 @@ export type UpdatePetsMutationError = Error;
 /**
  * @summary Update a pet
  */
-export const useUpdatePets = <TError = Error, TContext = unknown>(options?: {
+export const useUpdatePets = <
+  TData = Awaited<ReturnType<typeof updatePets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof updatePets>>,
+    TData,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationReturnType<
-  Awaited<ReturnType<typeof updatePets>>,
+  TData,
   TError,
   { data: NonReadonly<Pet> },
   TContext
@@ -354,7 +360,7 @@ export const showPetById = async (
   petId: string,
   options?: RequestInit,
 ): Promise<showPetByIdResponse> => {
-  return customFetch<Promise<showPetByIdResponse>>(getShowPetByIdUrl(petId), {
+  return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
   });
@@ -370,9 +376,7 @@ export const getShowPetByIdQueryOptions = <
 >(
   petId: MaybeRef<string>,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ) => {
@@ -389,7 +393,7 @@ export const getShowPetByIdQueryOptions = <
     queryFn,
     enabled: computed(() => !!unref(petId)),
     ...queryOptions,
-  } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
+  } as UseQueryOptions<TData, TError, TData>;
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -407,9 +411,7 @@ export function useShowPetById<
 >(
   petId: MaybeRef<string>,
   options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
+    query?: Partial<UseQueryOptions<TData, TError, TData>>;
     request?: SecondParameter<typeof customFetch>;
   },
 ): UseQueryReturnType<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -14,27 +14,27 @@ export const getListPetsResponseMock = (): Pets =>
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
   ).map(() => ({
-    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     id: (() => faker.number.int({ min: 1, max: 99999 }))(),
     name: (() => faker.person.lastName())(),
+    tag: (() => faker.person.lastName())(),
     status: faker.helpers.arrayElement([
       faker.helpers.arrayElement(Object.values(DomainStatusEnum)),
       undefined,
     ]),
-    tag: (() => faker.person.lastName())(),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   }));
 
 export const getCreatePetsResponseMock = (
   overrideResponse: Partial<Pet> = {},
 ): Pet => ({
-  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   id: faker.number.int({ min: undefined, max: undefined }),
   name: (() => faker.person.lastName())(),
+  tag: (() => faker.person.lastName())(),
   status: faker.helpers.arrayElement([
     faker.helpers.arrayElement(Object.values(DomainStatusEnum)),
     undefined,
   ]),
-  tag: (() => faker.person.lastName())(),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
   ...overrideResponse,
 });
 

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -67,10 +67,10 @@ export const getListPetsInfiniteQueryOptions = <
   options?: {
     query?: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -98,10 +98,10 @@ export const getListPetsInfiniteQueryOptions = <
     enabled: computed(() => !!unref(version)),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     TError,
     TData,
-    Awaited<ReturnType<typeof listPets>>,
+    TData,
     QueryKey,
     ListPetsParams['limit']
   >;
@@ -128,10 +128,10 @@ export function useListPetsInfinite<
   options?: {
     query?: Partial<
       UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         TError,
         TData,
-        Awaited<ReturnType<typeof listPets>>,
+        TData,
         QueryKey,
         ListPetsParams['limit']
       >
@@ -162,11 +162,7 @@ export const getListPetsQueryOptions = <
 >(
   params?: MaybeRef<ListPetsParams>,
   version: MaybeRef<number | undefined | null> = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -181,7 +177,7 @@ export const getListPetsQueryOptions = <
     queryFn,
     enabled: computed(() => !!unref(version)),
     ...queryOptions,
-  } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
+  } as UseQueryOptions<TData, TError, TData>;
 };
 
 export type ListPetsQueryResult = NonNullable<
@@ -199,11 +195,7 @@ export function useListPets<
 >(
   params?: MaybeRef<ListPetsParams>,
   version: MaybeRef<number | undefined | null> = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryReturnType<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
@@ -237,21 +229,17 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
+  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
-    { data: CreatePetsBody; version?: number },
+    { data: CreatePetsBody; version?: number | undefined | null },
     TContext
   >;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof createPets>>,
-  TError,
-  { data: CreatePetsBody; version?: number },
-  TContext
-> => {
+}) => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -263,14 +251,19 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    { data: CreatePetsBody; version?: number | undefined | null }
   > = (props) => {
     const { data, version } = props ?? {};
 
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    { data: CreatePetsBody; version?: number | undefined | null },
+    TContext
+  >;
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -282,17 +275,21 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
+export const useCreatePets = <
+  TData = Awaited<ReturnType<typeof createPets>>,
+  TError = Error,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof createPets>>,
+    TData,
     TError,
-    { data: CreatePetsBody; version?: number },
+    { data: CreatePetsBody; version?: number | undefined | null },
     TContext
   >;
 }): UseMutationReturnType<
-  Awaited<ReturnType<typeof createPets>>,
+  TData,
   TError,
-  { data: CreatePetsBody; version?: number },
+  { data: CreatePetsBody; version?: number | undefined | null },
   TContext
 > => {
   const mutationOptions = getCreatePetsMutationOptions(options);
@@ -331,15 +328,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
 >(
   petId: MaybeRef<string | undefined | null>,
   version: MaybeRef<number | undefined | null> = 1,
-  options?: {
-    query?: Partial<
-      UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof showPetById>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseInfiniteQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -354,11 +343,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
     queryFn,
     enabled: computed(() => !!(unref(version) && unref(petId))),
     ...queryOptions,
-  } as UseInfiniteQueryOptions<
-    Awaited<ReturnType<typeof showPetById>>,
-    TError,
-    TData
-  >;
+  } as UseInfiniteQueryOptions<TData, TError, TData>;
 };
 
 export type ShowPetByIdInfiniteQueryResult = NonNullable<
@@ -376,15 +361,7 @@ export function useShowPetByIdInfinite<
 >(
   petId: MaybeRef<string | undefined | null>,
   version: MaybeRef<number | undefined | null> = 1,
-  options?: {
-    query?: Partial<
-      UseInfiniteQueryOptions<
-        Awaited<ReturnType<typeof showPetById>>,
-        TError,
-        TData
-      >
-    >;
-  },
+  options?: { query?: Partial<UseInfiniteQueryOptions<TData, TError, TData>> },
 ): UseInfiniteQueryReturnType<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 } {
@@ -410,11 +387,7 @@ export const getShowPetByIdQueryOptions = <
 >(
   petId: MaybeRef<string | undefined | null>,
   version: MaybeRef<number | undefined | null> = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ) => {
   const { query: queryOptions } = options ?? {};
 
@@ -429,7 +402,7 @@ export const getShowPetByIdQueryOptions = <
     queryFn,
     enabled: computed(() => !!(unref(version) && unref(petId))),
     ...queryOptions,
-  } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
+  } as UseQueryOptions<TData, TError, TData>;
 };
 
 export type ShowPetByIdQueryResult = NonNullable<
@@ -447,11 +420,7 @@ export function useShowPetById<
 >(
   petId: MaybeRef<string | undefined | null>,
   version: MaybeRef<number | undefined | null> = 1,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
-    >;
-  },
+  options?: { query?: Partial<UseQueryOptions<TData, TError, TData>> },
 ): UseQueryReturnType<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 
@@ -476,21 +445,12 @@ export const postApiV1UserLogout = (signal?: AbortSignal) => {
 };
 
 export const getPostApiV1UserLogoutMutationOptions = <
+  TData = Awaited<ReturnType<typeof postApiV1UserLogout>>,
   TError = unknown,
   TContext = unknown,
 >(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postApiV1UserLogout>>,
-    TError,
-    void,
-    TContext
-  >;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof postApiV1UserLogout>>,
-  TError,
-  void,
-  TContext
-> => {
+  mutation?: UseMutationOptions<TData, TError, void, TContext>;
+}) => {
   const mutationKey = ['postApiV1UserLogout'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -507,7 +467,12 @@ export const getPostApiV1UserLogoutMutationOptions = <
     return postApiV1UserLogout();
   };
 
-  return { mutationFn, ...mutationOptions };
+  return { mutationFn, ...mutationOptions } as UseMutationOptions<
+    TData,
+    TError,
+    void,
+    TContext
+  >;
 };
 
 export type PostApiV1UserLogoutMutationResult = NonNullable<
@@ -520,21 +485,12 @@ export type PostApiV1UserLogoutMutationError = unknown;
  * @summary This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/orval-labs/orval/issues/857#issuecomment-1835317990
  */
 export const usePostApiV1UserLogout = <
+  TData = Awaited<ReturnType<typeof postApiV1UserLogout>>,
   TError = unknown,
   TContext = unknown,
 >(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postApiV1UserLogout>>,
-    TError,
-    void,
-    TContext
-  >;
-}): UseMutationReturnType<
-  Awaited<ReturnType<typeof postApiV1UserLogout>>,
-  TError,
-  void,
-  TContext
-> => {
+  mutation?: UseMutationOptions<TData, TError, void, TContext>;
+}): UseMutationReturnType<TData, TError, void, TContext> => {
   const mutationOptions = getPostApiV1UserLogoutMutationOptions(options);
 
   return useMutation(mutationOptions);

--- a/samples/vue-query/vue-query-basic/src/api/model/pet.ts
+++ b/samples/vue-query/vue-query-basic/src/api/model/pet.ts
@@ -7,9 +7,9 @@
 import type { DomainStatusEnum } from './domainStatusEnum';
 
 export interface Pet {
-  email?: string;
   id: number;
   name: string;
-  status?: DomainStatusEnum;
   tag?: string;
+  status?: DomainStatusEnum;
+  email?: string;
 }


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1761
In #1761 mention `cloudflare worker`, but the type annotation is valid for other use-cases too, so I added it.
Also, the sample apps were missing an regenerate, so I ran them again.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

you can check by sample apps