### PR TITLE
fix(mock): falsy examples were ignored

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getMockScalar } from './scalar';
-import { ContextSpecs } from '@orval/core';
+import type { ContextSpecs } from '@orval/core';
 
 describe('getMockScalar (int64 format handling)', () => {
   const baseArg = {
@@ -49,5 +49,46 @@ describe('getMockScalar (int64 format handling)', () => {
     });
 
     expect(result.value).toBe(specified);
+  });
+});
+
+describe('getMockScalar (example handling with falsy values)', () => {
+  const baseArg = {
+    item: {
+      name: 'test-item',
+      type: 'boolean',
+      nullable: true,
+    },
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+    mockOptions: {useExamples: true},
+    context: {},
+  };
+
+  it('should return the example value when it is a false value', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: { ...baseArg.item, example: false },
+    });
+
+    expect(result.value).toBe('false');
+  });
+
+  it('should return the example value when it is a null value', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: { ...baseArg.item, example: null },
+    });
+
+    expect(result.value).toBe('null');
+  });
+
+  it('should return a faker invocation when the example is undefined', () => {
+    const result = getMockScalar(baseArg);
+
+    expect(result.value).toBe('faker.datatype.boolean()');
   });
 });

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -65,7 +65,7 @@ describe('getMockScalar (example handling with falsy values)', () => {
     existingReferencedProperties: [],
     splitMockImplementations: [],
     mockOptions: { useExamples: true },
-    context: { output: {} }  as ContextSpecs,
+    context: { output: {} } as ContextSpecs,
   };
 
   it('should return the example value when it is a false value', () => {
@@ -87,7 +87,10 @@ describe('getMockScalar (example handling with falsy values)', () => {
   });
 
   it('should return a faker invocation when the example is undefined', () => {
-    const result = getMockScalar({...baseArg, item: {...baseArg.item, example: undefined}});
+    const result = getMockScalar({
+      ...baseArg,
+      item: { ...baseArg.item, example: undefined },
+    });
 
     expect(result.value).toBe('faker.datatype.boolean()');
   });

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -56,8 +56,8 @@ describe('getMockScalar (example handling with falsy values)', () => {
   const baseArg = {
     item: {
       name: 'test-item',
-      type: 'boolean',
-      nullable: true,
+      example: false,
+      type: 'boolean' as const,
     },
     imports: [],
     operationId: 'test-operation',
@@ -65,7 +65,7 @@ describe('getMockScalar (example handling with falsy values)', () => {
     existingReferencedProperties: [],
     splitMockImplementations: [],
     mockOptions: { useExamples: true },
-    context: {},
+    context: { output: {} }  as ContextSpecs,
   };
 
   it('should return the example value when it is a false value', () => {
@@ -87,7 +87,7 @@ describe('getMockScalar (example handling with falsy values)', () => {
   });
 
   it('should return a faker invocation when the example is undefined', () => {
-    const result = getMockScalar(baseArg);
+    const result = getMockScalar({...baseArg, item: {...baseArg.item, example: undefined}});
 
     expect(result.value).toBe('faker.datatype.boolean()');
   });

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -64,7 +64,7 @@ describe('getMockScalar (example handling with falsy values)', () => {
     tags: [],
     existingReferencedProperties: [],
     splitMockImplementations: [],
-    mockOptions: {useExamples: true},
+    mockOptions: { useExamples: true },
     context: {},
   };
 

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -1,16 +1,16 @@
 import {
-  ContextSpecs,
+  type ContextSpecs,
   EnumGeneration,
   escape,
-  GeneratorImport,
+  type GeneratorImport,
   isReference,
   isRootKey,
   mergeDeep,
-  MockOptions,
+  type MockOptions,
   pascal,
 } from '@orval/core';
-import { SchemaObject as SchemaObject31 } from 'openapi3-ts/oas31';
-import { MockDefinition, MockSchemaObject } from '../../types';
+import type { SchemaObject as SchemaObject31 } from 'openapi3-ts/oas31';
+import type { MockDefinition, MockSchemaObject } from '../../types';
 import { DEFAULT_FORMAT_MOCK } from '../constants';
 import {
   getNullable,
@@ -87,7 +87,7 @@ export const getMockScalar = ({
 
   if (
     (context.output.override?.mock?.useExamples || mockOptions?.useExamples) &&
-    item.example
+    item.example !== undefined
   ) {
     return {
       value: JSON.stringify(item.example),


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Properties with falsy examples (like a boolean with `false` or a nullable prop with `null`) didn't generate the mock with those examples and put a faker boolean call instead. This PR take into account those values.

## Related PRs

None

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Test were added. Anyway, just a property like this reproduces the error:

```
"isEnabled": {
  "type": "boolean",
  "example": false
},