### PR TITLE
feat(mock): enhance mock options to include all required fields from combined schemas

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -334,6 +334,7 @@ export type MockOptions = Omit<OverrideMockOptions, 'properties'> & {
   properties?: Record<string, unknown>;
   operations?: Record<string, { properties: Record<string, unknown> }>;
   tags?: Record<string, { properties: Record<string, unknown> }>;
+  allRequiredFields?: string[];
 };
 
 export type MockPropertiesObject = {

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -118,9 +118,14 @@ export const getMockObject = ({
           return undefined;
         }
 
+        // Check if this field is in the collected allRequiredFields from combined schemas
         const isRequired =
           mockOptions?.required ||
-          (Array.isArray(item.required) ? item.required : []).includes(key);
+          (Array.isArray(mockOptions?.allRequiredFields)
+            ? mockOptions.allRequiredFields.includes(key)
+            : (Array.isArray(item.required) ? item.required : []).includes(
+                key,
+              ));
 
         // Check to see if the property is a reference to an existing property
         // Fixes issue #910


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When you have a `required` field defined for a field included from a nested `ref` or in the parent object, it doesn't propogate to the sub-objects that are ref'ed. This combines all of the required fields, and includes them in each object.

Fix https://github.com/orval-labs/orval/issues/2029 or more info

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
