### PR TITLE
feat(fetch): avoid exception when the response body has no content

### DIFF
--- a/docs/src/pages/guides/fetch-client.md
+++ b/docs/src/pages/guides/fetch-client.md
@@ -48,7 +48,7 @@ export const listPets = async (
     ...options,
     method: 'GET',
   });
-  const data = await res.json();
+  const data: Pets = res.body ? await res.json() : {};
 
   return { status: res.status, data };
 };
@@ -133,10 +133,10 @@ export const listPets = async (
     ...options,
     method: 'GET',
   });
-  const data = await res.json();
+  const data: Pet = res.body ? await res.json() : {}
 
 -  return { status: res.status, data };
-+  return data as Pet;
++  return data;
 };
 ```
 

--- a/docs/src/pages/guides/fetch-client.md
+++ b/docs/src/pages/guides/fetch-client.md
@@ -48,7 +48,8 @@ export const listPets = async (
     ...options,
     method: 'GET',
   });
-  const data: Pets = res.body ? await res.json() : {};
+  const data: Pets =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data };
 };
@@ -133,7 +134,8 @@ export const listPets = async (
     ...options,
     method: 'GET',
   });
-  const data: Pet = res.body ? await res.json() : {}
+  const data: Pets =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
 -  return { status: res.status, data };
 +  return data;

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -181,7 +181,7 @@ ${
   `
     : `const res = await fetch(${fetchFnOptions})
 
-  const data:${response.definition.success} = res.body ? await res.json() : {}
+  const data:${response.definition.success} = ([204, 205, 304].includes(res.status) || !res.body) ? {} : await res.json()
 
   ${override.fetch.includeHttpResponseReturnType ? 'return { status: res.status, data, headers: res.headers }' : `return data as ${responseTypeName}`}
 `;

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -181,7 +181,7 @@ ${
   `
     : `const res = await fetch(${fetchFnOptions})
 
-  const data:${response.definition.success}  = await res.json()
+  const data:${response.definition.success} = res.body ? await res.json() : {}
 
   ${override.fetch.includeHttpResponseReturnType ? 'return { status: res.status, data, headers: res.headers }' : `return data as ${responseTypeName}`}
 `;

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -44,7 +44,8 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets = res.body ? await res.json() : {};
+  const data: Pets =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -73,7 +74,8 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -102,7 +104,8 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -129,7 +132,8 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -44,7 +44,7 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets = await res.json();
+  const data: Pets = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -73,7 +73,7 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -102,7 +102,7 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -129,7 +129,7 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -42,7 +42,8 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets = res.body ? await res.json() : {};
+  const data: Pets =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return data as Pets;
 };
@@ -105,7 +106,8 @@ export const createPets = async (
     body: JSON.stringify(createPetsBody),
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return data as Pet;
 };
@@ -165,7 +167,8 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return data as Pet;
 };

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -42,7 +42,7 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets = await res.json();
+  const data: Pets = res.body ? await res.json() : {};
 
   return data as Pets;
 };
@@ -105,7 +105,7 @@ export const createPets = async (
     body: JSON.stringify(createPetsBody),
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return data as Pet;
 };
@@ -165,7 +165,7 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return data as Pet;
 };

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -76,7 +76,8 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets = res.body ? await res.json() : {};
+  const data: Pets =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -144,7 +145,8 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -214,7 +216,8 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -282,7 +285,8 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet = res.body ? await res.json() : {};
+  const data: Pet =
+    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
 
   return { status: res.status, data, headers: res.headers };
 };

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -76,7 +76,7 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets = await res.json();
+  const data: Pets = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -144,7 +144,7 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -214,7 +214,7 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };
@@ -282,7 +282,7 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet = await res.json();
+  const data: Pet = res.body ? await res.json() : {};
 
   return { status: res.status, data, headers: res.headers };
 };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**HOLD**

 I'm waiting for more options to gather in #1656 

## Description

fix #1656

This avoids an exception that occurs when executing `res.json()` if there is no content in the response body.

```ts
export const listPets = async (
  params?: ListPetsParams,
  options?: RequestInit,
): Promise<listPetsResponse> => {
  const res = await fetch(getListPetsUrl(params), {
    ...options,
    method: 'GET',
  });

-  const data: Pets = await res.json();
+  const data: Pets =
    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();

  return { status: res.status, data, headers: res.headers };
};
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

you can check by sample apps
