### PR TITLE
feat(query): add optional queryClient argument when using TanStack Query v5

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -118,6 +118,7 @@ const SVELTE_QUERY_DEPENDENCIES: GeneratorDependency[] = [
       { name: 'InfiniteData' },
       { name: 'CreateMutationResult' },
       { name: 'DataTag' },
+      { name: 'QueryClient' },
     ],
     dependency: '@tanstack/svelte-query',
   },
@@ -289,6 +290,7 @@ const VUE_QUERY_DEPENDENCIES: GeneratorDependency[] = [
       { name: 'InfiniteData' },
       { name: 'UseMutationReturnType' },
       { name: 'DataTag' },
+      { name: 'QueryClient' },
     ],
     dependency: '@tanstack/vue-query',
   },
@@ -998,13 +1000,16 @@ ${hookOptions}
 }`;
 
   const operationPrefix = hasSvelteQueryV4 ? 'create' : 'use';
+  const optionalQueryClientArgument = hasQueryV5
+    ? ', queryClient?: QueryClient'
+    : '';
 
   const queryHookName = camel(`${operationPrefix}-${name}`);
 
   const overrideTypes = `
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${definedInitialDataQueryPropsDefinitions} ${definedInitialDataQueryArguments}\n  ): ${definedInitialDataReturnType}
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${undefinedInitialDataQueryArguments}\n  ): ${returnType}
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${queryArguments}\n  ): ${returnType}`;
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${definedInitialDataQueryPropsDefinitions} ${definedInitialDataQueryArguments} ${optionalQueryClientArgument}\n  ): ${definedInitialDataReturnType}
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${undefinedInitialDataQueryArguments} ${optionalQueryClientArgument}\n  ): ${returnType}
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${queryArguments} ${optionalQueryClientArgument}\n  ): ${returnType}`;
   return `
 ${queryOptionsFn}
 
@@ -1015,7 +1020,7 @@ export type ${pascal(name)}QueryError = ${errorType}
 
 ${hasQueryV5 && OutputClient.REACT_QUERY === outputClient ? overrideTypes : ''}
 ${doc}
-export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryProps} ${queryArguments}\n  ): ${returnType} {
+export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryProps} ${queryArguments} ${optionalQueryClientArgument} \n ): ${returnType} {
 
   const ${queryOptionsVarName} = ${queryOptionsFnName}(${queryProperties}${
     queryProperties ? ',' : ''
@@ -1023,7 +1028,7 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
 
   const ${queryResultVarName} = ${camel(
     `${operationPrefix}-${type}`,
-  )}(${queryOptionsVarName}) as ${returnType};
+  )}(${queryOptionsVarName} ${optionalQueryClientArgument ? ', queryClient' : ''}) as ${returnType};
 
   ${queryResultVarName}.queryKey = ${
     isVue(outputClient) ? `unref(${queryOptionsVarName})` : queryOptionsVarName

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -18,6 +18,7 @@ import type {
   DefinedUseQueryResult,
   InfiniteData,
   MutationFunction,
+  QueryClient,
   QueryFunction,
   QueryKey,
   UndefinedInitialDataOptions,
@@ -161,6 +162,7 @@ export function useListPetsInfinite<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): DefinedUseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -194,6 +196,7 @@ export function useListPetsInfinite<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): UseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -218,6 +221,7 @@ export function useListPetsInfinite<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -246,6 +250,7 @@ export function useListPetsInfinite<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 } {
@@ -255,10 +260,12 @@ export function useListPetsInfinite<
     options,
   );
 
-  const query = useInfiniteQuery(queryOptions) as UseInfiniteQueryResult<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData> };
+  const query = useInfiniteQuery(
+    queryOptions,
+    queryClient,
+  ) as UseInfiniteQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
 
   query.queryKey = queryOptions.queryKey;
 
@@ -320,6 +327,7 @@ export function useListPets<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -342,6 +350,7 @@ export function useListPets<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
@@ -354,6 +363,7 @@ export function useListPets<
       UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
     >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
  * @summary List all pets
@@ -370,12 +380,14 @@ export function useListPets<
       UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
     >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getListPetsQueryOptions(params, version, options);
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
-    queryKey: DataTag<QueryKey, TData>;
-  };
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData> };
 
   query.queryKey = queryOptions.queryKey;
 
@@ -434,6 +446,7 @@ export function useListPetsSuspense<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -452,6 +465,7 @@ export function useListPetsSuspense<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -470,6 +484,7 @@ export function useListPetsSuspense<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -492,6 +507,7 @@ export function useListPetsSuspense<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 } {
@@ -501,10 +517,12 @@ export function useListPetsSuspense<
     options,
   );
 
-  const query = useSuspenseQuery(queryOptions) as UseSuspenseQueryResult<
-    TData,
-    TError
-  > & { queryKey: DataTag<QueryKey, TData> };
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient,
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
 
   query.queryKey = queryOptions.queryKey;
 
@@ -589,6 +607,7 @@ export function useListPetsSuspenseInfinite<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -613,6 +632,7 @@ export function useListPetsSuspenseInfinite<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -637,6 +657,7 @@ export function useListPetsSuspenseInfinite<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -665,6 +686,7 @@ export function useListPetsSuspenseInfinite<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseSuspenseInfiniteQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 } {
@@ -676,6 +698,7 @@ export function useListPetsSuspenseInfinite<
 
   const query = useSuspenseInfiniteQuery(
     queryOptions,
+    queryClient,
   ) as UseSuspenseInfiniteQueryResult<TData, TError> & {
     queryKey: DataTag<QueryKey, TData>;
   };
@@ -860,6 +883,7 @@ export function useListPetsNestedArray<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -886,6 +910,7 @@ export function useListPetsNestedArray<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 export function useListPetsNestedArray<
   TData = Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -902,6 +927,7 @@ export function useListPetsNestedArray<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
  * @summary List all pets as nested array
@@ -922,6 +948,7 @@ export function useListPetsNestedArray<
       >
     >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getListPetsNestedArrayQueryOptions(
     params,
@@ -929,9 +956,10 @@ export function useListPetsNestedArray<
     options,
   );
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
-    queryKey: DataTag<QueryKey, TData>;
-  };
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData> };
 
   query.queryKey = queryOptions.queryKey;
 
@@ -1014,6 +1042,7 @@ export function useShowPetById<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
@@ -1036,6 +1065,7 @@ export function useShowPetById<
         'initialData'
       >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
@@ -1048,6 +1078,7 @@ export function useShowPetById<
       UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
     >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
  * @summary Info for a specific pet
@@ -1064,12 +1095,14 @@ export function useShowPetById<
       UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
     >;
   },
+  queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
   const queryOptions = getShowPetByIdQueryOptions(petId, version, options);
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
-    queryKey: DataTag<QueryKey, TData>;
-  };
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData> };
 
   query.queryKey = queryOptions.queryKey;
 


### PR DESCRIPTION
## Status

Ready

Fix #1278

## Description

In Version 5 of TanStack Query, the API for providing a custom queryClient within hooks was changed so that it could be framework agnostic: https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#removed-custom-context-prop-in-favor-of-custom-queryclient-instance.

https://tanstack.com/query/v5/docs/framework/svelte/reference/functions/createquery
https://tanstack.com/query/v5/docs/framework/react/reference/useQuery

This is a critical feature that allows for the use of the generated hooks outside of the component context.

This PR attempts to update the generated functions to account for this optional argument when v5 is detected.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
