### PR TITLE
feat(core): ability to provide custom validation ruleset

### DIFF
--- a/docs/src/pages/reference/configuration/input.md
+++ b/docs/src/pages/reference/configuration/input.md
@@ -21,11 +21,14 @@ module.exports = {
 
 ### validation
 
-Type: `Boolean`.
+Type: `Boolean` or `Object`
 
 Default Value: `false`.
 
-To enforce the best quality as possible of specification, we have integrated the amazing <a href="https://github.com/IBM/openapi-validator" target="_blank">OpenAPI linter from IBM</a>. We strongly encourage you to setup your custom rules with a `.validaterc` file, you can find all useful information about this configuration <a href="https://github.com/IBM/openapi-validator/#configuration" target="_blank">here</a>.
+To enforce the best quality as possible of specification, we have integrated the amazing <a href="https://github.com/IBM/openapi-validator" target="_blank">OpenAPI linter from IBM</a>.
+
+Specifying `true` will by default use the <a href="https://github.com/IBM/openapi-validator/blob/main/docs/ibm-cloud-rules.md"><em>IBM Cloud Validation Ruleset</em></a>.
+Specifying an `Object` will use the provided ruleset instead. You can learn more about creating rulesets <a href="https://docs.stoplight.io/docs/spectral/aa15cdee143a1-java-script-ruleset-format">here</a>.
 
 ```js
 module.exports = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,7 +156,7 @@ export type NormalizedOperationOptions = {
 
 export type NormalizedInputOptions = {
   target: string | Record<string, unknown> | OpenAPIObject;
-  validation: boolean;
+  validation: boolean | object;
   override: OverrideInput;
   converterOptions: swagger2openapi.Options;
   parserOptions: SwaggerParserOptions;
@@ -242,7 +242,7 @@ export type InputFiltersOption = {
 
 export type InputOptions = {
   target: string | Record<string, unknown> | OpenAPIObject;
-  validation?: boolean;
+  validation?: boolean | object;
   override?: OverrideInput;
   converterOptions?: swagger2openapi.Options;
   parserOptions?: SwaggerParserOptions;

--- a/packages/core/src/utils/validator.ts
+++ b/packages/core/src/utils/validator.ts
@@ -3,6 +3,7 @@ import {
   ibmOpenapiValidatorErrors,
   ibmOpenapiValidatorWarnings,
 } from './logger';
+import fs from 'node:fs/promises';
 
 const ibmOpenapiRuleset = require('@ibm-cloud/openapi-ruleset');
 const { Spectral } = require('@stoplight/spectral-core');
@@ -12,9 +13,14 @@ const { Spectral } = require('@stoplight/spectral-core');
  * More information: https://github.com/IBM/openapi-validator/#configuration
  * @param specs openAPI spec
  */
-export const ibmOpenapiValidator = async (specs: OpenAPIObject) => {
+export const ibmOpenapiValidator = async (
+  specs: OpenAPIObject,
+  validation: boolean | object,
+) => {
+  const ruleset =
+    typeof validation === 'boolean' ? ibmOpenapiRuleset : validation;
   const spectral = new Spectral();
-  spectral.setRuleset(ibmOpenapiRuleset);
+  spectral.setRuleset(ruleset);
   const results = await spectral.run(specs);
 
   const errors: { message: string; path: string[] }[] = [];

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -79,7 +79,7 @@ const generateInputSpecs = async ({
       const transfomedSchema = transformerFn ? transformerFn(schema) : schema;
 
       if (input.validation) {
-        await ibmOpenapiValidator(transfomedSchema);
+        await ibmOpenapiValidator(transfomedSchema, input.validation);
       }
 
       acc[specKey] = transfomedSchema;


### PR DESCRIPTION
Fixes #1887

## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This feature will give devs the ability to provide their own custom rulesets. Right now we always default to `@ibm-cloud/openapi-ruleset` with no way of modifying it

## Steps to Test or Reproduce

#### ruleset.ts
```ts
import { oas } from '@stoplight/spectral-rulesets';

export default {
  extends: [oas],
  rules: {
    'operation-operationId': 'error',
  },
};

```

#### orval.config.ts
```ts
import validation from './validate';

export default defineConfig({
  api: {
    input: {
      target: '../docs/swagger.json',
      validation,
    },
    ...
});
```
