### PR TITLE
chore: removes yarn restriction as release-it uses npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
       "name": "node",
       "version": ">=24",
       "onFail": "error"
-    },
-    "packageManager": {
-      "name": "yarn",
-      "onFail": "error"
     }
   },
   "scripts": {


### PR DESCRIPTION
Removes yarn restriction from devEngines as release-it uses npm which caused the release flow to fail.

Upstream issue filed: https://github.com/release-it/release-it/issues/1249