### PR TITLE
feat(zod): add output.orverride.zod.TimeOptions option

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1602,6 +1602,34 @@ module.exports = {
 
 You can find more details in the [zod documentation ](https://zod.dev/?id=datetimes).
 
+##### timeOptions
+
+Type: `Object`.
+
+Default Value: `{}`.
+
+Use to set options for zod `time` fields. These options are passed directly to zod `time` validation.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        zod: {
+          timeOptions: {
+            precision: -1,
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+You can find more details in the [zod documentation ](https://zod.dev/?id=times).
+
 #### mock
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -501,6 +501,10 @@ export type ZodDateTimeOptions = {
   precision?: number;
 };
 
+export type ZodTimeOptions = {
+  precision?: -1 | 0 | 1 | 2 | 3;
+};
+
 export type ZodOptions = {
   strict?: {
     param?: boolean;
@@ -531,6 +535,7 @@ export type ZodOptions = {
     response?: Mutator;
   };
   dateTimeOptions?: ZodDateTimeOptions;
+  timeOptions?: ZodTimeOptions;
   generateEachHttpStatus?: boolean;
 };
 
@@ -567,6 +572,7 @@ export type NormalizedZodOptions = {
   };
   generateEachHttpStatus: boolean;
   dateTimeOptions: ZodDateTimeOptions;
+  timeOptions: ZodTimeOptions;
 };
 
 export type HonoOptions = {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -343,6 +343,7 @@ export const normalizeOptions = async (
           generateEachHttpStatus:
             outputOptions.override?.zod?.generateEachHttpStatus ?? false,
           dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {},
+          timeOptions: outputOptions.override?.zod?.timeOptions ?? {},
         },
         swr: {
           ...(outputOptions.override?.swr ?? {}),
@@ -542,6 +543,7 @@ const normalizeOperationsAndTags = (
                     generateEachHttpStatus:
                       zod?.generateEachHttpStatus ?? false,
                     dateTimeOptions: zod?.dateTimeOptions ?? {},
+                    timeOptions: zod?.timeOptions ?? {},
                   },
                 }
               : {}),

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -127,6 +127,10 @@ type DateTimeOptions = {
   precision?: number;
 };
 
+type TimeOptions = {
+  precision?: '-1' | '0' | '1' | '2' | '3';
+};
+
 export const generateZodValidationSchemaDefinition = (
   schema: SchemaObject | SchemaObject31 | undefined,
   context: ContextSpecs,
@@ -136,6 +140,7 @@ export const generateZodValidationSchemaDefinition = (
   rules?: {
     required?: boolean;
     dateTimeOptions?: DateTimeOptions;
+    timeOptions?: TimeOptions;
   },
 ): ZodValidationSchemaDefinition => {
   if (!schema) return { functions: [], consts: [] };
@@ -322,9 +327,13 @@ export const generateZodValidationSchemaDefinition = (
       }
 
       if (schema.format === 'time') {
+        const options = context.output.override.zod?.timeOptions;
         const formatAPI = getZodTimeFormat(isZodV4);
 
-        functions.push([formatAPI, undefined]);
+        functions.push([
+          formatAPI,
+          options ? JSON.stringify(options) : undefined,
+        ]);
         break;
       }
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -128,7 +128,7 @@ type DateTimeOptions = {
 };
 
 type TimeOptions = {
-  precision?: '-1' | '0' | '1' | '2' | '3';
+  precision?: -1 | 0 | 1 | 2 | 3;
 };
 
 export const generateZodValidationSchemaDefinition = (

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -186,6 +186,22 @@ export default defineConfig({
       target: '../specifications/format.yaml',
     },
   },
+  timeOptions: {
+    output: {
+      target: '../generated/zod/time-options.ts',
+      client: 'zod',
+      override: {
+        zod: {
+          timeOptions: {
+            precision: -1,
+          },
+        },
+      },
+    },
+    input: {
+      target: '../specifications/format.yaml',
+    },
+  },
   enums: {
     output: {
       target: '../generated/zod/enums.ts',

--- a/tests/specifications/format.yaml
+++ b/tests/specifications/format.yaml
@@ -65,3 +65,6 @@ components:
           items:
             type: integer
             format: int64
+        feedingTime:
+          type: string
+          format: time


### PR DESCRIPTION
## Status

<!--- **READY** --->

**READY**

## Description

This extends Zod schema generation by allowing the use of the precision parameter in z.time()—similarly to how dateTimePrecision is already supported for z.datetime().

Example :
```ts
z.object({
  "departureTime": z.time({ precision: -1 }), // HH:MM
})
```

The option is optional and does not alter existing behavior.
Related to [fix#2215](https://github.com/orval-labs/orval/issues/2215)

## Related PRs

The implementation follows the same pattern as [#1984](https://github.com/orval-labs/orval/pull/1984), which introduced offset support for z.datetime().

## Todos

- [ X] Tests
- [ X] Documentation
- [ X] Changelog Entry (unreleased)

## Steps to Test or Reproduce

See tests
