### PR TITLE
chore(deps): add resolution for jsonpath-plus to avoid CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "zx": "^7.2.3"
   },
   "resolutions": {
-    "whatwg-url": ">=14"
+    "whatwg-url": ">=14",
+    "jsonpath-plus": "^10.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,7 +1071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsep-plugin/assignment@npm:^1.2.1, @jsep-plugin/assignment@npm:^1.3.0":
+"@jsep-plugin/assignment@npm:^1.3.0":
   version: 1.3.0
   resolution: "@jsep-plugin/assignment@npm:1.3.0"
   peerDependencies:
@@ -1089,7 +1089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsep-plugin/regex@npm:^1.0.3, @jsep-plugin/regex@npm:^1.0.4":
+"@jsep-plugin/regex@npm:^1.0.4":
   version: 1.0.4
   resolution: "@jsep-plugin/regex@npm:1.0.4"
   peerDependencies:
@@ -1281,23 +1281,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.7.0, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.8.0, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.7.0, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.8.0, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.7.0, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.8.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1332,60 +1332,60 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.7.0, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.8.0, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.7.0, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.8.0, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/zod": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/zod": "npm:7.8.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.7.0, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.8.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.7.0, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.8.0, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/fetch": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/fetch": "npm:7.8.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.7.0, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.8.0, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/fetch": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/fetch": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.7.0, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.8.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -6064,7 +6064,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsep@npm:^1.3.6, jsep@npm:^1.3.9, jsep@npm:^1.4.0":
+"jsep@npm:^1.3.6, jsep@npm:^1.4.0":
   version: 1.4.0
   resolution: "jsep@npm:1.4.0"
   checksum: 10c0/fe60adf47e050e22eadced42514a51a15a3cf0e2d147896584486acd8ee670fc16641101b9aeb81f4aaba382043d29744b7aac41171e8106515b14f27e0c7116
@@ -6154,23 +6154,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:10.1.0, jsonpath-plus@npm:^6.0.1 || ^10.1.0":
-  version: 10.1.0
-  resolution: "jsonpath-plus@npm:10.1.0"
-  dependencies:
-    "@jsep-plugin/assignment": "npm:^1.2.1"
-    "@jsep-plugin/regex": "npm:^1.0.3"
-    jsep: "npm:^1.3.9"
-  bin:
-    jsonpath: bin/jsonpath-cli.js
-    jsonpath-plus: bin/jsonpath-cli.js
-  checksum: 10c0/1ff0743f9113f7750b598563c7886e1b07c19f112c4a8d976165e6799ff9774279985d1f4a147e87eacc0b94eb27dbd6e3ab5cf0728d4ba947f00757bc6aebb4
-  languageName: node
-  linkType: hard
-
-"jsonpath-plus@npm:10.2.0":
-  version: 10.2.0
-  resolution: "jsonpath-plus@npm:10.2.0"
+"jsonpath-plus@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "jsonpath-plus@npm:10.3.0"
   dependencies:
     "@jsep-plugin/assignment": "npm:^1.3.0"
     "@jsep-plugin/regex": "npm:^1.0.4"
@@ -6178,7 +6164,7 @@ __metadata:
   bin:
     jsonpath: bin/jsonpath-cli.js
     jsonpath-plus: bin/jsonpath-cli.js
-  checksum: 10c0/46480781a0a0b5347dc592fd69ef7ff0fa5a5e322a3f1f23997319e77ee937762366d722facafcc5e8d16101e9cdf1ae14df1f1777b2933990aadd0cdb20d8f5
+  checksum: 10c0/f5ff53078ecab98e8afd1dcdb4488e528653fa5a03a32d671f52db1ae9c3236e6e072d75e1949a80929fd21b07603924a586f829b40ad35993fa0247fa4f7506
   languageName: node
   linkType: hard
 
@@ -7355,15 +7341,15 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.1"
-    "@orval/angular": "npm:7.7.0"
-    "@orval/axios": "npm:7.7.0"
-    "@orval/core": "npm:7.7.0"
-    "@orval/fetch": "npm:7.7.0"
-    "@orval/hono": "npm:7.7.0"
-    "@orval/mock": "npm:7.7.0"
-    "@orval/query": "npm:7.7.0"
-    "@orval/swr": "npm:7.7.0"
-    "@orval/zod": "npm:7.7.0"
+    "@orval/angular": "npm:7.8.0"
+    "@orval/axios": "npm:7.8.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/fetch": "npm:7.8.0"
+    "@orval/hono": "npm:7.8.0"
+    "@orval/mock": "npm:7.8.0"
+    "@orval/query": "npm:7.8.0"
+    "@orval/swr": "npm:7.8.0"
+    "@orval/zod": "npm:7.8.0"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #1964

## Description

jsonpath-plus versions <10.3.0 have a known CVE: https://github.com/advisories/GHSA-hw8r-x6gr-5gjp. jsonpath-plus v10.1.0 and v10.2.0 are brought in by @ibm-cloud/openapi-ruleset:

![Screenshot 2025-04-04 at 11 37 12](https://github.com/user-attachments/assets/48dc69fb-7a89-4599-9006-5c44fdc97229)

Although [a PR](https://github.com/orval-labs/orval/pull/1978) was opened and merged to update @ibm-cloud/openapi-ruleset, that dependency still brings in the vulnerable jsonpath-plus version. As it is quite a deep dependency, adding jsonpath-plus to resolutions seems to me like a faster solution than waiting on each subdependency.

## Steps to Test or Reproduce

Running `yarn npm audit -AR --severity high` on master branch will raise a CVE for jsonppath-plus. The CVE won't be there when running the same on this branch.
