### PR TITLE
Decode URL encoded parts in  value

### DIFF
--- a/packages/core/src/getters/ref.ts
+++ b/packages/core/src/getters/ref.ts
@@ -51,7 +51,7 @@ export const getRefInfo = (
   const refPaths = ref
     ?.slice(1)
     .split('/')
-    .map((part) => part.replace(regex, '/'));
+    .map((part) => decodeURIComponent(part.replace(regex, '/')));
 
   const suffix = refPaths
     ? get(context.output.override, [...refPaths.slice(0, 2), 'suffix'], '')


### PR DESCRIPTION
## Status

**READY**

## Description

Decode the URL encoded strings in the value of `$ref` to prevent an exception in case a parameter is referenced using ref to another request directly which already has a path parameters and { & } are URL encoded with %7B and %7D respectively.

Fix https://github.com/orval-labs/orval/issues/1834

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

Use orval to convert the schema present in the linked ticket
