### PR TITLE
feat: support new client `mcp` server 

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -260,6 +260,7 @@ export const OutputClient = {
   ZOD: 'zod',
   HONO: 'hono',
   FETCH: 'fetch',
+  MCP: 'mcp',
 } as const;
 
 export type OutputClient = (typeof OutputClient)[keyof typeof OutputClient];

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,29 @@
+[![npm version](https://badge.fury.io/js/orval.svg)](https://badge.fury.io/js/orval)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
+
+<p align="center">
+  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+</p>
+<h1 align="center">
+  Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!
+</h1>
+
+### Code Generation
+
+`orval` is able to generate client with appropriate type-signatures (TypeScript) from any valid OpenAPI v3 or Swagger v2 specification, either in `yaml` or `json` formats.
+
+`Generate`, `valid`, `cache` and `mock` in your React, Vue, Svelte and Angular applications all with your OpenAPI specification.
+
+### Samples
+
+You can find below some samples
+
+- [react app](https://github.com/orval-labs/orval/tree/master/samples/react-app)
+- [react query](https://github.com/orval-labs/orval/tree/master/samples/react-query)
+- [svelte query](https://github.com/orval-labs/orval/tree/master/samples/svelte-query)
+- [vue query](https://github.com/orval-labs/orval/tree/master/samples/vue-query)
+- [react app with swr](https://github.com/orval-labs/orval/tree/master/samples/react-app-with-swr)
+- [angular app](https://github.com/orval-labs/orval/tree/master/samples/angular-app)
+- [hono](https://github.com/orval-labs/orval/tree/master/samples/hono)
+- [next app with fetch](https://github.com/orval-labs/orval/tree/master/samples/next-app-with-fetch)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -15,6 +15,31 @@
 
 `Generate`, `valid`, `cache` and `mock` in your React, Vue, Svelte and Angular applications all with your OpenAPI specification.
 
+### How to use the generated mcp server
+
+Add a setting to the mcp client to launch the generated `server.ts`.
+For example, like this:
+
+```
+"pet-store-server": {
+  "command": "docker",
+  "args": [
+    "run",
+    "-i",
+    "--rm",
+    "pet-store-mcp",
+    "bash",
+    "-c",
+    "ts-node",
+    "src/gen/server.ts"
+  ],
+  "disabled": false,
+  "alwaysAllow": []
+}
+```
+
+Here, `src/gen/server.ts` is started using `Docker`.
+
 ### Samples
 
 You can find below some samples

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@orval/mcp",
+  "version": "7.8.0",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup ./src/index.ts --target node12 --clean --dts --sourcemap",
+    "dev": "tsup ./src/index.ts --target node12 --clean --watch --sourcemap src",
+    "lint": "eslint src/**/*.ts"
+  },
+  "dependencies": {
+    "@orval/core": "7.7.0",
+    "@orval/zod": "7.7.0"
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@orval/core": "7.7.0",
-    "@orval/zod": "7.7.0"
+    "@orval/core": "7.8.0",
+    "@orval/zod": "7.8.0"
   }
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,426 @@
+import {
+  generateVerbImports,
+  ClientBuilder,
+  ClientExtraFilesBuilder,
+  ClientFooterBuilder,
+  ClientGeneratorsBuilder,
+  ClientHeaderBuilder,
+  ContextSpecs,
+  generateMutatorImports,
+  GeneratorDependency,
+  GeneratorMutator,
+  GeneratorVerbOptions,
+  getFileInfo,
+  jsDoc,
+  NormalizedOutputOptions,
+  upath,
+} from '@orval/core';
+import { generateZod } from '@orval/zod';
+import {
+  generateRequestFunction as generateFetchRequestFunction,
+  generateClient,
+  generateFetchHeader,
+} from '@orval/fetch';
+
+import { InfoObject } from 'openapi3-ts/oas30';
+
+const MCP_DEPENDENCIES: GeneratorDependency[] = [
+  {
+    exports: [
+      {
+        name: 'McpServer',
+        values: true,
+      },
+    ],
+    dependency: '@modelcontextprotocol/sdk/server/mcp.js',
+  },
+  {
+    exports: [
+      {
+        name: 'StdioServerTransport',
+        values: true,
+      },
+    ],
+    dependency: '@modelcontextprotocol/sdk/server/stdio.js',
+  },
+];
+
+export const getMcpDependencies = () => MCP_DEPENDENCIES;
+
+const getHeader = (
+  option: false | ((info: InfoObject) => string | string[]),
+  info: InfoObject,
+): string => {
+  if (!option) {
+    return '';
+  }
+
+  const header = option(info);
+
+  return Array.isArray(header) ? jsDoc({ description: header }) : header;
+};
+
+export const getMcpHeader: ClientHeaderBuilder = ({
+  verbOptions,
+  clientImplementation,
+}) => {
+  const importToolSchemas = Object.values(verbOptions)
+    .flatMap((verbOption) => {
+      const imports = [];
+
+      if (verbOption.headers)
+        imports.push(`  ${verbOption.operationName}Header`);
+      if (verbOption.params.length)
+        imports.push(`  ${verbOption.operationName}Params`);
+      if (verbOption.queryParams)
+        imports.push(`  ${verbOption.operationName}QueryParams`);
+      if (verbOption.body.definition)
+        imports.push(`  ${verbOption.operationName}Body`);
+
+      return imports;
+    })
+    .join(',\n');
+  const importToolSchemasImplementation = `import {\n${importToolSchemas}\n} from './tool-schemas.zod';`;
+
+  const importHandlers = Object.values(verbOptions)
+    .filter((verbOption) =>
+      clientImplementation.includes(`${verbOption.operationName}Handler`),
+    )
+    .map((verbOption) => `  ${verbOption.operationName}Handler`)
+    .join(`,\n`);
+  const importHandlersImplementation = `import {\n${importHandlers}\n} from './handlers';`;
+
+  const newMcpServerImplementation = `
+const server = new McpServer({
+  name: 'mcp-server',
+  version: '1.0.0',
+});
+`;
+
+  return [
+    importHandlersImplementation,
+    importToolSchemasImplementation,
+    newMcpServerImplementation,
+  ].join('\n');
+};
+
+export const getMcpFooter: ClientFooterBuilder = () => `
+const transport = new StdioServerTransport();
+server.connect(transport).then(() => {
+  console.error('MCP server running on stdio');
+}).catch(console.error);
+`;
+
+export const generateMcp: ClientBuilder = async (verbOptions, options) => {
+  const imputSchemaTypes = [];
+  if (verbOptions.params.length)
+    imputSchemaTypes.push(`  pathParams: ${verbOptions.operationName}Params`);
+  if (verbOptions.queryParams)
+    imputSchemaTypes.push(
+      `  queryParams: ${verbOptions.operationName}QueryParams`,
+    );
+  if (verbOptions.body.definition)
+    imputSchemaTypes.push(`  bodyParams: ${verbOptions.operationName}Body`);
+
+  const imputSchemaImplementation = imputSchemaTypes.length
+    ? `  {
+  ${imputSchemaTypes.join(',\n  ')}
+  },`
+    : '';
+
+  const toolImplementation = `
+server.tool(
+  '${verbOptions.operationName}',
+  '${verbOptions.summary}',${imputSchemaImplementation ? `\n${imputSchemaImplementation}` : ''}
+  ${verbOptions.operationName}Handler
+);`;
+
+  const schemaImports = generateVerbImports(verbOptions);
+  const imports = [...schemaImports];
+
+  return {
+    implementation: toolImplementation ? `${toolImplementation}\n` : '',
+    imports,
+  };
+};
+
+const getHandler = (verbOption: GeneratorVerbOptions) => {
+  const handlerArgsTypes = [];
+  const pathParamsType = verbOption.params
+    .map((param) => {
+      const paramName = param.name.split(': ')[0];
+      const paramType = param.implementation.split(': ')[1];
+      return `    ${paramName}: ${paramType}`;
+    })
+    .join(',\n');
+  if (pathParamsType)
+    handlerArgsTypes.push(`  pathParams: {\n${pathParamsType}\n  };`);
+  if (verbOption.queryParams)
+    handlerArgsTypes.push(
+      `  queryParams: ${verbOption.queryParams.schema.name};`,
+    );
+  if (verbOption.body.definition)
+    handlerArgsTypes.push(`  bodyParams: ${verbOption.body.definition};`);
+
+  const handlerArgsName = `${verbOption.operationName}Args`;
+  const handlerArgsImplementation = handlerArgsTypes.length
+    ? `
+export type ${handlerArgsName} = {
+${handlerArgsTypes.join('\n')}
+}
+`
+    : '';
+
+  const fetchParams = [];
+  if (verbOption.params.length) {
+    const pathParamsArgs = verbOption.params
+      .map((param) => {
+        const paramName = param.name.split(': ')[0];
+
+        return `args.pathParams.${paramName}`;
+      })
+      .join(', ');
+
+    fetchParams.push(`${pathParamsArgs}`);
+  }
+  if (verbOption.body.definition) fetchParams.push(`args.bodyParams`);
+  if (verbOption.queryParams) fetchParams.push(`args.queryParams`);
+
+  const handlerName = `${verbOption.operationName}Handler`;
+  const handlerImplementation = `
+export const ${handlerName} = async (${handlerArgsTypes.length ? `args: ${handlerArgsName}` : ''}) => {
+  const res = await ${verbOption.operationName}(${fetchParams.join(', ')});
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(res),
+      },
+    ],
+  };
+};`;
+
+  return [handlerArgsImplementation, handlerImplementation].join('');
+};
+
+const generateHandlers = async (
+  verbOptions: Record<string, GeneratorVerbOptions>,
+  output: NormalizedOutputOptions,
+) => {
+  const { extension, dirname, filename } = getFileInfo(output.target);
+
+  const handlerPath = upath.join(dirname, `handlers${extension}`);
+
+  const relativeSchemaImportPath = output.schemas
+    ? upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
+    : './' + filename + '.schemas';
+  const importSchemaNames = await Promise.all(
+    Object.values(verbOptions)
+      .flatMap((verbOption) => generateVerbImports(verbOption))
+      .reduce((acc, imp) => {
+        if (!acc.find((name) => name === imp.name)) {
+          acc.push(imp.name);
+        }
+
+        return acc;
+      }, [] as string[]),
+  );
+  const importSchemasImplementation = `import { ${importSchemaNames.join(
+    ',\n',
+  )} } from '${relativeSchemaImportPath}';`;
+
+  const relativeFetchClientPath = './http-client';
+  const importFetchClientNames = await Promise.all(
+    Object.values(verbOptions)
+      .flatMap((verbOption) => verbOption.operationName)
+      .reduce((acc, name) => {
+        if (!acc.find((i) => i === name)) {
+          acc.push(name);
+        }
+
+        return acc;
+      }, [] as string[]),
+  );
+
+  const importFetchClientImplementation = `import { ${importFetchClientNames.join(
+    ',\n',
+  )} } from '${relativeFetchClientPath}';`;
+
+  const handlersImplementation = Object.values(verbOptions)
+    .map((verbOption) => {
+      return getHandler(verbOption);
+    })
+    .join('\n');
+
+  const content = [
+    importSchemasImplementation,
+    importFetchClientImplementation,
+    handlersImplementation,
+  ].join('\n');
+
+  return [
+    {
+      content,
+      path: handlerPath,
+    },
+  ];
+};
+
+const generateZodFiles = async (
+  verbOptions: Record<string, GeneratorVerbOptions>,
+  output: NormalizedOutputOptions,
+  context: ContextSpecs,
+) => {
+  const { extension, dirname, filename } = getFileInfo(output.target);
+
+  const header = getHeader(
+    output.override.header,
+    context.specs[context.specKey].info,
+  );
+
+  const zods = await Promise.all(
+    Object.values(verbOptions).map((verbOption) =>
+      generateZod(
+        verbOption,
+        {
+          route: verbOption.route,
+          pathRoute: verbOption.pathRoute,
+          override: output.override,
+          context,
+          mock: output.mock,
+          output: output.target!,
+        },
+        output.client,
+      ),
+    ),
+  );
+
+  const allMutators = zods.reduce(
+    (acc, z) => {
+      (z.mutators ?? []).forEach((mutator) => {
+        acc[mutator.name] = mutator;
+      });
+      return acc;
+    },
+    {} as Record<string, GeneratorMutator>,
+  );
+
+  const mutatorsImports = generateMutatorImports({
+    mutators: Object.values(allMutators),
+  });
+
+  let content = `${header}import { z as zod } from 'zod';\n${mutatorsImports}\n`;
+
+  const zodPath = upath.join(dirname, `tool-schemas.zod${extension}`);
+
+  content += zods.map((zod) => zod.implementation).join('\n');
+
+  return [
+    {
+      content,
+      path: zodPath,
+    },
+  ];
+};
+
+const generateHttpClinetFiles = async (
+  verbOptions: Record<string, GeneratorVerbOptions>,
+  output: NormalizedOutputOptions,
+  context: ContextSpecs,
+) => {
+  const { extension, dirname, filename } = getFileInfo(output.target);
+
+  const header = getHeader(
+    output.override.header,
+    context.specs[context.specKey].info,
+  );
+
+  const clients = await Promise.all(
+    Object.values(verbOptions).map((verbOption) => {
+      const options = {
+        route: verbOption.route,
+        pathRoute: verbOption.pathRoute,
+        override: output.override,
+        context,
+        mock: output.mock,
+        output: output.target!,
+      };
+
+      return generateClient(verbOption, options, output.client, output);
+    }),
+  );
+  const clientImplementation = clients
+    .map((client) => client.implementation)
+    .join('\n');
+
+  const relativeSchemasPath = output.schemas
+    ? upath.relativeSafe(dirname, getFileInfo(output.schemas).dirname)
+    : './' + filename + '.schemas';
+  const importNames = clients
+    .flatMap((client) => client.imports)
+    .reduce((acc, imp) => {
+      if (!acc.find((i) => i === imp.name)) {
+        acc.push(imp.name);
+      }
+
+      return acc;
+    }, [] as string[]);
+  const importImplementation = `import { ${importNames.join(
+    ',\n',
+  )} } from '${relativeSchemasPath}';`;
+
+  const fetchHeader = generateFetchHeader({
+    title: '',
+    isRequestOptions: false,
+    isMutator: false,
+    noFunction: false,
+    isGlobalMutator: false,
+    provideIn: false,
+    hasAwaitedType: false,
+    output,
+    verbOptions,
+    clientImplementation,
+  });
+
+  const content = [
+    header,
+    importImplementation,
+    fetchHeader,
+    clientImplementation,
+  ].join('\n');
+  const outputPath = upath.join(dirname, `http-client${extension}`);
+
+  return [
+    {
+      content,
+      path: outputPath,
+    },
+  ];
+};
+
+export const generateExtraFiles: ClientExtraFilesBuilder = async (
+  verbOptions,
+  output,
+  context,
+) => {
+  const [handlers, zods, httpClients] = await Promise.all([
+    generateHandlers(verbOptions, output),
+    generateZodFiles(verbOptions, output, context),
+    generateHttpClinetFiles(verbOptions, output, context),
+  ]);
+
+  return [...handlers, ...zods, ...httpClients];
+};
+
+const mcpClientBuilder: ClientGeneratorsBuilder = {
+  client: generateMcp,
+  dependencies: getMcpDependencies,
+  header: getMcpHeader,
+  footer: getMcpFooter,
+  extraFiles: generateExtraFiles,
+};
+
+export const builder = () => () => mcpClientBuilder;
+
+export default builder;

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,6 +12,7 @@ import {
   jsDoc,
   NormalizedOutputOptions,
   upath,
+  camel,
 } from '@orval/core';
 import { generateZod } from '@orval/zod';
 import {
@@ -168,13 +169,10 @@ export const generateServer = async (
   output: NormalizedOutputOptions,
   context: ContextSpecs,
 ) => {
+  const info = context.specs[context.specKey].info;
   const { extension, dirname } = getFileInfo(output.target);
   const serverPath = upath.join(dirname, `server${extension}`);
-
-  const header = getHeader(
-    output.override.header,
-    context.specs[context.specKey].info,
-  );
+  const header = getHeader(output.override.header, info);
 
   const toolImplementations = Object.values(verbOptions)
     .map((verbOption) => {
@@ -243,7 +241,7 @@ import {
 `;
   const newMcpServerImplementation = `
 const server = new McpServer({
-  name: 'mcp-server',
+  name: '${camel(info.title)}Server',
   version: '1.0.0',
 });
 `;

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -61,6 +61,7 @@
     "@orval/core": "7.8.0",
     "@orval/fetch": "7.8.0",
     "@orval/hono": "7.8.0",
+    "@orval/mcp": "7.8.0",
     "@orval/mock": "7.8.0",
     "@orval/query": "7.8.0",
     "@orval/swr": "7.8.0",

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -27,6 +27,7 @@ import * as mock from '@orval/mock';
 import query from '@orval/query';
 import swr from '@orval/swr';
 import zod from '@orval/zod';
+import mcp from '@orval/mcp';
 
 const DEFAULT_CLIENT = OutputClient.AXIOS;
 
@@ -45,6 +46,7 @@ const getGeneratorClient = (
     zod: zod()(),
     hono: hono()(),
     fetch: fetchClient()(),
+    mcp: mcp()(),
   };
 
   const generator = isFunction(outputClient)

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,13 +343,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/aix-ppc64@npm:0.25.2"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-arm64@npm:0.21.5"
@@ -367,13 +360,6 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/android-arm64@npm:0.25.1"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/android-arm64@npm:0.25.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -399,13 +385,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/android-arm@npm:0.25.2"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-x64@npm:0.21.5"
@@ -423,13 +402,6 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/android-x64@npm:0.25.1"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/android-x64@npm:0.25.2"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -455,13 +427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/darwin-arm64@npm:0.25.2"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/darwin-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/darwin-x64@npm:0.21.5"
@@ -479,13 +444,6 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/darwin-x64@npm:0.25.1"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/darwin-x64@npm:0.25.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -511,13 +469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.2"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/freebsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/freebsd-x64@npm:0.21.5"
@@ -535,13 +486,6 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/freebsd-x64@npm:0.25.1"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/freebsd-x64@npm:0.25.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -567,13 +511,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-arm64@npm:0.25.2"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-arm@npm:0.21.5"
@@ -595,13 +532,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-arm@npm:0.25.2"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-ia32@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-ia32@npm:0.21.5"
@@ -619,13 +549,6 @@ __metadata:
 "@esbuild/linux-ia32@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-ia32@npm:0.25.1"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-ia32@npm:0.25.2"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -658,13 +581,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-loong64@npm:0.25.2"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-mips64el@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-mips64el@npm:0.21.5"
@@ -682,13 +598,6 @@ __metadata:
 "@esbuild/linux-mips64el@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-mips64el@npm:0.25.1"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-mips64el@npm:0.25.2"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -714,13 +623,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-ppc64@npm:0.25.2"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-riscv64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-riscv64@npm:0.21.5"
@@ -738,13 +640,6 @@ __metadata:
 "@esbuild/linux-riscv64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-riscv64@npm:0.25.1"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-riscv64@npm:0.25.2"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -770,13 +665,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-s390x@npm:0.25.2"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-x64@npm:0.21.5"
@@ -798,23 +686,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/linux-x64@npm:0.25.2"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/netbsd-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/netbsd-arm64@npm:0.25.1"
-  conditions: os=netbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.2"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -840,13 +714,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/netbsd-x64@npm:0.25.2"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/openbsd-arm64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/openbsd-arm64@npm:0.23.0"
@@ -857,13 +724,6 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/openbsd-arm64@npm:0.25.1"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.2"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -889,13 +749,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/openbsd-x64@npm:0.25.2"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/sunos-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/sunos-x64@npm:0.21.5"
@@ -913,13 +766,6 @@ __metadata:
 "@esbuild/sunos-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/sunos-x64@npm:0.25.1"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/sunos-x64@npm:0.25.2"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -945,13 +791,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/win32-arm64@npm:0.25.2"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-ia32@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-ia32@npm:0.21.5"
@@ -973,13 +812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/win32-ia32@npm:0.25.2"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-x64@npm:0.21.5"
@@ -997,13 +829,6 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/win32-x64@npm:0.25.1"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.25.2":
-  version: 0.25.2
-  resolution: "@esbuild/win32-x64@npm:0.25.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1181,32 +1006,6 @@ __metadata:
   version: 1.7.1
   resolution: "@ibm-cloud/openapi-ruleset-utilities@npm:1.7.1"
   checksum: 10c0/ddc252733c260db238d0dbadee84da4ae312ad3e3574b0021d9ddd05a185067249915237af5023b45c8bd6b90032796ba8291cc9538a965ccff1a1a358feb224
-  languageName: node
-  linkType: hard
-
-"@ibm-cloud/openapi-ruleset-utilities@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@ibm-cloud/openapi-ruleset-utilities@npm:1.8.0"
-  checksum: 10c0/19e83c0f896e82c78312a99d7d3eebcad23a1171c1571d70358dfe388e8c815ce91f94283018b899ad8e6d9f3556ea9926a68303af7fb08aa55643f7ca926172
-  languageName: node
-  linkType: hard
-
-"@ibm-cloud/openapi-ruleset@npm:^1.29.2":
-  version: 1.30.0
-  resolution: "@ibm-cloud/openapi-ruleset@npm:1.30.0"
-  dependencies:
-    "@ibm-cloud/openapi-ruleset-utilities": "npm:1.8.0"
-    "@stoplight/spectral-formats": "npm:^1.8.2"
-    "@stoplight/spectral-functions": "npm:^1.9.3"
-    "@stoplight/spectral-rulesets": "npm:^1.21.3"
-    chalk: "npm:^4.1.2"
-    jsonschema: "npm:^1.5.0"
-    lodash: "npm:^4.17.21"
-    loglevel: "npm:^1.9.2"
-    loglevel-plugin-prefix: "npm:0.8.4"
-    minimatch: "npm:^6.2.0"
-    validator: "npm:^13.11.0"
-  checksum: 10c0/52992dc70801496fab2e83725356ba87b94d24c5bac8084a12698c7b3fd27dfc0290c9c0401a0878cf84e83f9650c42c6a524b0203899cf2c459bd1cb8262606
   languageName: node
   linkType: hard
 
@@ -1534,32 +1333,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.7.0":
-  version: 7.7.0
-  resolution: "@orval/core@npm:7.7.0"
-  dependencies:
-    "@apidevtools/swagger-parser": "npm:^10.1.1"
-    "@ibm-cloud/openapi-ruleset": "npm:^1.29.2"
-    acorn: "npm:^8.14.0"
-    ajv: "npm:^8.17.1"
-    chalk: "npm:^4.1.2"
-    compare-versions: "npm:^6.1.1"
-    debug: "npm:^4.3.7"
-    esbuild: "npm:^0.25.0"
-    esutils: "npm:2.0.3"
-    fs-extra: "npm:^11.2.0"
-    globby: "npm:11.1.0"
-    lodash.isempty: "npm:^4.4.0"
-    lodash.uniq: "npm:^4.5.0"
-    lodash.uniqby: "npm:^4.7.0"
-    lodash.uniqwith: "npm:^4.5.0"
-    micromatch: "npm:^4.0.8"
-    openapi3-ts: "npm:4.4.0"
-    swagger2openapi: "npm:^7.0.8"
-  checksum: 10c0/900cedbf843a84997c83334937986ebfea55d0fbeb060a00769aa67911fffa3eba8bea6ab99f5d12d03fd88cf95fba03f324ee63175d8ecfd7917717e22134a5
-  languageName: node
-  linkType: hard
-
 "@orval/core@npm:7.8.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
@@ -1618,8 +1391,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@orval/mcp@workspace:packages/mcp"
   dependencies:
-    "@orval/core": "npm:7.7.0"
-    "@orval/zod": "npm:7.7.0"
+    "@orval/core": "npm:7.8.0"
+    "@orval/zod": "npm:7.8.0"
   languageName: unknown
   linkType: soft
 
@@ -1652,16 +1425,6 @@ __metadata:
     "@orval/fetch": "npm:7.8.0"
   languageName: unknown
   linkType: soft
-
-"@orval/zod@npm:7.7.0":
-  version: 7.7.0
-  resolution: "@orval/zod@npm:7.7.0"
-  dependencies:
-    "@orval/core": "npm:7.7.0"
-    lodash.uniq: "npm:^4.5.0"
-  checksum: 10c0/224e7ca73cbd9ea48138911a8ec2be712f9a0ed68e1147dfd4e2529c84dcf0388735beee523729054d75eaf76a5b8c18b6d476f41ba773c0cf476d6393e3fc42
-  languageName: node
-  linkType: hard
 
 "@orval/zod@npm:7.8.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
@@ -3879,7 +3642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.7, debug@npm:^4.4.0":
+"debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -4680,92 +4443,6 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/08c148c067795165798c0467ce02d2d1ecedc096989bded5f0d795c61a1fcbec6c14d0a3c9f4ad6185cc29ec52087acaa335ed6d98be6ad57f7fa4264626bde0
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.25.0":
-  version: 0.25.2
-  resolution: "esbuild@npm:0.25.2"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.25.2"
-    "@esbuild/android-arm": "npm:0.25.2"
-    "@esbuild/android-arm64": "npm:0.25.2"
-    "@esbuild/android-x64": "npm:0.25.2"
-    "@esbuild/darwin-arm64": "npm:0.25.2"
-    "@esbuild/darwin-x64": "npm:0.25.2"
-    "@esbuild/freebsd-arm64": "npm:0.25.2"
-    "@esbuild/freebsd-x64": "npm:0.25.2"
-    "@esbuild/linux-arm": "npm:0.25.2"
-    "@esbuild/linux-arm64": "npm:0.25.2"
-    "@esbuild/linux-ia32": "npm:0.25.2"
-    "@esbuild/linux-loong64": "npm:0.25.2"
-    "@esbuild/linux-mips64el": "npm:0.25.2"
-    "@esbuild/linux-ppc64": "npm:0.25.2"
-    "@esbuild/linux-riscv64": "npm:0.25.2"
-    "@esbuild/linux-s390x": "npm:0.25.2"
-    "@esbuild/linux-x64": "npm:0.25.2"
-    "@esbuild/netbsd-arm64": "npm:0.25.2"
-    "@esbuild/netbsd-x64": "npm:0.25.2"
-    "@esbuild/openbsd-arm64": "npm:0.25.2"
-    "@esbuild/openbsd-x64": "npm:0.25.2"
-    "@esbuild/sunos-x64": "npm:0.25.2"
-    "@esbuild/win32-arm64": "npm:0.25.2"
-    "@esbuild/win32-ia32": "npm:0.25.2"
-    "@esbuild/win32-x64": "npm:0.25.2"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/87ce0b78699c4d192b8cf7e9b688e9a0da10e6f58ff85a368bf3044ca1fa95626c98b769b5459352282e0065585b6f994a5e6699af5cccf9d31178960e2b58fd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,6 +343,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/aix-ppc64@npm:0.25.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-arm64@npm:0.21.5"
@@ -360,6 +367,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/android-arm64@npm:0.25.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/android-arm64@npm:0.25.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -385,6 +399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/android-arm@npm:0.25.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-x64@npm:0.21.5"
@@ -402,6 +423,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/android-x64@npm:0.25.1"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/android-x64@npm:0.25.2"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -427,6 +455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/darwin-arm64@npm:0.25.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/darwin-x64@npm:0.21.5"
@@ -444,6 +479,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/darwin-x64@npm:0.25.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/darwin-x64@npm:0.25.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -469,6 +511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/freebsd-x64@npm:0.21.5"
@@ -486,6 +535,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/freebsd-x64@npm:0.25.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/freebsd-x64@npm:0.25.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -511,6 +567,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-arm64@npm:0.25.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-arm@npm:0.21.5"
@@ -532,6 +595,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-arm@npm:0.25.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-ia32@npm:0.21.5"
@@ -549,6 +619,13 @@ __metadata:
 "@esbuild/linux-ia32@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-ia32@npm:0.25.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-ia32@npm:0.25.2"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -581,6 +658,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-loong64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-loong64@npm:0.25.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-mips64el@npm:0.21.5"
@@ -598,6 +682,13 @@ __metadata:
 "@esbuild/linux-mips64el@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-mips64el@npm:0.25.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-mips64el@npm:0.25.2"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -623,6 +714,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ppc64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-ppc64@npm:0.25.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-riscv64@npm:0.21.5"
@@ -640,6 +738,13 @@ __metadata:
 "@esbuild/linux-riscv64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/linux-riscv64@npm:0.25.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-riscv64@npm:0.25.2"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -665,6 +770,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-s390x@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-s390x@npm:0.25.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-x64@npm:0.21.5"
@@ -686,9 +798,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/linux-x64@npm:0.25.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/netbsd-arm64@npm:0.25.1"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.2"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -714,6 +840,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/netbsd-x64@npm:0.25.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.23.0":
   version: 0.23.0
   resolution: "@esbuild/openbsd-arm64@npm:0.23.0"
@@ -724,6 +857,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/openbsd-arm64@npm:0.25.1"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.2"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -749,6 +889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/openbsd-x64@npm:0.25.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/sunos-x64@npm:0.21.5"
@@ -766,6 +913,13 @@ __metadata:
 "@esbuild/sunos-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/sunos-x64@npm:0.25.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/sunos-x64@npm:0.25.2"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -791,6 +945,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-arm64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/win32-arm64@npm:0.25.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-ia32@npm:0.21.5"
@@ -812,6 +973,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/win32-ia32@npm:0.25.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-x64@npm:0.21.5"
@@ -829,6 +997,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.25.1":
   version: 0.25.1
   resolution: "@esbuild/win32-x64@npm:0.25.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.2":
+  version: 0.25.2
+  resolution: "@esbuild/win32-x64@npm:0.25.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1006,6 +1181,32 @@ __metadata:
   version: 1.7.1
   resolution: "@ibm-cloud/openapi-ruleset-utilities@npm:1.7.1"
   checksum: 10c0/ddc252733c260db238d0dbadee84da4ae312ad3e3574b0021d9ddd05a185067249915237af5023b45c8bd6b90032796ba8291cc9538a965ccff1a1a358feb224
+  languageName: node
+  linkType: hard
+
+"@ibm-cloud/openapi-ruleset-utilities@npm:1.8.0":
+  version: 1.8.0
+  resolution: "@ibm-cloud/openapi-ruleset-utilities@npm:1.8.0"
+  checksum: 10c0/19e83c0f896e82c78312a99d7d3eebcad23a1171c1571d70358dfe388e8c815ce91f94283018b899ad8e6d9f3556ea9926a68303af7fb08aa55643f7ca926172
+  languageName: node
+  linkType: hard
+
+"@ibm-cloud/openapi-ruleset@npm:^1.29.2":
+  version: 1.30.0
+  resolution: "@ibm-cloud/openapi-ruleset@npm:1.30.0"
+  dependencies:
+    "@ibm-cloud/openapi-ruleset-utilities": "npm:1.8.0"
+    "@stoplight/spectral-formats": "npm:^1.8.2"
+    "@stoplight/spectral-functions": "npm:^1.9.3"
+    "@stoplight/spectral-rulesets": "npm:^1.21.3"
+    chalk: "npm:^4.1.2"
+    jsonschema: "npm:^1.5.0"
+    lodash: "npm:^4.17.21"
+    loglevel: "npm:^1.9.2"
+    loglevel-plugin-prefix: "npm:0.8.4"
+    minimatch: "npm:^6.2.0"
+    validator: "npm:^13.11.0"
+  checksum: 10c0/52992dc70801496fab2e83725356ba87b94d24c5bac8084a12698c7b3fd27dfc0290c9c0401a0878cf84e83f9650c42c6a524b0203899cf2c459bd1cb8262606
   languageName: node
   linkType: hard
 
@@ -1333,6 +1534,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@orval/core@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@orval/core@npm:7.7.0"
+  dependencies:
+    "@apidevtools/swagger-parser": "npm:^10.1.1"
+    "@ibm-cloud/openapi-ruleset": "npm:^1.29.2"
+    acorn: "npm:^8.14.0"
+    ajv: "npm:^8.17.1"
+    chalk: "npm:^4.1.2"
+    compare-versions: "npm:^6.1.1"
+    debug: "npm:^4.3.7"
+    esbuild: "npm:^0.25.0"
+    esutils: "npm:2.0.3"
+    fs-extra: "npm:^11.2.0"
+    globby: "npm:11.1.0"
+    lodash.isempty: "npm:^4.4.0"
+    lodash.uniq: "npm:^4.5.0"
+    lodash.uniqby: "npm:^4.7.0"
+    lodash.uniqwith: "npm:^4.5.0"
+    micromatch: "npm:^4.0.8"
+    openapi3-ts: "npm:4.4.0"
+    swagger2openapi: "npm:^7.0.8"
+  checksum: 10c0/900cedbf843a84997c83334937986ebfea55d0fbeb060a00769aa67911fffa3eba8bea6ab99f5d12d03fd88cf95fba03f324ee63175d8ecfd7917717e22134a5
+  languageName: node
+  linkType: hard
+
 "@orval/core@npm:7.8.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
@@ -1387,6 +1614,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@orval/mcp@npm:7.8.0, @orval/mcp@workspace:packages/mcp":
+  version: 0.0.0-use.local
+  resolution: "@orval/mcp@workspace:packages/mcp"
+  dependencies:
+    "@orval/core": "npm:7.7.0"
+    "@orval/zod": "npm:7.7.0"
+  languageName: unknown
+  linkType: soft
+
 "@orval/mock@npm:7.8.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
@@ -1416,6 +1652,16 @@ __metadata:
     "@orval/fetch": "npm:7.8.0"
   languageName: unknown
   linkType: soft
+
+"@orval/zod@npm:7.7.0":
+  version: 7.7.0
+  resolution: "@orval/zod@npm:7.7.0"
+  dependencies:
+    "@orval/core": "npm:7.7.0"
+    lodash.uniq: "npm:^4.5.0"
+  checksum: 10c0/224e7ca73cbd9ea48138911a8ec2be712f9a0ed68e1147dfd4e2529c84dcf0388735beee523729054d75eaf76a5b8c18b6d476f41ba773c0cf476d6393e3fc42
+  languageName: node
+  linkType: hard
 
 "@orval/zod@npm:7.8.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
@@ -3633,7 +3879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.4.0":
+"debug@npm:^4.3.7, debug@npm:^4.4.0":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -4434,6 +4680,92 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/08c148c067795165798c0467ce02d2d1ecedc096989bded5f0d795c61a1fcbec6c14d0a3c9f4ad6185cc29ec52087acaa335ed6d98be6ad57f7fa4264626bde0
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.25.0":
+  version: 0.25.2
+  resolution: "esbuild@npm:0.25.2"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.2"
+    "@esbuild/android-arm": "npm:0.25.2"
+    "@esbuild/android-arm64": "npm:0.25.2"
+    "@esbuild/android-x64": "npm:0.25.2"
+    "@esbuild/darwin-arm64": "npm:0.25.2"
+    "@esbuild/darwin-x64": "npm:0.25.2"
+    "@esbuild/freebsd-arm64": "npm:0.25.2"
+    "@esbuild/freebsd-x64": "npm:0.25.2"
+    "@esbuild/linux-arm": "npm:0.25.2"
+    "@esbuild/linux-arm64": "npm:0.25.2"
+    "@esbuild/linux-ia32": "npm:0.25.2"
+    "@esbuild/linux-loong64": "npm:0.25.2"
+    "@esbuild/linux-mips64el": "npm:0.25.2"
+    "@esbuild/linux-ppc64": "npm:0.25.2"
+    "@esbuild/linux-riscv64": "npm:0.25.2"
+    "@esbuild/linux-s390x": "npm:0.25.2"
+    "@esbuild/linux-x64": "npm:0.25.2"
+    "@esbuild/netbsd-arm64": "npm:0.25.2"
+    "@esbuild/netbsd-x64": "npm:0.25.2"
+    "@esbuild/openbsd-arm64": "npm:0.25.2"
+    "@esbuild/openbsd-x64": "npm:0.25.2"
+    "@esbuild/sunos-x64": "npm:0.25.2"
+    "@esbuild/win32-arm64": "npm:0.25.2"
+    "@esbuild/win32-ia32": "npm:0.25.2"
+    "@esbuild/win32-x64": "npm:0.25.2"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/87ce0b78699c4d192b8cf7e9b688e9a0da10e6f58ff85a368bf3044ca1fa95626c98b769b5459352282e0065585b6f994a5e6699af5cccf9d31178960e2b58fd
   languageName: node
   linkType: hard
 
@@ -7418,6 +7750,7 @@ __metadata:
     "@orval/core": "npm:7.8.0"
     "@orval/fetch": "npm:7.8.0"
     "@orval/hono": "npm:7.8.0"
+    "@orval/mcp": "npm:7.8.0"
     "@orval/mock": "npm:7.8.0"
     "@orval/query": "npm:7.8.0"
     "@orval/swr": "npm:7.8.0"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #1997

Add a new client that runs only in `single` mode as an `mcp` server.

```ts
import { defineConfig } from 'orval';

export default defineConfig({
  mcpDev: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'single',
      client: 'mcp',
      baseUrl: 'http://localhost:3000',
      target: 'src/gen/handlers.ts',
      schemas: 'src/gen/http-schemas',
    },
  }
})
```

The following files will be generated:

```
src/gen/
├── handlers.ts                    // Calls the fetch client and returns the value. Handler referenced from MCP tools
├── http-client.ts                 // fetch clients
├── http-schemas                   // Schema referenced by the fetch client
│   ├── createPetsBodyItem.ts
│   ├── error.ts
│   ├── index.ts
│   ├── listPetsParams.ts
│   ├── pet.ts
│   ├── pets.ts
│   └── updatePetByParamsParams.ts
├── server.ts                      // MCP tools and server definitions
└── tool-schemas.zod.ts            // MCP tools input schema
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can test it as mentioned above.
