### PR TITLE
fix(core): prevent unwanted response merging on same schema value

### DIFF
--- a/packages/core/src/getters/response.test.ts
+++ b/packages/core/src/getters/response.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { ResponsesObject } from 'openapi3-ts/oas30';
+import { getResponse } from './response';
+
+const context = {
+  output: {
+    override: {
+      formData: { arrayHandling: 'serialize', disabled: false },
+      enumGenerationType: 'const',
+    },
+  },
+  specKey: 'spec',
+  target: 'spec',
+  workspace: '',
+  specs: {
+    spec: {
+      components: { schemas: {} },
+    },
+  },
+};
+
+describe('getResponse', () => {
+  describe('multiple status codes with same schema', () => {
+    it('should generate separate types for each status code when using custom uniqueKey function', () => {
+      const responses: ResponsesObject = {
+        '200': {
+          description: 'Existing subscription',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateSubscriptionResponseDto',
+              },
+            },
+          },
+        },
+        '201': {
+          description: 'New subscription created',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateSubscriptionResponseDto',
+              },
+            },
+          },
+        },
+        '403': {
+          description: 'Forbidden',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/BaseError',
+              },
+            },
+          },
+        },
+        '404': {
+          description: 'Not found',
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/BaseError',
+              },
+            },
+          },
+        },
+      };
+
+      const result = getResponse({
+        responses,
+        operationName: 'configurationControllerCreateSubscription',
+        context: context as any,
+      });
+
+      expect(result.types.success).toHaveLength(2);
+      expect(result.types.errors).toHaveLength(2);
+
+      const successKeys = result.types.success.map((type) => type.key);
+      const errorKeys = result.types.errors.map((type) => type.key);
+
+      expect(successKeys).toContain('200');
+      expect(successKeys).toContain('201');
+      expect(errorKeys).toContain('403');
+      expect(errorKeys).toContain('404');
+
+      expect(result.definition.success).toContain(
+        'CreateSubscriptionResponseDto',
+      );
+
+      expect(result.definition.errors).toContain('BaseError');
+    });
+
+    it('should handle empty responses object', () => {
+      const result = getResponse({
+        responses: {},
+        operationName: 'testOperation',
+        context: context as any,
+      });
+
+      expect(result.definition.success).toBe('unknown');
+      expect(result.definition.errors).toBe('unknown');
+      expect(result.types.success).toHaveLength(0);
+      expect(result.types.errors).toHaveLength(0);
+    });
+
+    it('should handle undefined responses', () => {
+      const result = getResponse({
+        responses: undefined as any,
+        operationName: 'testOperation',
+        context: context as any,
+      });
+
+      expect(result.definition.success).toBe('');
+      expect(result.definition.errors).toBe('');
+      expect(result.types.success).toHaveLength(0);
+      expect(result.types.errors).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/getters/response.ts
+++ b/packages/core/src/getters/response.ts
@@ -37,7 +37,7 @@ export const getResponse = ({
     operationName,
     context,
     'void',
-    (type) => type.key.startsWith('2') + type.value,
+    (type) => `${type.key}-${type.value}`,
   );
 
   const filteredTypes = contentType


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

WIP

## Description

### Problem

Fixes #2177
Fix #2043
When an endpoint returns multiple status codes with the same schema (e.g., 200 and 201 both returning `CreateSubscriptionResponseDto`), Orval was merging them into a single type, causing the loss of status code-specific type information.

### Solution
Updated the `getResponse` function in `packages/core/src/getters/response.ts` to use a custom `uniqueKey` function that includes both the status code and content type: `${type.key}-${type.value}`.

This ensures that each status code gets its own distinct type, even when they share the same schema.

### Changes
- Modified `getResponse` function to pass custom uniqueKey function to `getResReqTypes`
- Added comprehensive unit tests to verify the behavior
- Tests cover the specific scenario described in the issue

### Testing
Added unit tests that verify:
- Multiple status codes with same schema generate separate types
- Each status code (200, 201, 403, 404) gets its own type entry
- Both success and error types are properly separated

### Example
Before: Only one type generated for 2XX/2YY or 4XX/4YY responses with same schema
After: Separate types generated for each status code, preserving all response variations