### PR TITLE
fix(core): use union type for additional properties

### DIFF
--- a/packages/core/src/generators/schema-definition.ts
+++ b/packages/core/src/generators/schema-definition.ts
@@ -146,6 +146,7 @@ function shouldCreateInterface(schema: SchemaObject) {
     !schema.anyOf &&
     !isReference(schema) &&
     !schema.nullable &&
-    !schema.enum
+    !schema.enum &&
+    !schema.additionalProperties
   );
 }

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -133,15 +133,16 @@ export const getObject = ({
 
         if (arr.length - 1 === index) {
           if (item.additionalProperties) {
+            acc.value += '\n}';
             if (isBoolean(item.additionalProperties)) {
-              acc.value += `\n  [key: string]: unknown;\n }`;
+              acc.value += ` | (${acc.value} & {\n  [key: string]: unknown;\n })`;
             } else {
               const resolvedValue = resolveValue({
                 schema: item.additionalProperties,
                 name,
                 context,
               });
-              acc.value += `\n  [key: string]: ${resolvedValue.value};\n}`;
+              acc.value += ` | (${acc.value} & {\n  [key: string]: ${resolvedValue.value};\n })`;
             }
           } else {
             acc.value += '\n}';


### PR DESCRIPTION
## Status

**HOLD**

## Description

I think this fixes #1516, #600 and #419
The solution is to use union type when additionalProperties is defined. The resulting type changes from
```ts
export type FooType = {
  foo?: string;
  bar?: boolean;
  [key: string]: string;
}
```
which would generate the following errors:
`Property 'foo' of type 'string | undefined' is not assignable to 'string' index type 'string'.`
`Property 'bar' of type 'boolean | undefined' is not assignable to 'string' index type 'string'.`

The change in this PR makes the resulting type be
```ts
export type FooType = {
  foo?: string;
  bar?: boolean;
} | ({
  foo?: string;
  bar?: boolean;
} & {
  [key: string]: string;
 });
```
This results in a (I think?) correct type:
![image](https://github.com/user-attachments/assets/090a8d2e-8723-401b-a93d-bab80325b070)
![image](https://github.com/user-attachments/assets/37021607-aeaf-449d-9d32-a514d0ed2196)
![image](https://github.com/user-attachments/assets/0b51dc75-ef5b-4fce-b639-eff460a4a86c)


Please check and see if there are any edge cases I've forgotten to check, otherwise I think this would be an improvement