### PR TITLE
feat: indexMockFiles now only exports mock handlers

### DIFF
--- a/docs/src/pages/guides/msw.md
+++ b/docs/src/pages/guides/msw.md
@@ -156,3 +156,16 @@ import { setupServer } from 'msw/node';
 const server = setupServer();
 server.use(...getPetsMock());
 ```
+
+You can also turn on [`indexMockFiles`](../reference/configuration/output#indexmockfiles) which will allow you dynamically import all mock handlers.
+
+```ts
+// node.ts
+import * as mocks from './endpoints/index.msw';
+import { setupServer } from 'msw/node';
+
+const handlers = Object.entries(mocks).flatMap(([, getMock]) => getMock());
+const server = setupServer(...handlers);
+
+export { server };
+```

--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -584,7 +584,7 @@ Type: `Boolean`
 
 Default Value: `false`.
 
-When `true`, adds a `index.msw.ts` file which exports all mock functions.
+When `true`, adds a `index.msw.ts` file which exports arrays with all mock functions.
 This is only valid when `mode` is `tags-split`.
 
 Example:
@@ -600,6 +600,13 @@ module.exports = {
     },
   },
 };
+```
+
+```ts
+// index.msw.ts
+export { getPetsMock } from './pets/pets.msw';
+export { getStoresMock } from './stores/stores.msw';
+// etc...
 ```
 
 ## docs

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -3,6 +3,7 @@ import { generateModelsInline, generateMutatorImports } from '../generators';
 import { OutputClient, WriteModeProps } from '../types';
 import {
   camel,
+  pascal,
   getFileInfo,
   isFunction,
   isSyntheticDefaultImportsAllow,
@@ -202,7 +203,10 @@ export const writeSplitTagsMode = async ({
               tag,
               tag + '.' + getMockFileExtensionByTypeName(output.mock!),
             );
-            fs.appendFile(indexFilePath, `export * from '${localMockPath}'\n`);
+            fs.appendFile(
+              indexFilePath,
+              `export { get${pascal(tag)}Mock } from '${localMockPath}'\n`,
+            );
           }
         }
 

--- a/samples/angular-app/orval.config.ts
+++ b/samples/angular-app/orval.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       target: 'src/api/endpoints/petstoreFromFileSpecWithTransformer.ts',
       schemas: 'src/api/model',
       client: 'angular',
-      mock: true,
+      mock: { indexMockFiles: true },
       tsconfig: './tsconfig.app.json',
       clean: true,
       override: {

--- a/samples/angular-app/src/api/browser.ts
+++ b/samples/angular-app/src/api/browser.ts
@@ -1,6 +1,7 @@
 import { setupWorker } from 'msw/browser';
-import { getPetsMock } from './endpoints/pets/pets.msw';
+import * as mocks from './endpoints/index.msw';
 
-const worker = setupWorker(...getPetsMock());
+const handlers = Object.entries(mocks).flatMap(([, getMock]) => getMock());
+const worker = setupWorker(...handlers);
 
 export { worker };

--- a/samples/angular-app/src/api/endpoints/index.msw.ts
+++ b/samples/angular-app/src/api/endpoints/index.msw.ts
@@ -1,0 +1,1 @@
+export { getPetsMock } from './pets/pets.msw';

--- a/samples/angular-app/src/api/node.ts
+++ b/samples/angular-app/src/api/node.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node';
-import { getPetsMock } from './endpoints/pets/pets.msw';
+import * as mocks from './endpoints/index.msw';
 
-const server = setupServer(...getPetsMock());
+const handlers = Object.entries(mocks).flatMap(([, getMock]) => getMock());
+const server = setupServer(...handlers);
 
 export { server };


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Closes #2247, #347

This is a breaking change!

`indexMockFiles` now only exports the mock handlers to be used by msw's `setupWorker`/`setupWorker`

example:
```ts
import { setupServer } from 'msw/node';
import * as mocks from './endpoints/index.msw';

const handlers = Object.entries(mocks).flatMap(([, getMock]) => getMock());
const server = setupServer(...handlers);

export { server };
```

The angular-app sample have been setup to utilize this.