### PR TITLE
fix(query): support generating queries for POST when operation options are set

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1166,11 +1166,16 @@ const generateQueryHook = async (
     (override.query.useQuery ||
       override.query.useSuspenseQuery ||
       override.query.useInfinite ||
-      override.query.useSuspenseInfiniteQuery ||
-      operationQueryOptions?.useQuery ||
-      operationQueryOptions?.useSuspenseQuery ||
-      operationQueryOptions?.useInfinite ||
-      operationQueryOptions?.useSuspenseInfiniteQuery);
+      override.query.useSuspenseInfiniteQuery);
+
+  // Allows operationQueryOptions to override non-GET verbs
+  const hasOperationQueryOption =
+    operationQueryOptions?.useQuery ||
+    operationQueryOptions?.useSuspenseQuery ||
+    operationQueryOptions?.useInfinite ||
+    operationQueryOptions?.useSuspenseInfiniteQuery;
+
+  isQuery = isQuery || hasOperationQueryOption;
 
   let isMutation = override.query.useMutation && verb !== Verbs.GET;
 


### PR DESCRIPTION
Previously, when a POST request had an operation configured with query-related flag set to `true`, a mutation was still generated.

This fix ensures that setting any query-related operation flag (e.g., `useQuery`, `useSuspenseQuery`, etc.) correctly results in a query being generated, even for non-GET verbs.

**Fixes:** [#2186](https://github.com/orval-labs/orval/issues/2186#issuecomment-3017449473)

## Status

**READY**

## Description

This PR updates the isQuery logic to allow **operation-level query-related flags** to generate query hooks even when the HTTP verb is not GET.

## Related PRs

| branch              | PR       |
| ------------------- | -------- |
| orval-labs/orval:master | [2097](https://github.com/orval-labs/orval/pull/2097) |

## Steps to Reproduce (before this fix)

1. Set a per-operation override for a POST request:
```
operations: {
  listPets: {
    query: {
      useQuery: true,
    }
  }
}
```
2. Run Orval generator
3. Observe that **mutation hooks** are generated instead of **query hooks**
