### PR TITLE
fix(query): allow useInfinite without useQuery in operation overrides

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1131,20 +1131,11 @@ const generateQueryHook = async (
     (override.query.useQuery ||
       override.query.useSuspenseQuery ||
       override.query.useInfinite ||
-      override.query.useSuspenseInfiniteQuery);
-
-  if (operationQueryOptions?.useInfinite !== undefined) {
-    isQuery = operationQueryOptions.useInfinite;
-  }
-  if (operationQueryOptions?.useSuspenseInfiniteQuery !== undefined) {
-    isQuery = operationQueryOptions.useSuspenseInfiniteQuery;
-  }
-  if (operationQueryOptions?.useQuery !== undefined) {
-    isQuery = operationQueryOptions.useQuery;
-  }
-  if (operationQueryOptions?.useSuspenseQuery !== undefined) {
-    isQuery = operationQueryOptions.useSuspenseQuery;
-  }
+      override.query.useSuspenseInfiniteQuery ||
+      operationQueryOptions?.useQuery ||
+      operationQueryOptions?.useSuspenseQuery ||
+      operationQueryOptions?.useInfinite ||
+      operationQueryOptions?.useSuspenseInfiniteQuery);
 
   let isMutation = override.query.useMutation && verb !== Verbs.GET;
 


### PR DESCRIPTION
Previously, when `useQuery` was explicitly set to `false` in a per-operation override, `useInfinite` (and other query-related flags) were ignored, and no hooks were generated.

This fix ensures that any query-related flag (e.g., `useInfinite`, `useSuspenseQuery`, etc.) correctly contributes to `isQuery`, even when `useQuery` is false.

Fixes: [#2088](https://github.com/orval-labs/orval/issues/2088)

---

## Status

**READY**

## Description

This PR updates the `isQuery` logic to accumulate all query-related flags when the HTTP verb is `GET`, instead of allowing `useQuery: false` to inadvertently disable hook generation entirely.

## Related PRs

_None._

## Todos

- [ ] Tests? — **Wasn't sure if I should add a config/import regression test under `/tests/regressions/`**

## Steps to Reproduce Bug (before this fix)

1. Set a per-operation override like:
   ```ts
   operations: {
     listPets: {
       query: {
         useQuery: false,
         useInfinite: true,
         useInfiniteQueryParam: "nextCursor"
       }
     }
   }
   ```
2. Run Orval generator
3. Observe that no hooks are generated
