### PR TITLE
fix: use override for text/plain response types

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -128,6 +128,9 @@ const generateDefinition = (
 
   const delay = getDelay(override, !isFunction(mock) ? mock : undefined);
   const infoParam = 'info';
+  const overrideResponse = `overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(${infoParam}) : overrideResponse)
+    : ${getResponseMockFunctionName}()`;
   const handlerImplementation = `
 export const ${handlerName} = (overrideResponse?: ${returnType} | ((${infoParam}: Parameters<Parameters<typeof http.${verb}>[1]>[0]) => Promise<${returnType}> | ${returnType})) => {
   return http.${verb}('${route}', async (${infoParam}) => {${
@@ -139,10 +142,8 @@ export const ${handlerName} = (overrideResponse?: ${returnType} | ((${infoParam}
     return new HttpResponse(${
       isReturnHttpResponse
         ? isTextPlain
-          ? `${getResponseMockFunctionName}()`
-          : `JSON.stringify(overrideResponse !== undefined 
-            ? (typeof overrideResponse === "function" ? await overrideResponse(${infoParam}) : overrideResponse) 
-            : ${getResponseMockFunctionName}())`
+          ? overrideResponse
+          : `JSON.stringify(${overrideResponse})`
         : null
     },
       { status: ${status === 'default' ? 200 : status.replace(/XX$/, '00')},


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Mock overrides were not previously applied to text/plain response types. This PR adds support for applying overrides to them.

fixes #2115 
