### PR TITLE
Fix for #2227 - correctly using the operations override

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1187,7 +1187,6 @@ const generateQueryHook = async (
     hasOperationQueryOption;
 
   let isMutation = override.query.useMutation && verb !== Verbs.GET;
-  
 
   if (operationQueryOptions?.useMutation !== undefined) {
     isMutation = operationQueryOptions.useMutation;

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1168,23 +1168,26 @@ const generateQueryHook = async (
   let implementation = '';
   let mutators = undefined;
 
+  // Allows operationQueryOptions (which is the Orval config override for the operationId)
+  // to override non-GET verbs
+  const hasOperationQueryOption = !!(
+    operationQueryOptions &&
+    (operationQueryOptions?.useQuery ||
+      operationQueryOptions?.useSuspenseQuery ||
+      operationQueryOptions?.useInfinite ||
+      operationQueryOptions?.useSuspenseInfiniteQuery)
+  );
+
   let isQuery =
-    Verbs.GET === verb &&
-    (override.query.useQuery ||
-      override.query.useSuspenseQuery ||
-      override.query.useInfinite ||
-      override.query.useSuspenseInfiniteQuery);
-
-  // Allows operationQueryOptions to override non-GET verbs
-  const hasOperationQueryOption =
-    operationQueryOptions?.useQuery ||
-    operationQueryOptions?.useSuspenseQuery ||
-    operationQueryOptions?.useInfinite ||
-    operationQueryOptions?.useSuspenseInfiniteQuery;
-
-  isQuery = isQuery || hasOperationQueryOption;
+    (Verbs.GET === verb &&
+      (override.query.useQuery ||
+        override.query.useSuspenseQuery ||
+        override.query.useInfinite ||
+        override.query.useSuspenseInfiniteQuery)) ||
+    hasOperationQueryOption;
 
   let isMutation = override.query.useMutation && verb !== Verbs.GET;
+  
 
   if (operationQueryOptions?.useMutation !== undefined) {
     isMutation = operationQueryOptions.useMutation;


### PR DESCRIPTION
Fix #2227 

This is a fix for #2227 where compilation changes the intentional code. By adding the correct code it should not be mangled anymore and stay exactly as intended.

I noticed i had to add to main package.json a resolution that ansi-styles stays on v4 since v5 is ESM. Not sure if thats only for me?

Also the naming `override` in the Orval config, and the naming override in `GeneratorVerbOptions` in the @orval/query library is **very confusing** since its not that override :) that actual override is in the second argument, which are the `GeneratorOptions`, which is the actual operational override you set in your config :exploding_head:.

_Will try this version in our own codebase first (_pnpm way it is correct for my apps now_), maybe we can also get an alpha since not easy to rewire with Bazel in our CI and see your compiled package?_

Thanks for this wonderfull library btw, i will be glad to think/work how we can improve the testability of at least the query package :)
