### PR TITLE
fix(fetch): respect OpenAPI 3.0 explode default value for query params

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -60,7 +60,7 @@ export const generateRequestFunction = (
   const explodeParameters = parameters.filter((parameter) => {
     const { schema } = resolveRef<ParameterObject>(parameter, context);
 
-    return schema.in === 'query' && schema.explode;
+    return schema.in === 'query' && schema.explode !== false;
   });
 
   const explodeParametersNames = explodeParameters.map((parameter) => {


### PR DESCRIPTION
## Status

**READY**

## Description

Fix explode parameter default value handling for query parameters in fetch client. According to [OpenAPI 3.0 specification](https://swagger.io/docs/specification/v3_0/serialization/#query), the default value of `explode` for query parameters should be `true` when the style is `form` (which is the default). The previous implementation only considered parameters with explicitly set `explode: true`, incorrectly excluding parameters where `explode` was undefined (should default to `true`).

## Related PRs

List related PRs against other branches:

## Todos

- [ ] Tests (Auto-generated tests updated via `yarn generate`)
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> cd tests
> yarn generate
```

Check the generated code in `tests/generated/fetch/parameters/endpoints.ts` to verify that query parameters without explicit `explode: false` are included in the `explodeParameters` array