### PR TITLE
Fix chaotic shuffle of generated types

### DIFF
--- a/packages/core/src/generators/models-inline.ts
+++ b/packages/core/src/generators/models-inline.ts
@@ -6,9 +6,7 @@ export const generateModelInline = (acc: string, model: string): string =>
 export const generateModelsInline = (
   obj: Record<string, GeneratorSchema[]>,
 ): string => {
-  const schemas = Object.values(obj)
-    .flatMap((it) => it)
-    .sort((a, b) => (a.imports.some((i) => i.name === b.name) ? 1 : -1));
+  const schemas = Object.values(obj).flatMap((it) => it);
 
   return schemas.reduce<string>(
     (acc, { model }) => generateModelInline(acc, model),


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

Fix #1382

**WIP**

## Description

Sometimes, when generating Orval schema, some generated types are moved around the file. This PR fixes it.
Related to issue [Types in generated react-query schema have unstable order, causing noisy diffs #1382 ](https://github.com/orval-labs/orval/issues/1382)

## Related PRs

No related PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
