### PR TITLE
fix: correct query condition logic in generateQueryHook

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1169,11 +1169,15 @@ const generateQueryHook = async (
   let mutators = undefined;
 
   let isQuery =
-    Verbs.GET === verb &&
-    (override.query.useQuery ||
-      override.query.useSuspenseQuery ||
-      override.query.useInfinite ||
-      override.query.useSuspenseInfiniteQuery);
+    (Verbs.GET === verb &&
+      (override.query.useQuery ||
+        override.query.useSuspenseQuery ||
+        override.query.useInfinite ||
+        override.query.useSuspenseInfiniteQuery)) ||
+    override.query.useQuery ||
+    override.query.useSuspenseQuery ||
+    override.query.useInfinite ||
+    override.query.useSuspenseInfiniteQuery;
 
   // Allows operationQueryOptions to override non-GET verbs
   const hasOperationQueryOption =


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

https://github.com/orval-labs/orval/issues/1723
Even though useQuery: true is configured globally, the POST request generates a useMutation instead of a useQuery.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. Follow steps in GitHub issue
