### PR TITLE
feat: support colon in path for msw route

### DIFF
--- a/packages/mock/src/faker/getters/route.ts
+++ b/packages/mock/src/faker/getters/route.ts
@@ -23,6 +23,7 @@ const getRoutePath = (path: string): string => {
 };
 
 export const getRouteMSW = (route: string, baseUrl = '*') => {
+  route = route.replaceAll(':', '\\\:');
   const splittedRoute = route.split('/');
 
   return splittedRoute.reduce((acc, path, i) => {


### PR DESCRIPTION
## Status

**READY**

## Description

When an API defines an operation using a colon separator in its path the generated mock route breaks as it effectively does the following when registering the handlers:

```
app.post('/v1/operations/:operation:cancel', handler);
```

rather than:

```
app.post('/v1/operations/:operation\\:cancel', handler);
```

## OpenAPI Spec

```yaml
#...
# part of Google API long running operations API.
  "/v1/operations/{operation}:cancel":
    post:
      tags:
        - Operations
      description: >-
        Starts asynchronous cancellation on a long-running operation.  The
        server
         makes a best effort to cancel the operation, but success is not
         guaranteed.  If the server doesn't support this method, it returns
         `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
         [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
         other methods to check whether the cancellation succeeded or whether the
         operation completed despite cancellation. On successful cancellation,
         the operation is not deleted; instead, it becomes an operation with
         an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
         corresponding to `Code.CANCELLED`.
      operationId: Operations_CancelOperation
      parameters:
        - name: operation
          in: path
          description: The operation id.
          required: true
          schema:
            type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/CancelOperationRequest"
        required: true
      responses:
        "200":
          description: OK
          content: {}
        default:
          description: Default error response
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Status"
#...
```

## Expect

```typescript

export const getOperationsCancelOperationMockHandler = (overrideResponse?: Status | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<Status> | Status)) => {
  return http.post('http://localhost:3333/v1/operations/:operation\\\:cancel', async (info) => {await delay(0);
  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
    return new HttpResponse(null,
      { status: 200,
        
      })
  })
}

```

## Actual

```typescript

export const getOperationsCancelOperationMockHandler = (overrideResponse?: Status | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<Status> | Status)) => {
  return http.post('http://localhost:3333/v1/operations/:operation:cancel', async (info) => {await delay(0);
  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
    return new HttpResponse(null,
      { status: 200,
        
      })
  })
}

```
