### PR TITLE
chore: use devEngines to indicate that node24 is required to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,17 @@
   ],
   "private": true,
   "packageManager": "yarn@4.9.3",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=24",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "yarn",
+      "onFail": "error"
+    }
+  },
   "scripts": {
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

There seems to be issues with building/testing the project using node 22. This PR uses [devEngines](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) to lists node24 as a requirement.

Support for devEngines is incomplete for yarn and pnpm. But hopefully that'll be fixed soon. 
Nevertheless having this field at least makes it clear that node24 is needed.