### PR TITLE
Fix/target naming convention

### DIFF
--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { generateImports } from '../generators';
 import { GeneratorSchema, NamingConvention } from '../types';
-import { camel, pascal, snake, kebab, upath, conventionName } from '../utils';
+import { upath, conventionName } from '../utils';
 
 const getSchema = ({
   schema: { imports, model },
@@ -142,7 +142,7 @@ export const writeSchemas = async ({
       } else {
         duplicateNamesMap.set(
           schema.name,
-          (duplicateNamesMap.get(schema.name) || 0) + 1,
+          (duplicateNamesMap.get(schema.name) || 1) + 1,
         );
       }
     });

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import { WriteModeProps } from '../types';
 import {
-  camel,
+  conventionName,
   getFileInfo,
   isFunction,
   isSyntheticDefaultImportsAllow,
@@ -21,7 +21,10 @@ export const writeSingleMode = async ({
 }: WriteModeProps): Promise<string[]> => {
   try {
     const { path, dirname } = getFileInfo(output.target, {
-      backupFilename: camel(builder.info.title),
+      backupFilename: conventionName(
+        builder.info.title,
+        output.namingConvention,
+      ),
       extension: output.fileExtension,
     });
 

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import { OutputClient, WriteModeProps } from '../types';
 import {
-  camel,
+  conventionName,
   getFileInfo,
   isFunction,
   isSyntheticDefaultImportsAllow,
@@ -22,7 +22,10 @@ export const writeSplitMode = async ({
 }: WriteModeProps): Promise<string[]> => {
   try {
     const { filename, dirname, extension } = getFileInfo(output.target, {
-      backupFilename: camel(builder.info.title),
+      backupFilename: conventionName(
+        builder.info.title,
+        output.namingConvention,
+      ),
       extension: output.fileExtension,
     });
 

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -293,8 +293,9 @@ export default defineConfig({
   petstoreNamingConventionCamelCase: {
     input: '../specifications/petstore.yaml',
     output: {
+      mode: 'split',
       target:
-        '../generated/default/petstore-naming-convention-camel-case/endpoints.ts',
+        '../generated/default/petstore-naming-convention-camel-case/endpoints',
       schemas:
         '../generated/default/petstore-naming-convention-camel-case/model',
       namingConvention: 'camelCase',
@@ -303,8 +304,9 @@ export default defineConfig({
   petstoreNamingConventionPascalCase: {
     input: '../specifications/petstore.yaml',
     output: {
+      mode: 'split',
       target:
-        '../generated/default/petstore-naming-convention-pascal-case/endpoints.ts',
+        '../generated/default/petstore-naming-convention-pascal-case/endpoints',
       schemas:
         '../generated/default/petstore-naming-convention-pascal-case/model',
       namingConvention: 'PascalCase',
@@ -313,8 +315,9 @@ export default defineConfig({
   petstoreNamingConventionKebabCase: {
     input: '../specifications/petstore.yaml',
     output: {
+      mode: 'split',
       target:
-        '../generated/default/petstore-naming-convention-kebab-case/endpoints.ts',
+        '../generated/default/petstore-naming-convention-kebab-case/endpoints',
       schemas:
         '../generated/default/petstore-naming-convention-kebab-case/model',
       namingConvention: 'kebab-case',
@@ -323,8 +326,9 @@ export default defineConfig({
   petstoreNamingConventionSnakeCase: {
     input: '../specifications/petstore.yaml',
     output: {
+      mode: 'split',
       target:
-        '../generated/default/petstore-naming-convention-snake-case/endpoints.ts',
+        '../generated/default/petstore-naming-convention-snake-case/endpoints',
       schemas:
         '../generated/default/petstore-naming-convention-snake-case/model',
       namingConvention: 'snake_case',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

I created the PR to add `namingConvention` output option and I forgot also to change the filenames for the target files

## Description

A few sentences describing the overall goals of the pull request's commits.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. specify `namingConvention: 'kebab-case'` and `mode: 'split'` in the `output` property of `orval.config.js`
2. execute `orval`
3. check the name of the files generated, specially the specified target.
