### PR TITLE
fix: assert query version takes overriden as priority

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -940,6 +940,7 @@ export type ClientDependenciesBuilder = (
   packageJson?: PackageJson,
   httpClient?: OutputHttpClient,
   hasTagsMutator?: boolean,
+  override?: NormalizedOverrideOutput,
 ) => GeneratorDependency[];
 
 export type ClientMockGeneratorImplementation = {

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -84,6 +84,7 @@ export const generateClientImports: GeneratorClientImports = ({
             packageJson,
             output.httpClient,
             hasTagsMutator,
+            output.override,
           ),
           ...imports,
         ]

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1132,7 +1132,7 @@ const generateQueryHook = async (
   const operationQueryOptions = operations[operationId]?.query;
   const isExactOptionalPropertyTypes =
     !!context.output.tsconfig?.compilerOptions?.exactOptionalPropertyTypes;
-  const queryVersion = query?.version || override.query.version;
+  const queryVersion = override.query.version ?? query?.version;
 
   const hasVueQueryV4 =
     OutputClient.VUE_QUERY === outputClient &&

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -215,6 +215,7 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
   packageJson,
   httpClient,
   hasTagsMutator,
+  override,
 ) => {
   const hasReactQuery =
     packageJson?.dependencies?.['react-query'] ??
@@ -225,13 +226,18 @@ export const getReactQueryDependencies: ClientDependenciesBuilder = (
     packageJson?.devDependencies?.['@tanstack/react-query'] ??
     packageJson?.peerDependencies?.['@tanstack/react-query'];
 
+  const useReactQueryV3 =
+    override?.query.version !== undefined
+      ? override?.query.version <= 3
+      : hasReactQuery && !hasReactQueryV4;
+
   return [
     ...(hasGlobalMutator || hasTagsMutator ? REACT_DEPENDENCIES : []),
     ...(!hasGlobalMutator && httpClient === OutputHttpClient.AXIOS
       ? AXIOS_DEPENDENCIES
       : []),
     ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
-    ...(hasReactQuery && !hasReactQueryV4
+    ...(useReactQueryV3
       ? REACT_QUERY_DEPENDENCIES_V3
       : REACT_QUERY_DEPENDENCIES),
   ];
@@ -1126,30 +1132,31 @@ const generateQueryHook = async (
   const operationQueryOptions = operations[operationId]?.query;
   const isExactOptionalPropertyTypes =
     !!context.output.tsconfig?.compilerOptions?.exactOptionalPropertyTypes;
+  const queryVersion = query?.version || override.query.version;
 
   const hasVueQueryV4 =
     OutputClient.VUE_QUERY === outputClient &&
-    (!isVueQueryV3(context.output.packageJson) || query.version === 4);
+    (!isVueQueryV3(context.output.packageJson) || queryVersion === 4);
   const hasSvelteQueryV4 =
     OutputClient.SVELTE_QUERY === outputClient &&
-    (!isSvelteQueryV3(context.output.packageJson) || query.version === 4);
+    (!isSvelteQueryV3(context.output.packageJson) || queryVersion === 4);
 
   const hasQueryV5 =
-    query.version === 5 ||
+    queryVersion === 5 ||
     isQueryV5(
       context.output.packageJson,
       outputClient as 'react-query' | 'vue-query' | 'svelte-query',
     );
 
   const hasQueryV5WithDataTagError =
-    query.version === 5 ||
+    queryVersion === 5 ||
     isQueryV5WithDataTagError(
       context.output.packageJson,
       outputClient as 'react-query' | 'vue-query' | 'svelte-query',
     );
 
   const hasQueryV5WithInfiniteQueryOptionsError =
-    query.version === 5 ||
+    queryVersion === 5 ||
     isQueryV5WithInfiniteQueryOptionsError(
       context.output.packageJson,
       outputClient as 'react-query' | 'vue-query' | 'svelte-query',


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Current behavior: Even with override.query.version being set to `3`, it's generating react-query code with `@tanstack/react-query` imports.

Update: I've now made sure to use the overridden version to determine the query version

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. Following the steps in this issue, set up the orval.config.ts file and provide an overridden react-query version set to 3. Notice `@tanstack/react-query` being imported in the generated code