### PR TITLE
fix(fetch): pass headers to `fetch` when `headers` option is activated

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -22,6 +22,7 @@ import {
 export const generateRequestFunction = (
   {
     queryParams,
+    headers,
     operationName,
     response,
     mutator,
@@ -169,6 +170,7 @@ ${
   const fetchFnOptions = `${getUrlFnName}(${getUrlFnProperties}),
   {${globalFetchOptions ? '\n' : ''}      ${globalFetchOptions}
     ${isRequestOptions ? '...options,' : ''}
+    ${headers ? 'headers: { ...headers, ...options?.headers },' : ''}
     ${fetchMethodOption}${fetchHeadersOption ? ',' : ''}
     ${fetchHeadersOption}${fetchBodyOption ? ',' : ''}
     ${fetchBodyOption}

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -105,6 +105,17 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  headers: {
+    output: {
+      target: '../generated/fetch/headers/endpoints.ts',
+      schemas: '../generated/fetch/headers/model',
+      client: 'fetch',
+      headers: true,
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
   formData: {
     output: {
       target: '../generated/fetch/form-data-optional-request/endpoints.ts',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Passes headers to `fetch` when `headers` option is activated. 

Fixes #1779.

I have not tested the patch since the build system doesn't support the system I am on.