### PR TITLE
fix: fix to import only the necessary schema

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,6 +13,7 @@ import {
   NormalizedOutputOptions,
   upath,
   camel,
+  pascal,
 } from '@orval/core';
 import { generateZod } from '@orval/zod';
 import {
@@ -50,17 +51,23 @@ export const getMcpHeader: ClientHeaderBuilder = ({
 
   const importSchemaNames = Object.values(verbOptions)
     .flatMap((verbOption) => {
-      const imports = generateVerbImports(verbOption);
+      const imports = [];
+      const pascalOperationName = pascal(verbOption.operationName);
 
-      return imports
-        .filter((i) => clientImplementation.includes(i.name))
-        .map((i) => i.name);
+      if (verbOption.queryParams) {
+        imports.push(`${pascalOperationName}Params`);
+      }
+
+      if (verbOption.body.definition) {
+        imports.push(`${pascalOperationName}Body`);
+      }
+
+      return imports;
     })
     .reduce((acc, name) => {
       if (!acc.find((i) => i === name)) {
         acc.push(name);
       }
-
       return acc;
     }, [] as string[]);
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

follow #1997.
I fix to only import necessary schemas.

For example:

### Before

```ts
import {
  Pet,   // unnecessary
  Pets, // unnecessary
  ListPetsParams,
  CreatePetsParams,
  CreatePetsBody
} from './http-schemas';
```

### After

```ts
import {
  ListPetsParams,
  CreatePetsParams,
  CreatePetsBody
} from './http-schemas';
```

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

I'll add test in another PR.