### PR TITLE
fix(hono): custom validator always does return value

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -941,6 +941,8 @@ export const zValidator =
         c.res = new Response(JSON.stringify(result.data), c.res);
       }
     }
+    
+    return;
   };
 `;
 

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
@@ -6,48 +6,6 @@
  */
 import axios from 'axios';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
-export type ListPetsNestedArrayParams = {
-  /**
-   * How many items to return at one time (max 100)
-   */
-  limit?: string;
-};
-
-export type CreatePetsBody = {
-  name: string;
-  tag: string;
-};
-
-export type ListPetsParams = {
-  /**
-   * How many items to return at one time (max 100)
-   */
-  limit?: string;
-};
-
-export interface Error {
-  code: number;
-  message: string;
-}
-
-/**
- * @minItems 1
- * @maxItems 20
- */
-export type PetsArray = Pet[];
-
-export interface PetsNestedArray {
-  data?: Pet[];
-}
-
-export type PetCountry = (typeof PetCountry)[keyof typeof PetCountry];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PetCountry = {
-  "People's_Republic_of_China": "People's Republic of China",
-  Uruguay: 'Uruguay',
-} as const;
-
 export type PetCallingCode =
   (typeof PetCallingCode)[keyof typeof PetCallingCode];
 
@@ -55,6 +13,14 @@ export type PetCallingCode =
 export const PetCallingCode = {
   '+33': '+33',
   '+420': '+420',
+} as const;
+
+export type PetCountry = (typeof PetCountry)[keyof typeof PetCountry];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PetCountry = {
+  "People's_Republic_of_China": "People's Republic of China",
+  Uruguay: 'Uruguay',
 } as const;
 
 export interface Pet {
@@ -81,6 +47,40 @@ export interface Pet {
   callingCode?: PetCallingCode;
   country?: PetCountry;
 }
+
+export interface PetsNestedArray {
+  data?: Pet[];
+}
+
+/**
+ * @minItems 1
+ * @maxItems 20
+ */
+export type PetsArray = Pet[];
+
+export interface Error {
+  code: number;
+  message: string;
+}
+
+export type ListPetsParams = {
+  /**
+   * How many items to return at one time (max 100)
+   */
+  limit?: string;
+};
+
+export type CreatePetsBody = {
+  name: string;
+  tag: string;
+};
+
+export type ListPetsNestedArrayParams = {
+  /**
+   * How many items to return at one time (max 100)
+   */
+  limit?: string;
+};
 
 /**
  * @summary List all pets

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.schemas.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.schemas.ts
@@ -4,10 +4,18 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-export type CreatePetsBodyItem = {
+export interface Pet {
+  id: number;
   name: string;
   tag: string;
-};
+}
+
+export type Pets = Pet[];
+
+export interface Error {
+  code: number;
+  message: string;
+}
 
 export type ListPetsParams = {
   /**
@@ -16,15 +24,7 @@ export type ListPetsParams = {
   limit?: string;
 };
 
-export interface Error {
-  code: number;
-  message: string;
-}
-
-export interface Pet {
-  id: number;
+export type CreatePetsBodyItem = {
   name: string;
   tag: string;
-}
-
-export type Pets = Pet[];
+};

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.validator.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.validator.ts
@@ -141,4 +141,6 @@ export const zValidator =
         c.res = new Response(JSON.stringify(result.data), c.res);
       }
     }
+
+    return;
   };

--- a/samples/hono/hono-with-zod/src/petstore.schemas.ts
+++ b/samples/hono/hono-with-zod/src/petstore.schemas.ts
@@ -4,88 +4,6 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-export type CreatePetsBodyItem = {
-  name: string;
-  tag: string;
-};
-
-export type ListPetsParams = {
-  /**
-   * How many items to return at one time (max 100)
-   */
-  limit?: string;
-};
-
-export interface Error {
-  code: number;
-  message: string;
-}
-
-export type Pets = Pet[];
-
-export type CatType = (typeof CatType)[keyof typeof CatType];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const CatType = {
-  cat: 'cat',
-} as const;
-
-export interface Cat {
-  readonly petsRequested?: number;
-  type: CatType;
-}
-
-export type DachshundBreed =
-  (typeof DachshundBreed)[keyof typeof DachshundBreed];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DachshundBreed = {
-  Dachshund: 'Dachshund',
-} as const;
-
-export interface Dachshund {
-  length: number;
-  breed: DachshundBreed;
-}
-
-export type LabradoodleBreed =
-  (typeof LabradoodleBreed)[keyof typeof LabradoodleBreed];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LabradoodleBreed = {
-  Labradoodle: 'Labradoodle',
-} as const;
-
-export interface Labradoodle {
-  cuteness: number;
-  breed: LabradoodleBreed;
-}
-
-export type DogType = (typeof DogType)[keyof typeof DogType];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DogType = {
-  dog: 'dog',
-} as const;
-
-export type Dog =
-  | (Labradoodle & {
-      barksPerMinute?: number;
-      type: DogType;
-    })
-  | (Dachshund & {
-      barksPerMinute?: number;
-      type: DogType;
-    });
-
-export type PetCountry = (typeof PetCountry)[keyof typeof PetCountry];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const PetCountry = {
-  "People's_Republic_of_China": "People's Republic of China",
-  Uruguay: 'Uruguay',
-} as const;
-
 export type PetCallingCode =
   (typeof PetCallingCode)[keyof typeof PetCallingCode];
 
@@ -93,6 +11,14 @@ export type PetCallingCode =
 export const PetCallingCode = {
   '+33': '+33',
   '+420': '+420',
+} as const;
+
+export type PetCountry = (typeof PetCountry)[keyof typeof PetCountry];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PetCountry = {
+  "People's_Republic_of_China": "People's Republic of China",
+  Uruguay: 'Uruguay',
 } as const;
 
 export type Pet =
@@ -114,3 +40,77 @@ export type Pet =
       callingCode?: PetCallingCode;
       country?: PetCountry;
     });
+
+export type DogType = (typeof DogType)[keyof typeof DogType];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DogType = {
+  dog: 'dog',
+} as const;
+
+export type Dog =
+  | (Labradoodle & {
+      barksPerMinute?: number;
+      type: DogType;
+    })
+  | (Dachshund & {
+      barksPerMinute?: number;
+      type: DogType;
+    });
+
+export type LabradoodleBreed =
+  (typeof LabradoodleBreed)[keyof typeof LabradoodleBreed];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const LabradoodleBreed = {
+  Labradoodle: 'Labradoodle',
+} as const;
+
+export interface Labradoodle {
+  cuteness: number;
+  breed: LabradoodleBreed;
+}
+
+export type DachshundBreed =
+  (typeof DachshundBreed)[keyof typeof DachshundBreed];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const DachshundBreed = {
+  Dachshund: 'Dachshund',
+} as const;
+
+export interface Dachshund {
+  length: number;
+  breed: DachshundBreed;
+}
+
+export type CatType = (typeof CatType)[keyof typeof CatType];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CatType = {
+  cat: 'cat',
+} as const;
+
+export interface Cat {
+  readonly petsRequested?: number;
+  type: CatType;
+}
+
+export type Pets = Pet[];
+
+export interface Error {
+  code: number;
+  message: string;
+}
+
+export type ListPetsParams = {
+  /**
+   * How many items to return at one time (max 100)
+   */
+  limit?: string;
+};
+
+export type CreatePetsBodyItem = {
+  name: string;
+  tag: string;
+};


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This is to avoid the following lint error:

```
error TS7030: Not all code paths return a value.
```

And update sample apps.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```ts
export default defineConfig({
  petstoreSplitHandlers: {
    input: '../specifications/petstore.yaml',
    output: {
      target: '../generated/hono/petstore-split-handlers/endpoints.ts',
      schemas: '../generated/hono/petstore-split-handlers/handlers/schemas',
      mode: 'split',
      client: 'hono',
      override: {
        hono: {
          handlers: '../generated/hono/petstore-split-handlers/handlers',
        },
      },
    },
  },
}