### PR TITLE
feat: generate `zod.literal` when schema has `const` value

### DIFF
--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -8,7 +8,7 @@ import {
   type ZodValidationSchemaDefinition,
 } from '.';
 
-import { ContextSpecs, GeneratorOptions } from '@orval/core';
+import { ContextSpecs } from '@orval/core';
 
 const queryParams: ZodValidationSchemaDefinition = {
   functions: [
@@ -1450,6 +1450,98 @@ describe('generateZodWithEdgeCases', () => {
 
     expect(result.implementation).toBe(
       'export const testBody = zod.object({\n  "$ref": zod.string().optional()\n})\n\n',
+    );
+  });
+});
+
+const schemaWithLiteralProperty = {
+  pathRoute: '/cats',
+  context: {
+    specKey: 'cat',
+    specs: {
+      cat: {
+        openapi: '3.0.0',
+        info: {
+          version: '1.0.0',
+          title: 'Cats',
+        },
+        paths: {
+          '/cats': {
+            post: {
+              operationId: 'xyz',
+              requestBody: {
+                required: true,
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        type: {
+                          type: 'string',
+                          const: 'WILD',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                '200': {},
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+};
+
+describe('generateZodWithLiteralProperty', () => {
+  it('correctly handles literal as a property name', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: false,
+              body: true,
+              response: true,
+              query: false,
+              header: false,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+          },
+        },
+      },
+      schemaWithLiteralProperty,
+      {},
+    );
+
+    expect(result.implementation).toBe(
+      'export const testBody = zod.object({\n  "type": zod.literal("WILD").optional()\n})\n\n',
     );
   });
 });

--- a/tests/specifications/example-v3-1.yaml
+++ b/tests/specifications/example-v3-1.yaml
@@ -28,6 +28,9 @@ components:
           title: Example tuple
         example_const:
           const: this_is_a_const
+        example_string_const:
+          type: string
+          const: this_is_a_string_const
         example_enum:
           type: string
           enum:

--- a/tests/specifications/typed-arrays-tuples-v3-1.yaml
+++ b/tests/specifications/typed-arrays-tuples-v3-1.yaml
@@ -51,6 +51,9 @@ components:
           type: array
         example_const:
           const: this_is_a_const
+        example_string_const:
+          type: string
+          const: this_is_a_string_const
         example_enum:
           type: string
           enum:


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

OpenAPI Schema 3.1 supports literal values when a `const` property exists in a string schema. This is important when we have discriminated unions based on a literal value. This PR adds support for generating zod schemas with literal values using `z.literal()` when a string schema has `const` property.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout feat/add-support-for-literal-values-in-zod
> grunt jasmine
> yarn
> yarn build
> cd tests
> yarn
> yarn generate:zod
```

1. check generated `typed-arrays-tuples-v3-1.ts` in generated/zod/*
2. check that a new property `example_string_const` has a value of `zod.literal("this_is_a_string_const")` instead of `zod.string()`