### PR TITLE
fix: use arrayMin and arrayMax as default values when minItems and maxItems are not defined

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1630,7 +1630,7 @@ Gives you the possibility to generate mocks for all the HTTP statuses in the `re
 
 Type: `Number`.
 
-Set the minimum length of generated arrays for properties that specify multiple items. (Default is `1`)
+Set the default minimum length of generated arrays for properties that specify multiple items. Used if `minItems` is not defined for the property. (Default is `1`)
 
 ```js
 module.exports = {
@@ -1650,7 +1650,7 @@ module.exports = {
 
 Type: `Number`.
 
-Set the maximum length of generated arrays for properties that specify multiple items. (Default is `10`)
+Set the default maximum length of generated arrays for properties that specify multiple items. Used if `maxItems` is not defined for the property. (Default is `10`)
 
 ```js
 module.exports = {

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -235,8 +235,8 @@ export const getMockScalar = ({
       return {
         value:
           `Array.from({ length: faker.number.int({ ` +
-          `min: ${mockOptions?.arrayMin ?? item.minItems ?? 1}, ` +
-          `max: ${mockOptions?.arrayMax ?? item.maxItems ?? 10} }) ` +
+          `min: ${item.minItems ?? mockOptions?.arrayMin}, ` +
+          `max: ${item.maxItems ?? mockOptions?.arrayMax} }) ` +
           `}, (_, i) => i + 1).map(() => (${mapValue}))`,
         imports: resolvedImports,
         name: item.name,

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -98,15 +98,15 @@ const getMockScalarJsTypes = (
     case 'number':
       return isArray
         ? `Array.from({length: faker.number.int({` +
-            `min: ${mockOptionsWithoutFunc.arrayMin ?? 1}, ` +
-            `max: ${mockOptionsWithoutFunc.arrayMax ?? 10}}` +
+            `min: ${mockOptionsWithoutFunc.arrayMin}, ` +
+            `max: ${mockOptionsWithoutFunc.arrayMax}}` +
             `)}, () => faker.number.int())`
         : 'faker.number.int()';
     case 'string':
       return isArray
         ? `Array.from({length: faker.number.int({` +
-            `min: ${mockOptionsWithoutFunc?.arrayMin ?? 1},` +
-            `max: ${mockOptionsWithoutFunc?.arrayMax ?? 10}}` +
+            `min: ${mockOptionsWithoutFunc?.arrayMin},` +
+            `max: ${mockOptionsWithoutFunc?.arrayMax}}` +
             `)}, () => faker.word.sample())`
         : 'faker.word.sample()';
     default:

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -205,6 +205,8 @@ export const normalizeOptions = async (
       override: {
         ...outputOptions.override,
         mock: {
+          arrayMin: outputOptions.override?.mock?.arrayMin ?? 1,
+          arrayMax: outputOptions.override?.mock?.arrayMax ?? 10,
           fractionDigits: outputOptions.override?.mock?.fractionDigits ?? 2,
           ...outputOptions.override?.mock,
         },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

Fix #2148

## Description

As discussed in #2141 with @soartec-lab we should always prioritize what is defined in OpenAPI specification instead of using options to override specification. This PR makes it so that arrayMin and arrayMax are only used if minItems and maxItems are not defined in the specification. Also clarified this behavior in the documentation.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)
