### PR TITLE
Fix/search transparency clean

### DIFF
--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -78,7 +78,6 @@ h6:hover .anchor::after {
 }
 
 /* Algolia v3 overrides */
-/* Algolia v3 overrides */
 :root {
   --docsearch-modal-background: #fff;
   --docsearch-highlight-color: #6f40c9;
@@ -98,6 +97,10 @@ h6:hover .anchor::after {
   background-color: rgba(243, 244, 246, 0.95) !important;
   opacity: 1 !important;
   transition: background-color 0.2s ease-in-out;
+}
+
+:root {
+  --docsearch-hit-active-color: #6b7280; 
 }
 
 .DocSearch--active #__next {

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -100,7 +100,7 @@ h6:hover .anchor::after {
 }
 
 :root {
-  --docsearch-hit-active-color: #6b7280; 
+  --docsearch-hit-active-color: #6b7280;
 }
 
 .DocSearch--active #__next {

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -78,11 +78,12 @@ h6:hover .anchor::after {
 }
 
 /* Algolia v3 overrides */
+/* Algolia v3 overrides */
 :root {
   --docsearch-modal-background: #fff;
-  --docsearch-highlight-color: #1965e0;
-  --docsearch-primary-color: #0052cc;
-  --docsearch-searchbox-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);
+  --docsearch-highlight-color: #6f40c9;
+  --docsearch-primary-color: #9e73f1;
+  --docsearch-searchbox-shadow: 0 0 0 3px rgba(166, 130, 250, 0.5);
   --ifm-z-index-fixed: 1000;
   --docsearch-searchbox-height: 48px;
   --docsearch-icon-stroke-width: 1.4;


### PR DESCRIPTION
## Status

**READY**

## Description

This PR adjusts the styling of the `DocSearch` modal component to improve accessibility and user experience. The changes include:

- Adjusted background color and opacity when a search result is focused (hover or keyboard navigation).
- Removed unnecessary transparency on focused items to match the expected design.
- Fixed focus ring and border behavior on the search input field.

These changes were tested locally using the Algolia modal integration. Due to API key restrictions, full API behavior could not be validated, but style adjustments reflect correctly with the modal enabled.

## Related PRs

| Branch                  | PR       |
| ----------------------- | -------- |
| fix/search-transparency | #2220 (previous styling attempt, now superseded) |

## Todos

- [ ] Tests
- [x] Manual visual validation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

```bash
git pull --prune
git checkout fix/search-transparency-clean
yarn install
yarn dev
