### PR TITLE
fix(mock): allow to pass custom mock generator to options

### DIFF
--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -100,7 +100,7 @@ export const normalizeOptions = async (
   if (typeof mockOption === 'boolean' && mockOption) {
     mock = DEFAULT_MOCK_OPTIONS;
   } else if (isFunction(mockOption)) {
-    // do nothing
+    mock = mockOption;
   } else if (!mockOption) {
     mock = undefined;
   } else {


### PR DESCRIPTION
## Status

**READY**

## Description

When you try to pass a custom mock generator into options (`output.mock` property), it is removed by the `normalizeOptions` function. 

You can find the difference by looking at the `tests/generated/mock/petstore-custom-mock-builder/endpoints.ts`, there are missing lines:

```ts
const listPetsMockHandler = () => { return { data: { id: 1, name: "myName" } } }
const createPetsMockHandler = () => { return { data: { id: 1, name: "myName" } } }
const showPetByIdMockHandler = () => { return { data: { id: 1, name: "myName" } } }
const deletePetByIdMockHandler = () => { return { data: { id: 1, name: "myName" } } }
const healthCheckMockHandler = () => { return { data: { id: 1, name: "myName" } } }
export const getSwaggerPetstoreMock = () => [
  listPetsMockHandler(),
  createPetsMockHandler(),
  showPetByIdMockHandler(),
  deletePetByIdMockHandler(),
  healthCheckMockHandler()]
```

