### PR TITLE
Support prefetch for suspenseQuery and suspenseInfiniteQuery

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -718,6 +718,8 @@ const generateQueryImplementation = ({
   hasQueryV5WithDataTagError,
   doc,
   usePrefetch,
+  useQuery,
+  useInfinite,
 }: {
   queryOption: {
     name: string;
@@ -748,6 +750,8 @@ const generateQueryImplementation = ({
   hasQueryV5WithDataTagError: boolean;
   doc?: string;
   usePrefetch?: boolean;
+  useQuery?: boolean;
+  useInfinite?: boolean;
 }) => {
   const queryPropDefinitions = toObjectString(props, 'definition');
   const definedInitialDataQueryPropsDefinitions = toObjectString(
@@ -1010,6 +1014,20 @@ ${hookOptions}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${definedInitialDataQueryPropsDefinitions} ${definedInitialDataQueryArguments} ${optionalQueryClientArgument}\n  ): ${definedInitialDataReturnType}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${undefinedInitialDataQueryArguments} ${optionalQueryClientArgument}\n  ): ${returnType}
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${queryPropDefinitions} ${queryArguments} ${optionalQueryClientArgument}\n  ): ${returnType}`;
+
+  const shouldGeneratePrefetch =
+    usePrefetch &&
+    (type === QueryType.QUERY ||
+      type === QueryType.INFINITE ||
+      (type === QueryType.SUSPENSE_QUERY && !useQuery) ||
+      (type === QueryType.SUSPENSE_INFINITE && !useInfinite));
+  const prefetchType =
+    type === QueryType.QUERY || type === QueryType.SUSPENSE_QUERY
+      ? 'query'
+      : 'infinite-query';
+  const prefetchVarName = camel(`prefetch-${operationName}-${prefetchType}`);
+  const prefetchFnName = camel(`prefetch-${prefetchType}`);
+
   return `
 ${queryOptionsFn}
 
@@ -1037,16 +1055,14 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
   return ${queryResultVarName};
 }\n
 ${
-  usePrefetch && (type === QueryType.QUERY || type === QueryType.INFINITE)
-    ? `${doc}export const ${camel(
-        `prefetch-${name}`,
-      )} = async <TData = Awaited<ReturnType<${dataType}>>, TError = ${errorType}>(\n queryClient: QueryClient, ${queryProps} ${queryArguments}\n  ): Promise<QueryClient> => {
+  shouldGeneratePrefetch
+    ? `${doc}export const ${prefetchVarName} = async <TData = Awaited<ReturnType<${dataType}>>, TError = ${errorType}>(\n queryClient: QueryClient, ${queryProps} ${queryArguments}\n  ): Promise<QueryClient> => {
 
   const ${queryOptionsVarName} = ${queryOptionsFnName}(${queryProperties}${
     queryProperties ? ',' : ''
   }${isRequestOptions ? 'options' : 'queryOptions'})
 
-  await queryClient.${camel(`prefetch-${type}`)}(${queryOptionsVarName});
+  await queryClient.${prefetchFnName}(${queryOptionsVarName});
 
   return queryClient;
 }\n`
@@ -1272,6 +1288,8 @@ const generateQueryHook = async (
           hasQueryV5WithDataTagError,
           doc,
           usePrefetch: query.usePrefetch,
+          useQuery: query.useQuery,
+          useInfinite: query.useInfinite,
         }),
       '',
     )}


### PR DESCRIPTION
## Status

READY

## Description

Fixes https://github.com/orval-labs/orval/issues/2051

This PR improves the prefetch generation behavior for `suspenseQuery` and `suspenseInfiniteQuery`.

Previously, prefetch hooks were only generated when `useQuery` or `useInfiniteQuery` was used. 
Now, prefetch hooks are also generated when only `useSuspenseQuery` or `useSuspenseInfiniteQuery` is enabled.

In addition, to avoid generating duplicate prefetch hooks when both `useQuery` and `useSuspenseQuery` (or both `useInfiniteQuery` and `useSuspenseInfiniteQuery`) are used, the hook is generated only once.

## Steps to Test or Reproduce

1. In `samples/react-query/orval.config.ts`, add the following override:
    ```ts
    override: {
      query: {
        usePrefetch,
      },
    },
    ```
2. Confirm that:
    - One prefetch function is generated for each `query` and `infiniteQuery`.
    - Prefetch functions are generated even when `useQuery` and `useInfiniteQuery` are set to `false`.
