### PR TITLE
feat(fetch): include error types in data type of fetch response

### DIFF
--- a/docs/src/pages/guides/fetch-client.md
+++ b/docs/src/pages/guides/fetch-client.md
@@ -20,7 +20,7 @@ module.exports = {
  * @summary List all pets
  */
 export type listPetsResponse = {
-  data: Pets;
+  data: Pets | BadRequest;
   status: number;
 };
 
@@ -120,7 +120,7 @@ module.exports = {
  * @summary List all pets
  */
 - export type listPetsResponse = {
--   data: Pets;
+-   data: Pets | BadRequest;
 -   status: number;
 - };
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -115,7 +115,7 @@ ${
 
   const responseDataType =
     response.definition.success || response.definition.errors
-      ? `${response.definition.success} | ${response.definition.errors}`
+      ? `${response.definition.success !== 'unknown' ? response.definition.success : ''}${response.definition.success !== 'unknown' && response.definition.errors !== 'unknown' ? ' | ' : ''}${response.definition.errors !== 'unknown' ? response.definition.errors : ''}`
       : 'unknown';
 
   const responseTypeImplementation = override.fetch

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -113,10 +113,15 @@ ${
     operationName,
   );
 
+  const responseDataType =
+    response.definition.success || response.definition.errors
+      ? `${response.definition.success} | ${response.definition.errors}`
+      : 'unknown';
+
   const responseTypeImplementation = override.fetch
     .includeHttpResponseReturnType
     ? `export type ${responseTypeName} = {
-  ${isNdJson ? 'stream: Response' : `data: ${response.definition.success || 'unknown'}`};
+  ${isNdJson ? 'stream: Response' : `data: ${responseDataType}`};
   status: number;
   headers: Headers;
 }\n\n`

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -6,6 +6,7 @@
  */
 import type {
   CreatePetsBodyItem,
+  Error,
   ListPetsParams,
   Pet,
   Pets,
@@ -52,7 +53,7 @@ export const listPets = async (
  * @summary Create a pet
  */
 export type createPetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -81,7 +82,7 @@ export const createPets = async (
  * @summary Update a pet
  */
 export type updatePetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -110,7 +111,7 @@ export const updatePets = async (
  * @summary Info for a specific pet
  */
 export type showPetByIdResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -6,6 +6,7 @@
  */
 import type {
   CreatePetsBodyItem,
+  Error,
   ListPetsParams,
   Pet,
   Pets,
@@ -77,7 +78,7 @@ export const listPets = async (
  * @summary Create a pet
  */
 export type createPetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -102,7 +103,7 @@ export const createPets = async (
  * @summary Update a pet
  */
 export type updatePetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -127,7 +128,7 @@ export const updatePets = async (
  * @summary Info for a specific pet
  */
 export type showPetByIdResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -187,7 +187,7 @@ export function useListPets<
  * @summary Create a pet
  */
 export type createPetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -282,7 +282,7 @@ export const useCreatePets = <
  * @summary Update a pet
  */
 export type updatePetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -372,7 +372,7 @@ export const useUpdatePets = <
  * @summary Info for a specific pet
  */
 export type showPetByIdResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -150,7 +150,7 @@ export function createListPets<
  * @summary Create a pet
  */
 export type createPetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -245,7 +245,7 @@ export const createCreatePets = <
  * @summary Update a pet
  */
 export type updatePetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -340,7 +340,7 @@ export const createUpdatePets = <
  * @summary Info for a specific pet
  */
 export type showPetByIdResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -124,7 +124,7 @@ export const useListPets = <TError = Promise<unknown>>(
  * @summary Create a pet
  */
 export type createPetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -194,7 +194,7 @@ export const useCreatePets = <TError = Promise<Error>>(options?: {
  * @summary Update a pet
  */
 export type updatePetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -264,7 +264,7 @@ export const useUpdatePets = <TError = Promise<Error>>(options?: {
  * @summary Info for a specific pet
  */
 export type showPetByIdResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -157,7 +157,7 @@ export function useListPets<
  * @summary Create a pet
  */
 export type createPetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -252,7 +252,7 @@ export const useCreatePets = <
  * @summary Update a pet
  */
 export type updatePetsResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };
@@ -347,7 +347,7 @@ export const useUpdatePets = <
  * @summary Info for a specific pet
  */
 export type showPetByIdResponse = {
-  data: Pet;
+  data: Pet | Error;
   status: number;
   headers: Headers;
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1588 
The data type of the fetch response now includes the error type.

### Context

When you have multiple response types schema like a below:

```yaml
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pets'
        '400':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/BadRequest'
```

### Before

So far, orval has only generated success type:

```ts
export type listPetsResponse = {
  data: Pets;
  status: number;
  headers: Headers;
};
```

### After

From now on, it will generate a union that includes the error type

```ts
export type listPetsResponse = {
  data: Pets | BadRequest;
  status: number;
  headers: Headers;
};
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

you can check by sample apps 