### PR TITLE
fix(fetch): param stringification for Safari < 17.0

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -71,7 +71,7 @@ export const generateRequestFunction = (
   const explodeArrayImplementation =
     explodeParameters.length > 0
       ? `const explodeParameters = ${JSON.stringify(explodeParametersNames)};
-      
+
     if (value instanceof Array && explodeParameters.includes(key)) {
       value.forEach((v) => normalizedParams.append(key, v === null ? 'null' : v.toString()));
       return;
@@ -98,9 +98,11 @@ ${
     : ''
 }
 
+  ${queryParams ? `const stringifiedParams = normalizedParams.toString();` : ``}
+
   ${
     queryParams
-      ? `return normalizedParams.size ? \`${route}${'?${normalizedParams.toString()}'}\` : \`${route}\``
+      ? `return stringifiedParams.length > 0 ? \`${route}${'?${stringifiedParams}'}\` : \`${route}\``
       : `return \`${route}\``
   }
 }\n`;
@@ -190,7 +192,7 @@ ${
 `;
   const fetchResponseImplementation = isNdJson
     ? `const stream = await fetch(${fetchFnOptions})
-  
+
   ${override.fetch.includeHttpResponseReturnType ? 'return { status: stream.status, stream, headers: stream.headers }' : `return stream`}
   `
     : `const res = await fetch(${fetchFnOptions})


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Sadly Safari below v17 does not support `URLSearchParams.size` therefore the fetch implementation is currently broken for those users.

This replaces the check for `size` with checking the stringification results length before returning the url.

See also: https://caniuse.com/mdn-api_urlsearchparams_size

## Todos

- Tests (did not investigate but hopefully there is already one in place to catch regressions here)
- Documentation (probably not needed I guess)
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. create a fetch client
2. try to run a generated request on Safari 16 for exmaple
3. fails due to unsupported size API

If anything is missing just let me know :slightly_smiling_face: 