### PR TITLE
fix(fetch):  `explode` params only target `Array` schema

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -19,6 +19,7 @@ import {
   ParameterObject,
   ReferenceObject,
 } from 'openapi3-ts/oas30';
+import { SchemaObject } from 'openapi3-ts/oas31';
 
 export const generateRequestFunction = (
   {
@@ -60,11 +61,18 @@ export const generateRequestFunction = (
 
   const explodeParameters = parameters.filter((parameter) => {
     const { schema } = resolveRef<ParameterObject>(parameter, context);
+    const schemaObject = schema.schema as SchemaObject;
 
     if (override.fetch.explode) {
-      return schema.in === 'query' && schema.explode;
+      return (
+        schema.in === 'query' && schemaObject.type === 'array' && schema.explode
+      );
     } else {
-      return schema.in === 'query' && schema.explode !== false;
+      return (
+        schema.in === 'query' &&
+        schemaObject.type === 'array' &&
+        schema.explode !== false
+      );
     }
   });
 

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -72,13 +72,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -102,13 +102,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -25,13 +25,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -120,13 +120,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -115,13 +115,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -106,13 +106,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -120,13 +120,8 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    const explodeParameters = ['limit'];
-
-    if (Array.isArray(value) && explodeParameters.includes(key)) {
-      value.forEach((v) =>
-        normalizedParams.append(key, v === null ? 'null' : v.toString()),
-      );
-      return;
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString());
     }
   });
 


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**HOLD**

## Description

fix #2266

I added a condition to the fetch client to check if the schema is an array type when determining if it is an `explode` query parameter.
Because, in #1604, the fetch client added support for `explode` for array-type query parameters.
The default behavior for query parameters that didn't specify `explode` was the same as `false`, but since #2143, `explode` is now treated the same as `true`.
As a result, query parameters that were not of type Array were also treated as `explode`, which caused an issue where query parameters did not work.

## Related PRs

- #1604 
- #2143 

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

It will be automatically generated using the sample definition below:
The `filter` query params is an `array`, so it will be included in the `explode`. But, the `limit` query parameter is a `string`, so it will not be included in the `explode`. 

```yaml
openapi: '3.0.0'
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    get:
      summary: List all pets
      operationId: listPets
      tags:
        - pets
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: string
        - name: filter
          in: query
          required: false
          schema:
            type: array
            items:
              type: string
      responses:
        '200':
          description: A paged array of pets
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Pets'
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      oneOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'
      properties:
        '@id':
          type: string
          format: iri-reference
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
        email:
          type: string
          format: email
        callingCode:
          type: string
          enum: ['+33', '+420', '+33'] # intentional duplicated value
        country:
          type: string
          enum: ["People's Republic of China", 'Uruguay']
    Dog:
      type: object
      oneOf:
        - $ref: '#/components/schemas/Labradoodle'
        - $ref: '#/components/schemas/Dachshund'
      required: ['type']
      properties:
        barksPerMinute:
          type: integer
        type:
          type: string
          enum:
            - dog
      discriminator:
        propertyName: breed
        mapping:
          Labradoodle: '#/components/schemas/Labradoodle'
          Dachshund: '#/components/schemas/Dachshund'
    Labradoodle:
      type: object
      required: ['cuteness']
      properties:
        cuteness:
          type: integer
    Dachshund:
      type: object
      required: ['length']
      properties:
        length:
          type: integer
    Cat:
      type: object
      required: ['type']
      properties:
        petsRequested:
          type: integer
          readOnly: true
        type:
          type: string
          enum:
            - cat
    Pets:
      type: array
      items:
        $ref: '#/components/schemas/Pet'
```

