### PR TITLE
chore(ci): enable caching of node_modules

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Enable corepack
         run: corepack enable
+      # until setup-node have better support for corepack
+      # we have to enable caching in 2 steps
+      # https://github.com/actions/setup-node/issues/531
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'yarn'
       - name: install
         run: yarn
       - name: build


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Enables caching of node_modules.

Unfortunately until setup-node have better support for corepack we have to enable caching in 2 steps
- https://github.com/actions/setup-node/issues/531

## Related PRs

List related PRs against other branches:

- #2303 