### PR TITLE
fix(core): handle parameters in custom instance returning useCallback

### DIFF
--- a/packages/core/src/generators/mutator.ts
+++ b/packages/core/src/generators/mutator.ts
@@ -259,10 +259,22 @@ const parseFunction = (
       (b: any) => b.type === 'ReturnStatement',
     );
 
+    // If the function directly returns an arrow function
     if (returnStatement?.argument?.params) {
       return {
         numberOfParams: node.params.length,
         returnNumberOfParams: returnStatement.argument.params.length,
+      };
+      // If the function returns a CallExpression (e.g., return useCallback(...))
+    } else if (
+      returnStatement?.argument?.type === 'CallExpression' &&
+      returnStatement.argument.arguments?.[0]?.type ===
+        'ArrowFunctionExpression'
+    ) {
+      const arrowFn = returnStatement.argument.arguments[0];
+      return {
+        numberOfParams: node.params.length,
+        returnNumberOfParams: arrowFn.params.length,
       };
     }
     return {
@@ -291,6 +303,15 @@ const parseFunction = (
     return {
       numberOfParams: declaration.init.params.length,
       returnNumberOfParams: returnStatement.argument.params.length,
+    };
+  } else if (
+    returnStatement?.argument?.type === 'CallExpression' &&
+    returnStatement.argument.arguments?.[0]?.type === 'ArrowFunctionExpression'
+  ) {
+    const arrowFn = returnStatement.argument.arguments[0];
+    return {
+      numberOfParams: declaration.init.params.length,
+      returnNumberOfParams: arrowFn.params.length,
     };
   }
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Resolves #1862

This PR fixes an issue in the code generation process where a custom instance hook returning a function wrapped in `useCallback` loses its second parameter.
