### PR TITLE
fix(mock): prevent multipleOf undefined in MSW mock generation for integer types

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -149,6 +149,121 @@ describe('getMockScalar (example handling with falsy values)', () => {
   });
 });
 
+describe('getMockScalar (multipleOf handling)', () => {
+  const createContext = (
+    packageJsonDeps?: Record<string, string>,
+  ): ContextSpecs => {
+    const context = {
+      output: {
+        override: {},
+        ...(packageJsonDeps && {
+          packageJson: { dependencies: packageJsonDeps },
+        }),
+      },
+    } as ContextSpecs;
+    return context;
+  };
+
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  it('should include multipleOf when defined for integer type with Faker v9', () => {
+    const integerType: SchemaObjectType = 'integer';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: integerType,
+        minimum: 0,
+        maximum: 100,
+        multipleOf: 5,
+        name: 'test-item',
+      },
+      context: createContext({ '@faker-js/faker': '^9.0.0' }),
+    });
+
+    expect(result.value).toBe(
+      'faker.number.int({min: 0, max: 100, multipleOf: 5})',
+    );
+  });
+
+  it('should not include multipleOf when undefined for integer type with Faker v9', () => {
+    const integerType: SchemaObjectType = 'integer';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: integerType,
+        minimum: 0,
+        maximum: 100,
+        multipleOf: undefined,
+        name: 'test-item',
+      },
+      context: createContext({ '@faker-js/faker': '^9.0.0' }),
+    });
+
+    expect(result.value).toBe('faker.number.int({min: 0, max: 100})');
+  });
+
+  it('should not include multipleOf for integer type with Faker v8', () => {
+    const integerType: SchemaObjectType = 'integer';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: integerType,
+        minimum: 0,
+        maximum: 100,
+        multipleOf: 5,
+        name: 'test-item',
+      },
+      context: createContext({ '@faker-js/faker': '^8.0.0' }),
+    });
+
+    expect(result.value).toBe('faker.number.int({min: 0, max: 100})');
+  });
+
+  it('should handle multipleOf for number (float) type', () => {
+    const numberType: SchemaObjectType = 'number';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: numberType,
+        minimum: 0,
+        maximum: 100,
+        multipleOf: 0.5,
+        name: 'test-item',
+      },
+      context: createContext(),
+    });
+
+    expect(result.value).toBe(
+      'faker.number.float({min: 0, max: 100, multipleOf: 0.5})',
+    );
+  });
+
+  it('should use fractionDigits when multipleOf is undefined for number type', () => {
+    const numberType: SchemaObjectType = 'number';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: numberType,
+        minimum: 0,
+        maximum: 100,
+        name: 'test-item',
+      },
+      mockOptions: { fractionDigits: 2 },
+      context: createContext(),
+    });
+
+    expect(result.value).toBe(
+      'faker.number.float({min: 0, max: 100, fractionDigits: 2})',
+    );
+  });
+});
+
 describe('getMockScalar (nested arrays handling)', () => {
   it('should generate valid syntax for nested arrays (array of arrays)', () => {
     const result = getMockScalar({

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -133,7 +133,7 @@ export const getMockScalar = ({
           ? 'bigInt'
           : 'int';
       let value = getNullable(
-        `faker.number.${intFunction}({min: ${item.minimum ?? mockOptions?.numberMin}, max: ${item.maximum ?? mockOptions?.numberMax}${isFakerV9 ? `, multipleOf: ${item.multipleOf}` : ''}})`,
+        `faker.number.${intFunction}({min: ${item.minimum ?? mockOptions?.numberMin}, max: ${item.maximum ?? mockOptions?.numberMax}${isFakerV9 && item.multipleOf !== undefined ? `, multipleOf: ${item.multipleOf}` : ''}})`,
         item.nullable,
       );
       if (type === 'number') {


### PR DESCRIPTION
Fixes #2353

## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

This PR fixes an issue where MSW mock generation produces `multipleOf: undefined` for integer types when using Faker.js v9+. This causes TypeScript compilation errors when `exactOptionalPropertyTypes: true` is enabled in tsconfig. The fix adds a conditional check to only include the `multipleOf` parameter when it has a defined value.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| N/A                 | N/A      |

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

1. Create an OpenAPI schema with an integer field without a `multipleOf` property
2. Generate MSW mocks using Orval v7.10.0+ with Faker.js v9+
3. Enable `exactOptionalPropertyTypes: true` in your tsconfig.json
4. Before this fix: TypeScript compilation fails with error about `multipleOf: undefined`
5. After this fix: TypeScript compilation succeeds and mocks are generated correctly

### Test the fix:
```bash
cd packages/mock
npm test -- scalar.test.ts
```

All tests should pass, including the new test cases for `multipleOf` handling.