### PR TITLE
chore: use yarn to run clean/nuke scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,8 @@
     "lint:samples": "turbo run lint --filter='./samples/**'",
     "dev": "turbo run dev --filter='./packages/*'",
     "clean": "rimraf .turbo",
-    "nuke": "rimraf .turbo .yarn node_modules",
-    "clean:all": "turbo run clean",
-    "nuke:all": "turbo run nuke"
+    "clean:all": "yarn workspaces foreach -A run clean",
+    "nuke:all": "yarn workspaces foreach -A run nuke && rimraf .turbo .yarn node_modules"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/turbo.json
+++ b/turbo.json
@@ -20,10 +20,6 @@
     "test": {
       "outputs": []
     },
-    "clean": { "cache": false },
-    "//#clean": { "cache": false },
-    "nuke": { "cache": false },
-    "//#nuke": { "cache": false },
     "generate-api": {
       "dependsOn": ["orval#build"]
     }


### PR DESCRIPTION
## Status

<!--- **READY/WIP/HOLD** --->

**READY**

## Description

Use yarn to run the clean/nuke scripts as turbo would fail to delete itself and other issues preventing the succesful rimraf-ing

Had to remove the root `nuke` script as it would remove the root node_modules folder first causing it to fail.
`nuke:all` will still nuke the root workspace