### PR TITLE
fix(core): shallow-copy while creating override (global/tag/identifier)

### DIFF
--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -223,42 +223,44 @@ export const addDependency = ({
     return acc;
   }, {});
 
-  return Object.entries(groupedBySpecKey)
-    .map(([key, { values, types }]) => {
-      let dep = '';
+  return (
+    Object.entries(groupedBySpecKey)
+      .map(([key, { values, types }]) => {
+        let dep = '';
 
-      if (values) {
-        dep += generateDependency({
-          deps: values,
-          isAllowSyntheticDefaultImports,
-          dependency,
-          specsName,
-          key,
-          onlyTypes: false,
-        });
-      }
-
-      if (types) {
-        let uniqueTypes = types;
         if (values) {
-          uniqueTypes = types.filter(
-            (t) => !values.some((v) => v.name === t.name),
-          );
-          dep += '\n';
+          dep += generateDependency({
+            deps: values,
+            isAllowSyntheticDefaultImports,
+            dependency,
+            specsName,
+            key,
+            onlyTypes: false,
+          });
         }
-        dep += generateDependency({
-          deps: uniqueTypes,
-          isAllowSyntheticDefaultImports,
-          dependency,
-          specsName,
-          key,
-          onlyTypes: true,
-        });
-      }
 
-      return dep;
-    })
-    .join('\n') + '\n';
+        if (types) {
+          let uniqueTypes = types;
+          if (values) {
+            uniqueTypes = types.filter(
+              (t) => !values.some((v) => v.name === t.name),
+            );
+            dep += '\n';
+          }
+          dep += generateDependency({
+            deps: uniqueTypes,
+            isAllowSyntheticDefaultImports,
+            dependency,
+            specsName,
+            key,
+            onlyTypes: true,
+          });
+        }
+
+        return dep;
+      })
+      .join('\n') + '\n'
+  );
 };
 
 const getLibName = (code: string) => {

--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -65,7 +65,6 @@ const generateVerbOptions = async ({
     description,
     summary,
   } = operation;
-
   const operationId = getOperationId(operation, route, verb);
   const overrideOperation = output.override.operations[operation.operationId!];
   const overrideTag = Object.entries(output.override.tags).reduce(
@@ -74,11 +73,10 @@ const generateVerbOptions = async ({
     {} as NormalizedOperationOptions,
   );
 
-  const override: NormalizedOverrideOutput = {
-    ...output.override,
-    ...overrideTag,
-    ...overrideOperation,
-  };
+  const override = mergeDeep(
+    mergeDeep(output.override, overrideTag),
+    overrideOperation,
+  );
 
   const overrideOperationName =
     overrideOperation?.operationName || output.override?.operationName;

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -89,7 +89,7 @@ const generateDefinition = (
     splitMockImplementations,
   });
 
-  const mockData = getMockOptionsDataOverride(operationId, override);
+  const mockData = getMockOptionsDataOverride(tags, operationId, override);
 
   let value = '';
 

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -261,10 +261,15 @@ export const getMockDefinition = ({
 };
 
 export const getMockOptionsDataOverride = (
+  operationTags: string[],
   operationId: string,
   override: NormalizedOverrideOutput,
 ) => {
-  const responseOverride = override?.operations?.[operationId]?.mock?.data;
+  const responseOverride =
+    override?.operations?.[operationId]?.mock?.data ||
+    operationTags
+      .map((operationTag) => override?.tags?.[operationTag]?.mock?.data)
+      .find((e) => e !== undefined);
   const implementation = isFunction(responseOverride)
     ? `(${responseOverride})()`
     : stringify(responseOverride);

--- a/tests/specifications/const.yaml
+++ b/tests/specifications/const.yaml
@@ -68,4 +68,4 @@ components:
           type: integer
           const: 1
           description: 'Unique exception code'
-      required: [ 'message', 'code' ]
+      required: ['message', 'code']


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

PR in response to 
Fix https://github.com/orval-labs/orval/issues/1893

Fix for 2 bugs:
- shallow-copy during creation of overrides, which resulted in some props missing 
- mocks were not respecting "tags"

Outstanding work:
`````
        output: {
            override: {
                query: {
                    useQuery: true,
                    useSuspenseQuery: true,
                    shouldExportHttpClient: false,
                    shouldExportQueryKey: false,
                    mutationOptions: {
                        path: '../src/integration/codegen-hooks.tsx',
                        name: 'invalidateAllCaches',
                    },
                },
                tags: {
                    MyCustomTag: {
                        query: {
                            useQuery: true,
                            useSuspenseQuery: true,
                            shouldExportHttpClient: false,
                            shouldExportQueryKey: false,
                            mutationOptions: {
                                path: '../src/integration/codegen-hooks.tsx',
                                name: 'invalidate',
                            }
                        }
                    },
`````
Results in incorrect path of "codegen-hooks":
```
${baseurl}/src/integration/src/integration/codegen-hooks.tsx
```

workaround is easy:
`````
MyCustomTag.(...).mutationOptions.path = ./../../../src/integration/codegen-hooks.tsx
`````

Will take a look on how to fix it later on.


## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
