### PR TITLE
feat: support uint64 type in `output.override.useBigInt`

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -2482,7 +2482,7 @@ Type: `Boolean`
 
 Valid values: true or false. Defaults to false.
 
-Use this property to convert OpenAPI `int64` format to JavaScript `BigInt` objects instead of `number`.
+Use this property to convert OpenAPI `int64` and `uint64` format to JavaScript `BigInt` objects instead of `number`.
 
 Example:
 

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -38,7 +38,8 @@ export const getScalar = ({
     case 'number':
     case 'integer': {
       let value =
-        item.format === 'int64' && context.output.override.useBigInt
+        context.output.override.useBigInt &&
+        (item.format === 'int64' || item.format === 'uint64')
           ? 'bigint'
           : 'number';
       let isEnum = false;

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -54,6 +54,57 @@ describe('getMockScalar (int64 format handling)', () => {
   });
 });
 
+describe('getMockScalar (uint64 format handling)', () => {
+  const baseArg = {
+    item: {
+      type: 'integer' as SchemaObjectType,
+      format: 'uint64',
+      minimum: 1,
+      maximum: 100,
+      name: 'test-item',
+    },
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  it('should return faker.number.bigInt() when format is uint64, useBigInt is true, and mockOptions.format.uint64 is NOT specified', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      context: { output: { override: { useBigInt: true } } } as ContextSpecs,
+    });
+
+    expect(result.value).toBe('faker.number.bigInt({min: 1, max: 100})');
+  });
+
+  it('should return faker.number.int() when format is uint64, useBigInt is false, and mockOptions.format.uint64 is NOT specified', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      context: { output: { override: { useBigInt: false } } } as ContextSpecs,
+    });
+
+    expect(result.value).toBe('faker.number.int({min: 1, max: 100})');
+  });
+
+  it('should return custom mockOptions.format.uint64 when format is uint64 and mockOptions.format.uint64 IS specified', () => {
+    const specified = 'faker.number.int({ min: 0, max: 200 }).toString()';
+
+    const result = getMockScalar({
+      ...baseArg,
+      mockOptions: {
+        format: {
+          uint64: specified,
+        },
+      },
+      context: { output: { override: { useBigInt: true } } } as ContextSpecs,
+    });
+
+    expect(result.value).toBe(specified);
+  });
+});
+
 describe('getMockScalar (example handling with falsy values)', () => {
   const baseArg = {
     item: {

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -128,7 +128,8 @@ export const getMockScalar = ({
     case 'number':
     case 'integer': {
       const intFunction =
-        item.format === 'int64' && context.output.override.useBigInt
+        context.output.override.useBigInt &&
+        (item.format === 'int64' || item.format === 'uint64')
           ? 'bigInt'
           : 'int';
       let value = getNullable(


### PR DESCRIPTION
## Status

**READY**

## Description

Adds support for treating the `uint64` data type as a bigint in the same way that `int64` is handled. I'm using orval on an api that has `uint64`s as well as `int64`, and the discrepancy on how they were handled bothered me, so here we are!

Not sure if I need to provide any steps or anything here, it's a pretty basic change, but let me know.