### PR TITLE
fix(mock): ensure getMockScalar respects custom overrides for int64 format

### DIFF
--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsup ./src/index.ts --target node12 --clean --sourcemap --dts",
     "dev": "tsup ./src/index.ts --target node12 --clean --sourcemap --watch src",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint src/**/*.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@orval/core": "7.4.1",

--- a/packages/mock/src/faker/getters/route.test.ts
+++ b/packages/mock/src/faker/getters/route.test.ts
@@ -1,4 +1,5 @@
 import { getRouteMSW } from './route';
+import { describe, it, expect } from 'vitest';
 
 describe('getRoute getter', () => {
   [

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { getMockScalar } from './scalar';
+import { ContextSpecs } from '@orval/core';
+
+describe('getMockScalar (int64 format handling)', () => {
+  const baseArg = {
+    item: {
+      format: 'int64',
+      minimum: 1,
+      maximum: 100,
+      name: 'test-item',
+    },
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  it('should return faker.number.bigInt() when format is int64, useBigInt is true, and mockOptions.format.int64 is NOT specified', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      context: { output: { override: { useBigInt: true } } } as ContextSpecs,
+    });
+
+    expect(result.value).toBe('faker.number.bigInt({min: 1, max: 100})');
+  });
+
+  it('should return faker.number.int() when format is int64, useBigInt is false, and mockOptions.format.int64 is NOT specified', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      context: { output: { override: { useBigInt: false } } } as ContextSpecs,
+    });
+
+    expect(result.value).toBe('faker.number.int({min: 1, max: 100})');
+  });
+
+  it('should return custom mockOptions.format.int64 when format is int64 and mockOptions.format.int64 IS specified', () => {
+    const specified = 'faker.number.int({ min: 0, max: 200 }).toString()';
+
+    const result = getMockScalar({
+      ...baseArg,
+      mockOptions: {
+        format: {
+          int64: specified,
+        },
+      },
+      context: { output: { override: { useBigInt: true } } } as ContextSpecs,
+    });
+
+    expect(result.value).toBe(specified);
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -101,7 +101,7 @@ export const getMockScalar = ({
     ...(mockOptions?.format ?? {}),
   };
 
-  if (item.format && (item.format === 'int64' || ALL_FORMAT[item.format])) {
+  if (item.format && ALL_FORMAT[item.format]) {
     let value = ALL_FORMAT[item.format] as string;
 
     const dateFormats = ['date', 'date-time'];
@@ -109,12 +109,19 @@ export const getMockScalar = ({
       value = `new Date(${value})`;
     }
 
-    if (item.format === 'int64') {
-      value = context.output.override.useBigInt
-        ? `faker.number.bigInt({min: ${item.minimum}, max: ${item.maximum}})`
-        : `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`;
-    }
+    return {
+      value: getNullable(value, item.nullable),
+      imports: [],
+      name: item.name,
+      overrided: false,
+    };
+  }
 
+  if (item.format && item.format === 'int64') {
+    const value = context.output.override.useBigInt
+      ? `faker.number.bigInt({min: ${item.minimum}, max: ${item.maximum}})`
+      : `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`;
+    
     return {
       value: getNullable(value, item.nullable),
       imports: [],

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -121,7 +121,7 @@ export const getMockScalar = ({
     const value = context.output.override.useBigInt
       ? `faker.number.bigInt({min: ${item.minimum}, max: ${item.maximum}})`
       : `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`;
-    
+
     return {
       value: getNullable(value, item.nullable),
       imports: [],


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes https://github.com/orval-labs/orval/issues/1828

Although commit [6850e62](https://github.com/orval-labs/orval/pull/1829/commits/6850e6223b3f7e28621a3d785aba3589e155e2b0) is not directly related to fixing the issue, changes were made to enable tests in the mock package.