### PR TITLE
fix(core): an object member cannot be declared optional

### DIFF
--- a/packages/core/src/generators/interface.test.ts
+++ b/packages/core/src/generators/interface.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { ContextSpecs, GeneratorSchema } from '../types';
+import type { ContextSpecs, GeneratorSchema } from '../types';
 import { generateInterface } from './interface';
-import { SchemaObject as SchemaObject31 } from 'openapi3-ts/oas31';
-import { SchemaObject as SchemaObject30 } from 'openapi3-ts/oas30';
+import type { SchemaObject as SchemaObject31 } from 'openapi3-ts/oas31';
+import type { SchemaObject as SchemaObject30 } from 'openapi3-ts/oas30';
 
 describe('generateInterface', () => {
   const context: ContextSpecs = {
@@ -26,6 +26,10 @@ describe('generateInterface', () => {
           type: 'integer',
           const: 1,
         },
+        isError: {
+          type: 'boolean',
+          const: false,
+        },
       },
       required: ['message', 'code'],
     };
@@ -42,6 +46,7 @@ describe('generateInterface', () => {
         model: `export const TestSchemaValue = {
   message: 'Invalid data',
   code: 1,
+  isError: false,
 } as const;
 export type TestSchema = typeof TestSchemaValue;
 `,

--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -1,6 +1,6 @@
-import { SchemaObject } from 'openapi3-ts/oas30';
+import type { SchemaObject } from 'openapi3-ts/oas30';
 import { getScalar } from '../getters';
-import { ContextSpecs } from '../types';
+import type { ContextSpecs } from '../types';
 import { jsDoc } from '../utils';
 
 /**
@@ -51,7 +51,9 @@ export const generateInterface = ({
       Object.values(schema.properties).length > 0 &&
       Object.values(schema.properties).every((item) => 'const' in item)
     ) {
-      const mappedScalarValue = scalar.value.replaceAll(';', ',');
+      const mappedScalarValue = scalar.value
+        .replaceAll(';', ',')
+        .replaceAll('?:', ':');
 
       model += `export const ${name}Value = ${mappedScalarValue} as const;\nexport type ${name} = typeof ${name}Value;\n`;
     } else {


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

In a regular object, members cannot be declared as optional. This is incorrect:

```ts
const a = { b?: 42 }
```

Optionals can be used only in types. This is causing a TS error number 1162 since `7.6.0` an issue when generating the schema files.

Fixes #2078

## Related PRs

None

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Try with an schema like this:

```
"UserValidation": {
  "properties": {
    "type": {
      "type": "string",
      "const": "valid",
      "title": "Type",
      "default": "valid"
    }
  },
  "type": "object",
  "title": "UserValidation",
  "description": "This object is provided if the user has been validated."
},
```