### PR TITLE
fix(query): properly handle dot-notation property names in useInfiniteQueryParam generation

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -784,7 +784,7 @@ const generateQueryImplementation = ({
           return param.name === 'params'
             ? `{...${
                 isVue(outputClient) ? `unref(params)` : 'params'
-              }, ${queryParam}: pageParam || ${
+              }, '${queryParam}': pageParam || ${
                 isVue(outputClient)
                   ? `unref(params)?.['${queryParam}']`
                   : `params?.['${queryParam}']`


### PR DESCRIPTION
## Status

READY

Fix #1377 

## Description

Current code generates invalid JavaScript when using dot-notation in useInfiniteQueryParam:

```javascript
const queryFn = ({ signal, pageParam }) => 
  exampleEndpoint(
    { ...params, pagination.page: pageParam || params?.['pagination.page']}, // ❌ syntax error
    { signal, ...axiosOptions }
  );
```

This syntax is invalid as dot-notation property names must be quoted or wrapped in brackets in object literals.

The fix quotes the property name:

```javascript
const queryFn = ({ signal, pageParam }) => 
  exampleEndpoint(
    { ...params, 'pagination.page': pageParam || params?.['pagination.page']}, // ✅ quoted key prevents syntax error
    { signal, ...axiosOptions }
  );
```

## Related Issue

Possible fix for https://github.com/orval-labs/orval/issues/1377

Auto‑closing keywords were intentionally omitted because I’m not entirely certain
this PR fully resolves the issue.
If it does, please close the issue manually.