### PR TITLE
fix(core): don't union required with already required props

### DIFF
--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -55,8 +55,21 @@ const combineValues = ({
     const joined = `${resolvedData.values.join(` & `)}${
       resolvedValue ? ` & ${resolvedValue.value}` : ''
     }`;
-    if (resolvedData.requiredProperties.length) {
-      return `${joined} & Required<Pick<${joined}, '${resolvedData.requiredProperties.join("' | '")}'>>`;
+
+    // Parent object may have set required properties that only exist in child
+    // objects. Make sure the resulting object has these properties as required,
+    // but there is no need to override properties that are already required
+    const overrideRequiredProperties = resolvedData.requiredProperties.filter(
+      (prop) =>
+        !resolvedData.originalSchema.some(
+          (schema) =>
+            schema &&
+            schema.properties?.[prop] &&
+            schema.required?.includes(prop),
+        ),
+    );
+    if (overrideRequiredProperties.length) {
+      return `${joined} & Required<Pick<${joined}, '${overrideRequiredProperties.join("' | '")}'>>`;
     }
     return joined;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,23 +1253,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.4.1, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.5.0, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.4.1, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.5.0, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.4.1, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.5.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1308,62 +1308,62 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.4.1, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.5.0, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.4.1, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.5.0, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.4.1"
-    "@orval/zod": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
+    "@orval/zod": "npm:7.5.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.4.1, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.5.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
     lodash.get: "npm:^4.4.2"
     lodash.omit: "npm:^4.5.0"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.4.1, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.5.0, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.4.1"
-    "@orval/fetch": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
+    "@orval/fetch": "npm:7.5.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.4.1, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.5.0, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.4.1"
-    "@orval/fetch": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
+    "@orval/fetch": "npm:7.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.4.1, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.5.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.4.1"
+    "@orval/core": "npm:7.5.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -7517,15 +7517,15 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@orval/angular": "npm:7.4.1"
-    "@orval/axios": "npm:7.4.1"
-    "@orval/core": "npm:7.4.1"
-    "@orval/fetch": "npm:7.4.1"
-    "@orval/hono": "npm:7.4.1"
-    "@orval/mock": "npm:7.4.1"
-    "@orval/query": "npm:7.4.1"
-    "@orval/swr": "npm:7.4.1"
-    "@orval/zod": "npm:7.4.1"
+    "@orval/angular": "npm:7.5.0"
+    "@orval/axios": "npm:7.5.0"
+    "@orval/core": "npm:7.5.0"
+    "@orval/fetch": "npm:7.5.0"
+    "@orval/hono": "npm:7.5.0"
+    "@orval/mock": "npm:7.5.0"
+    "@orval/query": "npm:7.5.0"
+    "@orval/swr": "npm:7.5.0"
+    "@orval/zod": "npm:7.5.0"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #1877 

Previously, `/generated/default/all-of/getNotHasPropertiesWithAllOfPets200.ts` had this generated code:
```ts
export type GetNotHasPropertiesWithAllOfPets200 = Pet &
  PetDetail &
  GetNotHasPropertiesWithAllOfPets200AllOf &
  GetNotHasPropertiesWithAllOfPets200AllOfTwo &
  Required<
    Pick<
      Pet &
        PetDetail &
        GetNotHasPropertiesWithAllOfPets200AllOf &
        GetNotHasPropertiesWithAllOfPets200AllOfTwo,
      'category' | 'color'
    >
  >;
```
The `Required<Pick<..., 'category' | 'color'>>` is unnecessary in this case, as both 'category' and 'color' is already required in `GetNotHasPropertiesWithAllOfPets200AllOf` and `GetNotHasPropertiesWithAllOfPets200AllOfTwo`.

This PR fixes that and only creates this `Required<Pick<` when there are non-required properties in a child object that should be required in this top level object. The generated code in `/generated/default/all-of/getNotHasPropertiesWithAllOfPets200.ts` is now:
```ts
export type GetNotHasPropertiesWithAllOfPets200 = Pet &
  PetDetail &
  GetNotHasPropertiesWithAllOfPets200AllOf &
  GetNotHasPropertiesWithAllOfPets200AllOfTwo;
```


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| require-inside-all-of | #1819  |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
