### PR TITLE
feat(msw): create an index file exporting msw for split tags mode

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -280,6 +280,28 @@ module.exports = {
 };
 ```
 
+### indexMockFiles
+
+Type: `Boolean`
+
+Valid values: true or false. Defaults to false.
+
+When true, adds a index.msw.ts file which exports all mock functions.
+This is only valid when `mode` is `tags-split`.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      schemas: 'src/gen/model',
+      indexMockFiles: true,
+    },
+  },
+};
+```
+
 ### title
 
 Type: `String` or `Function`.

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -547,9 +547,9 @@ Give you the possibility to set the locale for the mock generation. It is used b
 
 Type: `Boolean`
 
-Valid values: true or false. Defaults to false.
+Default Value: `false`.
 
-When true, adds a index.msw.ts file which exports all mock functions.
+When `true`, adds a `index.msw.ts` file which exports all mock functions.
 This is only valid when `mode` is `tags-split`.
 
 Example:

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -280,28 +280,6 @@ module.exports = {
 };
 ```
 
-### indexMockFiles
-
-Type: `Boolean`
-
-Valid values: true or false. Defaults to false.
-
-When true, adds a index.msw.ts file which exports all mock functions.
-This is only valid when `mode` is `tags-split`.
-
-Example:
-
-```js
-module.exports = {
-  petstore: {
-    output: {
-      schemas: 'src/gen/model',
-      indexMockFiles: true,
-    },
-  },
-};
-```
-
 ### title
 
 Type: `String` or `Function`.
@@ -564,6 +542,30 @@ Type: `String`.
 Default Value: `en`.
 
 Give you the possibility to set the locale for the mock generation. It is used by faker, see the list of available options [here](https://fakerjs.dev/guide/localization.html#available-locales). It should also be strongly typed using `defineConfig`.
+
+### indexMockFiles
+
+Type: `Boolean`
+
+Valid values: true or false. Defaults to false.
+
+When true, adds a index.msw.ts file which exports all mock functions.
+This is only valid when `mode` is `tags-split`.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      mode: 'tags-split',
+      mock: {
+        indexMockFiles: true,
+      },
+    },
+  },
+};
+```
 
 ### docs
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,6 +59,7 @@ export type NormalizedOutputOptions = {
   packageJson?: PackageJson;
   headers: boolean;
   indexFiles: boolean;
+  indexMockFiles: boolean;
   baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional: boolean;
   urlEncodeParameters: boolean;
@@ -209,6 +210,7 @@ export type OutputOptions = {
   packageJson?: string;
   headers?: boolean;
   indexFiles?: boolean;
+  indexMockFiles?: boolean;
   baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional?: boolean;
   urlEncodeParameters?: boolean;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,7 +59,6 @@ export type NormalizedOutputOptions = {
   packageJson?: PackageJson;
   headers: boolean;
   indexFiles: boolean;
-  indexMockFiles: boolean;
   baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional: boolean;
   urlEncodeParameters: boolean;
@@ -210,7 +209,6 @@ export type OutputOptions = {
   packageJson?: string;
   headers?: boolean;
   indexFiles?: boolean;
-  indexMockFiles?: boolean;
   baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional?: boolean;
   urlEncodeParameters?: boolean;
@@ -298,6 +296,7 @@ export type GlobalMockOptions = {
   baseUrl?: string;
   // This is used to set the locale of the faker library
   locale?: keyof typeof allLocales;
+  indexMockFiles?: boolean;
 };
 
 export type OverrideMockOptions = Partial<GlobalMockOptions> & {

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -32,7 +32,7 @@ export const writeSplitTagsMode = async ({
   );
 
   const indexFilePath =
-    output.mock && output.indexMockFiles
+    output.mock && !isFunction(output.mock) && output.mock.indexMockFiles
       ? upath.join(
           dirname,
           'index.' + getMockFileExtensionByTypeName(output.mock!) + extension,

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -32,8 +32,11 @@ export const writeSplitTagsMode = async ({
   );
 
   const indexFilePath =
-    output.mock && output.indexFiles
-      ? upath.join(dirname, 'index.mock' + extension)
+    output.mock && output.indexMockFiles
+      ? upath.join(
+          dirname,
+          'index.' + getMockFileExtensionByTypeName(output.mock!) + extension,
+        )
       : undefined;
   if (indexFilePath) {
     await fs.outputFile(indexFilePath, '');

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -33,10 +33,7 @@ export const writeSplitTagsMode = async ({
 
   const indexFilePath =
     output.mock && output.indexFiles
-      ? upath.join(
-          dirname,
-          'index.' + getMockFileExtensionByTypeName(output.mock!) + extension,
-        )
+      ? upath.join(dirname, 'index.mock' + extension)
       : undefined;
   if (indexFilePath) {
     await fs.outputFile(indexFilePath, '');

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -31,6 +31,17 @@ export const writeSplitTagsMode = async ({
     output.tsconfig,
   );
 
+  const indexFilePath =
+    output.mock && output.indexFiles
+      ? upath.join(
+          dirname,
+          'index.' + getMockFileExtensionByTypeName(output.mock!) + extension,
+        )
+      : undefined;
+  if (indexFilePath) {
+    await fs.outputFile(indexFilePath, '');
+  }
+
   const generatedFilePathsArray = await Promise.all(
     Object.entries(target).map(async ([tag, target]) => {
       try {
@@ -172,6 +183,14 @@ export const writeSplitTagsMode = async ({
 
         if (mockPath) {
           await fs.outputFile(mockPath, mockData);
+          if (indexFilePath) {
+            const localMockPath = upath.joinSafe(
+              './',
+              tag,
+              tag + '.' + getMockFileExtensionByTypeName(output.mock!),
+            );
+            fs.appendFile(indexFilePath, `export * from '${localMockPath}'\n`);
+          }
         }
 
         return [

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -158,6 +158,7 @@ export const normalizeOptions = async (
       packageJson,
       headers: outputOptions.headers ?? false,
       indexFiles: outputOptions.indexFiles ?? true,
+      indexMockFiles: outputOptions.indexMockFiles ?? false,
       baseUrl: outputOptions.baseUrl,
       unionAddMissingProperties:
         outputOptions.unionAddMissingProperties ?? false,

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -158,7 +158,6 @@ export const normalizeOptions = async (
       packageJson,
       headers: outputOptions.headers ?? false,
       indexFiles: outputOptions.indexFiles ?? true,
-      indexMockFiles: outputOptions.indexMockFiles ?? false,
       baseUrl: outputOptions.baseUrl,
       unionAddMissingProperties:
         outputOptions.unionAddMissingProperties ?? false,

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -214,8 +214,10 @@ export default defineConfig({
       target: '../generated/default/index-mock-file/endpoints.ts',
       schemas: '../generated/default/index-mock-file/model',
       client: 'fetch',
-      mock: true,
-      indexMockFiles: true,
+      mock: {
+        type: 'msw',
+        indexMockFiles: true,
+      },
       mode: 'tags-split',
     },
     input: {

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -209,4 +209,17 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  indexMockFiles: {
+    output: {
+      target: '../generated/default/index-mock-file/endpoints.ts',
+      schemas: '../generated/default/index-mock-file/model',
+      client: 'fetch',
+      mock: true,
+      indexMockFiles: true,
+      mode: 'tags-split',
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

**READY/WIP**

## Description

Fixes #512 
Is `index.msw.ts` a good name? Or should it be something like `mocks.ts`?

## Steps to Test or Reproduce

1. yarn generate:mock
2. check generated/mock/petstore-tags-split and there is a `index.msw.ts` file which exports * from all .msw.ts files