### PR TITLE
Fix enum generation

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -266,6 +266,24 @@ export const getMockScalar = ({
       };
 
     default: {
+      if (item.enum) {
+        const enumImports: GeneratorImport[] = [];
+        const value = getEnum(
+          item,
+          enumImports,
+          context,
+          existingReferencedProperties,
+          undefined,
+        );
+
+        return {
+          value,
+          enums: item.enum,
+          imports: enumImports,
+          name: item.name,
+        };
+      }
+
       return getMockObject({
         item,
         mockOptions,
@@ -304,16 +322,17 @@ const getEnum = (
   imports: GeneratorImport[],
   context: ContextSpecs,
   existingReferencedProperties: string[],
-  type: 'string' | 'number',
+  type: 'string' | 'number' | undefined,
 ) => {
   if (!item.enum) return '';
-  const joindEnumValues =
-    type === 'string'
-      ? `'${item.enum
-          .filter((e) => e !== null)
-          .map((e) => escape(e))
-          .join("','")}'`
-      : item.enum.filter((e) => e !== null).join(',');
+  const joindEnumValues = item.enum
+    .filter((e) => e !== null)
+    .map((e) =>
+      type === 'string' || (type === undefined && typeof e === 'string')
+        ? `'${escape(e)}'`
+        : e,
+    )
+    .join(',');
 
   let enumValue = `[${joindEnumValues}]`;
   if (context.output.override.useNativeEnums) {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -440,14 +440,22 @@ export const generateZodValidationSchemaDefinition = (
   }
 
   if (schema.enum) {
-    functions.push([
-      'enum',
-      [
-        `[${schema.enum
-          .map((value) => (isString(value) ? `'${escape(value)}'` : `${value}`))
-          .join(', ')}]`,
-      ],
-    ]);
+    if (schema.enum.every((value) => isString(value))) {
+      functions.push([
+        'enum',
+        `[${schema.enum.map((value) => `'${escape(value)}'`).join(', ')}]`,
+      ]);
+    } else {
+      functions.push([
+        'oneOf',
+        schema.enum.map((value) => ({
+          functions: [
+            ['literal', isString(value) ? `'${escape(value)}'` : value],
+          ],
+          consts: [],
+        })),
+      ]);
+    }
   }
 
   if (!required && schema.default) {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -642,7 +642,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
 
       expect(result).toEqual({
         functions: [
-          ['enum', ["['cat', 'dog']"]],
+          ['enum', "['cat', 'dog']"],
           ['optional', undefined],
         ],
         consts: [],
@@ -668,14 +668,20 @@ describe('generateZodValidationSchemaDefinition`', () => {
 
       expect(result).toEqual({
         functions: [
-          ['enum', ['[1, 2]']],
+          [
+            'oneOf',
+            [
+              { functions: [['literal', 1]], consts: [] },
+              { functions: [['literal', 2]], consts: [] },
+            ],
+          ],
           ['optional', undefined],
         ],
         consts: [],
       });
 
       const parsed = parseZodValidationSchemaDefinition(result, context, false);
-      expect(parsed.zod).toBe('zod.enum([1, 2]).optional()');
+      expect(parsed.zod).toBe('zod.literal(1).or(zod.literal(2)).optional()');
     });
 
     it('generates an enum for a boolean', () => {
@@ -694,14 +700,22 @@ describe('generateZodValidationSchemaDefinition`', () => {
 
       expect(result).toEqual({
         functions: [
-          ['enum', ['[true, false]']],
+          [
+            'oneOf',
+            [
+              { functions: [['literal', true]], consts: [] },
+              { functions: [['literal', false]], consts: [] },
+            ],
+          ],
           ['optional', undefined],
         ],
         consts: [],
       });
 
       const parsed = parseZodValidationSchemaDefinition(result, context, false);
-      expect(parsed.zod).toBe('zod.enum([true, false]).optional()');
+      expect(parsed.zod).toBe(
+        'zod.literal(true).or(zod.literal(false)).optional()',
+      );
     });
 
     it('generates an enum for any', () => {
@@ -719,14 +733,23 @@ describe('generateZodValidationSchemaDefinition`', () => {
 
       expect(result).toEqual({
         functions: [
-          ['enum', ["['cat', 1, true]"]],
+          [
+            'oneOf',
+            [
+              { functions: [['literal', "'cat'"]], consts: [] },
+              { functions: [['literal', 1]], consts: [] },
+              { functions: [['literal', true]], consts: [] },
+            ],
+          ],
           ['optional', undefined],
         ],
         consts: [],
       });
 
       const parsed = parseZodValidationSchemaDefinition(result, context, false);
-      expect(parsed.zod).toBe("zod.enum(['cat', 1, true]).optional()");
+      expect(parsed.zod).toBe(
+        "zod.literal('cat').or(zod.literal(1)).or(zod.literal(true)).optional()",
+      );
     });
   });
 });

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -186,4 +186,13 @@ export default defineConfig({
       target: '../specifications/format.yaml',
     },
   },
+  enums: {
+    output: {
+      target: '../generated/zod/enums.ts',
+      client: 'zod',
+    },
+    input: {
+      target: '../specifications/enums.yaml',
+    },
+  },
 });

--- a/tests/specifications/enums.yaml
+++ b/tests/specifications/enums.yaml
@@ -55,6 +55,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Duck'
+  /api/cat-dog:
+    get:
+      summary: sample cat dog
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatDog'
 components:
   schemas:
     Siamese:
@@ -148,3 +158,8 @@ components:
         - 3
       type: integer
       format: int32
+    CatDog:
+      enum:
+        - 1
+        - '2'
+        - a

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,23 +1281,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.7.0, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.8.0, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.7.0, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.8.0, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.7.0, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.8.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1332,60 +1332,60 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.7.0, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.8.0, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.7.0, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.8.0, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/zod": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/zod": "npm:7.8.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.7.0, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.8.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.7.0, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.8.0, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/fetch": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/fetch": "npm:7.8.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.7.0, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.8.0, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/fetch": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/fetch": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.7.0, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.8.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -7355,15 +7355,15 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.1"
-    "@orval/angular": "npm:7.7.0"
-    "@orval/axios": "npm:7.7.0"
-    "@orval/core": "npm:7.7.0"
-    "@orval/fetch": "npm:7.7.0"
-    "@orval/hono": "npm:7.7.0"
-    "@orval/mock": "npm:7.7.0"
-    "@orval/query": "npm:7.7.0"
-    "@orval/swr": "npm:7.7.0"
-    "@orval/zod": "npm:7.7.0"
+    "@orval/angular": "npm:7.8.0"
+    "@orval/axios": "npm:7.8.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/fetch": "npm:7.8.0"
+    "@orval/hono": "npm:7.8.0"
+    "@orval/mock": "npm:7.8.0"
+    "@orval/query": "npm:7.8.0"
+    "@orval/swr": "npm:7.8.0"
+    "@orval/zod": "npm:7.8.0"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"


### PR DESCRIPTION
## Status

READY

## Description

This PR fixes two issues:

1. Corrects a mistake in #1996 I previously submitted. I had mistakenly used `zod.enum` with non-string values, which is not supported. This resulted in generated TypeScript code that fails to build. Apologies for the oversight.
2. A bug in the mock data generation when enums contained a mix of string and number values.

The latter was found when I added a test case for enums.yaml.

## Related PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. When the schema has an enum with non-string values, the generated Zod schema was incorrect:
```yaml
schema:
    enum:
        - 1
        - 2
        - 3
```
Generated (incorrectly)
```typescript
z.enum([1,2,3])
```

2. When the schema has an enum containing both strings and numbers, incorrect mock code was generated.
See enums.yaml for the specific case.