### PR TITLE
Warning: A props object containing a "key" prop is being spread into JSX

### DIFF
--- a/docs/src/components/Highlight.js
+++ b/docs/src/components/Highlight.js
@@ -83,35 +83,35 @@ const Code = ({
               lineHeight: '1.5',
             }}
           >
-            {tokens.map((line, i) => (
-              <div
-                key={i}
-                {...getLineProps({
-                  line,
-                  key: i,
-                })}
-              >
-                {tokens.length > 1 ? (
-                  <span
-                    aria-hidden="true"
-                    className="select-none text-gray-300 text-right w-5 inline-block mx-2"
-                  >
-                    {i + 1}
-                  </span>
-                ) : (
-                  <span className="mx-2 w-5" />
-                )}{' '}
-                {line.map((token, key) => (
-                  <span
-                    key={key}
-                    {...getTokenProps({
+            {tokens.map((line, i) => {
+              const { key: lineKey, ...lineRestProps } = getLineProps({
+                line,
+                key: i,
+              });
+
+              return (
+                <div key={lineKey} {...lineRestProps}>
+                  {tokens.length > 1 ? (
+                    <span
+                      aria-hidden="true"
+                      className="select-none text-gray-300 text-right w-5 inline-block mx-2"
+                    >
+                      {i + 1}
+                    </span>
+                  ) : (
+                    <span className="mx-2 w-5" />
+                  )}{' '}
+                  {line.map((token, key) => {
+                    const { key: tokenKey, ...tokenRestProps } = getTokenProps({
                       token,
                       key,
-                    })}
-                  />
-                ))}
-              </div>
-            ))}
+                    });
+
+                    return <span key={tokenKey} {...tokenRestProps} />;
+                  })}
+                </div>
+              );
+            })}
           </pre>
         )}
       </Highlight>


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When you start docs locally, you could see this warning log:
```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, className: ..., children: ..., style: ...};
  <span {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {className: ..., children: ..., style: ...};
  <span key={someKey} {...props} />
    at Highlight (…/orval/docs/node_modules/prism-react-renderer/dist/index.cjs.js:198:15)
    at Code (webpack-internal:///./src/components/Highlight.js:30:17)
    at div
    at div
    at section
    at div
    at Home (webpack-internal:///./src/pages/index.js:43:13)
    at SearchProvider (webpack-internal:///./src/components/useSearch.js:32:27)
    at Hydrate (file:///.../orval/docs/node_modules/@tanstack/react-query/build/lib/Hydrate.mjs:23:3)
    at QueryClientProvider (file:///.../orval/docs/node_modules/@tanstack/react-query/build/lib/QueryClientProvider.mjs:41:3)
    at MyApp (webpack-internal:///./src/pages/_app.js:27:18)
    at StyleRegistry (/.../orval/docs/node_modules/styled-jsx/dist/index/index.js:449:36)
    at PathnameContextProviderAdapter (/.../orval/docs/node_modules/next/dist/shared/lib/router/adapters.js:78:11)
    at AppContainer (/.../orval/docs/node_modules/next/dist/server/render.js:337:29)
    at AppContainerWithIsomorphicFiberStructure (/.../orval/docs/node_modules/next/dist/server/render.js:373:57)
    at div
    at Body (/.../orval/docs/node_modules/next/dist/server/render.js:673:21)
```

## Steps to Test or Reproduce
1. Run `docs` locally
2. Go to home page (`localhost:3000`)
3. Watch log in dev tools / terminal
