### PR TITLE
fix(cli): orval cli options now correctly list their input values

### DIFF
--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import readline from 'node:readline';
 
 import chalk from 'chalk';
+
 export const log = console.log;
 
 export const startMessage = ({
@@ -11,13 +12,10 @@ export const startMessage = ({
   name: string;
   version: string;
   description: string;
-}) => {
-  log(
-    `🍻 Start ${chalk.cyan.bold(name)} ${chalk.green(`v${version}`)}${
-      description ? ` - ${description}` : ''
-    }`,
-  );
-};
+}) =>
+  `🍻 ${chalk.cyan.bold(name)} ${chalk.green(`v${version}`)}${
+    description ? ` - ${description}` : ''
+  }`;
 
 export const logError = (err: unknown, tag?: string) => {
   log(

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.0.0",
+    "@commander-js/extra-typings": "^14.0.0",
     "@orval/angular": "workspace:*",
     "@orval/axios": "workspace:*",
     "@orval/core": "workspace:*",
@@ -78,9 +79,9 @@
     "@orval/query": "workspace:*",
     "@orval/swr": "workspace:*",
     "@orval/zod": "workspace:*",
-    "cac": "^6.7.14",
     "chalk": "^4.1.2",
     "chokidar": "^4.0.3",
+    "commander": "^14.0.1",
     "enquirer": "^2.4.1",
     "execa": "^5.1.1",
     "find-up": "5.0.0",

--- a/packages/orval/src/bin/orval.ts
+++ b/packages/orval/src/bin/orval.ts
@@ -1,64 +1,78 @@
 #!/usr/bin/env node
-import { ErrorWithTag, isString, logError, startMessage } from '@orval/core';
-import { cac } from 'cac';
+import { Option, program } from '@commander-js/extra-typings';
+import {
+  ErrorWithTag,
+  isString,
+  log,
+  logError,
+  OutputClient,
+  OutputMode,
+  startMessage,
+} from '@orval/core';
 
 import pkg from '../../package.json';
 import { generateConfig, generateSpec } from '../generate';
 import { normalizeOptions } from '../utils/options';
 import { startWatcher } from '../utils/watcher';
 
-const cli = cac('orval');
-
-startMessage({
+const orvalMessage = startMessage({
   name: pkg.name,
   version: pkg.version,
   description: pkg.description,
 });
-
-cli.version(pkg.version);
+const cli = program
+  .name('orval')
+  .description(orvalMessage)
+  .version(pkg.version);
 
 cli
-  .command(
-    '[config]',
-    'generate client with appropriate type-signatures from OpenAPI specs',
-    {
-      ignoreOptionDefaultValue: true,
-    },
-  )
   .option('-o, --output <path>', 'output file destination')
   .option('-i, --input <path>', 'input file (yaml or json openapi specs)')
   .option('-c, --config <path>', 'override flags by a config file')
   .option('-p, --project <name>', 'focus a project of the config')
-  .option('-m, --mode <name>', 'default mode that will be used')
-  .option('-c, --client <name>', 'default client that will be used')
-  .option('--mock', 'activate the mock')
+  .addOption(
+    new Option('-m, --mode <name>', 'default mode that will be used').choices(
+      Object.values(OutputMode),
+    ),
+  )
   .option(
     '-w, --watch [path]',
     'Watch mode, if path is not specified, it watches the input target',
   )
-  .option('--clean [path]', 'Clean output directory')
-  .option('--prettier [path]', 'Prettier generated files')
-  .option('--biome [path]', 'biome generated files')
-  .option('--tsconfig [path]', 'path to your tsconfig file')
-  .action(async (paths, cmd) => {
-    if (!cmd.config && isString(cmd.input) && isString(cmd.output)) {
+  .addOption(
+    new Option('--client <name>', 'default client that will be used').choices(
+      Object.values(OutputClient),
+    ),
+  )
+  .option('--mock', 'activate the mock')
+  .option('--clean [path...]', 'Clean output directory')
+  .option('--prettier', 'Prettier generated files')
+  .option('--biome', 'biome generated files')
+  .option('--tsconfig <path>', 'path to your tsconfig file')
+  .action(async (options) => {
+    log(orvalMessage);
+    if (
+      !options.config &&
+      isString(options.input) &&
+      isString(options.output)
+    ) {
       const normalizedOptions = await normalizeOptions({
-        input: cmd.input,
+        input: options.input,
         output: {
-          target: cmd.output,
-          clean: cmd.clean,
-          prettier: cmd.prettier,
-          biome: cmd.biome,
-          mock: cmd.mock,
-          client: cmd.client,
-          mode: cmd.mode,
-          tsconfig: cmd.tsconfig,
+          target: options.output,
+          clean: options.clean,
+          prettier: options.prettier,
+          biome: options.biome,
+          mock: options.mock,
+          client: options.client,
+          mode: options.mode,
+          tsconfig: options.tsconfig,
         },
       });
 
-      if (cmd.watch) {
+      if (options.watch) {
         await startWatcher(
-          cmd.watch,
+          options.watch,
           async () => {
             try {
               await generateSpec(process.cwd(), normalizedOptions);
@@ -82,22 +96,21 @@ cli
         }
       }
     } else {
-      await generateConfig(cmd.config, {
-        projectName: cmd.project,
-        watch: cmd.watch,
-        clean: cmd.clean,
-        prettier: cmd.prettier,
-        biome: cmd.biome,
-        mock: cmd.mock,
-        client: cmd.client,
-        mode: cmd.mode,
-        tsconfig: cmd.tsconfig,
-        input: cmd.input,
-        output: cmd.output,
+      await generateConfig(options.config, {
+        projectName: options.project,
+        watch: options.watch,
+        clean: options.clean,
+        prettier: options.prettier,
+        biome: options.biome,
+        mock: options.mock,
+        client: options.client,
+        mode: options.mode,
+        tsconfig: options.tsconfig,
+        input: options.input,
+        output: options.output,
       });
     }
   });
 
-cli.help();
-
-cli.parse(process.argv);
+// TODO when moving to pure ESM change void to await
+void cli.parseAsync(process.argv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,6 +2202,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@commander-js/extra-typings@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@commander-js/extra-typings@npm:14.0.0"
+  peerDependencies:
+    commander: ~14.0.0
+  checksum: 10c0/b064889e254e1c895886ec8148ac6e0d9bfa3c0336b9ee58124178308819dcf008f15e2a7abdc89b6c1ac3bdbd8003d8cfdaf363971d41dcce64b28c9714af12
+  languageName: node
+  linkType: hard
+
 "@commitlint/cli@npm:^19.8.1":
   version: 19.8.1
   resolution: "@commitlint/cli@npm:19.8.1"
@@ -10705,6 +10714,13 @@ __metadata:
   version: 13.1.0
   resolution: "commander@npm:13.1.0"
   checksum: 10c0/7b8c5544bba704fbe84b7cab2e043df8586d5c114a4c5b607f83ae5060708940ed0b5bd5838cf8ce27539cde265c1cbd59ce3c8c6b017ed3eec8943e3a415164
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.1":
+  version: 14.0.1
+  resolution: "commander@npm:14.0.1"
+  checksum: 10c0/64439c0651ddd01c1d0f48c8f08e97c18a0a1fa693879451f1203ad01132af2c2aa85da24cf0d8e098ab9e6dc385a756be670d2999a3c628ec745c3ec124587b
   languageName: node
   linkType: hard
 
@@ -19704,6 +19720,7 @@ __metadata:
   resolution: "orval@workspace:packages/orval"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^12.0.0"
+    "@commander-js/extra-typings": "npm:^14.0.0"
     "@orval/angular": "workspace:*"
     "@orval/axios": "workspace:*"
     "@orval/core": "workspace:*"
@@ -19717,9 +19734,9 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     "@types/js-yaml": "npm:^4.0.9"
     "@types/lodash.uniq": "npm:^4.5.9"
-    cac: "npm:^6.7.14"
     chalk: "npm:^4.1.2"
     chokidar: "npm:^4.0.3"
+    commander: "npm:^14.0.1"
     enquirer: "npm:^2.4.1"
     eslint: "npm:^9.35.0"
     execa: "npm:^5.1.1"


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Changed `cac` for `commander`. `cac` haven't been updated in 3 years and `commander` with `@commander-js/extra-typings` provides accurate types for the input options.

`-c` from `-c, --client <name>` was conflicting with `-c, --config <path>`. Only `-c, --config <path>` was mentioned in the docs so I kept that one and removed `-c` from `--client`

`--clean` actually accepts a list of paths, fixed that

`--prettier` doesn't accept a path, fixed that

`--biome` doesn't accept a path, fixed that

`--tsconfig` requires a path so made the path required