### PR TITLE
feat(hono): added the ability to generate composite routes with the `hono` client

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -413,6 +413,7 @@ export type OverrideOutputContentType = {
 
 export type NormalizedHonoOptions = {
   handlers?: string;
+  compositeRoute: string;
   validator: boolean | 'hono';
   validatorOutputPath: string;
 };
@@ -485,6 +486,7 @@ export type NormalizedZodOptions = {
 
 export type HonoOptions = {
   handlers?: string;
+  compositeRoute?: string;
   validator?: boolean | 'hono';
   validatorOutputPath?: string;
 };

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -103,6 +103,13 @@ app.${verb.toLowerCase()}('${path}',...${operationName}Handlers)`;
 };
 
 export const generateHono: ClientBuilder = async (verbOptions, options) => {
+  if (options.override.hono.compositeRoute) {
+    return {
+      implementation: '',
+      imports: [],
+    };
+  }
+
   const routeImplementation = generateHonoRoute(verbOptions, options.pathRoute);
 
   return {

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -94,7 +94,7 @@ export const getHonoFooter: ClientFooterBuilder = () => 'export default app';
 
 const generateHonoRoute = (
   { operationName, verb }: GeneratorVerbOptions,
-  { pathRoute }: GeneratorOptions,
+  pathRoute: string,
 ) => {
   const path = getRoute(pathRoute);
 
@@ -103,7 +103,7 @@ app.${verb.toLowerCase()}('${path}',...${operationName}Handlers)`;
 };
 
 export const generateHono: ClientBuilder = async (verbOptions, options) => {
-  const routeImplementation = generateHonoRoute(verbOptions, options);
+  const routeImplementation = generateHonoRoute(verbOptions, options.pathRoute);
 
   return {
     implementation: routeImplementation ? `${routeImplementation}\n\n` : '',
@@ -962,17 +962,103 @@ export const zValidator =
   };
 };
 
+const generateCompositeRoutes = async (
+  verbOptions: Record<string, GeneratorVerbOptions>,
+  output: NormalizedOutputOptions,
+  context: ContextSpecs,
+) => {
+  const targetInfo = getFileInfo(output.target);
+  const compositeRouteInfo = getFileInfo(output.override.hono.compositeRoute);
+
+  const header = getHeader(
+    output.override.header,
+    context.specs[context.specKey].info,
+  );
+
+  const routes = Object.values(verbOptions)
+    .map((verbOption) => {
+      return generateHonoRoute(verbOption, verbOption.pathRoute);
+    })
+    .join();
+
+  const importHandlers = Object.values(verbOptions);
+
+  let ImportHandlersImplementation = '';
+  if (output.override.hono.handlers) {
+    const handlerFileInfo = getFileInfo(output.override.hono.handlers);
+    const operationNames = importHandlers.map(
+      (verbOption) => verbOption.operationName,
+    );
+
+    ImportHandlersImplementation = operationNames
+      .map((operationName) => {
+        const importHandlerName = `${operationName}Handlers`;
+
+        const handlersPath = upath.relativeSafe(
+          compositeRouteInfo.dirname,
+          upath.join(handlerFileInfo.dirname ?? '', `./${operationName}`),
+        );
+
+        return `import { ${importHandlerName} } from '${handlersPath}';`;
+      })
+      .join('\n');
+  } else {
+    const tags = importHandlers.map((verbOption) =>
+      kebab(verbOption.tags[0] ?? 'default'),
+    );
+    const uniqueTags = tags.filter((t, i) => tags.indexOf(t) === i);
+
+    ImportHandlersImplementation = uniqueTags
+      .map((tag) => {
+        const importHandlerNames = importHandlers
+          .filter((verbOption) => verbOption.tags[0] === tag)
+          .map((verbOption) => ` ${verbOption.operationName}Handlers`)
+          .join(`, \n`);
+
+        const handlersPath = upath.relativeSafe(
+          compositeRouteInfo.dirname,
+          upath.join(targetInfo.dirname ?? '', tag),
+        );
+
+        return `import {\n${importHandlerNames}\n} from '${handlersPath}/${tag}.handlers';`;
+      })
+      .join('\n');
+  }
+
+  const honoImport = `import { Hono } from 'hono';`;
+  const honoInitialization = `\nconst app = new Hono()`;
+  const honoAppExport = `\nexport default app`;
+
+  const content = `${header}${honoImport}
+${ImportHandlersImplementation}
+${honoInitialization}
+${routes}
+${honoAppExport}
+`;
+
+  return [
+    {
+      content,
+      path: output.override.hono.compositeRoute || '',
+    },
+  ];
+};
+
 export const generateExtraFiles: ClientExtraFilesBuilder = async (
   verbOptions,
   output,
   context,
 ) => {
-  const [handlers, contexts, zods, validator] = await Promise.all([
-    generateHandlers(verbOptions, output),
-    generateContext(verbOptions, output, context),
-    generateZodFiles(verbOptions, output, context),
-    generateZvalidator(output, context),
-  ]);
+  const [handlers, contexts, zods, validator, compositeRoutes] =
+    await Promise.all([
+      generateHandlers(verbOptions, output),
+      generateContext(verbOptions, output, context),
+      generateZodFiles(verbOptions, output, context),
+      generateZvalidator(output, context),
+      output.override.hono.compositeRoute
+        ? generateCompositeRoutes(verbOptions, output, context)
+        : [],
+    ]);
 
   return [
     ...handlers,
@@ -982,6 +1068,7 @@ export const generateExtraFiles: ClientExtraFilesBuilder = async (
     output.override.hono.validator !== 'hono'
       ? [validator]
       : []),
+    ...compositeRoutes,
   ];
 };
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -585,6 +585,7 @@ const normalizeHonoOptions = (
     ...(hono.handlers
       ? { handlers: upath.resolve(workspace, hono.handlers) }
       : {}),
+    compositeRoute: hono.compositeRoute ?? '',
     validator: hono.validator ?? true,
     validatorOutputPath: hono.validatorOutputPath
       ? upath.resolve(workspace, hono.validatorOutputPath)


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When i use the `tags-split` option in the `hono` client to auto-generate, a route definition file is generated for each tag.
Therefore, i had to manually define imports for each tag and configure the `hono` app.

### Before

```bash
$ tree hono-app/src/ -L 3
hono-app/src/
└── tags-split
    ├── health
    │   ├── health.context.ts
    │   ├── health.handlers.ts
    │   ├── health.ts              <--- health route definition file
    │   └── health.zod.ts
    ├── pets
    │   ├── pets.context.ts
    │   ├── pets.handlers.ts
    │   ├── pets.ts                <--- pets route definition file
    │   └── pets.zod.ts
    ├── schemas
    │   ├── createPetsBodyItem.ts
    │   ├── error.ts
    │   ├── index.ts
    │   ├── listPetsParams.ts
    │   ├── pet.ts
    │   └── pets.ts
    └── validator.ts
```

So, i added new option `orverride.hono.compositeRoutes`.
This will generate a composite route file that imports all the route definition files instead of each file for the tag.

### After

```bash

tree hono-app/src/ -L 3
hono-app/src/
└── tags-split
    ├── health
    │   ├── health.context.ts
    │   ├── health.handlers.ts
    │   └── health.zod.ts
    ├── pets
    │   ├── pets.context.ts
    │   ├── pets.handlers.ts
    │   └── pets.zod.ts
    ├── routes.ts                   <--- composite routes
    ├── schemas
    │   ├── createPetsBodyItem.ts
    │   ├── error.ts
    │   ├── index.ts
    │   ├── listPetsParams.ts
    │   ├── pet.ts
    │   └── pets.ts
    └── validator.ts
```

In the `hono` server configuration, it is always sufficient to refer only to `routes.ts`.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this with the following settings:

```ts
import { defineConfig } from 'orval';

export default defineConfig({
petstoreTagSplitApi: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'hono',
      target: 'hono-app/src',
      schemas: 'hono-app/src/schemas',
      override: {
        hono: {
          compositeRoute: 'hono-app/src/routes.ts',
          validatorOutputPath: 'hono-app/src/validator.ts',
        },
      },
    },
  },
});
```