### PR TITLE
fix(hono): `zValidate` path when using `tags` mode uses `output.target` based path

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -389,23 +389,24 @@ ${getHonoHandlers({
           };
         }
 
-        const outputRelativePath = `./${kebab(tag)}`;
-
         let validatorImport = '';
         if (hasZValidator) {
           if (output.override.hono.validator === true) {
-            const validatorPath = output.override.hono.validatorOutputPath
-              ? getValidatorOutputRelativePath(
-                  output.override.hono.validatorOutputPath,
-                  handlerPath,
-                )
-              : `${outputRelativePath}.validator`;
+            const validatorOutputPath =
+              output.override.hono.validatorOutputPath ||
+              `${dirname}/${filename}.validator${extension}`;
+            const validatorPath = getValidatorOutputRelativePath(
+              validatorOutputPath,
+              handlerPath,
+            );
 
             validatorImport = `\nimport { zValidator } from '${validatorPath}';`;
           } else if (output.override.hono.validator === 'hono') {
             validatorImport = `\nimport { zValidator } from '@hono/zod-validator';`;
           }
         }
+
+        const outputRelativePath = `./${kebab(tag)}`;
 
         const zodImports = output.override.hono.validator
           ? getZvalidatorImports(


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When the `hono` client uses `tags` or `tags-split` mode, an  error will occurs in handler file:

```bash
error TS2307: Cannot find module './pets.validator' or its corresponding type declarations.

2 import { zValidator } from './pets.validator';
                             ~~~~~~~~~~~~~~~~~~
```

This is because the import source of `zValidator` is the name of the `tag`.
`validator` is a single commonly used file so i fixed it by changing the path to be calculated from `output.target`.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

You can check by using the `hono` client with `tags` or `tags-split` mode in `orval.config`