### PR TITLE
feat(fetch): changed default value of `override.fetch.explode` from `false` to `true` to clarify its meaning

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1001,11 +1001,11 @@ If you want to return a defined return type instead of an automatically generate
 ##### explode
 
 Type: `Boolean`.
-Default: `false`
+Default: `true`
 
 By default, the `fetch` client follows the OpenAPI specification for query parameter explode behavior. This means that query parameters will be exploded unless explicitly set to `false` in the OpenAPI schema.
 
-If you want to maintain backward compatibility with the previous behavior (where only parameters with `explode: true` are exploded), you can set this value to `true`.
+If you want to maintain backward compatibility with the previous behavior (where only parameters with `explode: true` are exploded), you can set this value to `false`.
 
 ##### jsonReviver
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -63,17 +63,11 @@ export const generateRequestFunction = (
     const { schema } = resolveRef<ParameterObject>(parameter, context);
     const schemaObject = schema.schema as SchemaObject;
 
-    if (override.fetch.explode) {
-      return (
-        schema.in === 'query' && schemaObject.type === 'array' && schema.explode
-      );
-    } else {
-      return (
-        schema.in === 'query' &&
-        schemaObject.type === 'array' &&
-        schema.explode !== false
-      );
-    }
+    return (
+      schema.in === 'query' &&
+      schemaObject.type === 'array' &&
+      (schema.explode || override.fetch.explode)
+    );
   });
 
   const explodeParametersNames = explodeParameters.map((parameter) => {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -355,7 +355,7 @@ export const normalizeOptions = async (
           includeHttpResponseReturnType:
             outputOptions.override?.fetch?.includeHttpResponseReturnType ??
             true,
-          explode: outputOptions.override?.fetch?.explode ?? false,
+          explode: outputOptions.override?.fetch?.explode ?? true,
           ...(outputOptions.override?.fetch ?? {}),
         },
         useDates: outputOptions.override?.useDates || false,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Starting with #2143, the fetch client has changed so that array query parameters without the explode option behave the same as when explode is true. 
The previous behavior was the same as when explode is false, so we've added the `override.fetch.explode` option to maintain compatibility.

The default for `override.fetch.explode` is `false`.
When `override.fetch.explode` is `false`, array query parameters without explode specified behave the same as when explode is `true`.
It would be confusing to have the same behavior as if explode was `true` even though it was set to `false`, so I changed the default value from `false` to `true` to change the meaning.

### Before

- `override.fetch.explode` defaults to `false`
- When `override.fetch.explode` is `false`, array query parameters without the explode setting behave the same as when explode is set to `true`.

### After

- `override.fetch.explode` defaults to `true`
- When `override.fetch.explode` is `true`, array query parameters without the explode setting behave the same as when explode is set to `true`.

## Related PRs

List related PRs against other branches:

- #2143

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce

none