### PR TITLE
fix(axios): provide type parameter when inferring mutator `options` type

### DIFF
--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -137,7 +137,7 @@ const generateAxiosImplementation = (
 
     return `const ${operationName} = (\n    ${propsImplementation}\n ${
       isRequestOptions && mutator.hasSecondArg
-        ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}>,`
+        ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}<${response.definition.success || 'unknown'}>>,`
         : ''
     }) => {${bodyForm}
       return ${mutator.name}<${response.definition.success || 'unknown'}>(


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

When a mutator has a second parameter, the generated `options` was typed as `SecondParameter<typeof mutator>`, which drops the mutator's generic and widens the options type. That prevents strongly-typed per-endpoint config.

Instantiate the mutator with the endpoint success type when extracting the second parameter:

```ts
  SecondParameter<typeof mutator<SuccessType>>
```

This preserves the correct, strongly-typed options.

Closes #2351.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)
