### PR TITLE
feat(hono): add `orverride.hono.validatorOutputPath` option

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -411,6 +411,7 @@ export type OverrideOutputContentType = {
 export type NormalizedHonoOptions = {
   handlers?: string;
   validator: boolean | 'hono';
+  validatorOutputPath: string;
 };
 
 export type ZodOptions = {
@@ -482,6 +483,7 @@ export type NormalizedZodOptions = {
 export type HonoOptions = {
   handlers?: string;
   validator?: boolean | 'hono';
+  validatorOutputPath?: string;
 };
 
 export type NormalizedQueryOptions = {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -583,6 +583,9 @@ const normalizeHonoOptions = (
       ? { handlers: upath.resolve(workspace, hono.handlers) }
       : {}),
     validator: hono.validator ?? true,
+    validatorOutputPath: hono.validatorOutputPath
+      ? upath.resolve(workspace, hono.validatorOutputPath)
+      : '',
   };
 };
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Until now, `validator.ts` was output to the same directory as other files output to `target`.
In fact, `validator.ts` is only referenced in `handlers`, so I want to output it to the same hierarchy instead of `target`.
So I added an option to give me control over it.

### Before:
```bash
src/
├── endpoints.context.ts
├── endpoints.ts
├── endpoints.validator.ts  <--- They are grouped under `target`
├── endpoints.zod.ts
└── handlers
```

After:

```bash
src/
├── endpoints.context.ts
├── endpoints.ts
├── endpoints.zod.ts
└── handlers
    ├── createPets.ts
    ├── deletePetById.ts
    ├── healthCheck.ts
    ├── listPets.ts
    ├── schemas
    ├── showPetById.ts
    └── validator.ts  <--- By specifying the path, output will be under handlers.
```

## Related PRs

None

## Todos

The `hono` client hasn't yet been tests and docs, so I will add those in a separate PR.

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```ts
export default defineConfig({
  petstoreSplitValidatorOutputPath: {
    input: '../specifications/petstore.yaml',
    output: {
      target: '../generated/hono/petstore-split-validator-output-path/endpoints.ts',
      schemas: '../generated/hono/petstore-split-validator-output-path/handlers/schemas',
      mode: 'split',
      client: 'hono',
      override: {
        hono: {
          handlers: '../generated/hono/petstore-split-validator-output-path/handlers',
          validatorOutputPath: '../generated/hono/petstore-split-validator-output-path/handlers/validator.ts',
        },
      },
    },
  },
});
```