### PR TITLE
chore(ci): update to setup-node@5

### DIFF
--- a/.github/workflows/deploy-doc.yaml
+++ b/.github/workflows/deploy-doc.yaml
@@ -14,9 +14,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
+          # https://github.com/actions/setup-node/issues/1357
+          package-manager-cache: false
       - name: Install Vercel CLI
         run: |
           npm install -g vercel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,17 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
+          # disable setup-node@v5's caching to be able to setup yarn
+          # https://github.com/actions/setup-node/issues/1357
+          package-manager-cache: false
       - name: Enable corepack
         run: corepack enable
-      # until setup-node have better support for corepack
-      # we have to enable caching in 2 steps
+      # until setup-node have better support for corepack we have to setup yarn in 2 steps
       # https://github.com/actions/setup-node/issues/531
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'yarn'
+      - uses: actions/setup-node@v5
       - name: install
         run: yarn
       - name: build


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Updates to setup-node@5 which comes with caching on my default
https://github.com/actions/setup-node/releases/tag/v5.0.0

However this completely breaks when using yarn
- https://github.com/actions/setup-node/issues/1357

So more workarounds needs to be applied

## Related PRs

List related PRs against other branches:

- #2357