### PR TITLE
feat(zod): implemented string format compatible with zod v3 and v4

### DIFF
--- a/packages/zod/src/compatibleV4.test.ts
+++ b/packages/zod/src/compatibleV4.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { isZodVersionV4 } from './compatibleV4';
+
+describe('isZodVersionV4', () => {
+  it('should return false when zod is not in package.json', () => {
+    const packageJson = {
+      dependencies: {
+        'other-package': '1.0.0',
+      },
+    };
+
+    expect(isZodVersionV4(packageJson)).toBe(false);
+  });
+
+  it('should return false for zod v3', () => {
+    const packageJson = {
+      dependencies: {
+        zod: '3.24.3',
+      },
+    };
+
+    expect(isZodVersionV4(packageJson)).toBe(false);
+  });
+
+  it('should return true for zod v4', () => {
+    const packageJson = {
+      dependencies: {
+        zod: '4.0.0',
+      },
+    };
+
+    expect(isZodVersionV4(packageJson)).toBe(true);
+  });
+
+  it('should return true for zod v4+', () => {
+    const packageJson = {
+      dependencies: {
+        zod: '4.1.0',
+      },
+    };
+
+    expect(isZodVersionV4(packageJson)).toBe(true);
+  });
+
+  it('should handle release candidate versions correctly', () => {
+    const packageJson = {
+      dependencies: {
+        zod: '4.0.0-rc.1',
+      },
+    };
+
+    expect(isZodVersionV4(packageJson)).toBe(true);
+  });
+});

--- a/packages/zod/src/compatibleV4.ts
+++ b/packages/zod/src/compatibleV4.ts
@@ -1,0 +1,21 @@
+import { compareVersions, PackageJson } from '@orval/core';
+
+const getZodPackageVersion = (packageJson: PackageJson) => {
+  return (
+    packageJson.dependencies?.['zod'] ??
+    packageJson.devDependencies?.['zod'] ??
+    packageJson.peerDependencies?.['zod']
+  );
+};
+
+export const isZodVersionV4 = (packageJson: PackageJson) => {
+  const version = getZodPackageVersion(packageJson);
+
+  if (!version) {
+    return false;
+  }
+
+  const withoutRc = version.split('-')[0];
+
+  return compareVersions(withoutRc, '4.0.0');
+};

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -20,6 +20,7 @@ import {
   stringify,
   ZodCoerceType,
 } from '@orval/core';
+import { isZodVersionV4 } from './compatibleV4';
 import uniq from 'lodash.uniq';
 import {
   ParameterObject,
@@ -265,6 +266,10 @@ export const generateZodValidationSchemaDefinition = (
       ]);
       break;
     case 'string': {
+      const isZodV4 =
+        !!context.output.packageJson &&
+        isZodVersionV4(context.output.packageJson);
+
       if (schema.enum && type === 'string') {
         break;
       }
@@ -282,7 +287,14 @@ export const generateZodValidationSchemaDefinition = (
         break;
       }
 
-      functions.push([type as string, undefined]);
+      if (isZodV4) {
+        if (!schema.format) {
+          functions.push([type as string, undefined]);
+          break;
+        }
+      } else {
+        functions.push([type as string, undefined]);
+      }
 
       if (schema.format === 'date') {
         functions.push(['date', undefined]);


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

fix #2042 

I added an implementation to maintain compatibility between v3 and v4.
The implementation is modeled after the query package.

https://github.com/orval-labs/orval/blob/master/packages/query/src/index.ts#L337-L350

Because, the way string format is defined will change in zod v4.

https://v4.zod.dev/v4/changelog#zstring-updates

```ts
z.string().email(); // ❌ deprecated
z.email(); // ✅ 
```

## Related PRs

none

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this in the unit test I added.