### PR TITLE
chore(hono): add tests for `hono` client

### DIFF
--- a/tests/configs/hono.config.ts
+++ b/tests/configs/hono.config.ts
@@ -1,6 +1,24 @@
 import { defineConfig } from 'orval';
 
 export default defineConfig({
+  petstoreTagsSplit: {
+    input: '../specifications/petstore.yaml',
+    output: {
+      target: '../generated/hono/tags-split/endpoints.ts',
+      schemas: '../generated/hono/tags-split/schemas',
+      mode: 'tags-split',
+      client: 'hono',
+    },
+  },
+  petstoreTags: {
+    input: '../specifications/petstore.yaml',
+    output: {
+      target: '../generated/hono/tags/endpoints.ts',
+      schemas: '../generated/hono/tags/schemas',
+      mode: 'tags',
+      client: 'hono',
+    },
+  },
   petstoreSplit: {
     input: '../specifications/petstore.yaml',
     output: {
@@ -39,6 +57,23 @@ export default defineConfig({
             '../generated/hono/petstore-split-validator-output-path/handlers',
           validatorOutputPath:
             '../generated/hono/petstore-split-validator-output-path/handlers/validator.ts',
+        },
+      },
+    },
+  },
+  petstoreTagsSplitCompositeRoute: {
+    input: '../specifications/petstore.yaml',
+    output: {
+      target: '../generated/hono/petstore-tags-split-composite-route/endpoints',
+      schemas: '../generated/hono/petstore-tags-split-composite-route/schemas',
+      mode: 'tags-split',
+      client: 'hono',
+      override: {
+        hono: {
+          validatorOutputPath:
+            '../generated/hono/petstore-tags-split-composite-route/endpoints/validator.ts',
+          compositeRoute:
+            'generated/hono/petstore-tags-split-composite-route/routes.ts',
         },
       },
     },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

Some bug fixes made it possible to add a standard test that didn't work before, so I added it

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none