### PR TITLE
fix(zod): pass resolved specKey in context

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -9,7 +9,9 @@ import {
   GeneratorMutator,
   GeneratorOptions,
   GeneratorVerbOptions,
+  getFileInfo,
   getNumberWord,
+  getRefInfo,
   isBoolean,
   isObject,
   isString,
@@ -555,8 +557,17 @@ const deference = (
     childContext,
   );
 
+  const resolvedSpecKey = refName
+    ? getRefInfo(refName, context).specKey
+    : undefined;
+
+  const resolvedContext: ContextSpecs = {
+    ...childContext,
+    specKey: resolvedSpecKey ?? childContext.specKey,
+  };
+
   return Object.entries(resolvedSchema).reduce((acc, [key, value]) => {
-    acc[key] = deferenceScalar(value, childContext);
+    acc[key] = deferenceScalar(value, resolvedContext);
     return acc;
   }, {} as any);
 };

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -189,4 +189,12 @@ export default defineConfig({
       target: '../specifications/parameters.yaml',
     },
   },
+  importFromSubdirectory: {
+    output: {
+      target: '../generated/fetch/importFromSubdirectory/endpoints.ts',
+      schemas: '../generated/fetch/importFromSubdirectory/model',
+      client: 'fetch',
+    },
+    input: '../specifications/import-from-subdirectory/petstore.yaml',
+  },
 });

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -146,4 +146,11 @@ export default defineConfig({
       target: '../specifications/typed-arrays-tuples-v3-1.yaml',
     },
   },
+  importFromSubdirectory: {
+    output: {
+      target: '../generated/zod/import-from-subdirectory.ts',
+      client: 'zod',
+    },
+    input: '../specifications/import-from-subdirectory/petstore.yaml',
+  },
 });

--- a/tests/specifications/import-from-subdirectory/petstore.yaml
+++ b/tests/specifications/import-from-subdirectory/petstore.yaml
@@ -14,4 +14,13 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: 'subdirectory/petstore.yaml#/components/schemas/Pet'
+                  - $ref: './subdirectory/petstore.yaml#/components/schemas/Pet'
+    get:
+      responses:
+        '200':
+          description: All pets
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: './subdirectory/another-file.yaml#/components/schemas/AnotherSchema'

--- a/tests/specifications/import-from-subdirectory/subdirectory/another-file.yaml
+++ b/tests/specifications/import-from-subdirectory/subdirectory/another-file.yaml
@@ -1,0 +1,10 @@
+components:
+  schemas:
+    AnotherSchema:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64

--- a/tests/specifications/import-from-subdirectory/subdirectory/petstore.yaml
+++ b/tests/specifications/import-from-subdirectory/subdirectory/petstore.yaml
@@ -12,3 +12,5 @@ components:
         id:
           type: integer
           format: int64
+        file:
+          $ref: 'another-file.yaml#/components/schemas/AnotherSchema'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,23 +1253,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.3.0, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.4.0, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.3.0, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.4.0, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.3.0, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.4.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1308,62 +1308,62 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.3.0, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.4.0, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.3.0, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.4.0, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.3.0"
-    "@orval/zod": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
+    "@orval/zod": "npm:7.4.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.3.0, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.4.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
     lodash.get: "npm:^4.4.2"
     lodash.omit: "npm:^4.5.0"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.3.0, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.4.0, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.3.0"
-    "@orval/fetch": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
+    "@orval/fetch": "npm:7.4.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.3.0, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.4.0, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.3.0"
-    "@orval/fetch": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
+    "@orval/fetch": "npm:7.4.0"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.3.0, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.4.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.3.0"
+    "@orval/core": "npm:7.4.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -7578,15 +7578,15 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@orval/angular": "npm:7.3.0"
-    "@orval/axios": "npm:7.3.0"
-    "@orval/core": "npm:7.3.0"
-    "@orval/fetch": "npm:7.3.0"
-    "@orval/hono": "npm:7.3.0"
-    "@orval/mock": "npm:7.3.0"
-    "@orval/query": "npm:7.3.0"
-    "@orval/swr": "npm:7.3.0"
-    "@orval/zod": "npm:7.3.0"
+    "@orval/angular": "npm:7.4.0"
+    "@orval/axios": "npm:7.4.0"
+    "@orval/core": "npm:7.4.0"
+    "@orval/fetch": "npm:7.4.0"
+    "@orval/hono": "npm:7.4.0"
+    "@orval/mock": "npm:7.4.0"
+    "@orval/query": "npm:7.4.0"
+    "@orval/swr": "npm:7.4.0"
+    "@orval/zod": "npm:7.4.0"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"


### PR DESCRIPTION
## Status

**READY**

## Description

This PR adds a new entry to `tests/configs/zod.config.ts` that shows a bug for `$ref` objects and fixes it

If we reference a schema in subdirectory, it works at least for React Query and Fetch, however it fails for Zod.

**UPD**: The solution to the bug is to get specKey key from resolved schema and use it to resolve its fields
