### PR TITLE
feat(core): Look for config files with the .cjs extension

### DIFF
--- a/packages/core/src/utils/file.ts
+++ b/packages/core/src/utils/file.ts
@@ -93,6 +93,13 @@ export async function loadFile<File = any>(
     }
 
     if (!resolvedPath) {
+      const cjsFile = resolve(root, `${defaultFileName}.cjs`);
+      if (fs.existsSync(cjsFile)) {
+        resolvedPath = cjsFile;
+      }
+    }
+
+    if (!resolvedPath) {
       const tsFile = resolve(root, `${defaultFileName}.ts`);
       if (fs.existsSync(tsFile)) {
         resolvedPath = tsFile;
@@ -106,7 +113,7 @@ export async function loadFile<File = any>(
       createLogger(logLevel).error(chalk.red(`File not found => ${filePath}`));
     } else if (defaultFileName) {
       createLogger(logLevel).error(
-        chalk.red(`File not found => ${defaultFileName}.{js,mjs,ts}`),
+        chalk.red(`File not found => ${defaultFileName}.{js,mjs,cjs,ts}`),
       );
     } else {
       createLogger(logLevel).error(chalk.red(`File not found`));


### PR DESCRIPTION
## Status

**READY**

## Description

 - Adds the `.cjs` extension (CommonJs) to the list of allowed config file types.
 - This is necessary when the containing package.json has `"type"` set to `"module"` (at least when typescript is not being used).
 - After setting up this PR, I discovered that a workaround exists of using the `.ts` extension :facepalm:  so no big deal if this is rejected

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

1. Create a new js project with package.json:
```json
{
  "name": "test",
  "version": "1.0.0",
  "main": "index.js",
  "type": "module",
  "scripts": {
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "description": "",
  "dependencies": {},
  "devDependencies": {
    "orval": "^7.11.2"
  }
}
```

2. Create a `orval.config.js` file:
```js
module.exports = {
  api: {
    output: {
      client: 'zod',
      mode: 'single',
      target: 'api.gen.js',
    },
    input: {
      target: './api.yaml',
    },
  },
};
```

3. Run orval:
```bash
> npx orval
🍻 Start orval v7.11.2 - A swagger client generator for typescript
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "failed to load from /home/james/carter/services/mesh/clients/orval.config.js => Error [ERR_REQUIRE_ESM]: require() of ES Module /home/james/carter/services/mesh/clients/orval.config.js from /home/james/carter/services/mesh/node_modules/@orval/core/dist/index.js not supported.
orval.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename orval.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/james/carter/services/mesh/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

Note, I get the same result if the config file starts with `export default {` instead.
