### PR TITLE
fix: case-senstive for generated imports

### DIFF
--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -1,15 +1,19 @@
 import uniqBy from 'lodash.uniqby';
 import { GeneratorImport, NormalizedOutputOptions } from '../types';
-import { upath, camel } from '../utils';
+import { conventionName, upath } from '../utils';
 
 export const generateImportsForBuilder = (
   output: NormalizedOutputOptions,
   imports: GeneratorImport[],
   relativeSchemasPath: string,
-) =>
-  output.schemas && !output.indexFiles
-    ? uniqBy(imports, 'name').map((i) => ({
-        exports: [i],
-        dependency: upath.joinSafe(relativeSchemasPath, i.name),
-      }))
+) => {
+  return output.schemas && !output.indexFiles
+    ? uniqBy(imports, 'name').map((i) => {
+        const name = conventionName(i.name, output.namingConvention);
+        return {
+          exports: [i],
+          dependency: upath.joinSafe(relativeSchemasPath, name),
+        };
+      })
     : [{ exports: imports, dependency: relativeSchemasPath }];
+};

--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -10,6 +10,6 @@ export const generateImportsForBuilder = (
   output.schemas && !output.indexFiles
     ? uniqBy(imports, 'name').map((i) => ({
         exports: [i],
-        dependency: upath.joinSafe(relativeSchemasPath, camel(i.name)),
+        dependency: upath.joinSafe(relativeSchemasPath, i.name),
       }))
     : [{ exports: imports, dependency: relativeSchemasPath }];


### PR DESCRIPTION
## Summary

This PR fixes an issue where the file name casing in generated import statements did not match the actual file casing on disk. This resolves problems on case-sensitive file systems.

## Related Issue

Fix #2312

## Changes

- Removed the automatic `camelCase` transformation from `generateImportsForBuilder` in `packages/core/src/writers/generate-imports-for-builder.ts`.

---

Please review and let me know if any changes are required!