### PR TITLE
fix(hono): avoid syntax error in composite routes

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -986,7 +986,7 @@ const generateCompositeRoutes = async (
     .map((verbOption) => {
       return generateHonoRoute(verbOption, verbOption.pathRoute);
     })
-    .join();
+    .join(';');
 
   const importHandlers = Object.values(verbOptions);
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I fixed it because it was delimited by `,` and a syntax error occurred.

## Related PRs

https://github.com/orval-labs/orval/pull/1843

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this with the following settings:

```ts
import { defineConfig } from 'orval';

export default defineConfig({
petstoreTagSplitApi: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'tags-split',
      client: 'hono',
      target: 'hono-app/src',
      schemas: 'hono-app/src/schemas',
      override: {
        hono: {
          compositeRoute: 'hono-app/src/routes.ts',
          validatorOutputPath: 'hono-app/src/validator.ts',
        },
      },
    },
  },
```