### PR TITLE
docs: fix incorrect path example from './/' to './'

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -92,7 +92,7 @@ module.exports = {
   petstore: {
     output: {
       mode: 'split',
-      target: './/gen/endpoints',
+      target: './gen/endpoints',
       schemas: './gen/model',
       fileExtension: '.gen.ts',
     },
@@ -125,7 +125,7 @@ module.exports = {
     output: {
       namingConvention: 'PascalCase',
       mode: 'split',
-      target: './/gen/endpoints',
+      target: './gen/endpoints',
       schemas: './gen/model',
       fileExtension: '.gen.ts',
     },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix: https://github.com/orval-labs/orval/issues/2014

This pull request updates a small inconsistency in the documentation examples — replacing `'.//gen/endpoints'` with `'./gen/endpoints'.`
While both technically work, ./ is the standard and clearer notation, improving readability and avoiding confusion for new users.

For reference, the configuration options being updated are part of the [Output Configuration](https://orval.dev/reference/configuration/output#fileextension) and [Naming Convention](https://orval.dev/reference/configuration/output#namingconvention) sections.

## Related PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

N/A
