### PR TITLE
feat: allow index files customization

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -294,24 +294,39 @@ Same as the tags mode if you don't use the `schemas` property only one file will
 
 ### indexFiles
 
-Type: `Boolean`
+Type: `Boolean | Object`
 
-Valid values: true or false. Defaults to true.
+Valid values:
 
-Specify whether to place `index.ts` in `schemas` generation.
+- `true` (default): Generates index files for both workspace and schemas
+- `false`: Disables index file generation
+- Object with optional `workspace` and `schemas` functions to customize index file generation
 
-Example:
+The `indexFiles` option allows you to control the generation of index files that export all available components. When set to an object, you can customize the behavior for both workspace and schemas separately.
 
 ```js
 module.exports = {
   petstore: {
     output: {
       schemas: 'src/gen/model',
-      indexFiles: false,
+      indexFiles: {
+        workspace(implementations) {
+          // Filter out model files from workspace index
+          return implementations.filter((impl) => !impl.includes('models'));
+        },
+        schemas(schemas) {
+          // Filter schemas to include in index
+          return schemas.filter((schema) => schema.name !== 'Error');
+        },
+      },
     },
   },
 };
 ```
+
+The `workspace` function receives an array of implementation paths and should return the filtered/augmented array of paths to include in the workspace index file.
+
+The `schemas` function receives an array of schema objects and should return the filtered array of schemas to include in the schemas index file.
 
 ### title
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,7 +59,7 @@ export type NormalizedOutputOptions = {
   tsconfig?: Tsconfig;
   packageJson?: PackageJson;
   headers: boolean;
-  indexFiles: boolean;
+  indexFiles: NormalizedOutputIndexFiles;
   baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional: boolean;
   urlEncodeParameters: boolean;
@@ -163,6 +163,8 @@ export type NormalizedInputOptions = {
   filters?: InputFiltersOption;
 };
 
+export type NormalizedOutputIndexFiles = false | Required<OutputIndexFiles>;
+
 export type OutputClientFunc = (
   clients: GeneratorClients,
 ) => ClientGeneratorsBuilder;
@@ -230,7 +232,7 @@ export type OutputOptions = {
   tsconfig?: string | Tsconfig;
   packageJson?: string;
   headers?: boolean;
-  indexFiles?: boolean;
+  indexFiles?: boolean | OutputIndexFiles;
   baseUrl?: string | BaseUrlFromSpec | BaseUrlFromConstant;
   allParamsOptional?: boolean;
   urlEncodeParameters?: boolean;
@@ -290,6 +292,11 @@ export const OutputMode = {
 } as const;
 
 export type OutputMode = (typeof OutputMode)[keyof typeof OutputMode];
+
+export interface OutputIndexFiles {
+  workspace?: (implementations: string[]) => string[];
+  schemas?: (schemas: GeneratorSchema[]) => GeneratorSchema[];
+}
 
 export type OutputDocsOptions = {
   configPath?: string;
@@ -887,6 +894,7 @@ export type ClientBuilder = (
 export type ClientFileBuilder = {
   path: string;
   content: string;
+  exposeIndexFile?: boolean;
 };
 export type ClientExtraFilesBuilder = (
   verbOptions: Record<string, GeneratorVerbOptions>,

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -1,6 +1,10 @@
 import fs from 'fs-extra';
 import { generateImports } from '../generators';
-import { GeneratorSchema, NamingConvention } from '../types';
+import {
+  GeneratorSchema,
+  NamingConvention,
+  NormalizedOutputIndexFiles,
+} from '../types';
 import { upath, conventionName } from '../utils';
 
 const getSchema = ({
@@ -109,7 +113,7 @@ export const writeSchemas = async ({
   isRootKey: boolean;
   specsName: Record<string, string>;
   header: string;
-  indexFiles: boolean;
+  indexFiles: NormalizedOutputIndexFiles;
 }) => {
   await Promise.all(
     schemas.map((schema) =>
@@ -164,7 +168,8 @@ export const writeSchemas = async ({
         ? fileExtension.slice(0, -3)
         : fileExtension;
 
-      const importStatements = schemas
+      const importStatements = indexFiles
+        .schemas(schemas)
         .filter((schema) => {
           const name = conventionName(schema.name, namingConvention);
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -3,6 +3,7 @@ import {
   ConfigExternal,
   createLogger,
   FormDataArrayHandling,
+  GeneratorSchema,
   GlobalMockOptions,
   GlobalOptions,
   HonoOptions,
@@ -24,14 +25,15 @@ import {
   NormalizedMutator,
   NormalizedOperationOptions,
   NormalizedOptions,
+  NormalizedOutputIndexFiles,
   NormalizedOverrideOutput,
   NormalizedQueryOptions,
   OperationOptions,
   OptionsExport,
   OutputClient,
   OutputHttpClient,
+  OutputIndexFiles,
   OutputMode,
-  OutputOptions,
   OverrideOutput,
   PropertySortOrder,
   QueryOptions,
@@ -196,7 +198,7 @@ export const normalizeOptions = async (
       tsconfig,
       packageJson,
       headers: outputOptions.headers ?? false,
-      indexFiles: outputOptions.indexFiles ?? true,
+      indexFiles: normalizeIndexFiles(outputOptions.indexFiles),
       baseUrl: outputOptions.baseUrl,
       unionAddMissingProperties:
         outputOptions.unionAddMissingProperties ?? false,
@@ -428,6 +430,24 @@ export const normalizePath = <T>(path: T, workspace: string) => {
     return path;
   }
   return upath.resolve(workspace, path);
+};
+
+const normalizeIndexFiles = (
+  indexFiles: OutputIndexFiles | boolean | undefined = true,
+): NormalizedOutputIndexFiles => {
+  if (isBoolean(indexFiles)) {
+    return indexFiles
+      ? {
+          workspace: (implementations: string[]) => implementations,
+          schemas: (schemas: GeneratorSchema[]) => schemas,
+        }
+      : false;
+  }
+  return {
+    workspace: (implementations: string[]) => implementations,
+    schemas: (schemas: GeneratorSchema[]) => schemas,
+    ...indexFiles,
+  };
 };
 
 const normalizeOperationsAndTags = (

--- a/tests/configs/multi-client.config.ts
+++ b/tests/configs/multi-client.config.ts
@@ -1,0 +1,70 @@
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  reactQuery: {
+    input: '../specifications/petstore.yaml',
+    output: {
+      client: 'react-query',
+      mode: 'tags-split',
+      schemas: '../models',
+      target: './will-not-exists.ts',
+      workspace: '../generated/multi-client/react-query',
+      indexFiles: {
+        workspace(implementations) {
+          return implementations.filter((impl) => !impl.includes('models'));
+        },
+      },
+    },
+  },
+  fetch: {
+    input: '../specifications/petstore.yaml',
+    output: {
+      client: 'fetch',
+      mode: 'tags-split',
+      schemas: '../models',
+      target: './will-not-exists.ts',
+      workspace: '../generated/multi-client/fetch',
+      indexFiles: {
+        workspace(implementations) {
+          return implementations.filter((impl) => !impl.includes('models'));
+        },
+      },
+    },
+  },
+  zod: {
+    input: '../specifications/petstore.yaml',
+    output: {
+      client({ zod }) {
+        return {
+          client: zod.client,
+          async extraFiles(_, __, context) {
+            return [
+              {
+                path: context.output.workspace + '/extrafiles/index.ts',
+                content: 'export * from "./file1";\nexport * from "./file2";\n',
+                exposeIndexFile: true,
+              },
+              {
+                path: context.output.workspace + '/extrafiles/file1.ts',
+                content: 'export const extraFile1 = "extraFile1"',
+              },
+              {
+                path: context.output.workspace + '/extrafiles/file2.ts',
+                content: 'export const extraFile2 = "extraFile2"',
+              },
+            ];
+          },
+        };
+      },
+      mode: 'tags-split',
+      schemas: '../models',
+      target: './will-not-exists.ts',
+      workspace: '../generated/multi-client/zod',
+      indexFiles: {
+        workspace(implementations) {
+          return implementations.filter((impl) => !impl.includes('models'));
+        },
+      },
+    },
+  },
+});

--- a/tests/configs/multi-client.config.ts
+++ b/tests/configs/multi-client.config.ts
@@ -16,21 +16,6 @@ export default defineConfig({
       },
     },
   },
-  fetch: {
-    input: '../specifications/petstore.yaml',
-    output: {
-      client: 'fetch',
-      mode: 'tags-split',
-      schemas: '../models',
-      target: './will-not-exists.ts',
-      workspace: '../generated/multi-client/fetch',
-      indexFiles: {
-        workspace(implementations) {
-          return implementations.filter((impl) => !impl.includes('models'));
-        },
-      },
-    },
-  },
   zod: {
     input: '../specifications/petstore.yaml',
     output: {

--- a/tests/configs/multi-client.config.ts
+++ b/tests/configs/multi-client.config.ts
@@ -36,9 +36,16 @@ export default defineConfig({
     output: {
       client({ zod }) {
         return {
+          title: zod.title,
+          footer: zod.footer,
           client: zod.client,
-          async extraFiles(_, __, context) {
+          header: zod.header,
+          dependencies: zod.dependencies,
+          async extraFiles(verbOptions, output, context) {
             return [
+              ...(zod.extraFiles
+                ? await zod.extraFiles(verbOptions, output, context)
+                : []),
               {
                 path: context.output.workspace + '/extrafiles/index.ts',
                 content: 'export * from "./file1";\nexport * from "./file2";\n',

--- a/tests/package.json
+++ b/tests/package.json
@@ -20,6 +20,7 @@
     "generate:fetch": "yarn orval --config ./configs/fetch.config.ts",
     "generate:mcp": "yarn orval --config ./configs/mcp.config.ts",
     "generate:hono": "rm -rf generated/hono && yarn orval --config ./configs/hono.config.ts",
+    "generate:multi-client": "yarn orval --config ./configs/multi-client.config.ts",
     "build": "tsc"
   },
   "author": "Victor Bury",


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Related

Fix https://github.com/orval-labs/orval/issues/2044

## Description

add a way to customize index files:

```ts
export default defineConfig({
  output: {
    // ....rest of the config
    indexFiles: {
      schema: (schema) => schemaPaths.filter(schema => schema.name === "Dog"),
      workspace: (implementationPaths) => implementationPaths.filter(path => path.includes('do-not-expose-this-file')),
    },
  },
});
```


add a way to expose custom files:

```ts
export default defineConfig({
  output: {
    // ....rest of the config
    client() {
        return {
            // ... client definition
            extraFiles() {
                return [
                    {
                        path: 'src/file-to-expose.ts',
                        content: 'export default function () {}',
                        exposeIndexFile: true,
                    },
                    {
                        path: 'src/file-to-not-expose.ts',
                        content: 'export default function () {}',
                        exposeIndexFile: false,
                    },
                    {
                        path: 'src/file-to-not-expose-2.ts',
                        content: 'export default function () {}',
                    }
                ]
            }
        }
    }
});
```


## Steps to Test or Reproduce

```bash
> git pull --prune
> git checkout feat/customize-index-files
> grunt jasmine
> yarn
> yarn build
> cd tests
> yarn
> yarn generate:multi-client
```

1. check generated clients in `generated/multi-client/*`
2. check `index.ts` in each client, it should only include files that were exposed (no models)
3. check zod client and see exports for `./extrafiles/index`
