### PR TITLE
fix(mcp): include `baseUrl` and `servers` settings in the route path

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,7 @@ import {
   upath,
   camel,
   pascal,
+  getFullRoute,
 } from '@orval/core';
 import { generateZod } from '@orval/zod';
 import {
@@ -349,8 +350,14 @@ const generateHttpClinetFiles = async (
 
   const clients = await Promise.all(
     Object.values(verbOptions).map((verbOption) => {
+      const fullRoute = getFullRoute(
+        verbOption.route,
+        context.specs[context.specKey].servers,
+        output.baseUrl,
+      );
+
       const options = {
-        route: verbOption.route,
+        route: fullRoute,
         pathRoute: verbOption.pathRoute,
         override: output.override,
         context,
@@ -361,6 +368,7 @@ const generateHttpClinetFiles = async (
       return generateClient(verbOption, options, output.client, output);
     }),
   );
+
   const clientImplementation = clients
     .map((client) => client.implementation)
     .join('\n');


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description
fix #1997 

I fixed a bug in `mcp` where the `baseUrl` and `servers` settings were not included in the route path.
When i setting `baseUrl` in config:

### Before

route is `pet/findByStatus`.

### After 

route is `https://petstore3.swagger.io/api/v3/pet/findByStatus`

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this by using the following config:

```
import { defineConfig } from 'orval';

export default defineConfig({
  mcp: {
    input: {
      target: './petstore.yaml',
    },
    output: {
      mode: 'single',
      client: 'mcp',
      baseUrl: 'https://petstore3.swagger.io/api/v3',
      target: 'src/handlers.ts',
      schemas: 'src/http-schemas',
      clean: true,
    },
  },
});
```
