### PR TITLE
fix: avoid to include read only properties to request with multipart/form-data

### DIFF
--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -1,5 +1,6 @@
 import { ReferenceObject, SchemaObject } from 'openapi3-ts/oas30';
-import { resolveExampleRefs, resolveObject, resolveValue } from '../resolvers';
+import { resolveExampleRefs, resolveValue } from '../resolvers';
+import { resolveObject } from '../resolvers/object';
 import {
   ContextSpecs,
   PropertySortOrder,

--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { RequestBodyObject, SchemaObject } from 'openapi3-ts/oas30';
+import { getResReqTypes } from './res-req-types';
+
+// Simulates an OpenAPI schema with a readOnly property
+const schemaWithReadOnly: SchemaObject = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer', readOnly: true },
+    file: { type: 'string', format: 'binary' },
+    kind: { type: 'string', enum: ['LOGO', 'CONTENT'] },
+  },
+  required: ['file'],
+};
+
+const context = {
+  output: {
+    override: {
+      formData: { arrayHandling: 'serialize', disabled: false },
+      enumGenerationType: 'const',
+    },
+  },
+  specKey: 'spec',
+  target: 'spec',
+  workspace: '',
+  specs: {
+    spec: {
+      components: { schemas: {} },
+    },
+  },
+};
+
+describe('getResReqTypes (formData, readOnly property)', () => {
+  it('should not include readOnly properties in the generated formData', () => {
+    const reqBody: [string, RequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'multipart/form-data': {
+              schema: schemaWithReadOnly,
+            },
+          },
+          required: true,
+        },
+      ],
+    ];
+    const types = getResReqTypes(reqBody, 'UploadBody', context as any);
+    // Get the generated code for formData
+    expect(types[0]).toBeDefined();
+    expect(typeof types[0].formData).toBe('string');
+    const formDataCode = types[0].formData as string;
+    // Verify that the readOnly property "id" is NOT present in the generated code
+    expect(formDataCode).not.toContain('id');
+    // Verify that the non-readOnly fields are present
+    expect(formDataCode).toContain('file');
+    expect(formDataCode).toContain('kind');
+  });
+});

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -401,6 +401,11 @@ const resolveSchemaPropertiesToFormData = ({
     (acc, [key, value]) => {
       const { schema: property } = resolveRef<SchemaObject>(value, context);
 
+      // Skip readOnly properties for formData
+      if (property.readOnly) {
+        return acc;
+      }
+
       let formDataValue = '';
 
       const formattedKeyPrefix = !isRequestBodyOptional


### PR DESCRIPTION
fix: avoid to include read only properties to request with multipart/form-data (
Fix #2089

## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes read only fields being incorrectly included into the params of requests with multipart/form-data.

## Todos

- [x] Tests
