### PR TITLE
fix: use minItems and maxItems when mocking arrays

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -225,8 +225,8 @@ export const getMockScalar = ({
       return {
         value:
           `Array.from({ length: faker.number.int({ ` +
-          `min: ${mockOptions?.arrayMin}, ` +
-          `max: ${mockOptions?.arrayMax} }) ` +
+          `min: ${mockOptions?.arrayMin ?? item.minItems ?? 1}, ` +
+          `max: ${mockOptions?.arrayMax ?? item.maxItems ?? 10} }) ` +
           `}, (_, i) => i + 1).map(() => (${mapValue}))`,
         imports: resolvedImports,
         name: item.name,

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -97,15 +97,15 @@ const getMockScalarJsTypes = (
     case 'number':
       return isArray
         ? `Array.from({length: faker.number.int({` +
-            `min: ${mockOptionsWithoutFunc.arrayMin}, ` +
-            `max: ${mockOptionsWithoutFunc.arrayMax}}` +
+            `min: ${mockOptionsWithoutFunc.arrayMin ?? 1}, ` +
+            `max: ${mockOptionsWithoutFunc.arrayMax ?? 10}}` +
             `)}, () => faker.number.int())`
         : 'faker.number.int()';
     case 'string':
       return isArray
         ? `Array.from({length: faker.number.int({` +
-            `min: ${mockOptionsWithoutFunc?.arrayMin},` +
-            `max: ${mockOptionsWithoutFunc?.arrayMax}}` +
+            `min: ${mockOptionsWithoutFunc?.arrayMin ?? 1},` +
+            `max: ${mockOptionsWithoutFunc?.arrayMax ?? 10}}` +
             `)}, () => faker.word.sample())`
         : 'faker.word.sample()';
     default:

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -202,11 +202,7 @@ export const normalizeOptions = async (
         outputOptions.unionAddMissingProperties ?? false,
       override: {
         ...outputOptions.override,
-        mock: {
-          arrayMin: outputOptions.override?.mock?.arrayMin ?? 1,
-          arrayMax: outputOptions.override?.mock?.arrayMax ?? 10,
-          ...(outputOptions.override?.mock ?? {}),
-        },
+        mock: outputOptions.override?.mock ?? {},
         operations: normalizeOperationsAndTags(
           outputOptions.override?.operations ?? {},
           outputWorkspace,

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -78,7 +78,7 @@ export type ShowPetByIdResult = AxiosResponse<Pet>;
 
 export const getListPetsResponseMock = (): PetsArray =>
   Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 20 }) },
     (_, i) => i + 1,
   ).map(() => ({
     id: faker.number.int({ min: undefined, max: undefined }),

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -12,7 +12,7 @@ import type { Pet, PetsArray, PetsNestedArray } from '../model';
 
 export const getListPetsResponseMock = (): PetsArray =>
   Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 20 }) },
     (_, i) => i + 1,
   ).map(() => ({
     id: (() => faker.number.int({ min: 1, max: 99999 }))(),

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -12,7 +12,7 @@ import type { Pet, PetsArray, PetsNestedArray } from '../model';
 
 export const getListPetsResponseMock = (): PetsArray =>
   Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
+    { length: faker.number.int({ min: 1, max: 20 }) },
     (_, i) => i + 1,
   ).map(() => ({
     id: (() => faker.number.int({ min: 1, max: 99999 }))(),


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #2129

Use minItems and maxItems properties when mocking arrays. arrayMin and arrayMax options can still be used to override these. Removed default arrayMin and arrayMax values from normalizedOptions so we can detect when they are not set. Fallback values are handled when values are actually used further down the code.

## Related PRs

--

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Build repo and use minItems and maxItems in yaml for array types.
