### PR TITLE
prevent default axios client from being exported when `shouldExportHttpClient` is false

### DIFF
--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -219,7 +219,7 @@ export const generateAxiosRequestFunction = (
 
   const queryProps = toObjectString(props, 'implementation');
 
-  const httpRequestFunctionImplementation = `export const ${operationName} = (\n    ${queryProps} ${optionsArgs} ): Promise<AxiosResponse<${
+  const httpRequestFunctionImplementation = `${override.query.shouldExportHttpClient ? 'export ' : ''}const ${operationName} = (\n    ${queryProps} ${optionsArgs} ): Promise<AxiosResponse<${
     response.definition.success || 'unknown'
   }>> => {
     ${isVue ? vueUnRefParams(props) : ''}


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes https://github.com/orval-labs/orval/issues/2013

This PR ensures that the default axios client is no longer exported when `output.override.query.shouldExportHttpClient` is set to `false`.

Previously, the default axios function was always exported unless a custom mutator was defined.  
This change fixes that inconsistency, allowing generated code to omit the axios export as intended — especially useful in environments like TanStack Query hooks where internal axios usage should be encapsulated.

## Steps to Test or Reproduce

To test this behavior, modify `samples/react-query/orval.config.ts` **without specifying `override.mutator`**:

```ts
override: {
  query: {
    shouldExportHttpClient: false,
  },
  // ❌ No mutator is defined
},
```

Then run:

```bash
> yarn dev
```

### ✅ Expected Result

The generated function should **not be exported**, and look like:

```ts
/**
 * @summary List all pets
 */
const listPets = (
  params?: ListPetsParams,
  version: number = 1,
  options?: AxiosRequestConfig,
): Promise<AxiosResponse<PetsArray>> => {
  return axios.get(`/v${version}/pets`, {
    ...options,
    params: { ...params, ...options?.params },
  });
};
```

### ❌ Previously

Even with `shouldExportHttpClient: false`, the function was still exported:

```ts
/**
 * @summary List all pets
 */
export const listPets = (
  params?: ListPetsParams,
  version: number = 1,
  options?: AxiosRequestConfig,
): Promise<AxiosResponse<PetsArray>> => {
  return axios.get(`/v${version}/pets`, {
    ...options,
    params: { ...params, ...options?.params },
  });
};
```
