### PR TITLE
fix(core): export type with required properties in all-of object

### DIFF
--- a/tests/specifications/all-of.yaml
+++ b/tests/specifications/all-of.yaml
@@ -37,9 +37,15 @@ paths:
                   - $ref: '#/components/schemas/Pet'
                   - $ref: '#/components/schemas/PetDetail'
                   - type: object
+                    properties:
+                      category:
+                        type: string
                     required:
                       - category
                   - type: object
+                    properties:
+                      color:
+                        type: string
                     required:
                       - color
   /rested-ref-in-all-of-pets:


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #1670 
This allows spec to contain a `required` array either in parent object, or a sibling object inside the allOf:
```yaml
components:
  schemas:
    ContractPartial:
      type: object
      properties:
        uuid:
          type: string
        description:
          type: string
        start_date:
          type: string
          format: date
        end_date:
          type: string
          format: date
    Contract:
      type: object
      allOf:
        - $ref: '#/components/schemas/ContractPartial'
        - type: object
          properties:
            active:
              type: boolean
              description: If this contract is current active.
          required:
            - description
            - end_date
            - start_date
            - uuid
```
Would yield the same result as 
```yaml
components:
  schemas:
    ContractPartial:
      type: object
      properties:
        uuid:
          type: string
        description:
          type: string
        start_date:
          type: string
          format: date
        end_date:
          type: string
          format: date
    Contract:
      type: object
      required:
        - description
        - end_date
        - start_date
        - uuid
      allOf:
        - $ref: '#/components/schemas/ContractPartial'
        - type: object
          properties:
            active:
              type: boolean
              description: If this contract is current active.
```
which is:
```ts
export interface ContractPartial {
  uuid?: string;
  description?: string;
  start_date?: string;
  end_date?: string;
}

export type ContractAllOf = {
  /** If this contract is current active. */
  active?: boolean;
};

export type Contract = ContractPartial & ContractAllOf & Required<Pick<ContractPartial & ContractAllOf, 'description' | 'end_date' | 'start_date' | 'uuid'>>;
```
The resulting type is
```ts
{
  uuid: string;
  description: string;
  start_date: string;
  end_date: string;
  active?: boolean;
}
```
![image](https://github.com/user-attachments/assets/6e2718f0-c3d3-4f66-a7fc-b463a0f981a5)

