### PR TITLE
Fix next js example for tag revalidation

### DIFF
--- a/samples/next-app-with-fetch/custom-fetch.ts
+++ b/samples/next-app-with-fetch/custom-fetch.ts
@@ -49,8 +49,7 @@ export const customFetch = async <T>(
     headers: requestHeaders,
   };
 
-  const request = new Request(requestUrl, requestInit);
-  const response = await fetch(request);
+  const response = await fetch(requestUrl, requestInit);
   const data = await getBody<T>(response);
 
   return { status: response.status, data, headers: response.headers } as T;


### PR DESCRIPTION
## Description

Described a bug in the NextJs examples where tag revalidation wasn't working

Fix https://github.com/orval-labs/orval/issues/2011

This single line change fixes the issue
