### PR TITLE
feat(zod): add `output.orverride.zod.datetimeOptions` option

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1482,6 +1482,36 @@ module.exports = {
 };
 ```
 
+##### dateTimeOptions
+
+Type: `Object`.
+
+Default Value: `{}`.
+
+Use to set options for zod `datetime` fields. These options are passed directly to zod `datetime` validation.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        zod: {
+          dateTimeOptions: {
+            local: true,
+            offset: true,
+            precision: 3,
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+You can find more details in the [zod documentation ](https://zod.dev/?id=datetimes).
+
 #### mock
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -430,6 +430,12 @@ export type NormalizedHonoOptions = {
   validatorOutputPath: string;
 };
 
+export type ZodDateTimeOptions = {
+  offset?: boolean;
+  local?: boolean;
+  precision?: number;
+};
+
 export type ZodOptions = {
   strict?: {
     param?: boolean;
@@ -459,6 +465,7 @@ export type ZodOptions = {
     body?: Mutator;
     response?: Mutator;
   };
+  dateTimeOptions?: ZodDateTimeOptions;
   generateEachHttpStatus?: boolean;
 };
 
@@ -494,6 +501,7 @@ export type NormalizedZodOptions = {
     response?: NormalizedMutator;
   };
   generateEachHttpStatus: boolean;
+  dateTimeOptions: ZodDateTimeOptions;
 };
 
 export type HonoOptions = {

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -139,7 +139,8 @@ export const getMockScalar = ({
         `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`,
         item.nullable,
       );
-      let numberImports: GeneratorImport[] = [];
+      const numberImports: GeneratorImport[] = [];
+
       if (item.enum) {
         value = getEnum(
           item,
@@ -151,6 +152,7 @@ export const getMockScalar = ({
       } else if ('const' in item) {
         value = '' + (item as SchemaObject31).const;
       }
+
       return {
         value,
         enums: item.enum,
@@ -232,7 +234,7 @@ export const getMockScalar = ({
 
     case 'string': {
       let value = 'faker.string.alpha(20)';
-      let stringImports: GeneratorImport[] = [];
+      const stringImports: GeneratorImport[] = [];
 
       if (item.enum) {
         value = getEnum(

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -306,6 +306,7 @@ export const normalizeOptions = async (
           },
           generateEachHttpStatus:
             outputOptions.override?.zod?.generateEachHttpStatus ?? false,
+          dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {},
         },
         swr: {
           ...(outputOptions.override?.swr ?? {}),
@@ -500,6 +501,7 @@ const normalizeOperationsAndTags = (
                     },
                     generateEachHttpStatus:
                       zod?.generateEachHttpStatus ?? false,
+                    dateTimeOptions: zod?.dateTimeOptions ?? {},
                   },
                 }
               : {}),

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -112,6 +112,12 @@ const removeReadOnlyProperties = (schema: SchemaObject): SchemaObject => {
   return schema;
 };
 
+type DateTimeOptions = {
+  offset?: boolean;
+  local?: boolean;
+  precision?: number;
+};
+
 export const generateZodValidationSchemaDefinition = (
   schema: SchemaObject | undefined,
   context: ContextSpecs,
@@ -119,6 +125,7 @@ export const generateZodValidationSchemaDefinition = (
   strict: boolean,
   rules?: {
     required?: boolean;
+    dateTimeOptions?: DateTimeOptions;
   },
 ): ZodValidationSchemaDefinition => {
   if (!schema) return { functions: [], consts: [] };
@@ -284,7 +291,11 @@ export const generateZodValidationSchemaDefinition = (
       }
 
       if (schema.format === 'date-time') {
-        functions.push(['datetime', undefined]);
+        const options = context.output.override.zod?.dateTimeOptions;
+        functions.push([
+          'datetime',
+          options ? JSON.stringify(options) : undefined,
+        ]);
         break;
       }
 

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -169,4 +169,21 @@ export default defineConfig({
     },
     input: '../specifications/import-from-subdirectory/petstore.yaml',
   },
+  dateTimeOptions: {
+    output: {
+      target: '../generated/zod/date-time-options.ts',
+      client: 'zod',
+      override: {
+        zod: {
+          dateTimeOptions: {
+            offset: true,
+            precision: 3,
+          },
+        },
+      },
+    },
+    input: {
+      target: '../specifications/format.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1669 

i wanna use to `{offset: true}` in `datetime` function like this:

```ts
zod.object({
  "id": zod.number().optional(),
  "createdAt": zod.string().datetime({"offset":true}),
})
```

It still works as it is now and would be a breaking change, so we've made it optional.

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check by the test case i added.