### PR TITLE
 fix(core): Updated queryParamsProp with allParamsOptional check 

### DIFF
--- a/packages/core/src/getters/props.ts
+++ b/packages/core/src/getters/props.ts
@@ -34,16 +34,16 @@ export const getProps = ({
 
   const queryParamsProp = {
     name: 'params',
-    definition: `params${queryParams?.isOptional ? '?' : ''}: ${
+    definition: `params${queryParams?.isOptional || context.output.allParamsOptional ? '?' : ''}: ${
       queryParams?.schema.name
     }`,
-    implementation: `params${queryParams?.isOptional ? '?' : ''}: ${
+    implementation: `params${queryParams?.isOptional || context.output.allParamsOptional ? '?' : ''}: ${
       queryParams?.schema.name
     }`,
     default: false,
     required: !isUndefined(queryParams?.isOptional)
-      ? !queryParams?.isOptional
-      : false,
+      ? !queryParams?.isOptional && !context.output.allParamsOptional
+      : !context.output.allParamsOptional,
     type: GetterPropType.QUERY_PARAM,
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,14 +926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.25.1":
-  version: 9.25.1
-  resolution: "@eslint/js@npm:9.25.1"
-  checksum: 10c0/87d86b512ab109bfd3b9317ced3220ea3d444ac3bfa7abd853ca7f724d72c36e213062f9def16a632365d97dc29e0094312e3682a9767590ee6f43b3d5d873fd
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:^9.25.1":
+"@eslint/js@npm:9.25.1, @eslint/js@npm:^9.25.1":
   version: 9.25.1
   resolution: "@eslint/js@npm:9.25.1"
   checksum: 10c0/87d86b512ab109bfd3b9317ced3220ea3d444ac3bfa7abd853ca7f724d72c36e213062f9def16a632365d97dc29e0094312e3682a9767590ee6f43b3d5d873fd


### PR DESCRIPTION
## Status

**READY**

## Description

`allParamsOptional` was not being considered when creating `queryParamsProp` in `props.ts`

fixes #2087 