### PR TITLE
feat: use null over void for responses with no type

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -147,9 +147,11 @@ const generateImplementation = (
 
   returnTypesToWrite.set(
     operationName,
-    `export type ${pascal(
-      operationName,
-    )}ClientResult = NonNullable<${dataType}>`,
+    `export type ${pascal(operationName)}ClientResult = ${
+      dataType === 'null'
+        ? 'never' // NonNullable<null> is the type never
+        : `NonNullable<${dataType}>`
+    };`,
   );
 
   if (mutator) {

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -178,7 +178,7 @@ const generateAxiosImplementation = (
   } ): Promise<TData> => {${bodyForm}
     return axios${
       !isSyntheticDefaultImportsAllowed ? '.default' : ''
-    }.${verb}(${options});
+    }.${verb}(${options})${response.types.success.some((x) => x.type === 'null') ? '.then((res) => {if (res.data === "") res.data = null; return res as TData;})' : ''};
   }
 `;
 };

--- a/packages/core/src/getters/response.ts
+++ b/packages/core/src/getters/response.ts
@@ -36,7 +36,7 @@ export const getResponse = ({
     Object.entries(responses),
     operationName,
     context,
-    'void',
+    'null',
     (type) => `${type.key}-${type.value}`,
   );
 

--- a/samples/angular-app/orval.config.ts
+++ b/samples/angular-app/orval.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       schemas: 'src/api/model',
       client: 'angular',
       mock: true,
-      prettier: true,
       tsconfig: './tsconfig.app.json',
       override: {
         operations: {

--- a/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
@@ -56,10 +56,10 @@ export const getListPetsMockHandler = (
 
 export const getCreatePetsMockHandler = (
   overrideResponse?:
-    | void
+    | null
     | ((
         info: Parameters<Parameters<typeof http.post>[1]>[0],
-      ) => Promise<void> | void),
+      ) => Promise<null> | null),
 ) => {
   return http.post('*/v:version/pets', async (info) => {
     await delay(1000);

--- a/samples/angular-app/src/api/endpoints/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.service.ts
@@ -57,22 +57,22 @@ export class PetsService {
   /**
    * @summary Create a pet
    */
-  createPets<TData = void>(
+  createPets<TData = null>(
     createPetsBody: CreatePetsBody,
     version?: number,
     options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'body' },
   ): Observable<TData>;
-  createPets<TData = void>(
+  createPets<TData = null>(
     createPetsBody: CreatePetsBody,
     version?: number,
     options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'response' },
   ): Observable<AngularHttpResponse<TData>>;
-  createPets<TData = void>(
+  createPets<TData = null>(
     createPetsBody: CreatePetsBody,
     version?: number,
     options?: Omit<HttpClientOptions, 'observe'> & { observe?: 'events' },
   ): Observable<HttpEvent<TData>>;
-  createPets<TData = void>(
+  createPets<TData = null>(
     createPetsBody: CreatePetsBody,
     version: number = 1,
     options?: HttpClientOptions,
@@ -107,5 +107,5 @@ export class PetsService {
 }
 
 export type ListPetsClientResult = NonNullable<Pets>;
-export type CreatePetsClientResult = NonNullable<void>;
+export type CreatePetsClientResult = never;
 export type ShowPetByIdClientResult = NonNullable<Pet>;

--- a/samples/basic/api/endpoints/petstoreFromFileSpec.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpec.ts
@@ -98,7 +98,7 @@ export const listPets = <TData = AxiosResponse<PetsArray>>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = <TData = AxiosResponse<null>>(
   createPetsBody: CreatePetsBody,
   options?: AxiosRequestConfig,
 ): Promise<TData> => {

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
@@ -99,11 +99,14 @@ export const listPets = <TData = AxiosResponse<PetsArray>>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = <TData = AxiosResponse<null>>(
   createPetsBody: CreatePetsBody,
   options?: AxiosRequestConfig,
 ): Promise<TData> => {
-  return axios.post(`/pets`, createPetsBody, options);
+  return axios.post(`/pets`, createPetsBody, options).then((res) => {
+    if (res.data === '') res.data = null;
+    return res as TData;
+  });
 };
 
 /**
@@ -130,6 +133,6 @@ export const showPetById = <TData = AxiosResponse<Pet>>(
 };
 
 export type ListPetsResult = AxiosResponse<PetsArray>;
-export type CreatePetsResult = AxiosResponse<void>;
+export type CreatePetsResult = AxiosResponse<null>;
 export type ListPetsNestedArrayResult = AxiosResponse<PetsNestedArray>;
 export type ShowPetByIdResult = AxiosResponse<Pet>;

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -34,12 +34,17 @@ export const listPets = (params?: ListPetsParams, version: number = 1) => {
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = <TData = AxiosResponse<null>>(
   createPetsBody: CreatePetsBody,
   version: number = 1,
   options?: AxiosRequestConfig,
 ): Promise<TData> => {
-  return axios.post(`/v${version}/pets`, createPetsBody, options);
+  return axios
+    .post(`/v${version}/pets`, createPetsBody, options)
+    .then((res) => {
+      if (res.data === '') res.data = null;
+      return res as TData;
+    });
 };
 
 /**
@@ -72,7 +77,7 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
 export type ListPetsResult = NonNullable<Awaited<ReturnType<typeof listPets>>>;
-export type CreatePetsResult = AxiosResponse<void>;
+export type CreatePetsResult = AxiosResponse<null>;
 export type ListPetsNestedArrayResult = AxiosResponse<PetsNestedArray>;
 export type ShowPetByIdResult = AxiosResponse<Pet>;
 
@@ -175,10 +180,10 @@ export const getListPetsMockHandler = (
 
 export const getCreatePetsMockHandler = (
   overrideResponse?:
-    | void
+    | null
     | ((
         info: Parameters<Parameters<typeof http.post>[1]>[0],
-      ) => Promise<void> | void),
+      ) => Promise<null> | null),
 ) => {
   return http.post('*/v:version/pets', async (info) => {
     await delay(1000);

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -108,10 +108,10 @@ export const getListPetsMockHandler = (
 
 export const getCreatePetsMockHandler = (
   overrideResponse?:
-    | void
+    | null
     | ((
         info: Parameters<Parameters<typeof http.post>[1]>[0],
-      ) => Promise<void> | void),
+      ) => Promise<null> | null),
 ) => {
   return http.post('*/v:version/pets', async (info) => {
     await delay(1000);

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -712,7 +712,7 @@ export const createPets = (
   version: number = 1,
   signal?: AbortSignal,
 ) => {
-  return customInstance<void>({
+  return customInstance<null>({
     url: `/v${version}/pets`,
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -115,7 +115,7 @@ export const createPets = (
   createPetsBody: CreatePetsBody,
   signal?: AbortSignal,
 ) => {
-  return customInstance<void>({
+  return customInstance<null>({
     url: `/pets`,
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -114,7 +114,7 @@ export const createPets = (
   createPetsBody: CreatePetsBody,
   signal?: AbortSignal,
 ) => {
-  return customInstance<void>({
+  return customInstance<null>({
     url: `/pets`,
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/samples/react-query/hook-mutator/endpoints.ts
+++ b/samples/react-query/hook-mutator/endpoints.ts
@@ -117,7 +117,7 @@ export function useListPets<
  * @summary Create a pet
  */
 export const useCreatePetsHook = () => {
-  const createPets = useCustomInstance<void>();
+  const createPets = useCustomInstance<null>();
 
   return useCallback(
     (createPetsBody: CreatePetsBody, signal?: AbortSignal) => {

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -122,10 +122,10 @@ export const getShowPetByIdMockHandler = (
 
 export const getPostApiV1UserLogoutMockHandler = (
   overrideResponse?:
-    | void
+    | null
     | ((
         info: Parameters<Parameters<typeof http.post>[1]>[0],
-      ) => Promise<void> | void),
+      ) => Promise<null> | null),
 ) => {
   return http.post('*/api/v1/user/logout', async (info) => {
     await delay(1000);

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -502,7 +502,7 @@ export function useShowPetById<
  * @summary This is required to test case when there are no parameters (this path is ignored in add-version transformer), see https://github.com/orval-labs/orval/issues/857#issuecomment-1835317990
  */
 export const postApiV1UserLogout = (signal?: AbortSignal) => {
-  return customInstance<void>({
+  return customInstance<null>({
     url: `/api/v1/user/logout`,
     method: 'POST',
     signal,


### PR DESCRIPTION
## Status

**READY**

## Description

Fix #2226

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> grunt jasmine
```

1. 
