### PR TITLE
fix(orval): corrected path to d.ts types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,12 @@
     "turbo.json": "jsonc"
   },
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "debug.javascript.terminalOptions": {
+    "skipFiles": [
+      "**/node_modules/**",
+      "<node_internals>/**",
+      "**/node/corepack/**"
+    ]
+  }
 }

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -10,7 +10,7 @@
   "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "types": ["node"],
     "strict": true,
     "noUnusedLocals": true,
+    "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

The orval package was still using the old tsup path to index.d.ts