### PR TITLE
feat(zod): support for string format `time`

### DIFF
--- a/packages/zod/src/compatibleV4.test.ts
+++ b/packages/zod/src/compatibleV4.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isZodVersionV4,
   getZodDateFormat,
+  getZodTimeFormat,
   getZodDateTimeFormat,
 } from './compatibleV4';
 
@@ -64,6 +65,16 @@ describe('getZodDateFormat', () => {
 
   it('should return "date" when isZodV4 is false', () => {
     expect(getZodDateFormat(false)).toBe('date');
+  });
+});
+
+describe('getZodTimeFormat', () => {
+  it('should return "iso.time" when isZodV4 is true', () => {
+    expect(getZodTimeFormat(true)).toBe('iso.time');
+  });
+
+  it('should return "time" when isZodV4 is false', () => {
+    expect(getZodTimeFormat(false)).toBe('time');
   });
 });
 

--- a/packages/zod/src/compatibleV4.ts
+++ b/packages/zod/src/compatibleV4.ts
@@ -24,6 +24,10 @@ export const getZodDateFormat = (isZodV4: boolean) => {
   return isZodV4 ? 'iso.date' : 'date';
 };
 
+export const getZodTimeFormat = (isZodV4: boolean) => {
+  return isZodV4 ? 'iso.time' : 'time';
+};
+
 export const getZodDateTimeFormat = (isZodV4: boolean) => {
   return isZodV4 ? 'iso.datetime' : 'datetime';
 };

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -23,6 +23,7 @@ import {
 import {
   isZodVersionV4,
   getZodDateFormat,
+  getZodTimeFormat,
   getZodDateTimeFormat,
 } from './compatibleV4';
 import uniq from 'lodash.uniq';
@@ -304,6 +305,13 @@ export const generateZodValidationSchemaDefinition = (
 
       if (schema.format === 'date') {
         const formatAPI = getZodDateFormat(isZodV4);
+
+        functions.push([formatAPI, undefined]);
+        break;
+      }
+
+      if (schema.format === 'time') {
+        const formatAPI = getZodTimeFormat(isZodV4);
 
         functions.push([formatAPI, undefined]);
         break;


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

I added support for string format `time` of `zod`

## Related PRs

none

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this by defining `format: time` in `openapi`