### PR TITLE
feat(zod): In v4, `object().strict()` is deprecated, use `strictObject()` instead.

### DIFF
--- a/packages/zod/src/compatibleV4.test.ts
+++ b/packages/zod/src/compatibleV4.test.ts
@@ -4,6 +4,8 @@ import {
   getZodDateFormat,
   getZodTimeFormat,
   getZodDateTimeFormat,
+  getParameterFunctions,
+  getObjectFunctionName,
 } from './compatibleV4';
 
 describe('isZodVersionV4', () => {
@@ -85,5 +87,78 @@ describe('getZodDateTimeFormat', () => {
 
   it('should return "datetime" when isZodV4 is false', () => {
     expect(getZodDateTimeFormat(false)).toBe('datetime');
+  });
+});
+
+describe('getParameterFunctions', () => {
+  const parameters = { test: 'value' };
+
+  describe('when isZodV4 is true', () => {
+    describe('when strict is true', () => {
+      it('should return [["strictObject", parameters]]', () => {
+        const result = getParameterFunctions(true, true, parameters);
+        expect(result).toEqual([['strictObject', parameters]]);
+      });
+    });
+
+    describe('when strict is false', () => {
+      it('should return [["object", parameters]]', () => {
+        const result = getParameterFunctions(true, false, parameters);
+        expect(result).toEqual([['object', parameters]]);
+      });
+    });
+  });
+
+  describe('when isZodV4 is false', () => {
+    describe('when strict is true', () => {
+      it('should return [["object", parameters], ["strict", undefined]]', () => {
+        const result = getParameterFunctions(false, true, parameters);
+        expect(result).toEqual([
+          ['object', parameters],
+          ['strict', undefined],
+        ]);
+      });
+    });
+
+    describe('when strict is false', () => {
+      it('should return [["object", parameters]]', () => {
+        const result = getParameterFunctions(false, false, parameters);
+        expect(result).toEqual([['object', parameters]]);
+      });
+    });
+  });
+});
+
+describe('getObjectFunctionName', () => {
+  describe('when isZodV4 is true', () => {
+    describe('when strict is true', () => {
+      it('should return "strictObject"', () => {
+        const result = getObjectFunctionName(true, true);
+        expect(result).toBe('strictObject');
+      });
+    });
+
+    describe('when strict is false', () => {
+      it('should return "object"', () => {
+        const result = getObjectFunctionName(true, false);
+        expect(result).toBe('object');
+      });
+    });
+  });
+
+  describe('when isZodV4 is false', () => {
+    describe('when strict is true', () => {
+      it('should return "object"', () => {
+        const result = getObjectFunctionName(false, true);
+        expect(result).toBe('object');
+      });
+    });
+
+    describe('when strict is false', () => {
+      it('should return "object"', () => {
+        const result = getObjectFunctionName(false, false);
+        expect(result).toBe('object');
+      });
+    });
   });
 });

--- a/packages/zod/src/compatibleV4.ts
+++ b/packages/zod/src/compatibleV4.ts
@@ -31,3 +31,24 @@ export const getZodTimeFormat = (isZodV4: boolean) => {
 export const getZodDateTimeFormat = (isZodV4: boolean) => {
   return isZodV4 ? 'iso.datetime' : 'datetime';
 };
+
+export const getParameterFunctions = (
+  isZodV4: boolean,
+  strict: boolean,
+  parameters: Record<string, any>,
+): [string, any][] => {
+  if (isZodV4 && strict) {
+    return [['strictObject', parameters]];
+  } else {
+    return strict
+      ? [
+          ['object', parameters],
+          ['strict', undefined],
+        ]
+      : [['object', parameters]];
+  }
+};
+
+export const getObjectFunctionName = (isZodV4: boolean, strict: boolean) => {
+  return isZodV4 && strict ? 'strictObject' : 'object';
+};

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -81,6 +81,8 @@ describe('parseZodValidationSchemaDefinition', () => {
           },
         } as ContextSpecs,
         false,
+        false,
+        false,
       );
 
       expect(parseResult.zod).toBe(
@@ -101,6 +103,8 @@ describe('parseZodValidationSchemaDefinition', () => {
           },
         } as ContextSpecs,
         true,
+        false,
+        false,
       );
 
       expect(parseResult.zod).toBe(
@@ -119,6 +123,8 @@ describe('parseZodValidationSchemaDefinition', () => {
           },
         },
       } as ContextSpecs,
+      false,
+      false,
       false,
     );
 
@@ -190,6 +196,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       } as ContextSpecs,
       'strict',
       true,
+      false,
       {
         required: true,
       },
@@ -243,6 +250,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       } as ContextSpecs,
       'strict',
       true,
+      false,
       {
         required: true,
       },
@@ -299,6 +307,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       } as ContextSpecs,
       'strict',
       true,
+      false,
       {
         required: true,
       },
@@ -364,6 +373,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         context,
         'testStringDescription',
         false,
+        false,
         { required: false },
       );
 
@@ -376,7 +386,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: ['export const testStringDescriptionDefault = "hello";'],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe(
         "zod.string().default(testStringDescriptionDefault).describe('This is a test description')",
       );
@@ -403,6 +419,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         context,
         'testStringDefault',
         false,
+        false,
         { required: false },
       );
 
@@ -414,7 +431,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: [`export const testStringDefaultDefault = "hello";`],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe('zod.string().default(testStringDefaultDefault)');
       expect(parsed.consts).toBe(
         'export const testStringDefaultDefault = "hello";',
@@ -432,6 +455,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         context,
         'testNumberDefault',
         false,
+        false,
         { required: false },
       );
 
@@ -443,7 +467,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: ['export const testNumberDefaultDefault = 42;'],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe('zod.number().default(testNumberDefaultDefault)');
       expect(parsed.consts).toBe('export const testNumberDefaultDefault = 42;');
     });
@@ -459,6 +489,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         context,
         'testBooleanDefault',
         false,
+        false,
         { required: false },
       );
 
@@ -470,7 +501,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: ['export const testBooleanDefaultDefault = true;'],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe(
         'zod.boolean().default(testBooleanDefaultDefault)',
       );
@@ -491,6 +528,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         context,
         'testArrayDefault',
         false,
+        false,
         { required: false },
       );
 
@@ -502,7 +540,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: ['export const testArrayDefaultDefault = ["a", "b"];'],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe(
         'zod.array(zod.string()).default(testArrayDefaultDefault)',
       );
@@ -531,6 +575,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         schemaWithObjectDefault,
         context,
         'testObjectDefault',
+        false,
         false,
         { required: false },
       );
@@ -563,7 +608,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         ],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe(
         'zod.object({\n  "name": zod.string().optional(),\n  "age": zod.number().optional()\n}).default(testObjectDefaultDefault)',
       );
@@ -592,6 +643,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         dateContext,
         'testDateDefault',
         false,
+        false,
         { required: false },
       );
 
@@ -608,6 +660,8 @@ describe('generateZodValidationSchemaDefinition`', () => {
       const parsed = parseZodValidationSchemaDefinition(
         result,
         dateContext,
+        false,
+        false,
         false,
       );
       expect(parsed.zod).toBe('zod.date().default(testDateDefaultDefault)');
@@ -637,6 +691,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         context,
         'testEnumString',
         false,
+        false,
         { required: false },
       );
 
@@ -648,7 +703,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: [],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe("zod.enum(['cat', 'dog']).optional()");
     });
 
@@ -662,6 +723,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         schema,
         context,
         'testEnumNumber',
+        false,
         false,
         { required: false },
       );
@@ -680,7 +742,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: [],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe('zod.literal(1).or(zod.literal(2)).optional()');
     });
 
@@ -694,6 +762,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         schema,
         context,
         'testEnumBoolean',
+        false,
         false,
         { required: false },
       );
@@ -712,7 +781,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: [],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe(
         'zod.literal(true).or(zod.literal(false)).optional()',
       );
@@ -727,6 +802,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         schema,
         context,
         'testEnumAny',
+        false,
         false,
         { required: false },
       );
@@ -746,7 +822,13 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: [],
       });
 
-      const parsed = parseZodValidationSchemaDefinition(result, context, false);
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
       expect(parsed.zod).toBe(
         "zod.literal('cat').or(zod.literal(1)).or(zod.literal(true)).optional()",
       );
@@ -1330,6 +1412,7 @@ describe('parsePrefixItemsArrayAsTupleZod', () => {
       } as ContextSpecs,
       'example_tuple',
       true,
+      false,
       {
         required: true,
       },
@@ -1382,6 +1465,7 @@ describe('parsePrefixItemsArrayAsTupleZod', () => {
       } as ContextSpecs,
       'example_tuple',
       true,
+      false,
       {
         required: true,
       },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**HOLD**

## Description
fix #2042 

In zod v4, `object().strict()` is deprecated, use `strictObject()` instead.

https://v4.zod.dev/v4/changelog#deprecates-strict

```
// Zod 3
z.object({ name: z.string() }).strict();
 
// Zod 4
z.strictObject({ name: z.string() });
```

## Related PRs

none

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can check this in the unit test I added.