### PR TITLE
feat(core): override JSDoc config to customize default documentation

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -2475,6 +2475,142 @@ module.exports = {
 };
 ```
 
+#### jsDoc
+
+Type: `Function`.
+
+```ts
+// type signature
+(schema: Record<string, any>) => { key: string; value: string }[];
+```
+
+Function to override the JSDoc comments generated for each schema.
+
+Example:
+
+```ts
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        jsDoc: (schema) => {
+          const blacklist = [
+            '$ref',
+            'allOf',
+            'anyOf',
+            'oneOf',
+            'not',
+            'items',
+            'properties',
+            'additionalProperties',
+            'patternProperties',
+            'additionalItems',
+            'discriminator',
+            'xml',
+            'externalDocs',
+          ];
+          return Object.entries(schema || {})
+            .filter(([key]) => !blacklist.includes(key))
+            .map(([key, value]) => {
+              return {
+                key,
+                value,
+              };
+            })
+            .sort((a, b) => {
+              return a.key.length - b.key.length;
+            });
+        },
+      },
+    },
+  },
+};
+```
+
+Input:
+
+```yaml
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+      properties:
+        '@id':
+          type: string
+          format: iri-reference
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        email:
+          type: string
+          format: email
+        callingCode:
+          type: string
+          enum: ['+33', '+420', '+33'] # intentional duplicated value
+        country:
+          type: string
+          enum: ["People's Republic of China", 'Uruguay']
+```
+
+Result:
+
+```ts
+export interface Pet {
+  /**
+   * @type integer
+   * @format int64
+   */
+  id: number;
+  /**
+   * @type string
+   * @maxLength 0
+   * @minLength 40
+   * @description Name of pet
+   */
+  name: string;
+  /**
+   * @type integer
+   * @format int32
+   * @minimum 0
+   * @maximum 30
+   * @exclusiveMinimum true
+   * @exclusiveMaximum true
+   */
+  age?: number;
+  /**
+   * @type string
+   * @pattern ^\\d{3}-\\d{2}-\\d{4}$
+   * @nullable true
+   */
+  tag?: string | null;
+  /**
+   * @type string
+   * @format email
+   */
+  email?: string;
+  /**
+   * @type string
+   * @enum +33,+420,+33
+   */
+  callingCode?: PetCallingCode;
+  /**
+   * @type string
+   * @enum People's Republic of China,Uruguay
+   */
+  country?: PetCountry;
+}
+```
+
 ### allParamsOptional
 
 Type: `Boolean`

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -7,7 +7,13 @@ import {
   SchemaType,
   SchemaWithConst,
 } from '../types';
-import { isBoolean, isReference, jsDoc, pascal } from '../utils';
+import {
+  isBoolean,
+  isReference,
+  jsDoc,
+  keyValuePairsToJsDoc,
+  pascal,
+} from '../utils';
 import { combineSchemas } from './combine';
 import { getKey } from './keys';
 import { getRefInfo } from './ref';
@@ -120,7 +126,7 @@ export const getObject = ({
           acc.value += '{';
         }
 
-        const doc = jsDoc(schema as SchemaObject, true);
+        const doc = jsDoc(schema as SchemaObject, true, context);
 
         acc.hasReadonlyProps ||= isReadOnly || false;
         acc.imports.push(...resolvedValue.imports);

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -53,7 +53,14 @@ const getQueryParamsTypes = (
     });
 
     const key = getKey(name);
-    const doc = jsDoc(parameter);
+    const doc = jsDoc(
+      {
+        description: parameter.description,
+        ...schema,
+      },
+      void 0,
+      context,
+    );
 
     if (parameterImports.length) {
       return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -120,6 +120,7 @@ export type NormalizedOverrideOutput = {
   useNamedParameters?: boolean;
   enumGenerationType: EnumGeneration;
   suppressReadonlyModifier?: boolean;
+  jsDoc?: (schema: Record<string, any>) => { key: string; value: string }[];
 };
 
 export type NormalizedMutator = {
@@ -460,6 +461,7 @@ export type OverrideOutput = {
   useNativeEnums?: boolean;
   enumGenerationType?: EnumGeneration;
   suppressReadonlyModifier?: boolean;
+  jsDoc?: (schema: SchemaObject) => { key: string; value: string }[];
 };
 
 export type OverrideOutputContentType = {

--- a/packages/core/src/utils/doc.ts
+++ b/packages/core/src/utils/doc.ts
@@ -1,24 +1,12 @@
+import { ContextSpecs } from '../types';
+
 const search = '\\*/'; // Find '*/'
 const replacement = '*\\/'; // Replace With '*\/'
 
 const regex = new RegExp(search, 'g');
 
 export function jsDoc(
-  {
-    description,
-    deprecated,
-    summary,
-    minLength,
-    maxLength,
-    minimum,
-    maximum,
-    exclusiveMinimum,
-    exclusiveMaximum,
-    minItems,
-    maxItems,
-    nullable,
-    pattern,
-  }: {
+  schema: {
     description?: string[] | string;
     deprecated?: boolean;
     summary?: string;
@@ -34,7 +22,26 @@ export function jsDoc(
     pattern?: string;
   },
   tryOneLine = false,
+  context?: ContextSpecs,
 ): string {
+  if (context?.output?.override?.jsDoc) {
+    return keyValuePairsToJsDoc(context.output.override.jsDoc(schema));
+  }
+  const {
+    description,
+    deprecated,
+    summary,
+    minLength,
+    maxLength,
+    minimum,
+    maximum,
+    exclusiveMinimum,
+    exclusiveMaximum,
+    minItems,
+    maxItems,
+    nullable,
+    pattern,
+  } = schema;
   // Ensure there aren't any comment terminations in doc
   const lines = (
     Array.isArray(description)
@@ -121,5 +128,20 @@ export function jsDoc(
 
   doc += '*/\n';
 
+  return doc;
+}
+
+export function keyValuePairsToJsDoc(
+  keyValues: {
+    key: string;
+    value: string;
+  }[],
+) {
+  if (!keyValues.length) return '';
+  let doc = '/**\n';
+  keyValues.forEach(({ key, value }) => {
+    doc += ` * @${key} ${value}\n`;
+  });
+  doc += ' */\n';
   return doc;
 }

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -404,4 +404,42 @@ export default defineConfig({
       target: '../specifications/form-data-nested.yaml',
     },
   },
+  overrideJsDOc: {
+    output: {
+      target: '../generated/default/override-js-doc/endpoints.ts',
+      override: {
+        jsDoc(schema) {
+          const blacklist = [
+            '$ref',
+            'allOf',
+            'anyOf',
+            'oneOf',
+            'not',
+            'items',
+            'properties',
+            'additionalProperties',
+            'patternProperties',
+            'additionalItems',
+            'discriminator',
+            'xml',
+            'externalDocs',
+          ];
+          return Object.entries(schema || {})
+            .filter(([key]) => !blacklist.includes(key))
+            .map(([key, value]) => {
+              return {
+                key,
+                value,
+              };
+            })
+            .sort((a, b) => {
+              return a.key.length - b.key.length;
+            });
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
 });


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**
 
## why

I propose adding an option to preserve as many of the properties declared in the OpenAPI schema as possible.

## Description

 override JSDoc config to customize default documentation.
 
Example:

```ts
module.exports = {
  petstore: {
    output: {
      override: {
        jsDoc: (schema) => {
          const blacklist = [
            '$ref',
            'allOf',
            'anyOf',
            'oneOf',
            'not',
            'items',
            'properties',
            'additionalProperties',
            'patternProperties',
            'additionalItems',
            'discriminator',
            'xml',
            'externalDocs',
          ];
          return Object.entries(schema || {})
            .filter(([key]) => !blacklist.includes(key))
            .map(([key, value]) => {
              return {
                key,
                value,
              };
            })
            .sort((a, b) => {
              return a.key.length - b.key.length;
            });
        },
      },
    },
  },
};
```

Input:

```yaml
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      oneOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'
      properties:
        '@id':
          type: string
          format: iri-reference
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        email:
          type: string
          format: email
        callingCode:
          type: string
          enum: ['+33', '+420', '+33'] # intentional duplicated value
        country:
          type: string
          enum: ["People's Republic of China", 'Uruguay']
```

Result:

```ts
export interface Pet {
  /**
   * @type integer
   * @format int64
   */
  id: number;
  /**
   * @type string
   * @maxLength 0
   * @minLength 40
   * @description Name of pet
   */
  name: string;
  /**
   * @type integer
   * @format int32
   * @minimum 0
   * @maximum 30
   * @exclusiveMinimum true
   * @exclusiveMaximum true
   */
  age?: number;
  /**
   * @type string
   * @pattern ^\\d{3}-\\d{2}-\\d{4}$
   * @nullable true
   */
  tag?: string | null;
  /**
   * @type string
   * @format email
   */
  email?: string;
  /**
   * @type string
   * @enum +33,+420,+33
   */
  callingCode?: PetCallingCode;
  /**
   * @type string
   * @enum People's Republic of China,Uruguay
   */
  country?: PetCountry;
}
```


## Todos

- [x] Tests
- [x] Documentation

## Source
https://github.com/orval-labs/orval/discussions/2082