### PR TITLE
fix(fetch): Improved error handling when body does not exist in `fetch` client

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -196,9 +196,9 @@ ${
     : `const res = await fetch(${fetchFnOptions})
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text()
-  const data: ${response.definition.success} = body ? JSON.parse(body) : {}
+  const data: ${responseTypeName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = body ? JSON.parse(body) : {}
 
-  ${override.fetch.includeHttpResponseReturnType ? 'return { status: res.status, data, headers: res.headers }' : 'return data'}
+  ${override.fetch.includeHttpResponseReturnType ? `return { data, status: res.status, headers: res.headers } as ${responseTypeName}` : 'return data'}
 `;
   const customFetchResponseImplementation = `return ${mutator?.name}<${responseTypeName}>(${fetchFnOptions});`;
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -195,9 +195,10 @@ ${
   `
     : `const res = await fetch(${fetchFnOptions})
 
-  const data:${responseDataType} = ([204, 205, 304].includes(res.status) || !res.body) ? {} : await res.json()
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text()
+  const data: ${response.definition.success} = body ? JSON.parse(body) : {}
 
-  ${override.fetch.includeHttpResponseReturnType ? 'return { status: res.status, data, headers: res.headers }' : `return data as ${responseTypeName}`}
+  ${override.fetch.includeHttpResponseReturnType ? 'return { status: res.status, data, headers: res.headers }' : 'return data'}
 `;
   const customFetchResponseImplementation = `return ${mutator?.name}<${responseTypeName}>(${fetchFnOptions});`;
 

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -44,10 +44,10 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: listPetsResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
 /**
@@ -74,10 +74,14 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: createPetsResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as createPetsResponse;
 };
 
 /**
@@ -104,10 +108,14 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: updatePetsResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as updatePetsResponse;
 };
 
 /**
@@ -132,8 +140,12 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as showPetByIdResponse;
 };

--- a/samples/hono/hono-with-zod/src/petstore.validator.ts
+++ b/samples/hono/hono-with-zod/src/petstore.validator.ts
@@ -141,4 +141,6 @@ export const zValidator =
         c.res = new Response(JSON.stringify(result.data), c.res);
       }
     }
+
+    return;
   };

--- a/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
@@ -31,24 +31,17 @@ export const getListPetsResponseDachshundMock = (
 export const getListPetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getListPetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getListPetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseLabradoodleMock() },
+      { ...getListPetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -69,48 +62,28 @@ export const getListPetsResponseMock = (): Pets =>
   Array.from(
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
-  ).map(() =>
-    faker.helpers.arrayElement([
-      {
-        ...getListPetsResponseDogMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
-      {
-        ...getListPetsResponseCatMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
+  ).map(() => ({
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseDogMock() },
+      { ...getListPetsResponseCatMock() },
     ]),
-  );
+    '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    id: faker.number.int({ min: undefined, max: undefined }),
+    name: faker.string.alpha(20),
+    tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+    callingCode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+      undefined,
+    ]),
+    country: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([
+        "People's Republic of China",
+        'Uruguay',
+      ] as const),
+      undefined,
+    ]),
+  }));
 
 export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -135,24 +108,17 @@ export const getCreatePetsResponseDachshundMock = (
 export const getCreatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getCreatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getCreatePetsResponseLabradoodleMock() },
+      { ...getCreatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -169,47 +135,28 @@ export const getCreatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getCreatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getCreatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getCreatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getCreatePetsResponseDogMock() },
+    { ...getCreatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -234,24 +181,17 @@ export const getUpdatePetsResponseDachshundMock = (
 export const getUpdatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getUpdatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getUpdatePetsResponseLabradoodleMock() },
+      { ...getUpdatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -268,47 +208,28 @@ export const getUpdatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getUpdatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getUpdatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getUpdatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getUpdatePetsResponseDogMock() },
+    { ...getUpdatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -333,24 +254,17 @@ export const getShowPetByIdResponseDachshundMock = (
 export const getShowPetByIdResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getShowPetByIdResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getShowPetByIdResponseLabradoodleMock() },
+      { ...getShowPetByIdResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -367,47 +281,28 @@ export const getShowPetByIdResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getShowPetByIdResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getShowPetByIdResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getShowPetByIdResponseDogMock() },
+    { ...getShowPetByIdResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getListPetsMockHandler = (
   overrideResponse?:

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -42,10 +42,10 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: Pets = body ? JSON.parse(body) : {};
 
-  return data as Pets;
+  return data;
 };
 
 export const getListPetsKey = (params?: ListPetsParams) =>
@@ -106,10 +106,10 @@ export const createPets = async (
     body: JSON.stringify(createPetsBody),
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: Pet = body ? JSON.parse(body) : {};
 
-  return data as Pet;
+  return data;
 };
 
 export const getCreatePetsMutationFetcher = (options?: RequestInit) => {
@@ -167,10 +167,10 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: Pet = body ? JSON.parse(body) : {};
 
-  return data as Pet;
+  return data;
 };
 
 export const getShowPetByIdKey = (petId: string) =>

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -31,24 +31,17 @@ export const getListPetsResponseDachshundMock = (
 export const getListPetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getListPetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getListPetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseLabradoodleMock() },
+      { ...getListPetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -69,48 +62,28 @@ export const getListPetsResponseMock = (): Pets =>
   Array.from(
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
-  ).map(() =>
-    faker.helpers.arrayElement([
-      {
-        ...getListPetsResponseDogMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
-      {
-        ...getListPetsResponseCatMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
+  ).map(() => ({
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseDogMock() },
+      { ...getListPetsResponseCatMock() },
     ]),
-  );
+    '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    id: faker.number.int({ min: undefined, max: undefined }),
+    name: faker.string.alpha(20),
+    tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+    callingCode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+      undefined,
+    ]),
+    country: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([
+        "People's Republic of China",
+        'Uruguay',
+      ] as const),
+      undefined,
+    ]),
+  }));
 
 export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -135,24 +108,17 @@ export const getCreatePetsResponseDachshundMock = (
 export const getCreatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getCreatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getCreatePetsResponseLabradoodleMock() },
+      { ...getCreatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -169,47 +135,28 @@ export const getCreatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getCreatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getCreatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getCreatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getCreatePetsResponseDogMock() },
+    { ...getCreatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -234,24 +181,17 @@ export const getUpdatePetsResponseDachshundMock = (
 export const getUpdatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getUpdatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getUpdatePetsResponseLabradoodleMock() },
+      { ...getUpdatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -268,47 +208,28 @@ export const getUpdatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getUpdatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getUpdatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getUpdatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getUpdatePetsResponseDogMock() },
+    { ...getUpdatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -333,24 +254,17 @@ export const getShowPetByIdResponseDachshundMock = (
 export const getShowPetByIdResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getShowPetByIdResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getShowPetByIdResponseLabradoodleMock() },
+      { ...getShowPetByIdResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -367,47 +281,28 @@ export const getShowPetByIdResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getShowPetByIdResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getShowPetByIdResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getShowPetByIdResponseDogMock() },
+    { ...getShowPetByIdResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getListPetsMockHandler = (
   overrideResponse?:

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -31,24 +31,17 @@ export const getListPetsResponseDachshundMock = (
 export const getListPetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getListPetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getListPetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseLabradoodleMock() },
+      { ...getListPetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -69,48 +62,28 @@ export const getListPetsResponseMock = (): Pets =>
   Array.from(
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
-  ).map(() =>
-    faker.helpers.arrayElement([
-      {
-        ...getListPetsResponseDogMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
-      {
-        ...getListPetsResponseCatMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
+  ).map(() => ({
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseDogMock() },
+      { ...getListPetsResponseCatMock() },
     ]),
-  );
+    '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    id: faker.number.int({ min: undefined, max: undefined }),
+    name: faker.string.alpha(20),
+    tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+    callingCode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+      undefined,
+    ]),
+    country: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([
+        "People's Republic of China",
+        'Uruguay',
+      ] as const),
+      undefined,
+    ]),
+  }));
 
 export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -135,24 +108,17 @@ export const getCreatePetsResponseDachshundMock = (
 export const getCreatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getCreatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getCreatePetsResponseLabradoodleMock() },
+      { ...getCreatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -169,47 +135,28 @@ export const getCreatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getCreatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getCreatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getCreatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getCreatePetsResponseDogMock() },
+    { ...getCreatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -234,24 +181,17 @@ export const getUpdatePetsResponseDachshundMock = (
 export const getUpdatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getUpdatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getUpdatePetsResponseLabradoodleMock() },
+      { ...getUpdatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -268,47 +208,28 @@ export const getUpdatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getUpdatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getUpdatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getUpdatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getUpdatePetsResponseDogMock() },
+    { ...getUpdatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -333,24 +254,17 @@ export const getShowPetByIdResponseDachshundMock = (
 export const getShowPetByIdResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getShowPetByIdResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getShowPetByIdResponseLabradoodleMock() },
+      { ...getShowPetByIdResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -367,47 +281,28 @@ export const getShowPetByIdResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getShowPetByIdResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getShowPetByIdResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getShowPetByIdResponseDogMock() },
+    { ...getShowPetByIdResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getListPetsMockHandler = (
   overrideResponse?:

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.msw.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.msw.ts
@@ -31,24 +31,17 @@ export const getListPetsResponseDachshundMock = (
 export const getListPetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getListPetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getListPetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseLabradoodleMock() },
+      { ...getListPetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -69,48 +62,28 @@ export const getListPetsResponseMock = (): Pets =>
   Array.from(
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
-  ).map(() =>
-    faker.helpers.arrayElement([
-      {
-        ...getListPetsResponseDogMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
-      {
-        ...getListPetsResponseCatMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
+  ).map(() => ({
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseDogMock() },
+      { ...getListPetsResponseCatMock() },
     ]),
-  );
+    '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    id: faker.number.int({ min: undefined, max: undefined }),
+    name: faker.string.alpha(20),
+    tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+    callingCode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+      undefined,
+    ]),
+    country: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([
+        "People's Republic of China",
+        'Uruguay',
+      ] as const),
+      undefined,
+    ]),
+  }));
 
 export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -135,24 +108,17 @@ export const getCreatePetsResponseDachshundMock = (
 export const getCreatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getCreatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getCreatePetsResponseLabradoodleMock() },
+      { ...getCreatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -169,47 +135,28 @@ export const getCreatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getCreatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getCreatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getCreatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getCreatePetsResponseDogMock() },
+    { ...getCreatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -234,24 +181,17 @@ export const getUpdatePetsResponseDachshundMock = (
 export const getUpdatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getUpdatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getUpdatePetsResponseLabradoodleMock() },
+      { ...getUpdatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -268,47 +208,28 @@ export const getUpdatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getUpdatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getUpdatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getUpdatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getUpdatePetsResponseDogMock() },
+    { ...getUpdatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -333,24 +254,17 @@ export const getShowPetByIdResponseDachshundMock = (
 export const getShowPetByIdResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getShowPetByIdResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getShowPetByIdResponseLabradoodleMock() },
+      { ...getShowPetByIdResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -367,47 +281,28 @@ export const getShowPetByIdResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getShowPetByIdResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getShowPetByIdResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getShowPetByIdResponseDogMock() },
+    { ...getShowPetByIdResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getListPetsMockHandler = (
   overrideResponse?:

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -76,10 +76,10 @@ export const listPets = async (
     method: 'GET',
   });
 
-  const data: Pets =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: listPetsResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
 export const getListPetsKey = (params?: ListPetsParams) =>
@@ -145,10 +145,14 @@ export const createPets = async (
     body: JSON.stringify(createPetsBodyItem),
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: createPetsResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as createPetsResponse;
 };
 
 export const getCreatePetsMutationFetcher = (options?: RequestInit) => {
@@ -216,10 +220,14 @@ export const updatePets = async (
     body: JSON.stringify(pet),
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: updatePetsResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as updatePetsResponse;
 };
 
 export const getUpdatePetsMutationFetcher = (options?: RequestInit) => {
@@ -285,10 +293,14 @@ export const showPetById = async (
     method: 'GET',
   });
 
-  const data: Pet =
-    [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};
 
-  return { status: res.status, data, headers: res.headers };
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as showPetByIdResponse;
 };
 
 export const getShowPetByIdKey = (petId: string) =>

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -31,24 +31,17 @@ export const getListPetsResponseDachshundMock = (
 export const getListPetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getListPetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getListPetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseLabradoodleMock() },
+      { ...getListPetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -69,48 +62,28 @@ export const getListPetsResponseMock = (): Pets =>
   Array.from(
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
-  ).map(() =>
-    faker.helpers.arrayElement([
-      {
-        ...getListPetsResponseDogMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
-      {
-        ...getListPetsResponseCatMock(),
-        '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        id: faker.number.int({ min: undefined, max: undefined }),
-        name: faker.string.alpha(20),
-        tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-        email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-        callingCode: faker.helpers.arrayElement([
-          faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-          undefined,
-        ]),
-        country: faker.helpers.arrayElement([
-          faker.helpers.arrayElement([
-            "People's Republic of China",
-            'Uruguay',
-          ] as const),
-          undefined,
-        ]),
-      },
+  ).map(() => ({
+    ...faker.helpers.arrayElement([
+      { ...getListPetsResponseDogMock() },
+      { ...getListPetsResponseCatMock() },
     ]),
-  );
+    '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    id: faker.number.int({ min: undefined, max: undefined }),
+    name: faker.string.alpha(20),
+    tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+    email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+    callingCode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+      undefined,
+    ]),
+    country: faker.helpers.arrayElement([
+      faker.helpers.arrayElement([
+        "People's Republic of China",
+        'Uruguay',
+      ] as const),
+      undefined,
+    ]),
+  }));
 
 export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -135,24 +108,17 @@ export const getCreatePetsResponseDachshundMock = (
 export const getCreatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getCreatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getCreatePetsResponseLabradoodleMock() },
+      { ...getCreatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -169,47 +135,28 @@ export const getCreatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getCreatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getCreatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getCreatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getCreatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getCreatePetsResponseDogMock() },
+    { ...getCreatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -234,24 +181,17 @@ export const getUpdatePetsResponseDachshundMock = (
 export const getUpdatePetsResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getUpdatePetsResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getUpdatePetsResponseLabradoodleMock() },
+      { ...getUpdatePetsResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -268,47 +208,28 @@ export const getUpdatePetsResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getUpdatePetsResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getUpdatePetsResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getUpdatePetsResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getUpdatePetsResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getUpdatePetsResponseDogMock() },
+    { ...getUpdatePetsResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
@@ -333,24 +254,17 @@ export const getShowPetByIdResponseDachshundMock = (
 export const getShowPetByIdResponseDogMock = (
   overrideResponse: Omit<Partial<Dog>, 'breed'> = {},
 ): Dog => ({
-  ...faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseLabradoodleMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-    {
-      ...getShowPetByIdResponseDachshundMock(),
-      barksPerMinute: faker.helpers.arrayElement([
-        faker.number.int({ min: undefined, max: undefined }),
-        undefined,
-      ]),
-      type: faker.helpers.arrayElement(['dog'] as const),
-    },
-  ]),
+  ...{
+    ...faker.helpers.arrayElement([
+      { ...getShowPetByIdResponseLabradoodleMock() },
+      { ...getShowPetByIdResponseDachshundMock() },
+    ]),
+    barksPerMinute: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    type: faker.helpers.arrayElement(['dog'] as const),
+  },
   ...overrideResponse,
 });
 
@@ -367,47 +281,28 @@ export const getShowPetByIdResponseCatMock = (
   ...overrideResponse,
 });
 
-export const getShowPetByIdResponseMock = (): Pet =>
-  faker.helpers.arrayElement([
-    {
-      ...getShowPetByIdResponseDogMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-    {
-      ...getShowPetByIdResponseCatMock(),
-      '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      id: faker.number.int({ min: undefined, max: undefined }),
-      name: faker.string.alpha(20),
-      tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
-      email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
-      callingCode: faker.helpers.arrayElement([
-        faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
-        undefined,
-      ]),
-      country: faker.helpers.arrayElement([
-        faker.helpers.arrayElement([
-          "People's Republic of China",
-          'Uruguay',
-        ] as const),
-        undefined,
-      ]),
-    },
-  ]);
+export const getShowPetByIdResponseMock = (): Pet => ({
+  ...faker.helpers.arrayElement([
+    { ...getShowPetByIdResponseDogMock() },
+    { ...getShowPetByIdResponseCatMock() },
+  ]),
+  '@id': faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  id: faker.number.int({ min: undefined, max: undefined }),
+  name: faker.string.alpha(20),
+  tag: faker.helpers.arrayElement([faker.string.alpha(20), undefined]),
+  email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
+  callingCode: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(['+33', '+420', '+33'] as const),
+    undefined,
+  ]),
+  country: faker.helpers.arrayElement([
+    faker.helpers.arrayElement([
+      "People's Republic of China",
+      'Uruguay',
+    ] as const),
+    undefined,
+  ]),
+});
 
 export const getListPetsMockHandler = (
   overrideResponse?:


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1854 
The automatically generated source code has been changed as follows.

#### When `includeHttpResponseReturnType` is `true` (default):

```diff
+ const body = [204, 205, 304].includes(res.status) ? null : await res.text();
- const data: Pet = [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+ const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};

-  return { status: res.status, data, headers: res.headers };
+  return { data, status: res.status, headers: res.headers } as showPetByIdResponse;
```

#### When `includeHttpResponseReturnType` is `false`:

```diff
+ const body = [204, 205, 304].includes(res.status) ? null : await res.text();
- const data: Pet = [204, 205, 304].includes(res.status) || !res.body ? {} : await res.json();
+ const data: Pets = body ? JSON.parse(body) : {};

-  return data as Pets
+  return data;
```



## Related PRs

- #1773
- #1776

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Both patterns of options you can see in the sample app.