### PR TITLE
docs: fix branch name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git add <file> && git commit -m "feat/fix/chore/docs: commit message"
 
 When all that's done, it's time to file a pull request to upstream:
 
-**NOTE**: All pull requests should target the `main` branch.
+**NOTE**: All pull requests should target the `master` branch.
 
 ## Credits
 


### PR DESCRIPTION
CONTRIBUTING.md states that PRs should target `main` branch, but there is no `main`. I think this should be `master`?