### PR TITLE
fix(hono): avoid unnecessary `zValidator` imports

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -245,7 +245,7 @@ const generateHandlers = async (
           !!verbOption.headers ||
           !!verbOption.params.length ||
           !!verbOption.queryParams ||
-          !!verbOption.body;
+          !!verbOption.body.definition;
 
         const isExist = fs.existsSync(handlerPath);
 
@@ -332,7 +332,7 @@ ${getHonoHandlers({
             !!verb.headers ||
             !!verb.params.length ||
             !!verb.queryParams ||
-            !!verb.body,
+            !!verb.body.definition,
         );
 
         const isExist = fs.existsSync(handlerPath);
@@ -429,7 +429,7 @@ const factory = createFactory();`;
       !!verb.headers ||
       !!verb.params.length ||
       !!verb.queryParams ||
-      !!verb.body ||
+      !!verb.body.definition ||
       (verb.response.contentTypes.length === 1 &&
         verb.response.contentTypes[0] === 'application/json'),
   );


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

`verbOption.body` always exists even if the request body does not exist, because it contains the following object:

```ts
verbOption.body {
  originalSchema: undefined,
  definition: '',
  implementation: '',
  imports: [],
  schemas: [],
  isOptional: false,
  formData: '',
  formUrlEncoded: '',
  contentType: ''
}
```

Therefore, when checking whether the request body exists, `true` is always returned, which is not the intended result.
As a result, this resulted in an unnecessary `zValidator` being imported, which caused the following warning:

```
error TS6133: 'zValidator' is declared but its value is never read.
```

The intended behavior is achieved by checking whether `verbOption.body.definition` exists.

## Related PRs

None

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```ts
export default defineConfig({
  petstoreSplitHandlers: {
    input: '../specifications/petstore.yaml',
    output: {
      target: '../generated/hono/petstore-split-handlers/endpoints.ts',
      schemas: '../generated/hono/petstore-split-handlers/handlers/schemas',
      mode: 'split',
      client: 'hono',
      override: {
        hono: {
          handlers: '../generated/hono/petstore-split-handlers/handlers',
        },
      },
    },
  },
}