### PR TITLE
flatten zod objects in a discriminatedUnion

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -531,22 +531,20 @@ export const parseZodValidationSchemaDefinition = (
     const [fn, args = ''] = property;
 
     if (fn === 'flattenAllOf') {
-        const flattenedProperties: Record<string, any> = args.reduce(
-          (
-            acc: Record<string, any>,
-            {
-              functions
-            }: { functions: [string, any][];}
-          ) => {
-            functions.forEach(([_fn, schema]) => {
-              acc = { ...acc, ...schema}
-            })
-            return acc;
-          },
-          {}
-        )
-        const functionName = getObjectFunctionName(isZodV4, strict);
-        return `${parseProperty([functionName, flattenedProperties])}${strict ? parseProperty(['strict', undefined]) : ''}`
+      const flattenedProperties: Record<string, any> = args.reduce(
+        (
+          acc: Record<string, any>,
+          { functions }: { functions: [string, any][] },
+        ) => {
+          functions.forEach(([_fn, schema]) => {
+            acc = { ...acc, ...schema };
+          });
+          return acc;
+        },
+        {},
+      );
+      const functionName = getObjectFunctionName(isZodV4, strict);
+      return `${parseProperty([functionName, flattenedProperties])}${strict ? parseProperty(['strict', undefined]) : ''}`;
     }
     if (fn === 'allOf') {
       return args.reduce(
@@ -580,7 +578,13 @@ export const parseZodValidationSchemaDefinition = (
       const [, propertyName] = fn.split('discriminator__');
       const typeSchemas = args.map(
         ({ functions }: { functions: [string, any][]; consts: string[] }) => {
-          const schemaFunctions = functions.map(([fn, args]) => fn === 'allOf' ? parseProperty(['flattenAllOf', args]) : parseProperty([fn, args])).join('');
+          const schemaFunctions = functions
+            .map(([fn, args]) =>
+              fn === 'allOf'
+                ? parseProperty(['flattenAllOf', args])
+                : parseProperty([fn, args]),
+            )
+            .join('');
           return schemaFunctions;
         },
       );

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1230,13 +1230,13 @@ const apiSchemaWithDiscriminator: GeneratorOptions = {
               properties: {
                 breed: {
                   type: 'string',
-                }
-              }
+                },
+              },
             },
             Labradoodle: {
               allOf: [
                 {
-                  $ref: '#/components/schemas/BasicDog'
+                  $ref: '#/components/schemas/BasicDog',
                 },
                 {
                   type: 'object',
@@ -1250,14 +1250,14 @@ const apiSchemaWithDiscriminator: GeneratorOptions = {
                       type: 'string',
                       enum: ['Labradoodle'],
                     },
-                  }
-                }
-              ]
+                  },
+                },
+              ],
             },
             Dachshund: {
               allOf: [
                 {
-                  $ref: '#/components/schemas/BasicDog'
+                  $ref: '#/components/schemas/BasicDog',
                 },
                 {
                   type: 'object',
@@ -1272,8 +1272,8 @@ const apiSchemaWithDiscriminator: GeneratorOptions = {
                       enum: ['Dachshund'],
                     },
                   },
-                }
-              ]
+                },
+              ],
             },
           },
         },
@@ -1326,14 +1326,15 @@ describe('generateDiscriminatedUnionZod', () => {
       {},
     );
     expect(result.implementation).toBe(
-`export const testResponseItem = zod.discriminatedUnion('breed', [zod.object({
+      `export const testResponseItem = zod.discriminatedUnion('breed', [zod.object({
   "breed": zod.enum(['Labradoodle']).optional(),
   "cuteness": zod.number()
 }),zod.object({
   "breed": zod.enum(['Dachshund']).optional(),
   "length": zod.number()
 })])
-export const testResponse = zod.array(testResponseItem)\n\n`);;
+export const testResponse = zod.array(testResponseItem)\n\n`,
+    );
     expect(result.implementation).not.toContain('.or(zod.object');
     expect(result.implementation).not.toContain('.and(');
   });
@@ -1373,7 +1374,7 @@ export const testResponse = zod.array(testResponseItem)\n\n`);;
       {},
     );
     expect(result.implementation).toBe(
-`export const testResponseItem = zod.discriminatedUnion('breed', [zod.object({
+      `export const testResponseItem = zod.discriminatedUnion('breed', [zod.object({
   "breed": zod.enum(['Labradoodle']).optional(),
   "cuteness": zod.number()
 }).strict(),zod.object({
@@ -1423,7 +1424,7 @@ export const testResponse = zod.array(testResponseItem)\n\n`,
       {},
     );
     expect(result.implementation).toBe(
-`export const testResponseItem = zod.object({
+      `export const testResponseItem = zod.object({
   "breed": zod.string()
 }).and(zod.object({
   "cuteness": zod.number(),
@@ -1731,6 +1732,6 @@ describe('generateZodWithEdgeCases', () => {
     );
     expect(result.implementation).toBe(
       'export const testBody = zod.object({\n  "$ref": zod.string().optional()\n})\n\n',
-    );;
+    );
   });
 });


### PR DESCRIPTION
## Status

READY

## Description

The PR flattens allOf objects when they are used within the scope of a discriminatedUnion. A discriminatedUnion only accepts ZodObjects.
Fix https://github.com/orval-labs/orval/issues/2085

**IMPORTANT:** 

I created a PR for this issue, but it will not be a solution for all future scenarios. Since there can be multiple levels of nesting there may be a need for a more structured solution, perhaps always flattening the allOf properties regardless of the situation?
