### PR TITLE
fix(hono): remove unnecessary handler import when `tags` mode

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -55,12 +55,13 @@ export const getHonoHeader: ClientHeaderBuilder = ({
 
   let handlers = '';
 
+  const importHandlers = Object.values(verbOptions).filter((verbOption) =>
+    clientImplementation.includes(`${verbOption.operationName}Handlers`),
+  );
+
   if (output.override.hono.handlers) {
     const handlerFileInfo = getFileInfo(output.override.hono.handlers);
-    handlers = Object.values(verbOptions)
-      .filter((verbOption) =>
-        clientImplementation.includes(`${verbOption.operationName}Handlers`),
-      )
+    handlers = importHandlers
       .map((verbOption) => {
         const isTagMode =
           output.mode === 'tags' || output.mode === 'tags-split';
@@ -78,9 +79,11 @@ export const getHonoHeader: ClientHeaderBuilder = ({
       })
       .join('\n');
   } else {
-    handlers = `import {\n${Object.values(verbOptions)
+    const importHandlerNames = importHandlers
       .map((verbOption) => ` ${verbOption.operationName}Handlers`)
-      .join(`, \n`)}\n} from './${tag ?? targetInfo.filename}.handlers';`;
+      .join(`, \n`);
+
+    handlers = `import {\n${importHandlerNames}\n} from './${tag ?? targetInfo.filename}.handlers';`;
   }
 
   return `${handlers}\n\n


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

　
When i specify `tags` or `tags-split` as the `mode` with `hono` client, all handlers are imported into the split routing definition.

```ts
import {
 healthCheckHandlers, // <--- occurred error
 listPetsHandlers, 
 createPetsHandlers, 
 updatePetsHandlers, 
 showPetByIdHandlers
} from './pets.handlers';
```

For example, Since `healthCheck` does not have the `pets` tag, an error occurs due to unnecessary import.
So I fixed it.

## Related PRs

none

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this by using the `petstore` OpenAPI definition.