### PR TITLE
fix: remove transparency from search results and recents on hover

### DIFF
--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -91,6 +91,7 @@ h6:hover .anchor::after {
   --fds-animation-fade-out: cubic-bezier(0, 0, 1, 1);
 }
 
+/* Fixes transparency of results and recent results in search */
 .DocSearch-Hit:hover,
 .DocSearch-Hit[aria-selected="true"] {
   background-color: rgba(243, 244, 246, 0.95) !important;

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -91,6 +91,13 @@ h6:hover .anchor::after {
   --fds-animation-fade-out: cubic-bezier(0, 0, 1, 1);
 }
 
+.DocSearch-Hit:hover,
+.DocSearch-Hit[aria-selected="true"] {
+  background-color: rgba(243, 244, 246, 0.95) !important;
+  opacity: 1 !important;
+  transition: background-color 0.2s ease-in-out;
+}
+
 .DocSearch--active #__next {
   -webkit-filter: blur(2px);
   filter: blur(2px);

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -93,7 +93,7 @@ h6:hover .anchor::after {
 
 /* Fixes transparency of results and recent results in search */
 .DocSearch-Hit:hover,
-.DocSearch-Hit[aria-selected="true"] {
+.DocSearch-Hit[aria-selected='true'] {
   background-color: rgba(243, 244, 246, 0.95) !important;
   opacity: 1 !important;
   transition: background-color 0.2s ease-in-out;


### PR DESCRIPTION
## Status

**READY**

## Description

This PR fixes a visual issue where the search results and recent searches in the DocSearch component appear transparent or difficult to read when hovered or selected.

During investigation, I noticed that no explicit `:hover` or `[aria-selected="true"]` styles were defined locally. However, in the browser DevTools, the visual effect was reproducible and likely caused by internal styles from Algolia’s DocSearch library — specifically, a transparent `--hover-overlay` variable or similar styling.

To address this, I applied a scoped CSS override to ensure that both `:hover` and `aria-selected="true"` states have a solid, readable background color with full opacity.

---

## Related PRs

| branch              | PR       |
| ------------------- | -------- |
| N/A                 | N/A      |

---

## Todos

- [ ] Tests (N/A – visual CSS fix)
- [ ] Documentation (N/A)
- [ ] Changelog Entry (optional – if applicable)

---

## Steps to Test or Reproduce

```bash
> git pull --prune
> git checkout fix/search-transparency
> yarn dev
