### PR TITLE
fix(query): regression that breaks `TData` type check when using custom mutation

### DIFF
--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -153,7 +153,7 @@ export function useListPetsInfinite<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPets>>,
           TError,
-          TData,
+          Awaited<ReturnType<typeof listPets>>,
           QueryKey
         >,
         'initialData'
@@ -186,7 +186,7 @@ export function useListPetsInfinite<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPets>>,
           TError,
-          TData,
+          Awaited<ReturnType<typeof listPets>>,
           QueryKey
         >,
         'initialData'
@@ -313,7 +313,7 @@ export function useListPets<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPets>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof listPets>>
         >,
         'initialData'
       >;
@@ -335,7 +335,7 @@ export function useListPets<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPets>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof listPets>>
         >,
         'initialData'
       >;
@@ -701,17 +701,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody; version?: number },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -730,12 +734,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody; version?: number },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -748,18 +747,17 @@ export type CreatePetsMutationError = ErrorType<Error>;
  * @summary Create a pet
  */
 export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
 }): UseMutationResult<
-  TData,
+  Awaited<ReturnType<typeof createPets>>,
   TError,
   { data: CreatePetsBody; version?: number },
   TContext
@@ -855,7 +853,7 @@ export function useListPetsNestedArray<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPetsNestedArray>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof listPetsNestedArray>>
         >,
         'initialData'
       >;
@@ -881,7 +879,7 @@ export function useListPetsNestedArray<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPetsNestedArray>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof listPetsNestedArray>>
         >,
         'initialData'
       >;
@@ -1009,7 +1007,7 @@ export function useShowPetById<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof showPetById>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof showPetById>>
         >,
         'initialData'
       >;
@@ -1031,7 +1029,7 @@ export function useShowPetById<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof showPetById>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof showPetById>>
         >,
         'initialData'
       >;

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -153,17 +153,21 @@ export const useCreatePetsHook = () => {
 };
 
 export const useCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
     { data: BodyType<CreatePetsBody>; version?: number },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
+  TError,
+  { data: BodyType<CreatePetsBody>; version?: number },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -184,12 +188,7 @@ export const useCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: BodyType<CreatePetsBody>; version?: number },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -202,18 +201,17 @@ export type CreatePetsMutationError = ErrorType<Error>;
  * @summary Create a pet
  */
 export const useCreatePets = <
-  TData = Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError = ErrorType<Error>,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
     { data: BodyType<CreatePetsBody>; version?: number },
     TContext
   >;
 }): UseMutationResult<
-  TData,
+  Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
   { data: BodyType<CreatePetsBody>; version?: number },
   TContext

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -139,7 +139,7 @@ export function useListPets<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPets>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof listPets>>
         >,
         'initialData'
       >;
@@ -161,7 +161,7 @@ export function useListPets<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof listPets>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof listPets>>
         >,
         'initialData'
       >;
@@ -233,18 +233,22 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBodyItem[] },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -263,12 +267,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBodyItem[] },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -280,20 +279,16 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationResult<
-  TData,
+  Awaited<ReturnType<typeof createPets>>,
   TError,
   { data: CreatePetsBodyItem[] },
   TContext
@@ -328,18 +323,22 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof updatePets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof updatePets>>,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updatePets>>,
+  TError,
+  { data: NonReadonly<Pet> },
+  TContext
+> => {
   const mutationKey = ['updatePets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -358,12 +357,7 @@ export const getUpdatePetsMutationOptions = <
     return updatePets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: NonReadonly<Pet> },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type UpdatePetsMutationResult = NonNullable<
@@ -375,19 +369,20 @@ export type UpdatePetsMutationError = Error;
 /**
  * @summary Update a pet
  */
-export const useUpdatePets = <
-  TData = Awaited<ReturnType<typeof updatePets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useUpdatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof updatePets>>,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}): UseMutationResult<TData, TError, { data: NonReadonly<Pet> }, TContext> => {
+}): UseMutationResult<
+  Awaited<ReturnType<typeof updatePets>>,
+  TError,
+  { data: NonReadonly<Pet> },
+  TContext
+> => {
   const mutationOptions = getUpdatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);
@@ -469,7 +464,7 @@ export function useShowPetById<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof showPetById>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof showPetById>>
         >,
         'initialData'
       >;
@@ -491,7 +486,7 @@ export function useShowPetById<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof showPetById>>,
           TError,
-          TData
+          Awaited<ReturnType<typeof showPetById>>
         >,
         'initialData'
       >;

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -123,17 +123,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -152,12 +156,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -169,18 +168,19 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}): UseMutationResult<TData, TError, { data: CreatePetsBody }, TContext> => {
+}): UseMutationResult<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationOptions = getCreatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);

--- a/samples/react-query/form-data/endpoints.ts
+++ b/samples/react-query/form-data/endpoints.ts
@@ -123,17 +123,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -152,12 +156,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -169,18 +168,19 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}): UseMutationResult<TData, TError, { data: CreatePetsBody }, TContext> => {
+}): UseMutationResult<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationOptions = getCreatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -124,17 +124,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -153,12 +157,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -170,18 +169,19 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}): UseMutationResult<TData, TError, { data: CreatePetsBody }, TContext> => {
+}): UseMutationResult<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationOptions = getCreatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -123,17 +123,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -152,12 +156,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -169,18 +168,19 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}): UseMutationResult<TData, TError, { data: CreatePetsBody }, TContext> => {
+}): UseMutationResult<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationOptions = getCreatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);

--- a/samples/react-query/hook-mutator/endpoints.ts
+++ b/samples/react-query/hook-mutator/endpoints.ts
@@ -132,17 +132,21 @@ export const useCreatePetsHook = () => {
 };
 
 export const useCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -163,12 +167,7 @@ export const useCreatePetsMutationOptions = <
     return createPets(data);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -180,18 +179,19 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
     { data: CreatePetsBody },
     TContext
   >;
-}): UseMutationResult<TData, TError, { data: CreatePetsBody }, TContext> => {
+}): UseMutationResult<
+  Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
+  TError,
+  { data: CreatePetsBody },
+  TContext
+> => {
   const mutationOptions = useCreatePetsMutationOptions(options);
 
   return useMutation(mutationOptions);

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -134,17 +134,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: CreateMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
-}) => {
+}): CreateMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody; version?: number },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -163,12 +167,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions } as CreateMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody; version?: number },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -180,19 +179,15 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const createCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody; version?: number },
     TContext
   >;
 }): CreateMutationResult<
-  TData,
+  Awaited<ReturnType<typeof createPets>>,
   TError,
   { data: CreatePetsBody; version?: number },
   TContext

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -180,18 +180,22 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: CreateMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}) => {
+}): CreateMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBodyItem[] },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -210,12 +214,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions } as CreateMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBodyItem[] },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -227,20 +226,16 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const createCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
-  TData,
+  Awaited<ReturnType<typeof createPets>>,
   TError,
   { data: CreatePetsBodyItem[] },
   TContext
@@ -275,18 +270,22 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof updatePets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: CreateMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof updatePets>>,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}) => {
+}): CreateMutationOptions<
+  Awaited<ReturnType<typeof updatePets>>,
+  TError,
+  { data: NonReadonly<Pet> },
+  TContext
+> => {
   const mutationKey = ['updatePets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -305,12 +304,7 @@ export const getUpdatePetsMutationOptions = <
     return updatePets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions } as CreateMutationOptions<
-    TData,
-    TError,
-    { data: NonReadonly<Pet> },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type UpdatePetsMutationResult = NonNullable<
@@ -322,20 +316,16 @@ export type UpdatePetsMutationError = Error;
 /**
  * @summary Update a pet
  */
-export const createUpdatePets = <
-  TData = Awaited<ReturnType<typeof updatePets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const createUpdatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof updatePets>>,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
-  TData,
+  Awaited<ReturnType<typeof updatePets>>,
   TError,
   { data: NonReadonly<Pet> },
   TContext

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -183,18 +183,22 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBodyItem[] },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -213,12 +217,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBodyItem[] },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -230,20 +229,16 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBodyItem[] },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationReturnType<
-  TData,
+  Awaited<ReturnType<typeof createPets>>,
   TError,
   { data: CreatePetsBodyItem[] },
   TContext
@@ -278,18 +273,22 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof updatePets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof updatePets>>,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updatePets>>,
+  TError,
+  { data: NonReadonly<Pet> },
+  TContext
+> => {
   const mutationKey = ['updatePets'];
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
@@ -308,12 +307,7 @@ export const getUpdatePetsMutationOptions = <
     return updatePets(data, requestOptions);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: NonReadonly<Pet> },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type UpdatePetsMutationResult = NonNullable<
@@ -325,20 +319,16 @@ export type UpdatePetsMutationError = Error;
 /**
  * @summary Update a pet
  */
-export const useUpdatePets = <
-  TData = Awaited<ReturnType<typeof updatePets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useUpdatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof updatePets>>,
     TError,
     { data: NonReadonly<Pet> },
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationReturnType<
-  TData,
+  Awaited<ReturnType<typeof updatePets>>,
   TError,
   { data: NonReadonly<Pet> },
   TContext

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -237,17 +237,21 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationOptions = <
-  TData = Awaited<ReturnType<typeof createPets>>,
   TError = Error,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody; version?: number | undefined | null },
     TContext
   >;
-}) => {
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createPets>>,
+  TError,
+  { data: CreatePetsBody; version?: number | undefined | null },
+  TContext
+> => {
   const mutationKey = ['createPets'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -266,12 +270,7 @@ export const getCreatePetsMutationOptions = <
     return createPets(data, version);
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    { data: CreatePetsBody; version?: number | undefined | null },
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type CreatePetsMutationResult = NonNullable<
@@ -283,19 +282,15 @@ export type CreatePetsMutationError = Error;
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <
-  TData = Awaited<ReturnType<typeof createPets>>,
-  TError = Error,
-  TContext = unknown,
->(options?: {
+export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
-    TData,
+    Awaited<ReturnType<typeof createPets>>,
     TError,
     { data: CreatePetsBody; version?: number | undefined | null },
     TContext
   >;
 }): UseMutationReturnType<
-  TData,
+  Awaited<ReturnType<typeof createPets>>,
   TError,
   { data: CreatePetsBody; version?: number | undefined | null },
   TContext
@@ -481,12 +476,21 @@ export const postApiV1UserLogout = (signal?: AbortSignal) => {
 };
 
 export const getPostApiV1UserLogoutMutationOptions = <
-  TData = Awaited<ReturnType<typeof postApiV1UserLogout>>,
   TError = unknown,
   TContext = unknown,
 >(options?: {
-  mutation?: UseMutationOptions<TData, TError, void, TContext>;
-}) => {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postApiV1UserLogout>>,
+    TError,
+    void,
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postApiV1UserLogout>>,
+  TError,
+  void,
+  TContext
+> => {
   const mutationKey = ['postApiV1UserLogout'];
   const { mutation: mutationOptions } = options
     ? options.mutation &&
@@ -503,12 +507,7 @@ export const getPostApiV1UserLogoutMutationOptions = <
     return postApiV1UserLogout();
   };
 
-  return { mutationFn, ...mutationOptions } as UseMutationOptions<
-    TData,
-    TError,
-    void,
-    TContext
-  >;
+  return { mutationFn, ...mutationOptions };
 };
 
 export type PostApiV1UserLogoutMutationResult = NonNullable<
@@ -521,12 +520,21 @@ export type PostApiV1UserLogoutMutationError = unknown;
  * @summary This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/orval-labs/orval/issues/857#issuecomment-1835317990
  */
 export const usePostApiV1UserLogout = <
-  TData = Awaited<ReturnType<typeof postApiV1UserLogout>>,
   TError = unknown,
   TContext = unknown,
 >(options?: {
-  mutation?: UseMutationOptions<TData, TError, void, TContext>;
-}): UseMutationReturnType<TData, TError, void, TContext> => {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postApiV1UserLogout>>,
+    TError,
+    void,
+    TContext
+  >;
+}): UseMutationReturnType<
+  Awaited<ReturnType<typeof postApiV1UserLogout>>,
+  TError,
+  void,
+  TContext
+> => {
   const mutationOptions = getPostApiV1UserLogoutMutationOptions(options);
 
   return useMutation(mutationOptions);


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1820
This is a revert of #1735.
#1805 was also partially reverted, but I did a complete revert with this PR.
In #1735, we tried to improve type safety, but it seems like we made a bug. I'm not expecting this problem, so I'll revert it.

## Related PRs

- #1735 
- #1805 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check by tests and sample apps
