### PR TITLE
fix(docs): dropdown overlap

### DIFF
--- a/docs/src/components/playground/Playground.js
+++ b/docs/src/components/playground/Playground.js
@@ -57,7 +57,7 @@ export function Playground({ height }) {
 
   return (
     <div>
-      <div className="mx-auto mb-4 w-1/2">
+      <div className="mx-auto mb-4 w-1/2 relative z-20">
         <h3 className="mb-2 text-center">Choose Live Example:</h3>
         <Select
           isSearchable={false}


### PR DESCRIPTION
## Status

**READY**

## Description
Dropdown overlapped by editor sub-components
<img width="1224" alt="image" src="https://github.com/user-attachments/assets/9baa0afa-96ea-4697-9a63-744bcd29792e" />

## Steps to Test or Reproduce

Need to go to playground section (https://orval.dev/ or https://orval.dev/playground) and try to scroll so scrolling header appears, and open "Choose Live Example" dropdown
