### PR TITLE
feat(fetch): add ability to throw on error

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -105,7 +105,7 @@ export type NormalizedOverrideOutput = {
   angular: Required<AngularOptions>;
   swr: SwrOptions;
   zod: NormalizedZodOptions;
-  fetch: FetchOptions;
+  fetch: NormalizedFetchOptions;
   operationName?: (
     operation: OperationObject,
     route: string,
@@ -621,8 +621,14 @@ export type SwrOptions = {
   swrInfiniteOptions?: any;
 };
 
-export type FetchOptions = {
+export type NormalizedFetchOptions = {
   includeHttpResponseReturnType: boolean;
+  shouldThrowOnError: boolean;
+};
+
+export type FetchOptions = {
+  includeHttpResponseReturnType?: boolean;
+  shouldThrowOnError?: boolean;
 };
 
 export type InputTransformerFn = (spec: OpenAPIObject) => OpenAPIObject;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -353,6 +353,8 @@ export const normalizeOptions = async (
           includeHttpResponseReturnType:
             outputOptions.override?.fetch?.includeHttpResponseReturnType ??
             true,
+          shouldThrowOnError:
+            outputOptions.override?.fetch?.shouldThrowOnError ?? false,
           ...(outputOptions.override?.fetch ?? {}),
         },
         useDates: outputOptions.override?.useDates || false,

--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -15,7 +15,6 @@ import {
 } from '@orval/core';
 
 import {
-  fetchResponseTypeName,
   generateRequestFunction as generateFetchRequestFunction,
   generateFetchHeader,
 } from '@orval/fetch';
@@ -230,28 +229,6 @@ export const getSwrMutationFetcherOptionType = (
     return `SecondParameter<typeof ${mutator.name}>`;
   } else {
     return '';
-  }
-};
-
-export const getSwrMutationFetcherType = (
-  response: GetterResponse,
-  httpClient: OutputHttpClient,
-  includeHttpResponseReturnType: boolean,
-  operationName: string,
-  mutator?: GeneratorMutator,
-) => {
-  if (httpClient === OutputHttpClient.FETCH) {
-    const responseType = fetchResponseTypeName(
-      includeHttpResponseReturnType,
-      response.definition.success,
-      operationName,
-    );
-
-    return `Promise<${responseType}>`;
-  } else if (mutator) {
-    return `Promise<${response.definition.success || 'unknown'}>`;
-  } else {
-    return `Promise<AxiosResponse<${response.definition.success || 'unknown'}>>`;
   }
 };
 

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -30,7 +30,6 @@ import {
   getSwrRequestSecondArg,
   getHttpRequestSecondArg,
   getSwrMutationFetcherOptionType,
-  getSwrMutationFetcherType,
   getSwrHeader,
 } from './client';
 
@@ -530,13 +529,6 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
       `get-${operationName}-mutation-fetcher`,
     );
 
-    const swrMutationFetcherType = getSwrMutationFetcherType(
-      response,
-      httpClient,
-      override.fetch.includeHttpResponseReturnType,
-      operationName,
-      mutator,
-    );
     const swrMutationFetcherOptionType = getSwrMutationFetcherOptionType(
       httpClient,
       mutator,
@@ -560,7 +552,7 @@ export const ${swrKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
 
     const swrMutationFetcherFn = `
 export const ${swrMutationFetcherName} = (${swrProps} ${swrMutationFetcherOptions}) => {
-  return (_: Key, ${swrMutationFetcherArg}: { arg: ${swrBodyType} }): ${swrMutationFetcherType} => {
+  return (_: Key, ${swrMutationFetcherArg}: { arg: ${swrBodyType} }) => {
     return ${operationName}(${httpFnProperties}${
       swrMutationFetcherOptions.length
         ? (httpFnProperties.length ? ', ' : '') + 'options'

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -62,11 +62,10 @@ export type listPetsResponse200 = {
   status: 200;
 };
 
-export type listPetsResponseComposite = listPetsResponse200;
-
-export type listPetsResponse = listPetsResponseComposite & {
+export type listPetsResponseSuccess = listPetsResponse200 & {
   headers: Headers;
 };
+export type listPetsResponse = listPetsResponseSuccess;
 
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -95,7 +94,6 @@ export const listPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: listPetsResponse['data'] = body ? JSON.parse(body) : {};
-
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
@@ -112,13 +110,16 @@ export type createPetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type createPetsResponseComposite =
-  | createPetsResponse200
-  | createPetsResponseDefault;
-
-export type createPetsResponse = createPetsResponseComposite & {
+export type createPetsResponseSuccess = createPetsResponse200 & {
   headers: Headers;
 };
+export type createPetsResponseError = createPetsResponseDefault & {
+  headers: Headers;
+};
+
+export type createPetsResponse =
+  | createPetsResponseSuccess
+  | createPetsResponseError;
 
 export const getCreatePetsUrl = () => {
   return `http://localhost:8787/pets`;
@@ -137,7 +138,6 @@ export const createPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: createPetsResponse['data'] = body ? JSON.parse(body) : {};
-
   return {
     data,
     status: res.status,
@@ -158,13 +158,16 @@ export type updatePetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type updatePetsResponseComposite =
-  | updatePetsResponse200
-  | updatePetsResponseDefault;
-
-export type updatePetsResponse = updatePetsResponseComposite & {
+export type updatePetsResponseSuccess = updatePetsResponse200 & {
   headers: Headers;
 };
+export type updatePetsResponseError = updatePetsResponseDefault & {
+  headers: Headers;
+};
+
+export type updatePetsResponse =
+  | updatePetsResponseSuccess
+  | updatePetsResponseError;
 
 export const getUpdatePetsUrl = () => {
   return `http://localhost:8787/pets`;
@@ -183,7 +186,6 @@ export const updatePets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: updatePetsResponse['data'] = body ? JSON.parse(body) : {};
-
   return {
     data,
     status: res.status,
@@ -204,13 +206,16 @@ export type showPetByIdResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type showPetByIdResponseComposite =
-  | showPetByIdResponse200
-  | showPetByIdResponseDefault;
-
-export type showPetByIdResponse = showPetByIdResponseComposite & {
+export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
   headers: Headers;
 };
+export type showPetByIdResponseError = showPetByIdResponseDefault & {
+  headers: Headers;
+};
+
+export type showPetByIdResponse =
+  | showPetByIdResponseSuccess
+  | showPetByIdResponseError;
 
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8787/pets/${petId}`;
@@ -227,7 +232,6 @@ export const showPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};
-
   return {
     data,
     status: res.status,

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -92,11 +92,10 @@ export type listPetsResponse200 = {
   status: 200;
 };
 
-export type listPetsResponseComposite = listPetsResponse200;
-
-export type listPetsResponse = listPetsResponseComposite & {
+export type listPetsResponseSuccess = listPetsResponse200 & {
   headers: Headers;
 };
+export type listPetsResponse = listPetsResponseSuccess;
 
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -137,13 +136,16 @@ export type createPetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type createPetsResponseComposite =
-  | createPetsResponse200
-  | createPetsResponseDefault;
-
-export type createPetsResponse = createPetsResponseComposite & {
+export type createPetsResponseSuccess = createPetsResponse200 & {
   headers: Headers;
 };
+export type createPetsResponseError = createPetsResponseDefault & {
+  headers: Headers;
+};
+
+export type createPetsResponse =
+  | createPetsResponseSuccess
+  | createPetsResponseError;
 
 export const getCreatePetsUrl = () => {
   return `http://localhost:3000/pets`;
@@ -174,13 +176,16 @@ export type updatePetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type updatePetsResponseComposite =
-  | updatePetsResponse200
-  | updatePetsResponseDefault;
-
-export type updatePetsResponse = updatePetsResponseComposite & {
+export type updatePetsResponseSuccess = updatePetsResponse200 & {
   headers: Headers;
 };
+export type updatePetsResponseError = updatePetsResponseDefault & {
+  headers: Headers;
+};
+
+export type updatePetsResponse =
+  | updatePetsResponseSuccess
+  | updatePetsResponseError;
 
 export const getUpdatePetsUrl = () => {
   return `http://localhost:3000/pets`;
@@ -211,13 +216,16 @@ export type showPetByIdResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type showPetByIdResponseComposite =
-  | showPetByIdResponse200
-  | showPetByIdResponseDefault;
-
-export type showPetByIdResponse = showPetByIdResponseComposite & {
+export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
   headers: Headers;
 };
+export type showPetByIdResponseError = showPetByIdResponseDefault & {
+  headers: Headers;
+};
+
+export type showPetByIdResponse =
+  | showPetByIdResponseSuccess
+  | showPetByIdResponseError;
 
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:3000/pets/${petId}`;

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -88,7 +88,7 @@ export const createPets = (
 };
 
 export const getCreatePetsMutationFetcher = (version: number = 1) => {
-  return (_: Key, { arg }: { arg: CreatePetsBody }): Promise<Pet> => {
+  return (_: Key, { arg }: { arg: CreatePetsBody }) => {
     return createPets(arg, version);
   };
 };

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -48,7 +48,6 @@ export const listPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: Pets = body ? JSON.parse(body) : {};
-
   return data;
 };
 
@@ -112,12 +111,11 @@ export const createPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: Pet = body ? JSON.parse(body) : {};
-
   return data;
 };
 
 export const getCreatePetsMutationFetcher = (options?: RequestInit) => {
-  return (_: Key, { arg }: { arg: CreatePetsBody }): Promise<Pet> => {
+  return (_: Key, { arg }: { arg: CreatePetsBody }) => {
     return createPets(arg, options);
   };
 };
@@ -173,7 +171,6 @@ export const showPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: Pet = body ? JSON.parse(body) : {};
-
   return data;
 };
 

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -110,11 +110,10 @@ export type listPetsResponse200 = {
   status: 200;
 };
 
-export type listPetsResponseComposite = listPetsResponse200;
-
-export type listPetsResponse = listPetsResponseComposite & {
+export type listPetsResponseSuccess = listPetsResponse200 & {
   headers: Headers;
 };
+export type listPetsResponse = listPetsResponseSuccess;
 
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -277,13 +276,16 @@ export type createPetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type createPetsResponseComposite =
-  | createPetsResponse200
-  | createPetsResponseDefault;
-
-export type createPetsResponse = createPetsResponseComposite & {
+export type createPetsResponseSuccess = createPetsResponse200 & {
   headers: Headers;
 };
+export type createPetsResponseError = createPetsResponseDefault & {
+  headers: Headers;
+};
+
+export type createPetsResponse =
+  | createPetsResponseSuccess
+  | createPetsResponseError;
 
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -382,13 +384,16 @@ export type updatePetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type updatePetsResponseComposite =
-  | updatePetsResponse200
-  | updatePetsResponseDefault;
-
-export type updatePetsResponse = updatePetsResponseComposite & {
+export type updatePetsResponseSuccess = updatePetsResponse200 & {
   headers: Headers;
 };
+export type updatePetsResponseError = updatePetsResponseDefault & {
+  headers: Headers;
+};
+
+export type updatePetsResponse =
+  | updatePetsResponseSuccess
+  | updatePetsResponseError;
 
 export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -487,13 +492,16 @@ export type showPetByIdResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type showPetByIdResponseComposite =
-  | showPetByIdResponse200
-  | showPetByIdResponseDefault;
-
-export type showPetByIdResponse = showPetByIdResponseComposite & {
+export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
   headers: Headers;
 };
+export type showPetByIdResponseError = showPetByIdResponseDefault & {
+  headers: Headers;
+};
+
+export type showPetByIdResponse =
+  | showPetByIdResponseSuccess
+  | showPetByIdResponseError;
 
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -105,11 +105,10 @@ export type listPetsResponse200 = {
   status: 200;
 };
 
-export type listPetsResponseComposite = listPetsResponse200;
-
-export type listPetsResponse = listPetsResponseComposite & {
+export type listPetsResponseSuccess = listPetsResponse200 & {
   headers: Headers;
 };
+export type listPetsResponse = listPetsResponseSuccess;
 
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -218,13 +217,16 @@ export type createPetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type createPetsResponseComposite =
-  | createPetsResponse200
-  | createPetsResponseDefault;
-
-export type createPetsResponse = createPetsResponseComposite & {
+export type createPetsResponseSuccess = createPetsResponse200 & {
   headers: Headers;
 };
+export type createPetsResponseError = createPetsResponseDefault & {
+  headers: Headers;
+};
+
+export type createPetsResponse =
+  | createPetsResponseSuccess
+  | createPetsResponseError;
 
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -320,13 +322,16 @@ export type updatePetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type updatePetsResponseComposite =
-  | updatePetsResponse200
-  | updatePetsResponseDefault;
-
-export type updatePetsResponse = updatePetsResponseComposite & {
+export type updatePetsResponseSuccess = updatePetsResponse200 & {
   headers: Headers;
 };
+export type updatePetsResponseError = updatePetsResponseDefault & {
+  headers: Headers;
+};
+
+export type updatePetsResponse =
+  | updatePetsResponseSuccess
+  | updatePetsResponseError;
 
 export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -422,13 +427,16 @@ export type showPetByIdResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type showPetByIdResponseComposite =
-  | showPetByIdResponse200
-  | showPetByIdResponseDefault;
-
-export type showPetByIdResponse = showPetByIdResponseComposite & {
+export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
   headers: Headers;
 };
+export type showPetByIdResponseError = showPetByIdResponseDefault & {
+  headers: Headers;
+};
+
+export type showPetByIdResponse =
+  | showPetByIdResponseSuccess
+  | showPetByIdResponseError;
 
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -96,11 +96,10 @@ export type listPetsResponse200 = {
   status: 200;
 };
 
-export type listPetsResponseComposite = listPetsResponse200;
-
-export type listPetsResponse = listPetsResponseComposite & {
+export type listPetsResponseSuccess = listPetsResponse200 & {
   headers: Headers;
 };
+export type listPetsResponse = listPetsResponseSuccess;
 
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -129,7 +128,6 @@ export const listPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: listPetsResponse['data'] = body ? JSON.parse(body) : {};
-
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
@@ -185,13 +183,16 @@ export type createPetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type createPetsResponseComposite =
-  | createPetsResponse200
-  | createPetsResponseDefault;
-
-export type createPetsResponse = createPetsResponseComposite & {
+export type createPetsResponseSuccess = createPetsResponse200 & {
   headers: Headers;
 };
+export type createPetsResponseError = createPetsResponseDefault & {
+  headers: Headers;
+};
+
+export type createPetsResponse =
+  | createPetsResponseSuccess
+  | createPetsResponseError;
 
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -210,7 +211,6 @@ export const createPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: createPetsResponse['data'] = body ? JSON.parse(body) : {};
-
   return {
     data,
     status: res.status,
@@ -219,10 +219,7 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationFetcher = (options?: RequestInit) => {
-  return (
-    _: Key,
-    { arg }: { arg: CreatePetsBodyItem[] },
-  ): Promise<createPetsResponse> => {
+  return (_: Key, { arg }: { arg: CreatePetsBodyItem[] }) => {
     return createPets(arg, options);
   };
 };
@@ -272,13 +269,16 @@ export type updatePetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type updatePetsResponseComposite =
-  | updatePetsResponse200
-  | updatePetsResponseDefault;
-
-export type updatePetsResponse = updatePetsResponseComposite & {
+export type updatePetsResponseSuccess = updatePetsResponse200 & {
   headers: Headers;
 };
+export type updatePetsResponseError = updatePetsResponseDefault & {
+  headers: Headers;
+};
+
+export type updatePetsResponse =
+  | updatePetsResponseSuccess
+  | updatePetsResponseError;
 
 export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -297,7 +297,6 @@ export const updatePets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: updatePetsResponse['data'] = body ? JSON.parse(body) : {};
-
   return {
     data,
     status: res.status,
@@ -306,10 +305,7 @@ export const updatePets = async (
 };
 
 export const getUpdatePetsMutationFetcher = (options?: RequestInit) => {
-  return (
-    _: Key,
-    { arg }: { arg: NonReadonly<Pet> },
-  ): Promise<updatePetsResponse> => {
+  return (_: Key, { arg }: { arg: NonReadonly<Pet> }) => {
     return updatePets(arg, options);
   };
 };
@@ -359,13 +355,16 @@ export type showPetByIdResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type showPetByIdResponseComposite =
-  | showPetByIdResponse200
-  | showPetByIdResponseDefault;
-
-export type showPetByIdResponse = showPetByIdResponseComposite & {
+export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
   headers: Headers;
 };
+export type showPetByIdResponseError = showPetByIdResponseDefault & {
+  headers: Headers;
+};
+
+export type showPetByIdResponse =
+  | showPetByIdResponseSuccess
+  | showPetByIdResponseError;
 
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
@@ -382,7 +381,6 @@ export const showPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
   const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};
-
   return {
     data,
     status: res.status,

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -110,11 +110,10 @@ export type listPetsResponse200 = {
   status: 200;
 };
 
-export type listPetsResponseComposite = listPetsResponse200;
-
-export type listPetsResponse = listPetsResponseComposite & {
+export type listPetsResponseSuccess = listPetsResponse200 & {
   headers: Headers;
 };
+export type listPetsResponse = listPetsResponseSuccess;
 
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
@@ -225,13 +224,16 @@ export type createPetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type createPetsResponseComposite =
-  | createPetsResponse200
-  | createPetsResponseDefault;
-
-export type createPetsResponse = createPetsResponseComposite & {
+export type createPetsResponseSuccess = createPetsResponse200 & {
   headers: Headers;
 };
+export type createPetsResponseError = createPetsResponseDefault & {
+  headers: Headers;
+};
+
+export type createPetsResponse =
+  | createPetsResponseSuccess
+  | createPetsResponseError;
 
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -330,13 +332,16 @@ export type updatePetsResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type updatePetsResponseComposite =
-  | updatePetsResponse200
-  | updatePetsResponseDefault;
-
-export type updatePetsResponse = updatePetsResponseComposite & {
+export type updatePetsResponseSuccess = updatePetsResponse200 & {
   headers: Headers;
 };
+export type updatePetsResponseError = updatePetsResponseDefault & {
+  headers: Headers;
+};
+
+export type updatePetsResponse =
+  | updatePetsResponseSuccess
+  | updatePetsResponseError;
 
 export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
@@ -435,13 +440,16 @@ export type showPetByIdResponseDefault = {
   status: Exclude<HTTPStatusCodes, 200>;
 };
 
-export type showPetByIdResponseComposite =
-  | showPetByIdResponse200
-  | showPetByIdResponseDefault;
-
-export type showPetByIdResponse = showPetByIdResponseComposite & {
+export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
   headers: Headers;
 };
+export type showPetByIdResponseError = showPetByIdResponseDefault & {
+  headers: Headers;
+};
+
+export type showPetByIdResponse =
+  | showPetByIdResponseSuccess
+  | showPetByIdResponseError;
 
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -224,4 +224,19 @@ export default defineConfig({
       target: '../specifications/stream.yaml',
     },
   },
+  throwOnError: {
+    output: {
+      target: '../generated/fetch/throw-on-error/endpoints.ts',
+      schemas: '../generated/fetch/throw-on-error/model',
+      client: 'fetch',
+      override: {
+        fetch: {
+          shouldThrowOnError: true,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
 });

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -106,6 +106,11 @@ export default defineConfig({
       mode: 'tags-split',
       client: 'react-query',
       httpClient: 'fetch',
+      override: {
+        fetch: {
+          shouldThrowOnError: true,
+        },
+      },
     },
     input: {
       target: '../specifications/petstore.yaml',

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -58,6 +58,11 @@ export default defineConfig({
       mode: 'tags-split',
       client: 'swr',
       httpClient: 'fetch',
+      override: {
+        fetch: {
+          shouldThrowOnError: true,
+        },
+      },
     },
     input: {
       target: '../specifications/petstore.yaml',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes #2047 

When using a package like `swr` or `query`, they use exceptions to know if the response is an error or not. 
To accomplish this, I added the `shouldThrowOnError` setting. When set to true, the function is typed to return only the success type (or success types, if there are multiple), when set to false, the behavior is unchanged.

When the endpoint does not have an error specified:
```ts
export type listPetsResponse200 = {
  data: Pets;
  status: 200;
};

export type listPetsResponseSuccess = listPetsResponse200 & {
  headers: Headers;
};

export const listPets = async (
  params: ListPetsParams,
  options?: RequestInit,
): Promise<listPetsResponseSuccess> => {
  const res = await fetch(getListPetsUrl(params), {
    ...options,
    method: 'GET',
  });

  if (!res.ok) {
    const err: globalThis.Error & { info?: any; status?: number } =
      new globalThis.Error();
    const body = [204, 205, 304].includes(res.status) ? null : await res.text();
    const data = body ? JSON.parse(body) : {};
    err.info = data;
    err.status = res.status;
    throw err;
  }

  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
  const data: listPetsResponseSuccess['data'] = body ? JSON.parse(body) : {};
  return {
    data,
    status: res.status,
    headers: res.headers,
  } as listPetsResponseSuccess;
};
```

When the endpoint does have an error specified:
```ts
export type createPetsResponse200 = {
  data: Pet;
  status: 200;
};

export type createPetsResponseDefault = {
  data: Error;
  status: Exclude<HTTPStatusCodes, 200>;
};

export type createPetsResponseSuccess = createPetsResponse200 & {
  headers: Headers;
};
export type createPetsResponseError = createPetsResponseDefault & {
  headers: Headers;
};

export const createPets = async (
  createPetsBody: CreatePetsBody,
  params: CreatePetsParams,
  options?: RequestInit,
): Promise<createPetsResponseSuccess> => {
  const res = await fetch(getCreatePetsUrl(params), {
    ...options,
    method: 'POST',
    headers: { 'Content-Type': 'application/json', ...options?.headers },
    body: JSON.stringify(createPetsBody),
  });

  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
  if (!res.ok) {
    const err: globalThis.Error & {
      info?: createPetsResponseError['data'];
      status?: number;
    } = new globalThis.Error();
    const data: createPetsResponseError['data'] = body ? JSON.parse(body) : {};
    err.info = data;
    err.status = res.status;
    throw err;
  }

  const data: createPetsResponseSuccess['data'] = body ? JSON.parse(body) : {};
  return {
    data,
    status: res.status,
    headers: res.headers,
  } as createPetsResponseSuccess;
};
```
