### PR TITLE
fix(query): bugfix for custom mutator options

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1124,13 +1124,32 @@ module.exports = {
         query: {
           mutationOptions: {
             path: './api/mutator/custom-mutator-options.ts',
-            name: 'customMutatorOptionsFn',
+            name: 'useCustomMutatorOptions',
             // default: true
           },
         },
       },
     },
   },
+};
+```
+
+```ts
+// custom-mutator-options.ts
+
+export const useCustomMutatorOptions = <T, TError, TData, TContext>(
+  options: UseMutationOptions<T, TError, TData, TContext> &
+    Required<
+      Pick<UseMutationOptions<T, TError, TData, TContext>, 'mutationFn'>
+    >,
+  /* Optional */ path: { url: string },
+  /* Optional */ operation: { operationId: string; operationName: string },
+) => {
+  const queryClient = useQueryClient();
+  if (operation.operationId === 'createPet') {
+    queryClient.invalidateQueries({ queryKey: getGetPetsQueryKey() });
+  }
+  return options;
 };
 ```
 

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1385,8 +1385,12 @@ ${hooksOptionImplementation}
             ? `const customOptions = ${
                 mutationOptionsMutator.name
               }({...mutationOptions, mutationFn}${
+                mutationOptionsMutator.hasSecondArg
+                  ? `, { url: \`${route.replaceAll('/${', '/{')}\` }`
+                  : ''
+              }${
                 mutationOptionsMutator.hasThirdArg
-                  ? `, { url: \`${route}\` }`
+                  ? `, { operationId: '${operationId}', operationName: '${operationName}' }`
                   : ''
               });`
             : ''

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -55,7 +55,27 @@ export default defineConfig({
       schemas: '../generated/react-query/split-query-key/model',
       client: 'react-query',
       override: {
-        query: { shouldSplitQueryKey: true },
+        query: {
+          shouldSplitQueryKey: true,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
+  petstoreCustomMutatorOptions: {
+    output: {
+      target: '../generated/react-query/custom-mutator-options/endpoints.ts',
+      schemas: '../generated/react-query/custom-mutator-options/model',
+      client: 'react-query',
+      override: {
+        query: {
+          mutationOptions: {
+            path: '../mutators/custom-mutation.ts',
+            name: 'useCustomMutation',
+          },
+        },
       },
     },
     input: {

--- a/tests/mutators/custom-mutation.ts
+++ b/tests/mutators/custom-mutation.ts
@@ -1,0 +1,16 @@
+import { UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+
+export const useCustomMutation = <T, TError, TData, TContext>(
+  options: UseMutationOptions<T, TError, TData, TContext> &
+    Required<
+      Pick<UseMutationOptions<T, TError, TData, TContext>, 'mutationFn'>
+    >,
+  _: { url: string },
+  operation: { operationId: string; operationName: string },
+) => {
+  const queryClient = useQueryClient();
+  if (operation.operationId === 'deletePetById') {
+    queryClient.invalidateQueries({ queryKey: ['/pets'] });
+  }
+  return options;
+};


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

* Correctly check `hasSecondArg` instead of `hasThirdArg` for `{ url: route }`.
* Replace `/${` with `/{`, since we don't actually have the actual parameters to replace in the path, which caused a syntax error
* Add third arg which includes properties about the operation
* Add docs highlighting how the mutator should look
