### PR TITLE
fix oneOf faker generation (#2184)

### DIFF
--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -129,7 +129,11 @@ export const combineSchemasMock = ({
           return `${acc}...${resolvedValue.value},`;
         } else if (resolvedValue.type === 'object') {
           containsOnlyPrimitiveValues = false;
-          return `${acc}...{${resolvedValue.value}},`;
+          if (resolvedValue.value.startsWith('faker')) {
+            return `${acc}...${resolvedValue.value},`;
+          } else {
+            return `${acc}...{${resolvedValue.value}},`;
+          }
         }
       }
       return `${acc}${resolvedValue.value},`;

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -164,6 +164,14 @@ export default defineConfig({
       mock: true,
     },
   },
+  'one-of-nested': {
+    input: '../specifications/one-of-nested.yaml',
+    output: {
+      schemas: '../generated/default/one-of-nested/model',
+      target: '../generated/default/one-of-nested/endpoints.ts',
+      mock: true,
+    },
+  },
   'any-of-primitive': {
     input: '../specifications/any-of-primitive.yaml',
     output: {

--- a/tests/specifications/one-of-nested.yaml
+++ b/tests/specifications/one-of-nested.yaml
@@ -1,0 +1,88 @@
+openapi: 3.1.0
+info:
+  title: Orval MRE
+  description: Orval MRE
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /example:
+    get:
+      operationId: example
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Example'
+          description: example
+
+components:
+  schemas:
+    PointInFutureRelative:
+      type: object
+      required:
+        - kind
+        - value
+      properties:
+        kind:
+          type: string
+          enum:
+            - relative
+        value:
+          type: string
+    PointInFutureAbsolute:
+      type: object
+      required:
+        - kind
+        - value
+      properties:
+        kind:
+          type: string
+          enum:
+            - absolute
+        value:
+          type: string
+          format: date-time
+    PointInFuture:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/PointInFutureAbsolute'
+        - $ref: '#/components/schemas/PointInFutureRelative'
+      discriminator:
+        propertyName: kind
+        mapping:
+          absolute: '#/components/schemas/PointInFutureAbsolute'
+          relative: '#/components/schemas/PointInFutureRelative'
+    Example1:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          enum:
+            - example1
+    Example2:
+      type: object
+      required:
+        - kind
+        - expiry
+      properties:
+        kind:
+          type: string
+          enum:
+            - example2
+        expiry:
+          allOf:
+            - $ref: '#/components/schemas/PointInFuture'
+    Example:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/Example1'
+        - $ref: '#/components/schemas/Example2'
+      discriminator:
+        propertyName: kind
+        mapping:
+          example1: '#/components/schemas/Example1'
+          example2: '#/components/schemas/Example2'


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fixes https://github.com/orval-labs/orval/issues/2184

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Generated code before supported by this PR:
```javascript
export const getExampleResponseExample2Mock = (overrideResponse: Partial<Example2> = {}): Example2 => ({...{kind: faker.helpers.arrayElement(['example2'] as const), expiry: {...{faker.helpers.arrayElement([{...getExampleResponsePointInFutureAbsoluteMock()},{...getExampleResponsePointInFutureRelativeMock()},])},}}, ...overrideResponse});
```

After this PR (You can see at `one-of-nested` test)
```javascript
export const getExampleResponseExample2Mock = (overrideResponse: Partial<Example2> = {}): Example2 => ({...{kind: faker.helpers.arrayElement(['example2'] as const), expiry: {...faker.helpers.arrayElement([{...getExampleResponsePointInFutureAbsoluteMock()},{...getExampleResponsePointInFutureRelativeMock()},])},}, ...overrideResponse});
```