### PR TITLE
fix(query): vue-query generates undefined function "useCallback"

### DIFF
--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -132,7 +132,7 @@ export const generateAxiosRequestFunction = (
       : '';
 
     if (mutator.isHook) {
-      return `${
+      const ret = `${
         override.query.shouldExportMutatorHooks ? 'export ' : ''
       }const use${pascal(operationName)}Hook = () => {
         const ${operationName} = ${mutator.name}<${
@@ -150,6 +150,27 @@ export const generateAxiosRequestFunction = (
         }, [${operationName}])
       }
     `;
+
+      const vueRet = `${
+        override.query.shouldExportMutatorHooks ? 'export ' : ''
+      }const use${pascal(operationName)}Hook = () => {
+        const ${operationName} = ${mutator.name}<${
+          response.definition.success || 'unknown'
+        }>();
+
+        return (\n    ${propsImplementation}\n ${
+          isRequestOptions && mutator.hasSecondArg
+            ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<ReturnType<typeof ${mutator.name}>>,`
+            : ''
+        }${hasSignal ? 'signal?: AbortSignal\n' : ''}) => {${bodyForm}
+        return ${operationName}(
+          ${mutatorConfig},
+          ${requestOptions});
+        }
+      }
+    `;
+
+      return isVue ? vueRet : ret;
     }
 
     return `${override.query.shouldExportHttpClient ? 'export ' : ''}const ${operationName} = (\n    ${propsImplementation}\n ${


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix #1872 

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| N/A| N/A |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

※ I did tests with husky and generating samples made from my project

## Steps to Test or Reproduce

1. make files to set override: mutator, formData and query.
2. make orval.config.ts with property below:
````
client: 'vue-query',
override: {
          mutator: {
            path: "./mutator/use-custom-instance.ts",
            name: "useCustomInstance",
          },
          formData: {
            path: "./mutator/custom-form-data.ts",
            name: "customFormData",
          },
          query: {
            queryOptions: {
              path: "./mutator/custom-query-options.ts",
              name: "customQueryOptions",
            },
}
````
3. generate.
Before fix, it will generate file using method "useCallback" on all client.
After fix, it will generate file without useCallback on vue-query client while the other clients will execute as before.
