### PR TITLE
feat(zod): v4 compatible format `date` and `datetime`

### DIFF
--- a/packages/zod/src/compatibleV4.test.ts
+++ b/packages/zod/src/compatibleV4.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { isZodVersionV4 } from './compatibleV4';
+import {
+  isZodVersionV4,
+  getZodDateFormat,
+  getZodDateTimeFormat,
+} from './compatibleV4';
 
 describe('isZodVersionV4', () => {
   it('should return false when zod is not in package.json', () => {
@@ -50,5 +54,25 @@ describe('isZodVersionV4', () => {
     };
 
     expect(isZodVersionV4(packageJson)).toBe(true);
+  });
+});
+
+describe('getZodDateFormat', () => {
+  it('should return "iso.date" when isZodV4 is true', () => {
+    expect(getZodDateFormat(true)).toBe('iso.date');
+  });
+
+  it('should return "date" when isZodV4 is false', () => {
+    expect(getZodDateFormat(false)).toBe('date');
+  });
+});
+
+describe('getZodDateTimeFormat', () => {
+  it('should return "iso.datetime" when isZodV4 is true', () => {
+    expect(getZodDateTimeFormat(true)).toBe('iso.datetime');
+  });
+
+  it('should return "datetime" when isZodV4 is false', () => {
+    expect(getZodDateTimeFormat(false)).toBe('datetime');
   });
 });

--- a/packages/zod/src/compatibleV4.ts
+++ b/packages/zod/src/compatibleV4.ts
@@ -19,3 +19,11 @@ export const isZodVersionV4 = (packageJson: PackageJson) => {
 
   return compareVersions(withoutRc, '4.0.0');
 };
+
+export const getZodDateFormat = (isZodV4: boolean) => {
+  return isZodV4 ? 'iso.date' : 'date';
+};
+
+export const getZodDateTimeFormat = (isZodV4: boolean) => {
+  return isZodV4 ? 'iso.datetime' : 'datetime';
+};

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -20,7 +20,11 @@ import {
   stringify,
   ZodCoerceType,
 } from '@orval/core';
-import { isZodVersionV4 } from './compatibleV4';
+import {
+  isZodVersionV4,
+  getZodDateFormat,
+  getZodDateTimeFormat,
+} from './compatibleV4';
 import uniq from 'lodash.uniq';
 import {
   ParameterObject,
@@ -278,7 +282,9 @@ export const generateZodValidationSchemaDefinition = (
         context.output.override.useDates &&
         (schema.format === 'date' || schema.format === 'date-time')
       ) {
-        functions.push(['date', undefined]);
+        const formatAPI = getZodDateFormat(isZodV4);
+
+        functions.push([formatAPI, undefined]);
         break;
       }
 
@@ -297,14 +303,18 @@ export const generateZodValidationSchemaDefinition = (
       }
 
       if (schema.format === 'date') {
-        functions.push(['date', undefined]);
+        const formatAPI = getZodDateFormat(isZodV4);
+
+        functions.push([formatAPI, undefined]);
         break;
       }
 
       if (schema.format === 'date-time') {
         const options = context.output.override.zod?.dateTimeOptions;
+        const formatAPI = getZodDateTimeFormat(isZodV4);
+
         functions.push([
-          'datetime',
+          formatAPI,
           options ? JSON.stringify(options) : undefined,
         ]);
         break;


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description
fix #2042 
I've implemented v4 compatibility for `date` and `datetime`

```ts
// v3
z.string().date()
z.string().datetime()

// v4
z.iso.date()
z.iso.datetime()
```

Ref: https://v4.zod.dev/v4/changelog#zstring-updates

## Related PRs

none

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this in the unit test I added.