### PR TITLE
fix: use multipleOf when mocking numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rimraf": "^5.0.5",
     "tsup": "^8.4.0",
     "turbo": "^1.13.3",
-    "typescript": "^4.7.4",
+    "typescript": "^5.2.2",
     "typescript-eslint": "^8.26.0",
     "vitest": "^0.6.3",
     "zx": "^7.2.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.25.1",
-    "@faker-js/faker": "^8.4.0",
+    "@faker-js/faker": "^9.8.0",
     "@release-it-plugins/workspaces": "^4.2.0",
     "@release-it/conventional-changelog": "^10.0.0",
     "@types/node": "^20.13.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "test": "vitest run test.ts --global"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.4.0",
+    "@faker-js/faker": "^9.8.0",
     "@types/debug": "^4.1.12",
     "@types/fs-extra": "^11.0.4",
     "@types/inquirer": "^9.0.7",

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -137,7 +137,7 @@ export const getMockScalar = ({
     case 'number':
     case 'integer': {
       let value = getNullable(
-        `faker.number.int({min: ${item.minimum}, max: ${item.maximum}})`,
+        `faker.number.int({min: ${item.minimum}, max: ${item.maximum}, multipleOf: ${item.multipleOf}})`,
         item.nullable,
       );
       const numberImports: GeneratorImport[] = [];

--- a/samples/angular-app/package.json
+++ b/samples/angular-app/package.json
@@ -26,7 +26,7 @@
     "@angular-devkit/build-angular": "~12.2.14",
     "@angular/cli": "~12.2.14",
     "@angular/compiler-cli": "~12.2.15",
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@types/node": "^12.11.1",
     "codelyzer": "^6.0.0",
     "msw": "^2.0.2",

--- a/samples/angular-app/package.json
+++ b/samples/angular-app/package.json
@@ -33,6 +33,6 @@
     "orval": "link:../../packages/orval/dist",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~4.3.5"
+    "typescript": "^5.2.2"
   }
 }

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
@@ -28,8 +28,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -84,7 +84,7 @@ export const getListPetsResponseMock = (): PetsArray =>
     id: faker.number.int({ min: undefined, max: undefined }),
     name: 'jon',
     age: faker.helpers.arrayElement([
-      faker.number.int({ min: 0, max: 30 }),
+      faker.number.int({ min: 0, max: 30, multipleOf: undefined }),
       undefined,
     ]),
     tag: faker.helpers.arrayElement(['jon', null]),
@@ -113,7 +113,7 @@ export const getListPetsNestedArrayResponseMock = (
       id: faker.number.int({ min: undefined, max: undefined }),
       name: 'jon',
       age: faker.helpers.arrayElement([
-        faker.number.int({ min: 0, max: 30 }),
+        faker.number.int({ min: 0, max: 30, multipleOf: undefined }),
         undefined,
       ]),
       tag: faker.helpers.arrayElement(['jon', null]),

--- a/samples/basic/api/model/pet.ts
+++ b/samples/basic/api/model/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/basic/package.json
+++ b/samples/basic/package.json
@@ -16,7 +16,7 @@
     "orval": "link:../../packages/orval/dist"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "axios": "^1.8.2",
     "msw": "^2.0.2"
   }

--- a/samples/hono/hono-with-zod/src/petstore.zod.ts
+++ b/samples/hono/hono-with-zod/src/petstore.zod.ts
@@ -17,20 +17,19 @@ export const listPetsQueryParams = zod.object({
 export const listPetsResponseItem = zod.preprocess(
   stripNill,
   zod
-    .discriminatedUnion('breed', [
-      zod
-        .object({
-          cuteness: zod.number(),
-          breed: zod.enum(['Labradoodle']),
-        })
-        .strict(),
+    .object({
+      cuteness: zod.number(),
+      breed: zod.enum(['Labradoodle']),
+    })
+    .strict()
+    .or(
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    ])
+    )
     .or(
       zod
         .object({
@@ -51,20 +50,19 @@ export const createPetsBody = zod.array(createPetsBodyItem);
 export const createPetsResponse = zod.preprocess(
   stripNill,
   zod
-    .discriminatedUnion('breed', [
-      zod
-        .object({
-          cuteness: zod.number(),
-          breed: zod.enum(['Labradoodle']),
-        })
-        .strict(),
+    .object({
+      cuteness: zod.number(),
+      breed: zod.enum(['Labradoodle']),
+    })
+    .strict()
+    .or(
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    ])
+    )
     .or(
       zod
         .object({
@@ -76,16 +74,16 @@ export const createPetsResponse = zod.preprocess(
 );
 
 export const updatePetsBody = zod
-  .discriminatedUnion('breed', [
-    zod.object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    }),
+  .object({
+    cuteness: zod.number(),
+    breed: zod.enum(['Labradoodle']),
+  })
+  .or(
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  ])
+  )
   .or(
     zod.object({
       petsRequested: zod.number().optional(),
@@ -96,20 +94,19 @@ export const updatePetsBody = zod
 export const updatePetsResponse = zod.preprocess(
   stripNill,
   zod
-    .discriminatedUnion('breed', [
-      zod
-        .object({
-          cuteness: zod.number(),
-          breed: zod.enum(['Labradoodle']),
-        })
-        .strict(),
+    .object({
+      cuteness: zod.number(),
+      breed: zod.enum(['Labradoodle']),
+    })
+    .strict()
+    .or(
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    ])
+    )
     .or(
       zod
         .object({
@@ -128,20 +125,19 @@ export const showPetByIdParams = zod.object({
 export const showPetByIdResponse = zod.preprocess(
   stripNill,
   zod
-    .discriminatedUnion('breed', [
-      zod
-        .object({
-          cuteness: zod.number(),
-          breed: zod.enum(['Labradoodle']),
-        })
-        .strict(),
+    .object({
+      cuteness: zod.number(),
+      breed: zod.enum(['Labradoodle']),
+    })
+    .strict()
+    .or(
       zod
         .object({
           length: zod.number(),
           breed: zod.enum(['Dachshund']),
         })
         .strict(),
-    ])
+    )
     .or(
       zod
         .object({

--- a/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.msw.ts
@@ -14,7 +14,11 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -24,7 +28,11 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -39,7 +47,11 @@ export const getListPetsResponseDogMock = (
       { ...getListPetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -52,7 +64,11 @@ export const getListPetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -91,7 +107,11 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -101,7 +121,11 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -116,7 +140,11 @@ export const getCreatePetsResponseDogMock = (
       { ...getCreatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -129,7 +157,11 @@ export const getCreatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -164,7 +196,11 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -174,7 +210,11 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -189,7 +229,11 @@ export const getUpdatePetsResponseDogMock = (
       { ...getUpdatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -202,7 +246,11 @@ export const getUpdatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -237,7 +285,11 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -247,7 +299,11 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -262,7 +318,11 @@ export const getShowPetByIdResponseDogMock = (
       { ...getShowPetByIdResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -275,7 +335,11 @@ export const getShowPetByIdResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),

--- a/samples/react-app-with-swr/basic/package.json
+++ b/samples/react-app-with-swr/basic/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^17.0.1",
     "react-scripts": "^5.0.1",
     "swr": "^1.2.2",
-    "typescript": "^4.1.3"
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
     "orval": "link:../../../packages/orval/dist",

--- a/samples/react-app-with-swr/basic/package.json
+++ b/samples/react-app-with-swr/basic/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@types/node": "^14.14.13",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -20,10 +20,6 @@ import type {
 
 import { customInstance } from '../mutator/custom-instance';
 
-type AwaitedInput<T> = PromiseLike<T> | T;
-
-type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
-
 /**
  * @summary List all pets
  */

--- a/samples/react-app/package.json
+++ b/samples/react-app/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^17.0.1",
     "react-query": "^3.34.19",
     "react-scripts": "^5.0.1",
-    "typescript": "~4.1.3"
+    "typescript": "^5.2.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/samples/react-app/package.json
+++ b/samples/react-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@types/node": "^14.14.13",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -44,10 +44,6 @@ export const showPetById = (petId: string, version: number = 1) => {
   });
 };
 
-type AwaitedInput<T> = PromiseLike<T> | T;
-
-type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
-
 export type ListPetsResult = NonNullable<Awaited<ReturnType<typeof listPets>>>;
 export type CreatePetsResult = NonNullable<
   Awaited<ReturnType<typeof createPets>>

--- a/samples/react-query/basic/package.json
+++ b/samples/react-query/basic/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@tanstack/react-query": "^5.0.0",
     "@types/node": "^14.14.13",
     "@types/react": "^17.0.0",

--- a/samples/react-query/basic/package.json
+++ b/samples/react-query/basic/package.json
@@ -14,7 +14,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.2.4"
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
     "orval": "link:../../../packages/orval/dist",

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -18,7 +18,7 @@ export const getListPetsResponseMock = (): PetsArray =>
     id: (() => faker.number.int({ min: 1, max: 99999 }))(),
     name: (() => faker.person.lastName())(),
     age: faker.helpers.arrayElement([
-      faker.number.int({ min: 0, max: 30 }),
+      faker.number.int({ min: 0, max: 30, multipleOf: undefined }),
       undefined,
     ]),
     tag: faker.helpers.arrayElement([(() => faker.person.lastName())(), null]),
@@ -47,7 +47,7 @@ export const getListPetsNestedArrayResponseMock = (
       id: faker.number.int({ min: undefined, max: undefined }),
       name: (() => faker.person.lastName())(),
       age: faker.helpers.arrayElement([
-        faker.number.int({ min: 0, max: 30 }),
+        faker.number.int({ min: 0, max: 30, multipleOf: undefined }),
         undefined,
       ]),
       tag: faker.helpers.arrayElement([

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -47,10 +47,6 @@ import type {
 import { customInstance } from '../mutator/custom-instance';
 import type { ErrorType } from '../mutator/custom-instance';
 
-type AwaitedInput<T> = PromiseLike<T> | T;
-
-type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
-
 /**
  * @summary List all pets
  */

--- a/samples/react-query/basic/src/api/model/pet.ts
+++ b/samples/react-query/basic/src/api/model/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/custom-client/package.json
+++ b/samples/react-query/custom-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@types/faker": "^5.5.6",
     "@types/node": "^14.14.13",
     "@types/react": "^17.0.0",

--- a/samples/react-query/custom-client/package.json
+++ b/samples/react-query/custom-client/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^17.0.1",
     "react-query": "^3.34.19",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.1.3"
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
     "orval": "link:../../../packages/orval/dist",

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -18,7 +18,7 @@ export const getListPetsResponseMock = (): PetsArray =>
     id: (() => faker.number.int({ min: 1, max: 99999 }))(),
     name: (() => faker.person.lastName())(),
     age: faker.helpers.arrayElement([
-      faker.number.int({ min: 0, max: 30 }),
+      faker.number.int({ min: 0, max: 30, multipleOf: undefined }),
       undefined,
     ]),
     tag: faker.helpers.arrayElement([(() => faker.person.lastName())(), null]),
@@ -47,7 +47,7 @@ export const getListPetsNestedArrayResponseMock = (
       id: faker.number.int({ min: undefined, max: undefined }),
       name: (() => faker.person.lastName())(),
       age: faker.helpers.arrayElement([
-        faker.number.int({ min: 0, max: 30 }),
+        faker.number.int({ min: 0, max: 30, multipleOf: undefined }),
         undefined,
       ]),
       tag: faker.helpers.arrayElement([

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -30,10 +30,6 @@ import type {
 import { useCustomClient } from '../mutator/custom-client';
 import type { ErrorType, BodyType } from '../mutator/custom-client';
 
-type AwaitedInput<T> = PromiseLike<T> | T;
-
-type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
-
 /**
  * @summary List all pets
  */

--- a/samples/react-query/custom-client/src/api/model/pet.ts
+++ b/samples/react-query/custom-client/src/api/model/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -14,7 +14,11 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -24,7 +28,11 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -39,7 +47,11 @@ export const getListPetsResponseDogMock = (
       { ...getListPetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -52,7 +64,11 @@ export const getListPetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -91,7 +107,11 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -101,7 +121,11 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -116,7 +140,11 @@ export const getCreatePetsResponseDogMock = (
       { ...getCreatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -129,7 +157,11 @@ export const getCreatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -164,7 +196,11 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -174,7 +210,11 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -189,7 +229,11 @@ export const getUpdatePetsResponseDogMock = (
       { ...getUpdatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -202,7 +246,11 @@ export const getUpdatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -237,7 +285,11 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -247,7 +299,11 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -262,7 +318,11 @@ export const getShowPetByIdResponseDogMock = (
       { ...getShowPetByIdResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -275,7 +335,11 @@ export const getShowPetByIdResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),

--- a/samples/react-query/form-data-mutator/models/pet.ts
+++ b/samples/react-query/form-data-mutator/models/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/form-data-mutator/package.json
+++ b/samples/react-query/form-data-mutator/package.json
@@ -11,7 +11,7 @@
     "test": "tsc --noEmit endpoints.ts"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "axios": "^1.8.2",
     "react": "^18.2.0",
     "react-query": "^3.34.19"

--- a/samples/react-query/form-data/models/pet.ts
+++ b/samples/react-query/form-data/models/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/form-data/package.json
+++ b/samples/react-query/form-data/package.json
@@ -11,7 +11,7 @@
     "test": "tsc --noEmit endpoints.ts"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "axios": "^1.8.2",
     "react": "^18.2.0",
     "react-query": "^3.34.19"

--- a/samples/react-query/form-url-encoded-mutator/models/pet.ts
+++ b/samples/react-query/form-url-encoded-mutator/models/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/form-url-encoded-mutator/package.json
+++ b/samples/react-query/form-url-encoded-mutator/package.json
@@ -11,7 +11,7 @@
     "test": "tsc --noEmit endpoints.ts"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "axios": "^1.8.2",
     "react": "^18.2.0",
     "react-query": "^3.34.19"

--- a/samples/react-query/form-url-encoded/models/pet.ts
+++ b/samples/react-query/form-url-encoded/models/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/form-url-encoded/package.json
+++ b/samples/react-query/form-url-encoded/package.json
@@ -11,7 +11,7 @@
     "test": "tsc --noEmit endpoints.ts"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "axios": "^1.8.2",
     "react": "^18.2.0",
     "react-query": "^3.34.19"

--- a/samples/react-query/hook-mutator/models/pet.ts
+++ b/samples/react-query/hook-mutator/models/pet.ts
@@ -11,8 +11,8 @@ export interface Pet {
   id: number;
   /**
    * Name of pet
-   * @minLength 40
-   * @maxLength 0
+   * @minLength 0
+   * @maxLength 40
    */
   name: string;
   /**

--- a/samples/react-query/hook-mutator/package.json
+++ b/samples/react-query/hook-mutator/package.json
@@ -11,7 +11,7 @@
     "test": "tsc --noEmit endpoints.ts"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "axios": "^1.8.2",
     "react": "^18.2.0",
     "react-query": "^3.34.19"

--- a/samples/svelte-query/basic/package.json
+++ b/samples/svelte-query/basic/package.json
@@ -17,7 +17,7 @@
     "prepare": "see https://github.com/sveltejs/kit/issues/5390#issuecomment-1176480653"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@sveltejs/adapter-auto": "^2.0.0",
     "@sveltejs/kit": "^1.5.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",

--- a/samples/svelte-query/basic/package.json
+++ b/samples/svelte-query/basic/package.json
@@ -29,7 +29,7 @@
     "svelte": "^3.54.0",
     "svelte-check": "^3.0.1",
     "tslib": "^2.4.1",
-    "typescript": "^4.9.3",
+    "typescript": "^5.2.2",
     "vite": "^4.0.0"
   },
   "type": "module",

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -14,7 +14,11 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -24,7 +28,11 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -39,7 +47,11 @@ export const getListPetsResponseDogMock = (
       { ...getListPetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -52,7 +64,11 @@ export const getListPetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -91,7 +107,11 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -101,7 +121,11 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -116,7 +140,11 @@ export const getCreatePetsResponseDogMock = (
       { ...getCreatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -129,7 +157,11 @@ export const getCreatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -164,7 +196,11 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -174,7 +210,11 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -189,7 +229,11 @@ export const getUpdatePetsResponseDogMock = (
       { ...getUpdatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -202,7 +246,11 @@ export const getUpdatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -237,7 +285,11 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -247,7 +299,11 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -262,7 +318,11 @@ export const getShowPetByIdResponseDogMock = (
       { ...getShowPetByIdResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -275,7 +335,11 @@ export const getShowPetByIdResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.msw.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.msw.ts
@@ -14,7 +14,11 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -24,7 +28,11 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -39,7 +47,11 @@ export const getListPetsResponseDogMock = (
       { ...getListPetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -52,7 +64,11 @@ export const getListPetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -91,7 +107,11 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -101,7 +121,11 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -116,7 +140,11 @@ export const getCreatePetsResponseDogMock = (
       { ...getCreatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -129,7 +157,11 @@ export const getCreatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -164,7 +196,11 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -174,7 +210,11 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -189,7 +229,11 @@ export const getUpdatePetsResponseDogMock = (
       { ...getUpdatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -202,7 +246,11 @@ export const getUpdatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -237,7 +285,11 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -247,7 +299,11 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -262,7 +318,11 @@ export const getShowPetByIdResponseDogMock = (
       { ...getShowPetByIdResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -275,7 +335,11 @@ export const getShowPetByIdResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.zod.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.zod.ts
@@ -17,16 +17,16 @@ export const listPetsQueryParams = zod.object({
 });
 
 export const listPetsResponseItem = zod
-  .discriminatedUnion('breed', [
-    zod.object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    }),
+  .object({
+    cuteness: zod.number(),
+    breed: zod.enum(['Labradoodle']),
+  })
+  .or(
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  ])
+  )
   .or(
     zod.object({
       petsRequested: zod.number().optional(),
@@ -45,16 +45,16 @@ export const createPetsBodyItem = zod.object({
 export const createPetsBody = zod.array(createPetsBodyItem);
 
 export const createPetsResponse = zod
-  .discriminatedUnion('breed', [
-    zod.object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    }),
+  .object({
+    cuteness: zod.number(),
+    breed: zod.enum(['Labradoodle']),
+  })
+  .or(
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  ])
+  )
   .or(
     zod.object({
       petsRequested: zod.number().optional(),
@@ -66,16 +66,16 @@ export const createPetsResponse = zod
  * @summary Update a pet
  */
 export const updatePetsBody = zod
-  .discriminatedUnion('breed', [
-    zod.object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    }),
+  .object({
+    cuteness: zod.number(),
+    breed: zod.enum(['Labradoodle']),
+  })
+  .or(
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  ])
+  )
   .or(
     zod.object({
       petsRequested: zod.number().optional(),
@@ -84,16 +84,16 @@ export const updatePetsBody = zod
   );
 
 export const updatePetsResponse = zod
-  .discriminatedUnion('breed', [
-    zod.object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    }),
+  .object({
+    cuteness: zod.number(),
+    breed: zod.enum(['Labradoodle']),
+  })
+  .or(
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  ])
+  )
   .or(
     zod.object({
       petsRequested: zod.number().optional(),
@@ -110,16 +110,16 @@ export const showPetByIdParams = zod.object({
 });
 
 export const showPetByIdResponse = zod
-  .discriminatedUnion('breed', [
-    zod.object({
-      cuteness: zod.number(),
-      breed: zod.enum(['Labradoodle']),
-    }),
+  .object({
+    cuteness: zod.number(),
+    breed: zod.enum(['Labradoodle']),
+  })
+  .or(
     zod.object({
       length: zod.number(),
       breed: zod.enum(['Dachshund']),
     }),
-  ])
+  )
   .or(
     zod.object({
       petsRequested: zod.number().optional(),

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.msw.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.msw.ts
@@ -14,7 +14,11 @@ export const getListPetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -24,7 +28,11 @@ export const getListPetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -39,7 +47,11 @@ export const getListPetsResponseDogMock = (
       { ...getListPetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -52,7 +64,11 @@ export const getListPetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -91,7 +107,11 @@ export const getCreatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -101,7 +121,11 @@ export const getCreatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -116,7 +140,11 @@ export const getCreatePetsResponseDogMock = (
       { ...getCreatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -129,7 +157,11 @@ export const getCreatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -164,7 +196,11 @@ export const getUpdatePetsResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -174,7 +210,11 @@ export const getUpdatePetsResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -189,7 +229,11 @@ export const getUpdatePetsResponseDogMock = (
       { ...getUpdatePetsResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -202,7 +246,11 @@ export const getUpdatePetsResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),
@@ -237,7 +285,11 @@ export const getShowPetByIdResponseLabradoodleMock = (
   overrideResponse: Partial<Labradoodle> = {},
 ): Labradoodle => ({
   ...{
-    cuteness: faker.number.int({ min: undefined, max: undefined }),
+    cuteness: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Labradoodle'] as const),
   },
   ...overrideResponse,
@@ -247,7 +299,11 @@ export const getShowPetByIdResponseDachshundMock = (
   overrideResponse: Partial<Dachshund> = {},
 ): Dachshund => ({
   ...{
-    length: faker.number.int({ min: undefined, max: undefined }),
+    length: faker.number.int({
+      min: undefined,
+      max: undefined,
+      multipleOf: undefined,
+    }),
     breed: faker.helpers.arrayElement(['Dachshund'] as const),
   },
   ...overrideResponse,
@@ -262,7 +318,11 @@ export const getShowPetByIdResponseDogMock = (
       { ...getShowPetByIdResponseDachshundMock() },
     ]),
     barksPerMinute: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['dog'] as const),
@@ -275,7 +335,11 @@ export const getShowPetByIdResponseCatMock = (
 ): Cat => ({
   ...{
     petsRequested: faker.helpers.arrayElement([
-      faker.number.int({ min: undefined, max: undefined }),
+      faker.number.int({
+        min: undefined,
+        max: undefined,
+        multipleOf: undefined,
+      }),
       undefined,
     ]),
     type: faker.helpers.arrayElement(['cat'] as const),

--- a/samples/vue-query/vue-query-basic/package.json
+++ b/samples/vue-query/vue-query-basic/package.json
@@ -11,7 +11,7 @@
     "test": "vue-tsc --noEmit && vitest --run && yarn test-types"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.0.2",
+    "@faker-js/faker": "^9.8.0",
     "@tanstack/vue-query": "^5.28.4",
     "axios": "^1.8.2",
     "vue": "^3.3.4"

--- a/samples/yarn.lock
+++ b/samples/yarn.lock
@@ -3645,10 +3645,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:^8.0.2":
-  version: 8.4.1
-  resolution: "@faker-js/faker@npm:8.4.1"
-  checksum: 10c0/4f2aecddcfdc2cc8b50b2d15d1e37302a7c7a5bbd184ae910a9d271bc11248533ca74dcdd4a9ccbe20410553e7af0f6a4d334c5b955635e09a32ddf4a64942d4
+"@faker-js/faker@npm:^9.8.0":
+  version: 9.8.0
+  resolution: "@faker-js/faker@npm:9.8.0"
+  checksum: 10c0/f5db1125c1ea0115b9142fb4d4cb37cac2da4cd12ed02afb1cabf3b9600bd365bf480386250975a4fb200d77c00e8364dc8f61ac273a9dcdd2f2f42c3b29b0ec
   languageName: node
   linkType: hard
 
@@ -7198,7 +7198,7 @@ __metadata:
     "@angular/platform-browser": "npm:~12.2.15"
     "@angular/platform-browser-dynamic": "npm:~12.2.15"
     "@angular/router": "npm:~12.2.15"
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@types/node": "npm:^12.11.1"
     codelyzer: "npm:^6.0.0"
     msw: "npm:^2.0.2"
@@ -8066,7 +8066,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "basic@workspace:basic"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     axios: "npm:^1.8.2"
     msw: "npm:^2.0.2"
     npm-run-all: "npm:^4.1.5"
@@ -19656,7 +19656,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-app@workspace:react-app"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@types/node": "npm:^14.14.13"
     "@types/react": "npm:^17.0.0"
     "@types/react-dom": "npm:^17.0.0"
@@ -19761,7 +19761,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-basic@workspace:react-query/basic"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@tanstack/react-query": "npm:^5.0.0"
     "@types/node": "npm:^14.14.13"
     "@types/react": "npm:^17.0.0"
@@ -19782,7 +19782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-custom-client@workspace:react-query/custom-client"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@types/faker": "npm:^5.5.6"
     "@types/node": "npm:^14.14.13"
     "@types/react": "npm:^17.0.0"
@@ -19826,7 +19826,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-form-data-mutator@workspace:react-query/form-data-mutator"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     axios: "npm:^1.8.2"
     orval: "link:../../../packages/orval/dist"
     prettier: "npm:^3.0.3"
@@ -19839,7 +19839,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-form-data@workspace:react-query/form-data"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     axios: "npm:^1.8.2"
     orval: "link:../../../packages/orval/dist"
     prettier: "npm:^3.0.3"
@@ -19852,7 +19852,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-form-url-encoded-mutator@workspace:react-query/form-url-encoded-mutator"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     axios: "npm:^1.8.2"
     orval: "link:../../../packages/orval/dist"
     prettier: "npm:^3.0.3"
@@ -19865,7 +19865,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-form-url-encoded@workspace:react-query/form-url-encoded"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     axios: "npm:^1.8.2"
     orval: "link:../../../packages/orval/dist"
     prettier: "npm:^3.0.3"
@@ -19878,7 +19878,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-query-hook-mutator@workspace:react-query/hook-mutator"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     axios: "npm:^1.8.2"
     orval: "link:../../../packages/orval/dist"
     prettier: "npm:^3.0.3"
@@ -22259,7 +22259,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "svelte-query-basic@workspace:svelte-query/basic"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@sveltejs/adapter-auto": "npm:^2.0.0"
     "@sveltejs/kit": "npm:^1.5.0"
     "@tanstack/svelte-query": "npm:^4.24.9"
@@ -22377,7 +22377,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "swr-basic@workspace:react-app-with-swr/basic"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@types/node": "npm:^14.14.13"
     "@types/react": "npm:^17.0.0"
     "@types/react-dom": "npm:^17.0.0"
@@ -23996,7 +23996,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vue-query-basic@workspace:vue-query/vue-query-basic"
   dependencies:
-    "@faker-js/faker": "npm:^8.0.2"
+    "@faker-js/faker": "npm:^9.8.0"
     "@tanstack/vue-query": "npm:^5.28.4"
     "@testing-library/vue": "npm:^8.0.1"
     "@vitejs/plugin-vue": "npm:^4.5.0"

--- a/samples/yarn.lock
+++ b/samples/yarn.lock
@@ -7207,7 +7207,7 @@ __metadata:
     ts-node: "npm:~8.3.0"
     tslib: "npm:^2.0.0"
     tslint: "npm:~6.1.0"
-    typescript: "npm:~4.3.5"
+    typescript: "npm:^5.2.2"
     zone.js: "npm:~0.11.4"
   languageName: unknown
   linkType: soft
@@ -19668,7 +19668,7 @@ __metadata:
     react-dom: "npm:^17.0.1"
     react-query: "npm:^3.34.19"
     react-scripts: "npm:^5.0.1"
-    typescript: "npm:~4.1.3"
+    typescript: "npm:^5.2.2"
   languageName: unknown
   linkType: soft
 
@@ -19774,7 +19774,7 @@ __metadata:
     react: "npm:^17.0.1"
     react-dom: "npm:^17.0.1"
     react-scripts: "npm:^5.0.1"
-    typescript: "npm:^4.2.4"
+    typescript: "npm:^5.2.2"
   languageName: unknown
   linkType: soft
 
@@ -19796,7 +19796,7 @@ __metadata:
     react-dom: "npm:^17.0.1"
     react-query: "npm:^3.34.19"
     react-scripts: "npm:^5.0.1"
-    typescript: "npm:^4.1.3"
+    typescript: "npm:^5.2.2"
   languageName: unknown
   linkType: soft
 
@@ -22274,7 +22274,7 @@ __metadata:
     svelte: "npm:^3.54.0"
     svelte-check: "npm:^3.0.1"
     tslib: "npm:^2.4.1"
-    typescript: "npm:^4.9.3"
+    typescript: "npm:^5.2.2"
     vite: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
@@ -22389,7 +22389,7 @@ __metadata:
     react-dom: "npm:^17.0.1"
     react-scripts: "npm:^5.0.1"
     swr: "npm:^1.2.2"
-    typescript: "npm:^4.1.3"
+    typescript: "npm:^5.2.2"
   languageName: unknown
   linkType: soft
 
@@ -23240,23 +23240,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.3.5, typescript@npm:~4.3.5":
+"typescript@npm:4.3.5":
   version: 4.3.5
   resolution: "typescript@npm:4.3.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/7699b1635e34008eb4167ede70d475e4eaece150622e9a143de6c58b160df3c52bae00beb1cd3a836a35cb32defc4d1dc56bdfb11f7ddbebaa003e405f97ad3a
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^4.1.3, typescript@npm:^4.2.4, typescript@npm:^4.9.3":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/5f6cad2e728a8a063521328e612d7876e12f0d8a8390d3b3aaa452a6a65e24e9ac8ea22beb72a924fd96ea0a49ea63bb4e251fb922b12eedfb7f7a26475e5c56
   languageName: node
   linkType: hard
 
@@ -23280,33 +23270,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.1.3":
-  version: 4.1.6
-  resolution: "typescript@npm:4.1.6"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/afc8e2d2cc0d3dceb91d592326a259b0db88f60fa3419e4b2b47bf5e321027f5da1426cd6862acf0c29fde5d3224f7c8337ad24bcd8da8e25514cc53b750b129
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A4.3.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~4.3.5#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A4.3.5#optional!builtin<compat/typescript>":
   version: 4.3.5
   resolution: "typescript@patch:typescript@npm%3A4.3.5#optional!builtin<compat/typescript>::version=4.3.5&hash=dba6d9"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/8991b4a568bd5a9dab8fa470b5e51368f588e46aebde3a773d9c993ef83e8a1ec0832deae4496d2c788a23c400471117d60b8f9607578ae79779cb3f379308ae
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^4.1.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.2.4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.9.3#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
   languageName: node
   linkType: hard
 
@@ -23327,16 +23297,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/5a437c416251334deeaf29897157032311f3f126547cfdc4b133768b606cb0e62bcee733bb97cf74c42fe7268801aea1392d8e40988cdef112e9546eba4c03c5
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~4.1.3#optional!builtin<compat/typescript>":
-  version: 4.1.6
-  resolution: "typescript@patch:typescript@npm%3A4.1.6#optional!builtin<compat/typescript>::version=4.1.6&hash=4a8eb8"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/84238344c2b1fead8ab239fef22f821edd88c29a989e281441fb4344fceceacd70cf56991d3084b95799c4b0a7aec997b6aec5489db453db5260a9bd70ee09d7
   languageName: node
   linkType: hard
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@angular/common": "^17.1.1",
     "@angular/core": "^17.1.1",
-    "@faker-js/faker": "^8.1.0",
+    "@faker-js/faker": "^9.8.0",
     "@hono/zod-validator": "^0.4.2",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tanstack/react-query": "^5.63.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -90,10 +90,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "@faker-js/faker@npm:8.1.0"
-  checksum: 10c0/e930fdebe46414174093f534418836e0fdd70c027caa25fbd2fa816f62f855616238402270c5a0033df987da8e8c97029820997788f1d6115ff1b7dc635bd00d
+"@faker-js/faker@npm:^9.8.0":
+  version: 9.8.0
+  resolution: "@faker-js/faker@npm:9.8.0"
+  checksum: 10c0/f5db1125c1ea0115b9142fb4d4cb37cac2da4cd12ed02afb1cabf3b9600bd365bf480386250975a4fb200d77c00e8364dc8f61ac273a9dcdd2f2f42c3b29b0ec
   languageName: node
   linkType: hard
 
@@ -579,7 +579,7 @@ __metadata:
   dependencies:
     "@angular/common": "npm:^17.1.1"
     "@angular/core": "npm:^17.1.1"
-    "@faker-js/faker": "npm:^8.1.0"
+    "@faker-js/faker": "npm:^9.8.0"
     "@hono/zod-validator": "npm:^0.4.2"
     "@modelcontextprotocol/sdk": "npm:^1.9.0"
     "@tanstack/react-query": "npm:^5.63.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7553,7 +7553,7 @@ __metadata:
     rimraf: "npm:^5.0.5"
     tsup: "npm:^8.4.0"
     turbo: "npm:^1.13.3"
-    typescript: "npm:^4.7.4"
+    typescript: "npm:^5.2.2"
     typescript-eslint: "npm:^8.26.0"
     vitest: "npm:^0.6.3"
     zx: "npm:^7.2.3"
@@ -9746,13 +9746,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.7.4":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.2.2":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f6cad2e728a8a063521328e612d7876e12f0d8a8390d3b3aaa452a6a65e24e9ac8ea22beb72a924fd96ea0a49ea63bb4e251fb922b12eedfb7f7a26475e5c56
+  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
   languageName: node
   linkType: hard
 
@@ -9766,13 +9766,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.7.4#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
+  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,10 +957,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:^8.4.0":
-  version: 8.4.1
-  resolution: "@faker-js/faker@npm:8.4.1"
-  checksum: 10c0/4f2aecddcfdc2cc8b50b2d15d1e37302a7c7a5bbd184ae910a9d271bc11248533ca74dcdd4a9ccbe20410553e7af0f6a4d334c5b955635e09a32ddf4a64942d4
+"@faker-js/faker@npm:^9.8.0":
+  version: 9.8.0
+  resolution: "@faker-js/faker@npm:9.8.0"
+  checksum: 10c0/f5db1125c1ea0115b9142fb4d4cb37cac2da4cd12ed02afb1cabf3b9600bd365bf480386250975a4fb200d77c00e8364dc8f61ac273a9dcdd2f2f42c3b29b0ec
   languageName: node
   linkType: hard
 
@@ -1363,7 +1363,7 @@ __metadata:
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.1"
-    "@faker-js/faker": "npm:^8.4.0"
+    "@faker-js/faker": "npm:^9.8.0"
     "@ibm-cloud/openapi-ruleset": "npm:^1.29.4"
     "@types/debug": "npm:^4.1.12"
     "@types/fs-extra": "npm:^11.0.4"
@@ -7525,7 +7525,7 @@ __metadata:
     "@commitlint/config-conventional": "npm:^19.8.0"
     "@eslint/eslintrc": "npm:^3.2.0"
     "@eslint/js": "npm:^9.25.1"
-    "@faker-js/faker": "npm:^8.4.0"
+    "@faker-js/faker": "npm:^9.8.0"
     "@release-it-plugins/workspaces": "npm:^4.2.0"
     "@release-it/conventional-changelog": "npm:^10.0.0"
     "@types/node": "npm:^20.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7531,8 +7531,6 @@ __metadata:
     "@commitlint/cli": "npm:^19.8.1"
     "@commitlint/config-conventional": "npm:^19.8.0"
     "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:^9.25.1"
-    "@faker-js/faker": "npm:^9.8.0"
     "@eslint/js": "npm:^9.28.0"
     "@faker-js/faker": "npm:^9.8.0"
     "@release-it-plugins/workspaces": "npm:^4.2.0"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**WIP**

## Description

Fixes #2133

Use multipleOf when mocking numbers if defined.

## Related PRs

--

## Todos

Tests are currently failing due to TS errors because Faker 8 that is currently used doesn't support multipleOf that was added in version 9. This change doesn't break current mocks but Faker 8 doesn't utilize it either. Upgrading to version 9 will cause tests to pass but not sure if this is breaking change that should be considered separately.

## Steps to Test or Reproduce

Build repo and use multipleOf in yaml file.
