### PR TITLE
chore: disable turbo deamon to fix file locks in node_modules

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["ORVAL_DEBUG_FILTER", "CI", "DEBUG"],
+  // disable background process as it is causing issues with file locks in the node_modules folder
+  "daemon": false,
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Disables turbo's deamon mode to fix file locks in node_modules

https://turborepo.com/docs/reference/configuration#daemon