### PR TITLE
feat: add useSWRMutationForGet option for SWR custom hook generation

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1341,6 +1341,30 @@ Type: `Boolean`.
 
 Use to generate a <a href="https://swr.vercel.app/docs/pagination#useswrinfinite" target="_blank">useSWRInfinite</a> custom hook.
 
+##### useSWRMutationForGet
+
+Type: `Boolean`.
+
+Use to generate a <a href="https://swr.vercel.app/docs/mutation#useswrmutation" target="_blank">useSWRMutation</a> custom hook for get request.
+
+Example:
+
+```js
+module.exports = {
+  petstore: {
+    output: {
+      override: {
+        swr: {
+          swrOptions: {
+            useSWRMutationForGet: true,
+          },
+        },
+      },
+    },
+  },
+};
+```
+
 ##### swrOptions
 
 Type: `Object`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -622,6 +622,7 @@ export type AngularOptions = {
 
 export type SwrOptions = {
   useInfinite?: boolean;
+  useSWRMutationForGet?: boolean;
   swrOptions?: any;
   swrMutationOptions?: any;
   swrInfiniteOptions?: any;

--- a/tests/configs/swr.config.ts
+++ b/tests/configs/swr.config.ts
@@ -165,6 +165,7 @@ export default defineConfig({
       override: {
         swr: {
           useInfinite: true,
+          useSWRMutationForGet: true,
           swrOptions: {
             dedupingInterval: 10000,
           },


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Fix https://github.com/orval-labs/orval/discussions/2218

I added the new feature to `swr` client to generate useSWRMutation even with GET requests.
Whn cofigration file has `useSWRMutationForGet`, this feature is working.

```
output: {
  client: 'swr',
  target: 'src/gen/endpoints',
  schemas: 'src/gen/model',
  override: {
    swr: {
      useSWRMutationForGet: true,
    },
  },
},
```

## Related PRs

none

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
1. Please define override.swr.useSWRMutationForGet to true in the configuration file as below:
```
output: {
  client: 'swr',
  target: 'src/gen/endpoints',
  schemas: 'src/gen/model',
  override: {
    swr: {
      useSWRMutationForGet: true,
    },
  },
},
```
2. orval execite
orval

3. An implementation definition using useSWRMutationForGet is generated

```ts
export const getListPetsMutationFetcher = (
  params?: ListPetsParams,
  version: number = 1,
) => {
  return (_: Key, __: { arg?: never }): Promise<Pets> => {
    return listPets(params, version);
  };
};

export type ListPetsMutationResult = NonNullable<
  Awaited<ReturnType<typeof listPets>>
>;
export type ListPetsMutationError = Error;

/**
 * @summary List all pets
 */
export const useListPetsMutation = <TError = Error>(
  params?: ListPetsParams,
  version: number = 1,
  options?: {
    swr?: SWRMutationConfiguration<
      Awaited<ReturnType<typeof listPets>>,
      TError,
      Key,
      never,
      Awaited<ReturnType<typeof listPets>>
    > & { swrKey?: string };
  },
) => {
  const { swr: swrOptions } = options ?? {};

  const swrKey = swrOptions?.swrKey ?? getListPetsKey(params, version);
  const swrFn = getListPetsMutationFetcher(params, version);

  const query = useSWRMutation(swrKey, swrFn, swrOptions);

  return {
    swrKey,
    ...query,
  };
};
```