### PR TITLE
fix(zod): strict true when using a discriminator

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -441,9 +441,11 @@ export const parseZodValidationSchemaDefinition = (
     }
     if (fn.startsWith('discriminator__')) {
       const [, propertyName] = fn.split('discriminator__');
-      const typeSchemas = args.flatMap(
-        ({ functions }: { functions: [string, any][]; consts: string[] }) =>
-          functions.map(parseProperty),
+      const typeSchemas = args.map(
+        ({ functions }: { functions: [string, any][]; consts: string[] }) => {
+          const schemaFunctions = functions.map(parseProperty).join('');
+          return schemaFunctions;
+        },
       );
       return `zod.discriminatedUnion('${propertyName}', [${typeSchemas.join(
         ',',

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -815,6 +815,45 @@ describe('generateDiscriminatedUnionZod', () => {
     );
     expect(result.implementation).not.toContain('.or(zod.object');
   });
+  it('generated discriminatedUnion zod schema strict setting', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/dogs',
+        verb: 'get',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+          },
+        },
+      },
+      apiSchemaWithDiscriminator,
+      {},
+    );
+    expect(result.implementation).toBe(
+      `export const testResponseItem = zod.discriminatedUnion('breed', [zod.object({\n  "cuteness": zod.number(),\n  "breed": zod.enum(['Labradoodle']).optional()\n}).strict(),zod.object({\n  "length": zod.number(),\n  "breed": zod.enum(['Labradoodle']).optional()\n}).strict()])\nexport const testResponse = zod.array(testResponseItem)\n\n`,
+    );
+  });
   it('does not generate a discriminatedUnion zod schema when discriminator is absent', async () => {
     const schemaWithoutDiscriminator = { ...apiSchemaWithDiscriminator };
     const dogSchema = schemaWithoutDiscriminator.context.specs['dog']

--- a/samples/hono/hono-with-zod/src/petstore.zod.ts
+++ b/samples/hono/hono-with-zod/src/petstore.zod.ts
@@ -14,19 +14,20 @@ export const listPetsQueryParams = zod.object({
 export const listPetsResponseItem = zod.preprocess(
   stripNill,
   zod
-    .object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    })
-    .strict()
-    .or(
+    .discriminatedUnion('breed', [
+      zod
+        .object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        })
+        .strict(),
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    )
+    ])
     .or(
       zod
         .object({
@@ -47,19 +48,20 @@ export const createPetsBody = zod.array(createPetsBodyItem);
 export const createPetsResponse = zod.preprocess(
   stripNill,
   zod
-    .object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    })
-    .strict()
-    .or(
+    .discriminatedUnion('breed', [
+      zod
+        .object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        })
+        .strict(),
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    )
+    ])
     .or(
       zod
         .object({
@@ -71,16 +73,16 @@ export const createPetsResponse = zod.preprocess(
 );
 
 export const updatePetsBody = zod
-  .object({
-    cuteness: zod.number(),
-    breed: zod.enum(['Labradoodle']),
-  })
-  .or(
+  .discriminatedUnion('breed', [
+    zod.object({
+      cuteness: zod.number(),
+      breed: zod.enum(['Labradoodle']),
+    }),
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  )
+  ])
   .or(
     zod.object({
       petsRequested: zod.number().optional(),
@@ -91,19 +93,20 @@ export const updatePetsBody = zod
 export const updatePetsResponse = zod.preprocess(
   stripNill,
   zod
-    .object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    })
-    .strict()
-    .or(
+    .discriminatedUnion('breed', [
+      zod
+        .object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        })
+        .strict(),
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    )
+    ])
     .or(
       zod
         .object({
@@ -122,19 +125,20 @@ export const showPetByIdParams = zod.object({
 export const showPetByIdResponse = zod.preprocess(
   stripNill,
   zod
-    .object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    })
-    .strict()
-    .or(
+    .discriminatedUnion('breed', [
+      zod
+        .object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        })
+        .strict(),
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    )
+    ])
     .or(
       zod
         .object({


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix https://github.com/orval-labs/orval/pull/1907#issuecomment-2674233805 where strict() did not work correctly with discrinimatedUnions in zod due to how schemas were being merged
## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_master     | [link](https://github.com/orval-labs/orval/pull/1907) |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Before:

Run from the samples/hono/hono-with-zod

```bash
npm run generate-api
```

1. See invalid typescript code

After
1. Repeat the same
2. See the new unit test for this case
