### PR TITLE
fix: display correct amount of duplicate schemas

### DIFF
--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -142,7 +142,7 @@ export const writeSchemas = async ({
       } else {
         duplicateNamesMap.set(
           schema.name,
-          (duplicateNamesMap.get(schema.name) || 0) + 1,
+          (duplicateNamesMap.get(schema.name) || 1) + 1,
         );
       }
     });


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Duplicate schema names were showing one less than the actual number of schemas (e.g. showing `1x` instead of `2x` when there were 2 schemas with the same name)

Another thought is that we should probably detect duplicate schemas even if `indexFiles` is set to `false`, but that breaks the (unsafe) workaround mentioned in #1733 

## Steps to Test or Reproduce

1. Edit `petstore.yaml`:
```diff
        email:
          type: string
          format: email
+       calling_code:
+         type: number
+         enum: [1, 2, 3]
        callingCode:
          type: string
          enum: ['+33', '+420', '+33'] # intentional duplicated value
```
2. generate orval with config that has indexFiles: true
3. Notice error