### PR TITLE
docs(custom-client): update example to match the generated api

### DIFF
--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -24,13 +24,11 @@ module.exports = {
 
 const baseURL = '<BACKEND URL>'; // use your own URL here or environment variable
 
-export const customInstance = async <T>({
-  url,
+export const customInstance = async <T>(url: string, {
   method,
   params,
   data,
 }: {
-  url: string;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: any;
   data?: BodyType<unknown>;

--- a/docs/src/pages/guides/custom-client.md
+++ b/docs/src/pages/guides/custom-client.md
@@ -24,16 +24,19 @@ module.exports = {
 
 const baseURL = '<BACKEND URL>'; // use your own URL here or environment variable
 
-export const customInstance = async <T>(url: string, {
-  method,
-  params,
-  data,
-}: {
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
-  params?: any;
-  data?: BodyType<unknown>;
-  responseType?: string;
-}): Promise<T> => {
+export const customInstance = async <T>(
+  url: string,
+  {
+    method,
+    params,
+    body,
+  }: {
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+    params?: any;
+    body?: BodyType<unknown>;
+    responseType?: string;
+  },
+): Promise<T> => {
   let targetUrl = `${baseURL}${url}`;
 
   if (params) {
@@ -42,7 +45,7 @@ export const customInstance = async <T>(url: string, {
 
   const response = await fetch(targetUrl, {
     method,
-    ...(data ? { body: JSON.stringify(data) } : {}),
+    body,
   });
 
   return response.json();


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY/WIP/HOLD**

## Description

The usage is incorrect and according to docs the first element should be the url

https://github.com/PWNDAO/pwn-sdks/commit/6a2809cc4448bae2f39a637efe85def3debe4d54#diff-0fea3ac51887bbd80168c7716f7886d140606eeda3fe575f32f4f69020ba0296R29

Later I also adjusted parameters to remove data propery and rely on body because encoding happens before calling custom-client

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)
