### PR TITLE
fix(ndjson): fix issues with streaming ndjson

### DIFF
--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -7,141 +7,141 @@
       
 	<url>
 		<loc>https://orval.dev/guides/angular</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/basics</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/client-with-zod</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/custom-axios</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/custom-client</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/enums</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/fetch-client</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/fetch</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/hono</loc>
-		<lastmod>2025-04-20</lastmod>
-	</url>
-
-	<url>
-		<loc>https://orval.dev/guides/mcp-blog-ja</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/mcp</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/msw</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/react-query</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/set-base-url</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
+	</url>
+
+	<url>
+		<loc>https://orval.dev/guides/stream-ndjson</loc>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/svelte-query</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/swr</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/vue-query</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/guides/zod</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/installation</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/overview</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/quick-start</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/cli</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/full-example</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/hooks</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/input</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/output</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/configuration/overview</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 
 	<url>
 		<loc>https://orval.dev/reference/integration</loc>
-		<lastmod>2025-04-20</lastmod>
+		<lastmod>2025-06-16</lastmod>
 	</url>
 </urlset>

--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -109,6 +109,11 @@
           "title": "MCP server",
           "path": "/guides/mcp",
           "editUrl": "/guides/mcp.md"
+        },
+        {
+          "title": "Stream NDJSON",
+          "path": "/guides/stream-ndjson",
+          "editUrl": "/guides/stream-ndjson.md"
         }
       ]
     },

--- a/docs/src/pages/guides/stream-ndjson.md
+++ b/docs/src/pages/guides/stream-ndjson.md
@@ -1,0 +1,160 @@
+---
+id: stream-ndjson
+title: Stream Newline Delimited JSON
+---
+
+### Introduction
+
+`Orval` generates code that properly types responses streamed from `NDJSON`.
+[NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#Newline-delimited_JSON) is a technique to stream an array of JSON objects. This is mostly used when the data set is large.
+
+### How to use
+
+`Orval` does not generate code for actually parsing the stream, but rather provides type safety. You can use the code in the example below to see how you can achieve reading streamed data.
+Proper type support is only supported when using the `fetch` client as either a standalone client, or as a [httpClient](../reference/configuration/output#httpclient).
+
+#### Example
+
+```ts
+// orval.config.ts
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './stream.yaml',
+    },
+    output: {
+      client: 'fetch',
+      target: 'src/endpoints.ts',
+      schemas: 'src/model',
+    },
+  },
+});
+```
+
+```yml
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Stream
+paths:
+  /stream:
+    get:
+      operationId: stream
+      description: Stream results
+      responses:
+        '200':
+          description: The stream result.
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: '#/components/schemas/StreamEntry'
+components:
+  schemas:
+    StreamEntry:
+      type: object
+      properties:
+        foo:
+          type: number
+        bar:
+          type: string
+```
+
+```ts
+// Generated code
+interface TypedResponse<T> extends Response {
+  json(): Promise<T>;
+}
+
+/**
+ * Stream results
+ */
+export type streamResponse200 = {
+  stream: TypedResponse<StreamEntry>;
+  status: 200;
+};
+export type streamResponseComposite = streamResponse200;
+
+export type streamResponse = streamResponseComposite & {
+  headers: Headers;
+};
+
+export const getStreamUrl = () => {
+  return `/stream`;
+};
+
+export const stream = async (
+  options?: RequestInit,
+): Promise<streamResponse> => {
+  const stream = await fetch(getStreamUrl(), {
+    ...options,
+    method: 'GET',
+    headers: { Accept: 'application/x-ndjson', ...options?.headers },
+  });
+
+  return {
+    status: stream.status,
+    stream,
+    headers: stream.headers,
+  } as streamResponse;
+};
+```
+
+```ts
+// Calling code
+export const readStream = <T extends object>(
+  response: Response & { json(): Promise<T> },
+  processLine: (value: T) => void | boolean,
+  onError?: (response?: Response) => any,
+): Promise<any> => {
+  if (!response.ok && onError) {
+    return onError(response);
+  }
+  if (!response.body) return Promise.resolve(() => {});
+
+  const stream = response.body.getReader();
+  const matcher = /\r?\n/;
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const loop: () => Promise<undefined> = () =>
+    stream.read().then(({ done, value }) => {
+      if (done) {
+        if (buffer.length > 0) processLine(JSON.parse(buffer));
+      } else {
+        const chunk = decoder.decode(value, {
+          stream: true,
+        });
+        buffer += chunk;
+
+        const parts = buffer.split(matcher);
+        buffer = parts.pop() ?? '';
+        const validParts = parts.filter((p) => p);
+        if (validParts.length !== 0) {
+          for (const i of validParts) {
+            const p = JSON.parse(i) as T;
+            processLine(p);
+          }
+          return loop();
+        }
+      }
+    });
+
+  return loop();
+};
+
+export const getResult = async () => {
+  const results: StreamEntry[] = [];
+
+  const streamResponse = await stream();
+  if (streamResponse.status !== 200) return results;
+
+  // The promise is resolved when the stream is complete.
+  await readStream(streamResponse.stream, (obj) => {
+    // obj is typed as StreamEntry
+    results.push(obj);
+  });
+  return results;
+};
+```

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -114,7 +114,10 @@ export const writeSingleMode = async ({
       data += generateMutatorImports({ mutators: paramsSerializer });
     }
 
-    if (implementation.includes('NonReadonly<')) {
+    if (
+      implementation.includes('NonReadonly<') ||
+      implementation.includes('TypedResponse<')
+    ) {
       data += getOrvalGeneratedTypes();
       data += '\n';
     }

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -135,7 +135,10 @@ export const writeSplitMode = async ({
       });
     }
 
-    if (implementation.includes('NonReadonly<')) {
+    if (
+      implementation.includes('NonReadonly<') ||
+      implementation.includes('TypedResponse<')
+    ) {
       implementationData += getOrvalGeneratedTypes();
     }
 

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -150,7 +150,10 @@ export const writeSplitTagsMode = async ({
           });
         }
 
-        if (implementation.includes('NonReadonly<')) {
+        if (
+          implementation.includes('NonReadonly<') ||
+          implementation.includes('TypedResponse<')
+        ) {
           implementationData += getOrvalGeneratedTypes();
           implementationData += '\n';
         }

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -131,7 +131,10 @@ export const writeTagsMode = async ({
 
         data += '\n\n';
 
-        if (implementation.includes('NonReadonly<')) {
+        if (
+          implementation.includes('NonReadonly<') ||
+          implementation.includes('TypedResponse<')
+        ) {
           data += getOrvalGeneratedTypes();
           data += '\n';
         }

--- a/packages/core/src/writers/types.ts
+++ b/packages/core/src/writers/types.ts
@@ -24,4 +24,8 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>] ? {
     ? NonReadonly<NonNullable<T[P]>>
     : T[P];
 } : DistributeReadOnlyOverUnions<T>;
+
+interface TypedResponse<T> extends Response {
+  json(): Promise<T>;
+}
 `;

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -645,7 +645,10 @@ const generateContext = async (
             (imp, i, arr) => arr.findIndex((v) => v.name === imp.name) === i,
           );
 
-        if (contexts.includes('NonReadonly<')) {
+        if (
+          contexts.includes('NonReadonly<') ||
+          contexts.includes('TypedResponse<')
+        ) {
           content += getOrvalGeneratedTypes();
           content += '\n';
         }
@@ -701,7 +704,10 @@ const generateContext = async (
     .filter((imp) => contexts.includes(imp.name))
     .filter((imp, i, arr) => arr.findIndex((v) => v.name === imp.name) === i);
 
-  if (contexts.includes('NonReadonly<')) {
+  if (
+    contexts.includes('NonReadonly<') ||
+    contexts.includes('TypedResponse<')
+  ) {
     content += getOrvalGeneratedTypes();
     content += '\n';
   }

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -214,4 +214,14 @@ export default defineConfig({
       target: '../specifications/empty-response.yaml',
     },
   },
+  stream: {
+    output: {
+      target: '../generated/fetch/stream/endpoints.ts',
+      schemas: '../generated/fetch/stream/model',
+      client: 'fetch',
+    },
+    input: {
+      target: '../specifications/stream.yaml',
+    },
+  },
 });

--- a/tests/specifications/stream.yaml
+++ b/tests/specifications/stream.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Stream
+paths:
+  /stream:
+    get:
+      operationId: stream
+      description: Stream results
+      responses:
+        '200':
+          description: The stream result.
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: '#/components/schemas/StreamEntry'
+components:
+  schemas:
+    StreamEntry:
+      type: object
+      properties:
+        foo:
+          type: number
+        bar:
+          type: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,23 +1349,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.9.0, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.10.0, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.9.0, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.10.0, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.9.0, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.10.0, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1400,69 +1400,69 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.9.0, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.10.0, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.9.0, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.10.0, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.9.0"
-    "@orval/zod": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
+    "@orval/zod": "npm:7.10.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mcp@npm:7.9.0, @orval/mcp@workspace:packages/mcp":
+"@orval/mcp@npm:7.10.0, @orval/mcp@workspace:packages/mcp":
   version: 0.0.0-use.local
   resolution: "@orval/mcp@workspace:packages/mcp"
   dependencies:
-    "@orval/core": "npm:7.9.0"
-    "@orval/zod": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
+    "@orval/zod": "npm:7.10.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.9.0, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.10.0, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.9.0, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.10.0, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.9.0"
-    "@orval/fetch": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
+    "@orval/fetch": "npm:7.10.0"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.9.0, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.10.0, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.9.0"
-    "@orval/fetch": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
+    "@orval/fetch": "npm:7.10.0"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.9.0, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.10.0, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.9.0"
+    "@orval/core": "npm:7.10.0"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -7591,16 +7591,16 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.1"
-    "@orval/angular": "npm:7.9.0"
-    "@orval/axios": "npm:7.9.0"
-    "@orval/core": "npm:7.9.0"
-    "@orval/fetch": "npm:7.9.0"
-    "@orval/hono": "npm:7.9.0"
-    "@orval/mcp": "npm:7.9.0"
-    "@orval/mock": "npm:7.9.0"
-    "@orval/query": "npm:7.9.0"
-    "@orval/swr": "npm:7.9.0"
-    "@orval/zod": "npm:7.9.0"
+    "@orval/angular": "npm:7.10.0"
+    "@orval/axios": "npm:7.10.0"
+    "@orval/core": "npm:7.10.0"
+    "@orval/fetch": "npm:7.10.0"
+    "@orval/hono": "npm:7.10.0"
+    "@orval/mcp": "npm:7.10.0"
+    "@orval/mock": "npm:7.10.0"
+    "@orval/query": "npm:7.10.0"
+    "@orval/swr": "npm:7.10.0"
+    "@orval/zod": "npm:7.10.0"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

There were a few issues when generating code that handled ndjson.
* There were no way of getting the type of the json object that was streamed
* There were issues where we didn't cast the response correctly, so it generated invalid typescript
* The header Accept: 'application/x-ndjson'/Accept: 'application/nd-json' was not added automatically when the response was streamed.

Also, there were other issues that I discovered when generating the Lichess API:
* When calling endpoints with 'Content-Type': 'text/plain', we tried to stringify the parameter as the body when the parameter was already string
* When an endpoint had multiple response contents for a single response, we had a clash in naming them, e.g.
```json
"responses": {
  "200": {
    "content": {
      "application/x-chess-pgn": {
        "schema": {
          "$ref": "#/components/schemas/GamePgn"
        }
      },
      "application/x-ndjson": {
        "schema": {
          "$ref": "#/components/schemas/GameJson"
        }
      }
    }
  }
}
```
originally gave
```ts
export type getTournamentByIdGamesResponse200 = {
  data: GamePgn
  status: 200
}

export type getTournamentByIdGamesResponse200 = {
  stream: Response
  status: 200
}
```
but now instead gives
```ts
export type getTournamentByIdGamesResponse200ApplicationXChessPgn= {
  data: GamePgn
  status: 200
}

export type getTournamentByIdGamesResponse200ApplicationXNdjson= {
  stream: TypedResponse<GameJson>
  status: 200
}
```

I also added some documentation about how to read the response from stream