### PR TITLE
fix(mock): add Faker v9 multipleOf support for number type

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -225,7 +225,7 @@ describe('getMockScalar (multipleOf handling)', () => {
     expect(result.value).toBe('faker.number.int({min: 0, max: 100})');
   });
 
-  it('should handle multipleOf for number (float) type', () => {
+  it('should include multipleOf for number type with Faker v9', () => {
     const numberType: SchemaObjectType = 'number';
     const result = getMockScalar({
       ...baseArg,
@@ -236,11 +236,51 @@ describe('getMockScalar (multipleOf handling)', () => {
         multipleOf: 0.5,
         name: 'test-item',
       },
-      context: createContext(),
+      context: createContext({ '@faker-js/faker': '^9.0.0' }),
     });
 
     expect(result.value).toBe(
       'faker.number.float({min: 0, max: 100, multipleOf: 0.5})',
+    );
+  });
+
+  it('should not include multipleOf when undefined for number type with Faker v9', () => {
+    const numberType: SchemaObjectType = 'number';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: numberType,
+        minimum: 0,
+        maximum: 100,
+        multipleOf: undefined,
+        name: 'test-item',
+      },
+      mockOptions: { fractionDigits: 2 },
+      context: createContext({ '@faker-js/faker': '^9.0.0' }),
+    });
+
+    expect(result.value).toBe(
+      'faker.number.float({min: 0, max: 100, fractionDigits: 2})',
+    );
+  });
+
+  it('should not include multipleOf for number type with Faker v8', () => {
+    const numberType: SchemaObjectType = 'number';
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: numberType,
+        minimum: 0,
+        maximum: 100,
+        multipleOf: 0.5,
+        name: 'test-item',
+      },
+      mockOptions: { fractionDigits: 2 },
+      context: createContext({ '@faker-js/faker': '^8.0.0' }),
+    });
+
+    expect(result.value).toBe(
+      'faker.number.float({min: 0, max: 100, fractionDigits: 2})',
     );
   });
 

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -138,7 +138,7 @@ export const getMockScalar = ({
       );
       if (type === 'number') {
         value = getNullable(
-          `faker.number.float({min: ${item.minimum ?? mockOptions?.numberMin}, max: ${item.maximum ?? mockOptions?.numberMax}, ${item.multipleOf ? `multipleOf: ${item.multipleOf}` : `fractionDigits: ${mockOptions?.fractionDigits}`}})`,
+          `faker.number.float({min: ${item.minimum ?? mockOptions?.numberMin}, max: ${item.maximum ?? mockOptions?.numberMax}${isFakerV9 && item.multipleOf !== undefined ? `, multipleOf: ${item.multipleOf}` : `, fractionDigits: ${mockOptions?.fractionDigits}`}})`,
           item.nullable,
         );
       }


### PR DESCRIPTION
https://github.com/orval-labs/orval/pull/2354#pullrequestreview-3212682964

## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

  This PR adds Faker v9 support for the multipleOf parameter in faker.number.float() calls for number type schemas. Previously, only integer types supported the multipleOf parameter with Faker v9, while number (float) types always used fractionDigits.
   This change ensures consistent behavior across both numeric types when using Faker v9.

## Related PRs

List related PRs against other branches:

| branch              | PR       |
| ------------------- | -------- |
| other_pr_production | [link]() |
| other_pr_master     | [link]() |

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce

  Outline the steps to test or reproduce the PR here.

  > git pull --prune
  > git checkout fix/faker-v9-multipleof-number-type
  > cd packages/mock
  > npm test -- scalar.test.ts

  1. Verify that faker.number.float() includes multipleOf parameter when using Faker v9 and multipleOf is defined in the schema
  2. Verify that faker.number.float() falls back to fractionDigits when using Faker v8 or when multipleOf is undefined
  3. Run the test suite to ensure all 17 tests pass, including the newly added test cases for Faker v9 number type handling

