### PR TITLE
fix(core): import aliases for crossfiles refs with same names

### DIFF
--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -67,8 +67,8 @@ export const generateInterface = ({
   }
 
   // Filter out imports that refer to the type defined in current file (OpenAPI recursive schema definitions)
-  const externalModulesImportsOnly = scalar.imports.filter(
-    (importName) => importName.name !== name,
+  const externalModulesImportsOnly = scalar.imports.filter((importName) =>
+    importName.alias ? importName.alias !== name : importName.name !== name,
   );
 
   return [

--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -14,6 +14,7 @@ import {
   getEnumNames,
 } from './enum';
 import { getScalar } from './scalar';
+import { getAliasedImports, getImportAliasForRefOrValue } from './imports';
 import uniq from 'lodash.uniq';
 
 type CombinedData = {
@@ -156,8 +157,21 @@ export const combineSchemas = ({
         context,
       });
 
-      acc.values.push(resolvedValue.value);
-      acc.imports.push(...resolvedValue.imports);
+      const aliasedImports = getAliasedImports({
+        context,
+        name,
+        resolvedValue,
+        existingImports: acc.imports,
+      });
+
+      const value = getImportAliasForRefOrValue({
+        context,
+        resolvedValue,
+        imports: aliasedImports,
+      });
+
+      acc.values.push(value);
+      acc.imports.push(...aliasedImports);
       acc.schemas.push(...resolvedValue.schemas);
       acc.isEnum.push(resolvedValue.isEnum);
       acc.types.push(resolvedValue.type);

--- a/packages/core/src/getters/imports.test.ts
+++ b/packages/core/src/getters/imports.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getAliasedImports,
+  getImportAliasForRefOrValue,
+  needCreateImportAlias,
+} from './imports';
+import { ContextSpecs, GeneratorImport, ResolverValue } from '../types';
+
+const baseContext: Omit<ContextSpecs, 'output'> = {
+  specKey: 'spec',
+  target: 'spec',
+  workspace: '',
+  specs: {},
+};
+
+const contextWithSchemas = {
+  ...baseContext,
+  output: {
+    schemas: '/schemas',
+  },
+} as ContextSpecs;
+
+const contextWithouSchemas = {
+  ...baseContext,
+  output: {
+    schemas: undefined,
+  },
+} as ContextSpecs;
+
+const baseResolvedValue: ResolverValue = {
+  isRef: false,
+  imports: [],
+  hasReadonlyProps: false,
+  isEnum: false,
+  originalSchema: {},
+  schemas: [],
+  type: 'object',
+  value: '',
+};
+
+describe('getAliasedImports getter', () => {
+  it('should return resolvedValue imports when resolvedValue.isRef field is false', () => {
+    const resolvedValue: ResolverValue = {
+      ...baseResolvedValue,
+      isRef: false,
+      imports: [],
+    };
+
+    expect(
+      getAliasedImports({
+        context: contextWithSchemas,
+        existingImports: [],
+        resolvedValue,
+      }),
+    ).toBe(resolvedValue.imports);
+  });
+
+  it('should return resolvedValue.imports field when context.output.schemas field is empty', () => {
+    const resolvedValue: ResolverValue = {
+      ...baseResolvedValue,
+      isRef: true,
+      imports: [],
+    };
+
+    expect(
+      getAliasedImports({
+        context: contextWithouSchemas,
+        existingImports: [],
+        resolvedValue,
+      }),
+    ).toBe(resolvedValue.imports);
+  });
+
+  describe('with non empty context.output.schemas field and truthy resolvedValue.isRef field', () => {
+    const testCases: Array<
+      [
+        Omit<Parameters<typeof getAliasedImports>[0], 'context'>,
+        Array<string | undefined>,
+      ]
+    > = [
+      [
+        {
+          existingImports: [],
+          name: 'A',
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            imports: [
+              {
+                name: 'A',
+                specKey: 'spec',
+              },
+            ],
+          },
+        },
+        ['__A'],
+      ],
+      [
+        {
+          existingImports: [],
+          name: 'A',
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            imports: [
+              {
+                name: 'B',
+                specKey: 'spec',
+              },
+            ],
+          },
+        },
+        [undefined],
+      ],
+      [
+        {
+          existingImports: [
+            {
+              name: 'A',
+              specKey: 'spec',
+            },
+          ],
+          name: undefined,
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            imports: [
+              {
+                name: 'A',
+                specKey: 'another_spec',
+              },
+            ],
+          },
+        },
+        ['AnotherSpec__A'],
+      ],
+      [
+        {
+          existingImports: [
+            {
+              name: 'A',
+              specKey: 'spec',
+            },
+          ],
+          name: undefined,
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            imports: [
+              {
+                name: 'A',
+                specKey: 'spec',
+              },
+            ],
+          },
+        },
+        [undefined],
+      ],
+      [
+        {
+          existingImports: [
+            {
+              name: 'A',
+              specKey: 'spec',
+            },
+          ],
+          name: undefined,
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            imports: [
+              {
+                name: 'A',
+                specKey: '45.yaml',
+              },
+            ],
+          },
+        },
+        ['__45__A'],
+      ],
+    ];
+
+    it.each(testCases)('aliases for %j should be %j', (input, aliases) => {
+      const expected = aliases.map((alias, index) => ({
+        ...input.resolvedValue.imports.at(index),
+        ...(alias === undefined ? {} : { alias }),
+      }));
+
+      const result = getAliasedImports({
+        ...input,
+        context: contextWithSchemas,
+      });
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});
+
+describe('needCreateImportAlias', () => {
+  it('should return false when import has alias', () => {
+    const existingImports: GeneratorImport[] = [
+      { name: 'A', specKey: 'spec1' },
+      { name: 'B', specKey: 'spec2' },
+    ];
+
+    const imp: GeneratorImport = {
+      alias: 'AliasForC',
+      name: 'C',
+      specKey: 'spec3',
+    };
+
+    expect(needCreateImportAlias({ existingImports, imp })).toBeFalsy();
+  });
+
+  it('should return false when existingImports is empty', () => {
+    const imp: GeneratorImport = { name: 'A', specKey: 'spec1' };
+
+    expect(needCreateImportAlias({ existingImports: [], imp })).toBeFalsy();
+  });
+
+  it('should return false when import has not alias and import existingImports has not item with eq name and different specKey', () => {
+    const existingImports: GeneratorImport[] = [
+      { name: 'A', specKey: 'spec1' },
+      { name: 'B', specKey: 'spec2' },
+    ];
+
+    const imp: GeneratorImport = { name: 'C', specKey: 'spec3' };
+
+    expect(needCreateImportAlias({ existingImports, imp })).toBeFalsy();
+  });
+
+  it('should return true when name eq import name and import has not alias', () => {
+    const existingImports: GeneratorImport[] = [
+      { name: 'A', specKey: 'spec1' },
+      { name: 'B', specKey: 'spec2' },
+    ];
+
+    const imp: GeneratorImport = { name: 'C', specKey: 'spec3' };
+
+    expect(
+      needCreateImportAlias({
+        existingImports,
+        imp,
+        name: 'C',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('should return true when import has not alias and and existingImports has item with eq name and different specKey', () => {
+    const existingImports: GeneratorImport[] = [
+      { name: 'A', specKey: 'spec1' },
+      { name: 'B', specKey: 'spec2' },
+    ];
+
+    const imp: GeneratorImport = { name: 'A', specKey: 'spec3' };
+
+    expect(needCreateImportAlias({ existingImports, imp })).toBeTruthy();
+  });
+});
+
+describe('getImportAliasForRefOrValue getter', () => {
+  it('should return resolvedValue.value when resolvedValue.isRef field is false', () => {
+    const resolvedValue: ResolverValue = {
+      ...baseResolvedValue,
+      isRef: false,
+      imports: [],
+      value: 'A',
+    };
+
+    expect(
+      getImportAliasForRefOrValue({
+        context: contextWithSchemas,
+        resolvedValue,
+        imports: [
+          {
+            name: 'A',
+            alias: 'AnoterSpec__A',
+          },
+        ],
+      }),
+    ).toBe(resolvedValue.value);
+  });
+
+  it('should return resolvedValue.value field when context.output.schemas field is empty', () => {
+    const resolvedValue: ResolverValue = {
+      ...baseResolvedValue,
+      isRef: true,
+      imports: [],
+      value: 'A',
+    };
+
+    expect(
+      getImportAliasForRefOrValue({
+        context: contextWithouSchemas,
+        resolvedValue,
+        imports: [
+          {
+            name: 'A',
+            alias: 'AnoterSpec__A',
+          },
+        ],
+      }),
+    ).toBe(resolvedValue.value);
+  });
+
+  describe('with non empty context.output.schemas field and truthy resolvedValue.isRef field', () => {
+    const testCases: Array<
+      [
+        Omit<Parameters<typeof getImportAliasForRefOrValue>[0], 'context'>,
+        string,
+      ]
+    > = [
+      [
+        {
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            value: 'A',
+          },
+          imports: [],
+        },
+        'A',
+      ],
+      [
+        {
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            value: 'A',
+          },
+          imports: [
+            {
+              name: 'B',
+              alias: 'AnoterSpec__B',
+            },
+          ],
+        },
+        'A',
+      ],
+      [
+        {
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            value: 'A',
+          },
+          imports: [
+            {
+              name: 'A',
+              alias: undefined,
+            },
+          ],
+        },
+        'A',
+      ],
+      [
+        {
+          resolvedValue: {
+            ...baseResolvedValue,
+            isRef: true,
+            value: 'A',
+          },
+          imports: [
+            {
+              name: 'A',
+              alias: 'AnoterSpec__A',
+            },
+          ],
+        },
+        'AnoterSpec__A',
+      ],
+    ];
+
+    it.each(testCases)('value for %j should be %j', (input, expected) => {
+      const result = getImportAliasForRefOrValue({
+        ...input,
+        context: contextWithSchemas,
+      });
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/core/src/getters/imports.ts
+++ b/packages/core/src/getters/imports.ts
@@ -1,0 +1,78 @@
+import { ContextSpecs, GeneratorImport, ResolverValue } from '../types';
+import { pascal } from '../utils';
+import { getSpecName } from '../utils/path';
+
+export const getAliasedImports = ({
+  name,
+  resolvedValue,
+  existingImports,
+  context,
+}: {
+  name?: string;
+  resolvedValue: ResolverValue;
+  existingImports: GeneratorImport[];
+  context: ContextSpecs;
+}): GeneratorImport[] =>
+  context.output.schemas && resolvedValue.isRef
+    ? resolvedValue.imports.map((imp) => {
+        if (
+          !needCreateImportAlias({
+            name,
+            imp,
+            existingImports,
+          })
+        ) {
+          return imp;
+        }
+
+        const specName = pascal(
+          getSpecName(imp.specKey ?? '', context.specKey),
+        );
+
+        // for spec starts from digit
+        const normalizedSpecName = /^\d/.test(specName)
+          ? `__${specName}`
+          : specName;
+
+        return {
+          ...imp,
+          alias: `${normalizedSpecName}__${imp.name}`,
+        };
+      })
+    : resolvedValue.imports;
+
+export const needCreateImportAlias = ({
+  existingImports,
+  imp,
+  name,
+}: {
+  name?: string;
+  imp: GeneratorImport;
+  existingImports: GeneratorImport[];
+}): boolean =>
+  !imp.alias &&
+  // !!imp.specKey &&
+  (imp.name === name ||
+    existingImports.some(
+      (existingImport) =>
+        imp.name === existingImport.name &&
+        imp.specKey !== existingImport.specKey,
+    ));
+
+export const getImportAliasForRefOrValue = ({
+  context,
+  imports,
+  resolvedValue,
+}: {
+  resolvedValue: ResolverValue;
+  imports: GeneratorImport[];
+  context: ContextSpecs;
+}): string => {
+  if (!context.output.schemas || !resolvedValue.isRef) {
+    return resolvedValue.value;
+  }
+  const importWithSameName = imports.find(
+    (imp) => imp.name === resolvedValue.value,
+  );
+  return importWithSameName?.alias ?? resolvedValue.value;
+};

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -443,4 +443,12 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  'multi-files-with-same-import-names': {
+    output: {
+      target:
+        '../generated/default/multi-files-with-same-import-names/endpoints.ts',
+      schemas: '../generated/default/multi-files-with-same-import-names/model',
+    },
+    input: '../specifications/multi-files-with-same-import-names/api.yaml',
+  },
 });

--- a/tests/specifications/multi-files-with-same-import-names/3.yaml
+++ b/tests/specifications/multi-files-with-same-import-names/3.yaml
@@ -1,0 +1,35 @@
+openapi: '3.0.3'
+info:
+  title: External backend service 3
+  version: "0.0.1"
+servers:
+  - description: Remote
+    url: "/external-backend-service3/"
+  - description: Local
+    url: "/"
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        from: 
+          type: string
+          description: Field from service 3
+          enum:
+            - service3
+      required:
+        - from
+

--- a/tests/specifications/multi-files-with-same-import-names/api.yaml
+++ b/tests/specifications/multi-files-with-same-import-names/api.yaml
@@ -1,0 +1,66 @@
+openapi: '3.0.3'
+info:
+  title: My bff service
+  version: "0.0.1"
+servers:
+  - description: Remote
+    url: "/bff/"
+  - description: Local
+    url: "/"
+paths:
+
+  /test:
+    get:
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+
+components:
+  schemas:
+    Response:
+      type: object
+      properties:
+        petFromComponents: 
+          $ref: '#/components/schemas/Pet'
+        petFromService1: 
+          $ref: './external-backend-service1.yaml#/components/schemas/Pet'
+        petFromService2: 
+          $ref: './external-backend-service2.yaml#/components/schemas/Pet'
+        petFromService3: 
+          $ref: './3.yaml#/components/schemas/Pet'
+        petWithAllOf:
+          allOf:
+            - $ref: './3.yaml#/components/schemas/Pet'
+            - $ref: './external-backend-service2.yaml#/components/schemas/Pet'
+            - $ref: './external-backend-service1.yaml#/components/schemas/Pet'
+            - $ref: '#/components/schemas/Pet'
+        petWithOneOf:
+          oneOf:
+            - $ref: '#/components/schemas/Pet'         
+            - $ref: './3.yaml#/components/schemas/Pet'
+            - $ref: './external-backend-service2.yaml#/components/schemas/Pet'
+            - $ref: './external-backend-service1.yaml#/components/schemas/Pet'
+        petWithAnyOf:
+          anyOf:
+            - $ref: './external-backend-service1.yaml#/components/schemas/Pet'
+            - $ref: './external-backend-service2.yaml#/components/schemas/Pet'
+            - $ref: './3.yaml#/components/schemas/Pet'
+            - $ref: '#/components/schemas/Pet'
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        from: 
+          type: string
+          description: Field from bff
+          enum:
+            - bff
+      required:
+        - from
+        
+

--- a/tests/specifications/multi-files-with-same-import-names/external-backend-service1.yaml
+++ b/tests/specifications/multi-files-with-same-import-names/external-backend-service1.yaml
@@ -1,0 +1,35 @@
+openapi: '3.0.3'
+info:
+  title: External backend service 1
+  version: "0.0.1"
+servers:
+  - description: Remote
+    url: "/external-backend-service1/"
+  - description: Local
+    url: "/"
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        from: 
+          type: string
+          description: Field from service 1
+          enum:
+            - service1
+      required:
+        - from
+

--- a/tests/specifications/multi-files-with-same-import-names/external-backend-service2.yaml
+++ b/tests/specifications/multi-files-with-same-import-names/external-backend-service2.yaml
@@ -1,0 +1,35 @@
+openapi: '3.0.3'
+info:
+  title: External backend service 2
+  version: "0.0.1"
+servers:
+  - description: Remote
+    url: "/external-backend-service2/"
+  - description: Local
+    url: "/"
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        from: 
+          type: string
+          description: Field from service 2
+          enum:
+            - service2
+      required:
+        - from
+

--- a/tests/specifications/multi-files/schemas/personInfo.yaml
+++ b/tests/specifications/multi-files/schemas/personInfo.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.2
+info:
+  title: PetStore
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Person:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        info:
+          type: string


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes https://github.com/orval-labs/orval/issues/2195

Adding `SchemaName__` aliases to imports when using multiple openapi schemas with the same component names in one object or allOf/anyOf/oneOf expressions.

This pr works if `output.schemas` property defined in the config file.

## Related PRs

none

## Todos

- [x ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. See openapi example file: `./tests/specifications/multi-files-with-same-import-names/api.yaml`
```
openapi: '3.0.3'
info:
  title: My bff service
  version: "0.0.1"
servers:
  - description: Remote
    url: "/bff/"
  - description: Local
    url: "/"
paths:

  /test:
    get:
      responses:
        200:
          description: Ok
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Response"

components:
  schemas:
    Response:
      type: object
      properties:
        petFromComponents: 
          $ref: '#/components/schemas/Pet'
        petFromService1: 
          $ref: './external-backend-service1.yaml#/components/schemas/Pet'
        petFromService2: 
          $ref: './external-backend-service2.yaml#/components/schemas/Pet'
        petFromService3: 
          $ref: './3.yaml#/components/schemas/Pet'
        petWithAllOf:
          allOf:
            - $ref: './3.yaml#/components/schemas/Pet'
            - $ref: './external-backend-service2.yaml#/components/schemas/Pet'
            - $ref: './external-backend-service1.yaml#/components/schemas/Pet'
            - $ref: '#/components/schemas/Pet'
        petWithOneOf:
          oneOf:
            - $ref: '#/components/schemas/Pet'         
            - $ref: './3.yaml#/components/schemas/Pet'
            - $ref: './external-backend-service2.yaml#/components/schemas/Pet'
            - $ref: './external-backend-service1.yaml#/components/schemas/Pet'
        petWithAnyOf:
          anyOf:
            - $ref: './external-backend-service1.yaml#/components/schemas/Pet'
            - $ref: './external-backend-service2.yaml#/components/schemas/Pet'
            - $ref: './3.yaml#/components/schemas/Pet'
            - $ref: '#/components/schemas/Pet'
    Pet:
      type: object
      properties:
        name:
          type: string
        from: 
          type: string
          description: Field from bff
          enum:
            - bff
      required:
        - from
```

2. Run `generate:default` command in `tests` package

```bash
cd ./tests
yarn generate:default
```

3. See generated files in `./tests/generated/default/multi-files-with-same-import-names/model` folder.

Object expression - `tests/generated/default/multi-files-with-same-import-names/model/response.ts`:
```typescript
/**
 * Generated by orval v7.10.0 🍺
 * Do not edit manually.
 * My bff service
 * OpenAPI spec version: 0.0.1
 */
import type { Pet } from './pet';
import type { Pet as ExternalBackendService1__Pet } from './external-backend-service1/pet';
import type { Pet as ExternalBackendService2__Pet } from './external-backend-service2/pet';
import type { Pet as __3__Pet } from './3/pet';
import type { ResponsePetWithAllOf } from './responsePetWithAllOf';
import type { ResponsePetWithOneOf } from './responsePetWithOneOf';
import type { ResponsePetWithAnyOf } from './responsePetWithAnyOf';

export interface Response {
  petFromComponents?: Pet;
  petFromService1?: ExternalBackendService1__Pet;
  petFromService2?: ExternalBackendService2__Pet;
  petFromService3?: __3__Pet;
  petWithAllOf?: ResponsePetWithAllOf;
  petWithOneOf?: ResponsePetWithOneOf;
  petWithAnyOf?: ResponsePetWithAnyOf;
}

```

allOf expression - `tests/generated/default/multi-files-with-same-import-names/model/responsePetWithAllOf.ts`:
```typescript
/**
 * Generated by orval v7.10.0 🍺
 * Do not edit manually.
 * My bff service
 * OpenAPI spec version: 0.0.1
 */
import type { Pet } from './3/pet';
import type { Pet as ExternalBackendService2__Pet } from './external-backend-service2/pet';
import type { Pet as ExternalBackendService1__Pet } from './external-backend-service1/pet';
import type { Pet as __Pet } from './pet';

export type ResponsePetWithAllOf = Pet & ExternalBackendService2__Pet & ExternalBackendService1__Pet & __Pet;

```

oneOf expression - `./tests/generated/default/multi-files-with-same-import-names/model/responsePetWithOneOf.ts`:
```typescript
/**
 * Generated by orval v7.10.0 🍺
 * Do not edit manually.
 * My bff service
 * OpenAPI spec version: 0.0.1
 */
import type { Pet } from './pet';
import type { Pet as __3__Pet } from './3/pet';
import type { Pet as ExternalBackendService2__Pet } from './external-backend-service2/pet';
import type { Pet as ExternalBackendService1__Pet } from './external-backend-service1/pet';

export type ResponsePetWithOneOf = Pet | __3__Pet | ExternalBackendService2__Pet | ExternalBackendService1__Pet;
```
