### PR TITLE
docs(mcp): add `mcp` guide

### DIFF
--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -7,131 +7,141 @@
       
 	<url>
 		<loc>https://orval.dev/guides/angular</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/basics</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/client-with-zod</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/custom-axios</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/custom-client</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/enums</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/fetch-client</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/fetch</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/hono</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
+	</url>
+
+	<url>
+		<loc>https://orval.dev/guides/mcp-blog-ja</loc>
+		<lastmod>2025-04-20</lastmod>
+	</url>
+
+	<url>
+		<loc>https://orval.dev/guides/mcp</loc>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/msw</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/react-query</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/set-base-url</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/svelte-query</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/swr</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/vue-query</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/zod</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/installation</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/overview</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/quick-start</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/cli</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/full-example</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/hooks</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/input</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/output</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/overview</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/integration</loc>
-		<lastmod>2025-04-02</lastmod>
+		<lastmod>2025-04-20</lastmod>
 	</url>
 </urlset>

--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -104,6 +104,11 @@
           "title": "Enum names",
           "path": "/guides/enums",
           "editUrl": "/guides/enums.md"
+        },
+        {
+          "title": "MCP server",
+          "path": "/guides/mcp",
+          "editUrl": "/guides/mcp.md"
         }
       ]
     },

--- a/docs/src/pages/guides/hono.md
+++ b/docs/src/pages/guides/hono.md
@@ -27,8 +27,6 @@ module.exports = {
 };
 ```
 
-Currently, Please note that the `hono` client only works in `split` mode.
-
 #### generate template
 
 `orval` generates a file like the following:

--- a/docs/src/pages/guides/mcp.md
+++ b/docs/src/pages/guides/mcp.md
@@ -1,0 +1,103 @@
+---
+id: mcp
+title: MCP
+---
+
+### Introduction
+
+`Orval` generates `MCP server` from `OpenAPI`.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server create great value by simply relaying `API` clients.
+This eliminates the need to wait for someone to develop it or publish it on the marketplace. You can create an `MCP server` with various services that you have `OpenAPI` for yourself and use them with AI agents.
+And from a single `OpenAPI` specification, various `API` ecosystem components can be generated. The same specification can be used to support both traditional client-server applications and AI agent integration.
+
+### How to use
+
+If you want to generate a server of [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction), define the `client` property to `mcp` and a server of `MCP` will be generated in the target file and directory. You can check <a href="https://github.com/modelcontextprotocol/typescript-sdk" target="_blank">typescript-sdk</a>.
+
+#### Example with orval.config.js
+
+```ts
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './petstore.yaml',
+    },
+    output: {
+      mode: 'single',
+      client: 'mcp',
+      baseUrl: 'https://petstore3.swagger.io/api/v3',
+      target: 'src/handlers.ts',
+      schemas: 'src/http-schemas',
+    },
+  },
+});
+```
+
+Currently, Please note that the `hono` client only works in `single` mode.
+
+#### Generated Template Structure
+
+`orval` generates files in the following structure:
+
+```
+src/
+├── http-schemas
+│   ├── createPetsBodyItem.ts
+│   ├── error.ts
+│   ├── index.ts
+│   ├── listPetsParams.ts
+│   ├── pet.ts
+│   ├── pets.ts
+│   └── updatePetByParamsParams.ts
+├── handlers.ts
+├── http-client.ts
+├── server.ts
+└── tool-schemas.zod.ts
+```
+
+Each generated file serves a specific purpose:
+
+- `http-schemas/`: Directory containing `TypeScript` type definitions for `request`/`response` data
+- `handlers.ts`: Contains handler functions that use the `fetch` client to make `API` calls and return results in `MCP` format
+- `http-client.ts`: Contains generated `fetch` client functions for `API` communication
+- `server.ts`: Defines `MCP tools` and server configurations
+- `tool-schemas.zod.ts`: Defines `Zod` schemas for `MCP tool` inputs
+
+#### Using the generated MCP Server
+
+To use the generated code as an `MCP server`, follow these steps:
+
+1. Build the Docker image:
+
+```sh
+docker build ./ -t mcp-petstore
+```
+
+2. Configure the MCP server in your AI agent's configuration:
+
+Here we will introduce the settings using the `cline` for the ai agent. It will work with other ai agents, so please adjust the detailed settings accordingly.
+For `clile`, specify as follows:
+
+```
+{
+  "mcpServers": {
+    "petstore": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp-petstore"
+      ],
+      "disabled": false,
+      "alwaysAllow": []
+    },
+  }
+}
+```
+
+This setup allows your AI agent to interact with the petstore API through the MCP protocol, using the generated handlers and tools.
+
+Checkout <a href="https://github.com/orval-labs/orval/tree/master/samples/mcp/petstore" target="_blank">here</a> for the full example.

--- a/docs/src/pages/guides/mcp.md
+++ b/docs/src/pages/guides/mcp.md
@@ -35,7 +35,7 @@ export default defineConfig({
 });
 ```
 
-Currently, Please note that the `hono` client only works in `single` mode.
+Currently, Please note that the `mcp` client only works in `single` mode.
 
 #### Generated Template Structure
 

--- a/samples/mcp/petstore/README.md
+++ b/samples/mcp/petstore/README.md
@@ -12,7 +12,8 @@ docker build ./ -t mcp-petstore
 
 ### 2. Setup as mcp server in your ai agent.
 
-For clients, specify as follows:
+Here we will introduce the settings using the `cline` for the ai agent. It will work with other ai agents, so please adjust the detailed settings accordingly.
+For `clile`, specify as follows:
 
 ```
 {
@@ -30,6 +31,6 @@ For clients, specify as follows:
     },
   }
 }
-
-That's it.
 ```
+
+This setup allows your AI agent to interact with the petstore API through the MCP protocol, using the generated handlers and tools.


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description
fix #1997 
I've added the `mcp` guide and made some small modifications to the sample app `mcp-petstore`.

## Related PRs

none

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none