### PR TITLE
feat: Sanitize model names in

### DIFF
--- a/packages/core/src/getters/ref.ts
+++ b/packages/core/src/getters/ref.ts
@@ -1,7 +1,7 @@
 import get from 'lodash.get';
 import { ReferenceObject } from 'openapi3-ts/oas30';
 import { ContextSpecs } from '../types';
-import { getFileInfo, isUrl, pascal, upath } from '../utils';
+import { getFileInfo, isUrl, pascal, sanitize, upath } from '../utils';
 
 type RefComponent = 'schemas' | 'responses' | 'parameters' | 'requestBodies';
 
@@ -63,7 +63,10 @@ export const getRefInfo = (
 
   if (!pathname) {
     return {
-      name: pascal(originalName) + suffix,
+      name: sanitize(pascal(originalName) + suffix, {
+        es5keyword: true,
+        es5IdentifierName: true,
+      }),
       originalName,
       refPaths,
     };
@@ -74,7 +77,10 @@ export const getRefInfo = (
     : upath.resolve(getFileInfo(context.specKey).dirname, pathname);
 
   return {
-    name: pascal(originalName) + suffix,
+    name: sanitize(pascal(originalName) + suffix, {
+      es5keyword: true,
+      es5IdentifierName: true,
+    }),
     originalName,
     specKey: path,
     refPaths,


### PR DESCRIPTION
## Status

**READY**

## Description

If the component name in the schema was not a valid name from TypeScript, Orval generated a client which had syntax errors, these changes sanitizes the generated name to make it TypeScript compatible. 

Fix #1858 

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

A schema which produces error syntax is available in the issue description. 

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
