### PR TITLE
feat(core): add new operations modes

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -264,6 +264,8 @@ export const OutputMode = {
   SPLIT: 'split',
   TAGS: 'tags',
   TAGS_SPLIT: 'tags-split',
+  TAGS_OPERATIONS: 'tags-operations',
+  TAGS_SPLIT_OPERATIONS: 'tags-split-operations',
 } as const;
 
 export type OutputMode = (typeof OutputMode)[keyof typeof OutputMode];

--- a/packages/core/src/writers/index.ts
+++ b/packages/core/src/writers/index.ts
@@ -6,3 +6,5 @@ export * from './split-tags-mode';
 export * from './tags-mode';
 export * from './target';
 export * from './target-tags';
+export * from './tags-operations-mode';
+export * from './split-tags-operations-mode';

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -31,15 +31,15 @@ export const writeSplitTagsMode = async ({
     output.tsconfig,
   );
 
-  const indexFilePath =
+  const indexMockFilePath =
     output.mock && !isFunction(output.mock) && output.mock.indexMockFiles
       ? upath.join(
           dirname,
           'index.' + getMockFileExtensionByTypeName(output.mock!) + extension,
         )
       : undefined;
-  if (indexFilePath) {
-    await fs.outputFile(indexFilePath, '');
+  if (indexMockFilePath) {
+    await fs.outputFile(indexMockFilePath, '');
   }
 
   const generatedFilePathsArray = await Promise.all(
@@ -183,13 +183,16 @@ export const writeSplitTagsMode = async ({
 
         if (mockPath) {
           await fs.outputFile(mockPath, mockData);
-          if (indexFilePath) {
+          if (indexMockFilePath) {
             const localMockPath = upath.joinSafe(
               './',
               tag,
               tag + '.' + getMockFileExtensionByTypeName(output.mock!),
             );
-            fs.appendFile(indexFilePath, `export * from '${localMockPath}'\n`);
+            await fs.appendFile(
+              indexMockFilePath,
+              `export * from '${localMockPath}'\n`,
+            );
           }
         }
 

--- a/packages/core/src/writers/split-tags-operations-mode.ts
+++ b/packages/core/src/writers/split-tags-operations-mode.ts
@@ -1,0 +1,218 @@
+import fs from 'fs-extra';
+import { generateModelsInline, generateMutatorImports } from '../generators';
+import { WriteModeProps } from '../types';
+import {
+  camel,
+  getFileInfo,
+  getMockFileExtensionByTypeName,
+  isFunction,
+  isSyntheticDefaultImportsAllow,
+  kebab,
+  upath,
+} from '../utils';
+import { generateImportsForBuilder } from './generate-imports-for-builder';
+import { generateTargetForOperations } from './target-operations';
+import { getOrvalGeneratedTypes } from './types';
+
+export const writeSplitTagsOperationsMode = async ({
+  builder,
+  output,
+  specsName,
+  header,
+  needSchema,
+}: WriteModeProps): Promise<string[]> => {
+  const { filename, dirname, extension } = getFileInfo(output.target, {
+    backupFilename: camel(builder.info.title),
+    extension: output.fileExtension,
+  });
+
+  const target = generateTargetForOperations(builder, output);
+
+  const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(
+    output.tsconfig,
+  );
+
+  const indexMockFilePath =
+    output.mock && !isFunction(output.mock) && output.mock.indexMockFiles
+      ? upath.join(
+          dirname,
+          'index.' + getMockFileExtensionByTypeName(output.mock!) + extension,
+        )
+      : undefined;
+  if (indexMockFilePath) {
+    await fs.outputFile(indexMockFilePath, '');
+  }
+
+  const generatedFilePathsArray = await Promise.all(
+    Object.entries(target).flatMap(async ([tag, operations]) => {
+      const indexFilePath = upath.join(dirname, tag, 'index' + extension);
+      if (output.indexFiles) {
+        await fs.outputFile(indexFilePath, '');
+      }
+      return await Promise.all(
+        Object.entries(operations).map(async ([operation, target]) => {
+          try {
+            const {
+              imports,
+              implementation,
+              implementationMock,
+              importsMock,
+              mutators,
+              clientMutators,
+              formData,
+              formUrlEncoded,
+              paramsSerializer,
+            } = target;
+
+            let data = header;
+            let mockData = header;
+
+            const schemasPathRelative = output.schemas
+              ? '../' +
+                upath.relativeSafe(
+                  dirname,
+                  getFileInfo(output.schemas, {
+                    extension: output.fileExtension,
+                  }).dirname,
+                )
+              : '../' + filename + '.schemas';
+
+            const importsForBuilder = generateImportsForBuilder(
+              output,
+              imports,
+              schemasPathRelative,
+            );
+
+            data += builder.imports({
+              client: output.client,
+              implementation,
+              imports: importsForBuilder,
+              specsName,
+              hasSchemaDir: !!output.schemas,
+              isAllowSyntheticDefaultImports,
+              hasGlobalMutator: !!output.override.mutator,
+              hasTagsMutator: Object.values(output.override.tags).some(
+                (tag) => !!tag.mutator,
+              ),
+              hasParamsSerializerOptions:
+                !!output.override.paramsSerializerOptions,
+              packageJson: output.packageJson,
+              output,
+            });
+
+            if (output.mock) {
+              const importsMockForBuilder = generateImportsForBuilder(
+                output,
+                importsMock,
+                schemasPathRelative,
+              );
+
+              mockData += builder.importsMock({
+                implementation: implementationMock,
+                imports: importsMockForBuilder,
+                specsName,
+                hasSchemaDir: !!output.schemas,
+                isAllowSyntheticDefaultImports,
+                options: !isFunction(output.mock) ? output.mock : undefined,
+              });
+            }
+
+            const schemasPath = !output.schemas
+              ? upath.join(dirname, filename + '.schemas' + extension)
+              : undefined;
+
+            if (schemasPath && needSchema) {
+              const schemasData =
+                header + generateModelsInline(builder.schemas);
+
+              await fs.outputFile(schemasPath, schemasData);
+            }
+
+            if (mutators) {
+              data += generateMutatorImports({ mutators, implementation });
+            }
+
+            if (clientMutators) {
+              data += generateMutatorImports({
+                mutators: clientMutators,
+              });
+            }
+
+            if (formData) {
+              data += generateMutatorImports({ mutators: formData });
+            }
+
+            if (formUrlEncoded) {
+              data += generateMutatorImports({ mutators: formUrlEncoded });
+            }
+
+            if (paramsSerializer) {
+              data += generateMutatorImports({ mutators: paramsSerializer });
+            }
+
+            data += '\n\n';
+
+            if (implementation.includes('NonReadonly<')) {
+              data += getOrvalGeneratedTypes();
+              data += '\n';
+            }
+
+            data += `\n${implementation}`;
+            mockData += `\n${implementationMock}`;
+
+            const implementationPath = upath.join(
+              dirname,
+              tag,
+              `${kebab(operation)}${extension}`,
+            );
+            await fs.outputFile(implementationPath, data);
+
+            if (output.indexFiles) {
+              await fs.appendFile(
+                indexFilePath,
+                `export * from '${upath.joinSafe('./', kebab(operation))}'\n`,
+              );
+            }
+            const mockPath = output.mock
+              ? upath.join(
+                  dirname,
+                  tag,
+                  kebab(operation) +
+                    '.' +
+                    getMockFileExtensionByTypeName(output.mock) +
+                    extension,
+                )
+              : undefined;
+
+            if (mockPath) {
+              await fs.outputFile(mockPath, mockData);
+              if (indexMockFilePath) {
+                const localMockPath = upath.joinSafe(
+                  './',
+                  tag,
+                  kebab(operation) +
+                    '.' +
+                    getMockFileExtensionByTypeName(output.mock!),
+                );
+                await fs.appendFile(
+                  indexMockFilePath,
+                  `export * from '${localMockPath}'\n`,
+                );
+              }
+            }
+
+            return [
+              implementationPath,
+              ...(schemasPath ? [schemasPath] : []),
+              ...(mockPath ? [mockPath] : []),
+            ];
+          } catch (e) {
+            throw `Oups... 🍻. An Error occurred while writing operation ${operation} => ${e}`;
+          }
+        }),
+      );
+    }),
+  );
+
+  return generatedFilePathsArray.flatMap((it) => it).flatMap((it) => it);
+};

--- a/packages/core/src/writers/tags-operations-mode.ts
+++ b/packages/core/src/writers/tags-operations-mode.ts
@@ -1,0 +1,181 @@
+import fs from 'fs-extra';
+import { generateModelsInline, generateMutatorImports } from '../generators';
+import { GeneratorTarget, WriteModeProps } from '../types';
+import {
+  camel,
+  getFileInfo,
+  isFunction,
+  isSyntheticDefaultImportsAllow,
+  kebab,
+  upath,
+} from '../utils';
+import { generateImportsForBuilder } from './generate-imports-for-builder';
+import { generateTargetForOperations } from './target-operations';
+import { getOrvalGeneratedTypes } from './types';
+
+export const writeTagsOperationsMode = async ({
+  builder,
+  output,
+  specsName,
+  header,
+  needSchema,
+}: WriteModeProps): Promise<string[]> => {
+  const { filename, dirname, extension } = getFileInfo(output.target, {
+    backupFilename: camel(builder.info.title),
+    extension: output.fileExtension,
+  });
+
+  const target = generateTargetForOperations(builder, output);
+
+  const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(
+    output.tsconfig,
+  );
+
+  const generatedFilePathsArray = await Promise.all(
+    Object.entries(target).flatMap(async ([tag, operations]) => {
+      const indexFilePath = upath.join(dirname, tag, 'index' + extension);
+      if (output.indexFiles) {
+        await fs.outputFile(indexFilePath, '');
+      }
+      return await Promise.all(
+        Object.entries(operations).map(async ([operation, target]) => {
+          try {
+            const {
+              imports,
+              implementation,
+              implementationMock,
+              importsMock,
+              mutators,
+              clientMutators,
+              formData,
+              formUrlEncoded,
+              paramsSerializer,
+            } = target;
+
+            let data = header;
+
+            const schemasPathRelative = output.schemas
+              ? '../' +
+                upath.relativeSafe(
+                  dirname,
+                  getFileInfo(output.schemas, {
+                    extension: output.fileExtension,
+                  }).dirname,
+                )
+              : '../' + filename + '.schemas';
+
+            const importsForBuilder = generateImportsForBuilder(
+              output,
+              imports.filter(
+                (imp) =>
+                  !importsMock.some((impMock) => imp.name === impMock.name),
+              ),
+              schemasPathRelative,
+            );
+
+            data += builder.imports({
+              client: output.client,
+              implementation,
+              imports: importsForBuilder,
+              specsName,
+              hasSchemaDir: !!output.schemas,
+              isAllowSyntheticDefaultImports,
+              hasGlobalMutator: !!output.override.mutator,
+              hasTagsMutator: Object.values(output.override.tags).some(
+                (tag) => !!tag.mutator,
+              ),
+              hasParamsSerializerOptions:
+                !!output.override.paramsSerializerOptions,
+              packageJson: output.packageJson,
+              output,
+            });
+
+            if (output.mock) {
+              const importsMockForBuilder = generateImportsForBuilder(
+                output,
+                importsMock,
+                schemasPathRelative,
+              );
+
+              data += builder.importsMock({
+                implementation: implementationMock,
+                imports: importsMockForBuilder,
+                specsName,
+                hasSchemaDir: !!output.schemas,
+                isAllowSyntheticDefaultImports,
+                options: !isFunction(output.mock) ? output.mock : undefined,
+              });
+            }
+
+            const schemasPath = !output.schemas
+              ? upath.join(dirname, filename + '.schemas' + extension)
+              : undefined;
+
+            if (schemasPath && needSchema) {
+              const schemasData =
+                header + generateModelsInline(builder.schemas);
+
+              await fs.outputFile(schemasPath, schemasData);
+            }
+
+            if (mutators) {
+              data += generateMutatorImports({ mutators, implementation });
+            }
+
+            if (clientMutators) {
+              data += generateMutatorImports({
+                mutators: clientMutators,
+              });
+            }
+
+            if (formData) {
+              data += generateMutatorImports({ mutators: formData });
+            }
+
+            if (formUrlEncoded) {
+              data += generateMutatorImports({ mutators: formUrlEncoded });
+            }
+
+            if (paramsSerializer) {
+              data += generateMutatorImports({ mutators: paramsSerializer });
+            }
+
+            data += '\n\n';
+
+            if (implementation.includes('NonReadonly<')) {
+              data += getOrvalGeneratedTypes();
+              data += '\n';
+            }
+
+            data += implementation;
+
+            if (output.mock) {
+              data += '\n\n';
+
+              data += implementationMock;
+            }
+
+            const implementationPath = upath.join(
+              dirname,
+              tag,
+              `${kebab(operation)}${extension}`,
+            );
+            await fs.outputFile(implementationPath, data);
+
+            if (output.indexFiles) {
+              await fs.appendFile(
+                indexFilePath,
+                `export * from '${upath.joinSafe('./', kebab(operation))}'\n`,
+              );
+            }
+            return [implementationPath, ...(schemasPath ? [schemasPath] : [])];
+          } catch (e) {
+            throw `Oups... 🍻. An Error occurred while writing operation ${operation} => ${e}`;
+          }
+        }),
+      );
+    }),
+  );
+
+  return generatedFilePathsArray.flatMap((it) => it).flatMap((it) => it);
+};

--- a/packages/core/src/writers/target-operations.ts
+++ b/packages/core/src/writers/target-operations.ts
@@ -1,0 +1,100 @@
+import {
+  GeneratorOperation,
+  GeneratorTarget,
+  GeneratorTargetFull,
+  NormalizedOutputOptions,
+  OutputClient,
+  WriteSpecsBuilder,
+} from '../types';
+import { compareVersions, kebab, pascal } from '../utils';
+
+const addDefaultTagIfEmpty = (operation: GeneratorOperation) => ({
+  ...operation,
+  tags: operation.tags.length ? operation.tags : ['default'],
+});
+
+export const generateTargetForOperations = (
+  builder: WriteSpecsBuilder,
+  options: NormalizedOutputOptions,
+) => {
+  const isAngularClient = options.client === OutputClient.ANGULAR;
+  return Object.values(builder.operations)
+    .map(addDefaultTagIfEmpty)
+    .reduce(
+      (acc, operation, index, arr) => {
+        const isMutator =
+          !!operation.mutator &&
+          (isAngularClient
+            ? operation.mutator.hasThirdArg
+            : operation.mutator.hasSecondArg);
+
+        const typescriptVersion =
+          options.packageJson?.dependencies?.['typescript'] ??
+          options.packageJson?.devDependencies?.['typescript'] ??
+          '4.4.0';
+
+        const hasAwaitedType = compareVersions(typescriptVersion, '4.5.0');
+
+        const titles = builder.title({
+          outputClient: options.client,
+          title: pascal(operation.operationName),
+          customTitleFunc: options.override.title,
+          output: options,
+        });
+
+        const footer = builder.footer({
+          outputClient: options?.client,
+          operationNames: [operation.operationName],
+          hasMutator: !!operation.mutator,
+          hasAwaitedType,
+          titles,
+          output: options,
+        });
+
+        const header = builder.header({
+          outputClient: options.client,
+          isRequestOptions: options.override.requestOptions !== false,
+          isMutator,
+          isGlobalMutator: !!options.override.mutator,
+          provideIn: options.override.angular.provideIn,
+          hasAwaitedType,
+          titles,
+          output: options,
+          verbOptions: builder.verbOptions,
+          tag: operation.tags[0],
+          clientImplementation: operation.implementation,
+        });
+
+        if (!acc[operation.tags[0]]) {
+          acc[operation.tags[0]] = {};
+        }
+        acc[operation.tags[0]][operation.operationName] = {
+          implementation:
+            header.implementation +
+            operation.implementation +
+            footer.implementation,
+          implementationMock:
+            operation.implementationMock.function +
+            operation.implementationMock.handler +
+            header.implementationMock +
+            '  ' +
+            operation.implementationMock.handlerName +
+            '()' +
+            footer.implementationMock,
+          imports: operation.imports,
+          importsMock: operation.importsMock,
+          mutators: operation.mutator ? [operation.mutator] : [],
+          clientMutators: operation.clientMutators,
+          formData: operation.formData ? [operation.formData] : [],
+          formUrlEncoded: operation.formUrlEncoded
+            ? [operation.formUrlEncoded]
+            : [],
+          paramsSerializer: operation.paramsSerializer
+            ? [operation.paramsSerializer]
+            : [],
+        };
+        return acc;
+      },
+      {} as { [tag: string]: { [operation: string]: GeneratorTarget } },
+    );
+};

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -13,7 +13,9 @@ import {
   WriteSpecsBuilder,
   writeSplitMode,
   writeSplitTagsMode,
+  writeSplitTagsOperationsMode,
   writeTagsMode,
+  writeTagsOperationsMode,
 } from '@orval/core';
 import chalk from 'chalk';
 import execa from 'execa';
@@ -63,7 +65,13 @@ export const writeSpecs = async (
   if (output.schemas) {
     const rootSchemaPath = output.schemas;
 
-    const fileExtension = ['tags', 'tags-split', 'split'].includes(output.mode)
+    const fileExtension = [
+      'tags',
+      'tags-split',
+      'split',
+      'tags-operations',
+      'tags-split-operations',
+    ].includes(output.mode)
       ? '.ts'
       : output.fileExtension ?? '.ts';
 
@@ -249,6 +257,10 @@ const getWriteMode = (mode: OutputMode) => {
       return writeTagsMode;
     case OutputMode.TAGS_SPLIT:
       return writeSplitTagsMode;
+    case OutputMode.TAGS_OPERATIONS:
+      return writeTagsOperationsMode;
+    case OutputMode.TAGS_SPLIT_OPERATIONS:
+      return writeSplitTagsOperationsMode;
     case OutputMode.SINGLE:
     default:
       return writeSingleMode;


### PR DESCRIPTION
## Status

**WIP**

## Description

Two new modes for generating one file per operation. Thoughts?

Generated files for `petstore.yaml` in mode `TAGS_OPERATIONS` will be:
```
src/
├── health
│   ├── health-check.ts
│   └── index.ts
├── models
│   └── ...
└── pets
    ├── create-pets.ts
    ├── delete-pet-by-id.ts
    ├── index.ts
    ├── list-pets.ts
    └── show-pet-by-id.ts
```
Generated files for  `petstore.yaml` in mode `TAGS_SPLIT_OPERATIONS` will be:
```
src/
├── health
│   ├── health-check.msw.ts
│   ├── health-check.ts
│   └── index.ts
├── models
│   └── ...
└── pets
    ├── create-pets.msw.ts
    ├── create-pets.ts
    ├── delete-pet-by-id.msw.ts
    ├── delete-pet-by-id.ts
    ├── index.ts
    ├── list-pets.msw.ts
    ├── list-pets.ts
    ├── show-pet-by-id.msw.ts
    └── show-pet-by-id.ts
```
