### PR TITLE
fix: await asyncReduce in generateSpecs

### DIFF
--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -70,7 +70,7 @@ export const generateSpecs = async (
   }
 
   let hasErrors: true | undefined;
-  const accumulate = asyncReduce(
+  const accumulate = await asyncReduce(
     Object.entries(config),
     async (acc, [projectName, options]) => {
       try {


### PR DESCRIPTION
## Status

READY

## Description

Orval was not exiting with status code `1` when there was an error. #1497 is similar (although that specific case is fixed now and can be closed)

## Related PRs

Fix https://github.com/orval-labs/orval/issues/1497

## Steps to Test or Reproduce

(See exit codes at bottom of screenshots)

Before:
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/de20e871-6e22-4765-9bef-09f43f751d02" />

After:
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/138096a1-2dc9-4a41-9925-331df972e46f" />

