### PR TITLE
feat(zod): support multipart/form-data

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -231,6 +231,11 @@ export const generateZodValidationSchemaDefinition = (
         break;
       }
 
+      if (schema.format === 'binary') {
+        functions.push(['instanceof', 'File']);
+        break;
+      }
+
       functions.push([type as string, undefined]);
 
       if (schema.format === 'date') {
@@ -623,17 +628,18 @@ const parseBodyAndResponse = ({
     context,
   ).schema;
 
-  if (!resolvedRef.content?.['application/json']?.schema) {
+  const schema =
+    resolvedRef.content?.['application/json']?.schema ||
+    resolvedRef.content?.['multipart/form-data']?.schema;
+
+  if (!schema) {
     return {
       input: { functions: [], consts: [] },
       isArray: false,
     };
   }
 
-  const resolvedJsonSchema = deference(
-    resolvedRef.content['application/json'].schema,
-    context,
-  );
+  const resolvedJsonSchema = deference(schema, context);
 
   // keep the same behaviour for array
   if (resolvedJsonSchema.items) {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -958,3 +958,105 @@ describe('parsePrefixItemsArrayAsTupleZod', () => {
     });
   });
 });
+
+const formDataSchema = {
+  pathRoute: '/cats',
+  context: {
+    specKey: 'cat',
+    specs: {
+      cat: {
+        paths: {
+          '/cats': {
+            post: {
+              operationId: 'xyz',
+              requestBody: {
+                required: true,
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                        },
+                        catImage: {
+                          type: 'string',
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          name: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+};
+
+describe('generateFormData', () => {
+  it('Only generate request body', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: false,
+              body: true,
+              response: false,
+              query: false,
+              header: false,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+          },
+        },
+      },
+      formDataSchema,
+      {},
+    );
+    expect(result.implementation).toBe(
+      'export const testBody = zod.object({\n  "name": zod.string().optional(),\n  "catImage": zod.instanceof(File).optional()\n})\n\n',
+    );
+  });
+});


### PR DESCRIPTION
## Status

READY

## Description

Fix #1741

It appears that `z.custom<File>()` or `z.instanceof(File)` can be used to check for a File.
Since i can't determine whether the user is using TypeScript, i opted for `z.instanceof(File)`.
However, this validation may have compatibility issues depending on the [Node.js version](https://nodejs.org/api/buffer.html#class-file) (requires Node v20.0 or later).

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| N/A | N/A |
| N/A     | N/A |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Added test cases