### PR TITLE
chore: cleaning up your development environment

### DIFF
--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -79,7 +79,7 @@
     "string-argv": "^0.3.2",
     "tsconfck": "^2.0.1",
     "typedoc": "^0.28.7",
-    "typedoc-plugin-markdown": "^4.4.2",
+    "typedoc-plugin-markdown": "^4.8.0",
     "typescript": "^5.6.3"
   }
 }

--- a/samples/angular-app/angular.json
+++ b/samples/angular-app/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "yarn"
+    "packageManager": "yarn",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/samples/angular-app/package.json
+++ b/samples/angular-app/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test": "CI=true ng test --no-watch",
     "lint": "ng lint",
     "generate-api": "node ../../packages/orval/dist/bin/orval.js"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,23 +1351,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@orval/angular@npm:7.11.0, @orval/angular@workspace:packages/angular":
+"@orval/angular@npm:7.11.1, @orval/angular@workspace:packages/angular":
   version: 0.0.0-use.local
   resolution: "@orval/angular@workspace:packages/angular"
   dependencies:
-    "@orval/core": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
   languageName: unknown
   linkType: soft
 
-"@orval/axios@npm:7.11.0, @orval/axios@workspace:packages/axios":
+"@orval/axios@npm:7.11.1, @orval/axios@workspace:packages/axios":
   version: 0.0.0-use.local
   resolution: "@orval/axios@workspace:packages/axios"
   dependencies:
-    "@orval/core": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
   languageName: unknown
   linkType: soft
 
-"@orval/core@npm:7.11.0, @orval/core@workspace:packages/core":
+"@orval/core@npm:7.11.1, @orval/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@orval/core@workspace:packages/core"
   dependencies:
@@ -1402,70 +1402,70 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@orval/fetch@npm:7.11.0, @orval/fetch@workspace:packages/fetch":
+"@orval/fetch@npm:7.11.1, @orval/fetch@workspace:packages/fetch":
   version: 0.0.0-use.local
   resolution: "@orval/fetch@workspace:packages/fetch"
   dependencies:
-    "@orval/core": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
   languageName: unknown
   linkType: soft
 
-"@orval/hono@npm:7.11.0, @orval/hono@workspace:packages/hono":
+"@orval/hono@npm:7.11.1, @orval/hono@workspace:packages/hono":
   version: 0.0.0-use.local
   resolution: "@orval/hono@workspace:packages/hono"
   dependencies:
-    "@orval/core": "npm:7.11.0"
-    "@orval/zod": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
+    "@orval/zod": "npm:7.11.1"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
-"@orval/mcp@npm:7.11.0, @orval/mcp@workspace:packages/mcp":
+"@orval/mcp@npm:7.11.1, @orval/mcp@workspace:packages/mcp":
   version: 0.0.0-use.local
   resolution: "@orval/mcp@workspace:packages/mcp"
   dependencies:
-    "@orval/core": "npm:7.11.0"
-    "@orval/fetch": "npm:7.11.0"
-    "@orval/zod": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
+    "@orval/fetch": "npm:7.11.1"
+    "@orval/zod": "npm:7.11.1"
   languageName: unknown
   linkType: soft
 
-"@orval/mock@npm:7.11.0, @orval/mock@workspace:packages/mock":
+"@orval/mock@npm:7.11.1, @orval/mock@workspace:packages/mock":
   version: 0.0.0-use.local
   resolution: "@orval/mock@workspace:packages/mock"
   dependencies:
-    "@orval/core": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
     openapi3-ts: "npm:^4.2.2"
   languageName: unknown
   linkType: soft
 
-"@orval/query@npm:7.11.0, @orval/query@workspace:packages/query":
+"@orval/query@npm:7.11.1, @orval/query@workspace:packages/query":
   version: 0.0.0-use.local
   resolution: "@orval/query@workspace:packages/query"
   dependencies:
-    "@orval/core": "npm:7.11.0"
-    "@orval/fetch": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
+    "@orval/fetch": "npm:7.11.1"
     "@types/lodash.omitby": "npm:^4.6.7"
     lodash.omitby: "npm:^4.6.0"
     vitest: "npm:^0.34.6"
   languageName: unknown
   linkType: soft
 
-"@orval/swr@npm:7.11.0, @orval/swr@workspace:packages/swr":
+"@orval/swr@npm:7.11.1, @orval/swr@workspace:packages/swr":
   version: 0.0.0-use.local
   resolution: "@orval/swr@workspace:packages/swr"
   dependencies:
-    "@orval/core": "npm:7.11.0"
-    "@orval/fetch": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
+    "@orval/fetch": "npm:7.11.1"
   languageName: unknown
   linkType: soft
 
-"@orval/zod@npm:7.11.0, @orval/zod@workspace:packages/zod":
+"@orval/zod@npm:7.11.1, @orval/zod@workspace:packages/zod":
   version: 0.0.0-use.local
   resolution: "@orval/zod@workspace:packages/zod"
   dependencies:
-    "@orval/core": "npm:7.11.0"
+    "@orval/core": "npm:7.11.1"
     "@types/lodash.uniq": "npm:^4.5.7"
     lodash.uniq: "npm:^4.5.0"
   languageName: unknown
@@ -7612,16 +7612,16 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.1"
-    "@orval/angular": "npm:7.11.0"
-    "@orval/axios": "npm:7.11.0"
-    "@orval/core": "npm:7.11.0"
-    "@orval/fetch": "npm:7.11.0"
-    "@orval/hono": "npm:7.11.0"
-    "@orval/mcp": "npm:7.11.0"
-    "@orval/mock": "npm:7.11.0"
-    "@orval/query": "npm:7.11.0"
-    "@orval/swr": "npm:7.11.0"
-    "@orval/zod": "npm:7.11.0"
+    "@orval/angular": "npm:7.11.1"
+    "@orval/axios": "npm:7.11.1"
+    "@orval/core": "npm:7.11.1"
+    "@orval/fetch": "npm:7.11.1"
+    "@orval/hono": "npm:7.11.1"
+    "@orval/mcp": "npm:7.11.1"
+    "@orval/mock": "npm:7.11.1"
+    "@orval/query": "npm:7.11.1"
+    "@orval/swr": "npm:7.11.1"
+    "@orval/zod": "npm:7.11.1"
     "@types/inquirer": "npm:^9.0.6"
     "@types/js-yaml": "npm:^4.0.8"
     "@types/lodash.uniq": "npm:^4.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7639,7 +7639,7 @@ __metadata:
     tsconfck: "npm:^2.0.1"
     typedoc: "npm:^0.28.7"
     typedoc-plugin-coverage: "npm:^3.4.1"
-    typedoc-plugin-markdown: "npm:^4.4.2"
+    typedoc-plugin-markdown: "npm:^4.8.0"
     typescript: "npm:^5.6.3"
   bin:
     orval: dist/bin/orval.js
@@ -9782,12 +9782,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "typedoc-plugin-markdown@npm:4.4.2"
+"typedoc-plugin-markdown@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "typedoc-plugin-markdown@npm:4.8.0"
   peerDependencies:
-    typedoc: 0.27.x
-  checksum: 10c0/93112f0f06f1c0bc7eec1ba7f9034b88a6817a92ec41e491e8ac73c23a5fbda84df537d136395295737499fc1d5afa94d1500a1921b1a967248dc5d3054fc9d6
+    typedoc: 0.28.x
+  checksum: 10c0/c97953b1999b8df8e45b760c927e2819a0b4697bb7eb99487defb536e9c2763263c2c37778e6c747a9712d4664a2b616a84c31b3b4616654337099dc8a131a4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Cleaned up for local development.

- The error that occurred when running `yarn generate-api` in `samples/react-app` was resolved by updating the `typedoc-plugin-markdown` in `@orval/orval`.
- The `Angular` version of the sample app has been updated to `v20` from #2239, but `yarn test` would freeze halfway through because the cli now enters interaction mode. This was resolved by adding CI=true` when executing the `ng test` command.
- Also, since `analytics` is no longer necessary, the option has been updated to `false`.

## Related PRs

- #2239 

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

You can verify that the following command does not cause any errors:

```
yarn test
yarn build
```
