### PR TITLE
feat: Add descriptions for zod

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -446,6 +446,10 @@ export const generateZodValidationSchemaDefinition = (
     functions.push(['optional', undefined]);
   }
 
+  if (schema.description) {
+    functions.push(['describe', `'${jsStringEscape(schema.description)}'`]);
+  }
+
   return { functions, consts: uniq(consts) };
 };
 
@@ -797,6 +801,7 @@ const parseParameters = ({
       }
 
       const schema = deference(parameter.schema, context);
+      schema.description = parameter.description;
 
       const mapStrict = {
         path: strict.param,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -343,6 +343,46 @@ describe('generateZodValidationSchemaDefinition`', () => {
     });
   });
 
+  describe('description handling', () => {
+    const context: ContextSpecs = {
+      output: {
+        override: {
+          useDates: false,
+        },
+      },
+    } as ContextSpecs;
+
+    it('generates a description for a parameter', () => {
+      const schemaWithDefault: SchemaObject = {
+        type: 'string',
+        description: 'This is a test description',
+        default: 'hello',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithDefault,
+        context,
+        'testStringDescription',
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['string', undefined],
+          ['default', 'testStringDescriptionDefault'],
+          ['describe', "'This is a test description'"],
+        ],
+        consts: ['export const testStringDescriptionDefault = "hello";'],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      expect(parsed.zod).toBe(
+        "zod.string().default(testStringDescriptionDefault).describe('This is a test description')",
+      );
+    });
+  });
+
   describe('default value handling', () => {
     const context: ContextSpecs = {
       output: {


### PR DESCRIPTION
## Status

**READY**

Fix https://github.com/orval-labs/orval/issues/1715

## Description

Adds parameter descriptions to generated zod definitions, using the `zod.describe("<string>")` function.

Example output:

```ts
export const addListQueryLimitRegExp = new RegExp('^\\+\\d{10, 15}');


export const addListQueryParams = zod.object({
  "limit": zod.string().regex(addListQueryLimitRegExp).optional().describe('How many items to return at one time (max 100)'),
  "birthdate": zod.string().date().optional().describe('birth date')
})
```

Reference docs: https://zod.dev/?id=describe

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Related Issues

Found this before doing the work:

- https://github.com/orval-labs/orval/issues/1715
