### PR TITLE
Revert "fix(core): adjustments to native enums"

### DIFF
--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -51,18 +51,7 @@ const combineValues = ({
   }
 
   if (separator === 'allOf') {
-    let resolvedDataValue = resolvedData.values.join(` & `);
-    if (resolvedData.originalSchema.length > 0 && resolvedValue) {
-      const discriminatedPropertySchemas = resolvedData.originalSchema.filter(
-        (s) =>
-          s?.discriminator &&
-          resolvedValue.value.includes(` ${s.discriminator.propertyName}:`),
-      ) as SchemaObject[];
-      if (discriminatedPropertySchemas.length > 0) {
-        resolvedDataValue = `Omit<${resolvedDataValue}, '${discriminatedPropertySchemas.map((s) => s.discriminator?.propertyName).join("' | '")}'>`;
-      }
-    }
-    const joined = `${resolvedDataValue}${
+    const joined = `${resolvedData.values.join(` & `)}${
       resolvedValue ? ` & ${resolvedValue.value}` : ''
     }`;
 

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -128,7 +128,7 @@ export const getObject = ({
           isReadOnly && !context.output.override.suppressReadonlyModifier
             ? 'readonly '
             : ''
-        }${getKey(key)}${isRequired ? '' : '?'}: ${resolvedValue.value};`;
+        }${getKey(key)}${isRequired ? '' : '?'}: ${resolvedValue.isEnum && context.output.override.useNativeEnums ? `(keyof typeof ${resolvedValue.value})` : resolvedValue.value};`;
         acc.schemas.push(...resolvedValue.schemas);
 
         if (arr.length - 1 === index) {

--- a/packages/core/src/resolvers/object.ts
+++ b/packages/core/src/resolvers/object.ts
@@ -69,7 +69,9 @@ const resolveObjectOriginal = ({
     );
 
     return {
-      value: propName,
+      value: context.output.override.useNativeEnums
+        ? `(keyof typeof ${propName})`
+        : propName,
       imports: [{ name: propName }],
       schemas: [
         ...resolvedValue.schemas,

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -2,6 +2,7 @@ import {
   ContextSpecs,
   escape,
   GeneratorImport,
+  isReference,
   isRootKey,
   mergeDeep,
   MockOptions,
@@ -138,21 +139,38 @@ export const getMockScalar = ({
         `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`,
         item.nullable,
       );
+      let numberImports: GeneratorImport[] = [];
       if (item.enum) {
-        value = getEnum(
-          item,
-          imports,
-          context,
-          existingReferencedProperties,
-          'number',
-        );
+        // By default the value isn't a reference, so we don't have the object explicitly defined.
+        // So we have to create an array with the enum values and force them to be a const.
+        const joinedEnumValues = item.enum.filter(Boolean).join(',');
+
+        let enumValue = `[${joinedEnumValues}] as const`;
+
+        // But if the value is a reference, we can use the object directly via the imports and using Object.values.
+        if (item.isRef) {
+          enumValue = `Object.values(${item.name})`;
+          numberImports = [
+            {
+              name: item.name,
+              values: true,
+              ...(!isRootKey(context.specKey, context.target)
+                ? { specKey: context.specKey }
+                : {}),
+            },
+          ];
+        }
+
+        value = item.path?.endsWith('[]')
+          ? `faker.helpers.arrayElements(${enumValue})`
+          : `faker.helpers.arrayElement(${enumValue})`;
       } else if ('const' in item) {
         value = '' + (item as SchemaObject31).const;
       }
       return {
         value,
         enums: item.enum,
-        imports,
+        imports: numberImports,
         name: item.name,
       };
     }
@@ -187,6 +205,7 @@ export const getMockScalar = ({
         value,
         enums,
         imports: resolvedImports,
+        name,
       } = resolveMockValue({
         schema: {
           ...item.items,
@@ -204,9 +223,32 @@ export const getMockScalar = ({
       });
 
       if (enums) {
+        if (!isReference(item.items)) {
+          return {
+            value,
+            imports: resolvedImports,
+            name: item.name,
+          };
+        }
+
+        const enumImp = imports.find(
+          (imp) => name.replace('[]', '') === imp.name,
+        );
+        const enumValue = enumImp?.name || name;
         return {
-          value,
-          imports: resolvedImports,
+          value: `faker.helpers.arrayElements(Object.values(${enumValue}))`,
+          imports: enumImp
+            ? [
+                ...resolvedImports,
+                {
+                  ...enumImp,
+                  values: true,
+                  ...(!isRootKey(context.specKey, context.target)
+                    ? { specKey: context.specKey }
+                    : {}),
+                },
+              ]
+            : resolvedImports,
           name: item.name,
         };
       }
@@ -230,15 +272,35 @@ export const getMockScalar = ({
 
     case 'string': {
       let value = 'faker.string.alpha(20)';
+      let imports: GeneratorImport[] = [];
 
       if (item.enum) {
-        value = getEnum(
-          item,
-          imports,
-          context,
-          existingReferencedProperties,
-          'string',
-        );
+        // By default the value isn't a reference, so we don't have the object explicitly defined.
+        // So we have to create an array with the enum values and force them to be a const.
+        const joindEnumValues = item.enum
+          .filter(Boolean)
+          .map((e) => escape(e))
+          .join("','");
+
+        let enumValue = `['${joindEnumValues}'] as const`;
+
+        // But if the value is a reference, we can use the object directly via the imports and using Object.values.
+        if (item.isRef) {
+          enumValue = `Object.values(${item.name})`;
+          imports = [
+            {
+              name: item.name,
+              values: true,
+              ...(!isRootKey(context.specKey, context.target)
+                ? { specKey: context.specKey }
+                : {}),
+            },
+          ];
+        }
+
+        value = item.path?.endsWith('[]')
+          ? `faker.helpers.arrayElements(${enumValue})`
+          : `faker.helpers.arrayElement(${enumValue})`;
       } else if (item.pattern) {
         value = `faker.helpers.fromRegExp('${item.pattern}')`;
       } else if ('const' in item) {
@@ -293,70 +355,3 @@ function getItemType(item: MockSchemaObject) {
   if (!type) return;
   return ['string', 'number'].includes(type) ? type : undefined;
 }
-
-const getEnum = (
-  item: MockSchemaObject,
-  imports: GeneratorImport[],
-  context: ContextSpecs,
-  existingReferencedProperties: string[],
-  type: 'string' | 'number',
-) => {
-  if (!item.enum) return '';
-  const joindEnumValues =
-    type === 'string'
-      ? `'${item.enum
-          .filter((e) => e !== null)
-          .map((e) => escape(e))
-          .join("','")}'`
-      : item.enum.filter((e) => e !== null);
-
-  let enumValue = `[${joindEnumValues}]`;
-  if (context.output.override.useNativeEnums) {
-    if (item.isRef) {
-      enumValue += ` as ${item.name}${item.name.endsWith('[]') ? '' : '[]'}`;
-      imports.push({
-        name: item.name,
-        ...(!isRootKey(context.specKey, context.target)
-          ? { specKey: context.specKey }
-          : {}),
-      });
-    } else if (existingReferencedProperties.length > 0) {
-      enumValue += ` as ${existingReferencedProperties[existingReferencedProperties.length - 1]}['${item.name}']`;
-      if (!item.path?.endsWith('[]')) enumValue += '[]';
-      imports.push({
-        name: existingReferencedProperties[
-          existingReferencedProperties.length - 1
-        ],
-        ...(!isRootKey(context.specKey, context.target)
-          ? { specKey: context.specKey }
-          : {}),
-      });
-    } else {
-      enumValue += ` as ${item.name}${item.name.endsWith('[]') ? '' : '[]'}`;
-      imports.push({
-        name: item.name,
-        ...(!isRootKey(context.specKey, context.target)
-          ? { specKey: context.specKey }
-          : {}),
-      });
-    }
-  } else {
-    enumValue += ' as const';
-  }
-
-  // But if the value is a reference, we can use the object directly via the imports and using Object.values.
-  if (item.isRef && type === 'string') {
-    enumValue = `Object.values(${item.name})`;
-    imports.push({
-      name: item.name,
-      values: true,
-      ...(!isRootKey(context.specKey, context.target)
-        ? { specKey: context.specKey }
-        : {}),
-    });
-  }
-
-  return item.path?.endsWith('[]')
-    ? `faker.helpers.arrayElements(${enumValue})`
-    : `faker.helpers.arrayElement(${enumValue})`;
-};

--- a/tests/specifications/enums.yaml
+++ b/tests/specifications/enums.yaml
@@ -12,9 +12,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DogGroup'
+                $ref: '#/components/schemas/Cat'
   /api/required-cat:
     get:
       summary: sample required cat
@@ -77,11 +75,6 @@ components:
           type: array
           items:
             type: string
-            x-enumNames:
-              - Black
-              - Brown
-              - White
-              - Grey
             enum:
               - BLACK
               - BROWN


### PR DESCRIPTION
Reverts orval-labs/orval#1882

Becouse, it seems that RangeError: Maximum call stack size exceeded has started to occur in my complex OpenAPI since this PR merged.

```
petstoreFile - RangeError: Maximum call stack size exceeded
    at /app/packages/mock/dist/index.js:183:16
    at Array.map (<anonymous>)
    at getMockObject (/app/packages/mock/dist/index.js:159:36)
    at getMockScalar (/app/packages/mock/dist/index.js:419:14)
    at resolveMockValue (/app/packages/mock/dist/index.js:543:21)
    at /app/packages/mock/dist/index.js:665:29
    at Array.reduce (<anonymous>)
    at combineSchemasMock (/app/packages/mock/dist/index.js:647:60)
    at getMockObject (/app/packages/mock/dist/index.js:119:12)
    at getMockScalar (/app/packages/mock/dist/index.js:419:14)
```