### PR TITLE
fix(zod): always prioritize `required` definitions to determine `optional()`

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -137,8 +137,7 @@ export const generateZodValidationSchemaDefinition = (
 
   const functions: [string, any][] = [];
   const type = resolveZodType(schema);
-  const required =
-    schema.default !== undefined ? false : rules?.required ?? false;
+  const required = rules?.required ?? false;
   const nullable =
     schema.nullable ??
     (Array.isArray(schema.type) && schema.type.includes('null'));


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Currently, `optional` is always define in generated `zod` schema when defined `default` in `OpenAPI`.
However, there are fields that I want to make required even though they have default values, so these do not need to be synced.
In the future, `required` definitions should always be prioritized to determine whether to apply `optional()`.

## Related PRs

none

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Here are some examples.

### 1. when defining `default`

```yaml
Pet:
  type: object
  required:
    - id
  properties:
    id:
      type: integer
      format: bigint
      default: 0
```

```diff
export const listPetsResponseItem = zod.object({
- id: zod.number().optional(),
+ id: zod.number(),
});
```

### 2. when remove `id` from required

```yaml
Pet:
  type: object
  required:
    - name
  properties:
    id:
      type: integer
      format: bigint
      default: 0
```

defined `optional()`

```ts
export const listPetsResponseItem = zod.object({
  id: zod.number().optional(),
});
```

### 3. when defining nullable

```yaml
Pet:
  type: object
  required:
    - id
  properties:
    id:
      type: integer
      format: bigint
      default: 0
      nullable: true
```

defined `nullable()`

```ts
export const listPetsResponseItem = zod.object({
  id: zod.number().nullable(),
});
```

### 4. when remove id from required and define ture to `nullable`

```yaml
Pet:
  type: object
  required:
    - name
  properties:
    id:
      type: integer
      format: bigint
      default: 0
      nullable: true
```

defined `nullish()`

```ts
export const listPetsResponseItem = zod.object({
  id: zod.number().nullish(),
});
```