### PR TITLE
fix: Generate correct header type definitions

### DIFF
--- a/packages/core/src/generators/parameter-definition.ts
+++ b/packages/core/src/generators/parameter-definition.ts
@@ -22,7 +22,7 @@ export const generateParameterDefinition = (
         context,
       );
 
-      if (schema.in !== 'query') {
+      if ((schema.in === 'path') || (schema.in === 'cookie')) {
         return acc;
       }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

If the header parameter is defined using the #/components/parameters/... syntax, then an incomplete type definition is generated for the headers, this fixes the behaviour by adding the missing types.

Fix #1790

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
