### PR TITLE
fix(query): prioritize query over mutation for non-GET operations in generateQueryHook

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -992,13 +992,17 @@ module.exports = {
 
 Type: `Boolean`.
 
-Use to generate a <a href="https://tanstack.com/query/latest/docs/react/reference/useQuery" target="_blank">useQuery</a> custom hook. If the query key isn't provided that's the default hook generated.
+Use to generate a <a href="https://tanstack.com/query/latest/docs/react/reference/useQuery" target="_blank">useQuery</a> custom hook.
+If the query key isn't provided that's the default hook generated.
 
 ##### useMutation
 
 Type: `Boolean`.
 
 Use to generate a <a href="https://tanstack.com/query/latest/docs/react/reference/useMutation" target="_blank">useMutation</a> custom hook.
+The hook will only be generated if the operation is not a `GET` operation, and not configured to generate a [query](#useQuery).
+
+The [operations override](#operations) will take precedence if both are configured.
 
 ##### useInfinite
 

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1129,6 +1129,15 @@ const generateQueryHook = async (
     isQuery = operationQueryOptions.useSuspenseQuery;
   }
 
+  // For non-GET operations, only register query OR mutation hooks, not both
+  let isMutation =
+    operationQueryOptions?.useMutation || override.query.useMutation;
+
+  // If both query and mutation are true for a non-GET operation, prioritize query
+  if (verb !== Verbs.GET && isQuery) {
+    isMutation = false;
+  }
+
   if (isQuery) {
     const queryKeyMutator = query.queryKey
       ? await generateMutator({
@@ -1286,11 +1295,6 @@ const generateQueryHook = async (
         : undefined;
   }
 
-  let isMutation = verb !== Verbs.GET && override.query.useMutation;
-  if (operationQueryOptions?.useMutation !== undefined) {
-    isMutation = operationQueryOptions.useMutation;
-  }
-
   if (isMutation) {
     const mutationOptionsMutator = query.mutationOptions
       ? await generateMutator({
@@ -1365,7 +1369,7 @@ const generateQueryHook = async (
 
     const mutationOptionsFn = `export const ${mutationOptionsFnName} = <TError = ${errorType},
     TContext = unknown>(${mutationArguments}): ${mutationOptionFnReturnType} => {
-    
+
 ${hooksOptionImplementation}
 
       ${


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #2025

## Description

Ensures that only one of the queries or mutations are generated, giving priority to queries.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Run on the test repo that shows the bug in action

https://github.com/Edward-Upton/orval-duplicate-hook-bug