### PR TITLE
fix(core): no not sanitize operationName when overridden

### DIFF
--- a/packages/core/src/generators/verbs-options.ts
+++ b/packages/core/src/generators/verbs-options.ts
@@ -80,10 +80,9 @@ const generateVerbOptions = async ({
 
   const overrideOperationName =
     overrideOperation?.operationName || output.override?.operationName;
-  const overriddenOperationName = overrideOperationName
+  const operationName = overrideOperationName
     ? overrideOperationName(operation, route, verb)
-    : camel(operationId);
-  const operationName = sanitize(overriddenOperationName, { es5keyword: true });
+    : sanitize(camel(operationId), { es5keyword: true });
 
   const response = getResponse({
     responses,


### PR DESCRIPTION
## Status

**READY**

Fix #552 

## Description

The current behaviour is really strange when overriding `operationName` in `output`, see this related issue: https://github.com/orval-labs/orval/issues/552

Maybe I should add in documentation that  when overriding, you need to sanitize on your side

## Related PRs


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1.
