### PR TITLE
chore: disable postinstall scripts to prevent supply chain attacks

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,10 @@
 nodeLinker: node-modules
 
 packageExtensions:
+  # issue with @vue/test-utils@2.4.6
+  # https://github.com/vuejs/test-utils/issues/2581
   '@vue/test-utils@*':
     peerDependencies:
       vue: '*'
+
+enableScripts: false

--- a/samples/angular-app/package.json
+++ b/samples/angular-app/package.json
@@ -34,6 +34,11 @@
     "typescript": "~5.8.3",
     "vitest": "^3.2.4"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "msw": {
     "workerDirectory": [
       "public"

--- a/samples/basic/package.json
+++ b/samples/basic/package.json
@@ -19,5 +19,10 @@
     "@faker-js/faker": "^9.9.0",
     "axios": "^1.12.2",
     "msw": "^2.11.2"
+  },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
   }
 }

--- a/samples/next-app-with-fetch/package.json
+++ b/samples/next-app-with-fetch/package.json
@@ -27,5 +27,10 @@
     "postcss": "8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3"
+  },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
   }
 }

--- a/samples/react-app-with-swr/basic/package.json
+++ b/samples/react-app-with-swr/basic/package.json
@@ -18,6 +18,11 @@
   "devDependencies": {
     "orval": "workspace:*"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/samples/react-app/package.json
+++ b/samples/react-app/package.json
@@ -39,6 +39,11 @@
     "msw": "^2.11.2",
     "orval": "workspace:*"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "msw": {
     "workerDirectory": "public"
   }

--- a/samples/react-query/basic/package.json
+++ b/samples/react-query/basic/package.json
@@ -19,6 +19,11 @@
   "devDependencies": {
     "orval": "workspace:*"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/samples/react-query/custom-client/package.json
+++ b/samples/react-query/custom-client/package.json
@@ -20,6 +20,11 @@
   "devDependencies": {
     "orval": "workspace:*"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/samples/svelte-query/basic/package.json
+++ b/samples/svelte-query/basic/package.json
@@ -37,6 +37,11 @@
     "@tanstack/svelte-query": "^4.41.0",
     "axios": "^1.12.2"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "msw": {
     "workerDirectory": "static"
   }

--- a/samples/vue-query/vue-query-basic/package.json
+++ b/samples/vue-query/vue-query-basic/package.json
@@ -30,6 +30,11 @@
     "vitest": "^3.2.4",
     "vue-tsc": "^2.2.12"
   },
+  "dependenciesMeta": {
+    "msw": {
+      "built": true
+    }
+  },
   "msw": {
     "workerDirectory": "public"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9165,6 +9165,9 @@ __metadata:
     tslib: "npm:^2.8.1"
     typescript: "npm:~5.8.3"
     vitest: "npm:^3.2.4"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -9840,6 +9843,9 @@ __metadata:
     msw: "npm:^2.11.2"
     npm-run-all: "npm:^4.1.5"
     orval: "workspace:*"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -18587,6 +18593,9 @@ __metadata:
     react-dom: "npm:^18.3.1"
     tailwindcss: "npm:^3.4.17"
     typescript: "npm:~5.8.3"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -21426,6 +21435,9 @@ __metadata:
     react-query: "npm:^3.39.3"
     react-scripts: "npm:^5.0.1"
     typescript: "npm:~5.8.3"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -21518,6 +21530,9 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-scripts: "npm:^5.0.1"
     typescript: "npm:~5.8.3"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -21539,6 +21554,9 @@ __metadata:
     react-query: "npm:^3.39.3"
     react-scripts: "npm:^5.0.1"
     typescript: "npm:~5.8.3"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -24239,6 +24257,9 @@ __metadata:
     tslib: "npm:^2.8.1"
     typescript: "npm:~5.8.3"
     vite: "npm:^4.5.14"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -24375,6 +24396,9 @@ __metadata:
     react-scripts: "npm:^5.0.1"
     swr: "npm:^2.3.6"
     typescript: "npm:~5.8.3"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -26097,6 +26121,9 @@ __metadata:
     vitest: "npm:^3.2.4"
     vue: "npm:^3.5.21"
     vue-tsc: "npm:^2.2.12"
+  dependenciesMeta:
+    msw:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Disabled postinstall scripts.
This should help prevent supply chain attacks.

Packages that are deemed safe/trusted that have postinstall scripts must be whitelisted using [dependenciesMeta.built](https://yarnpkg.com/configuration/manifest#dependenciesMeta.built)

Example
```jsonc
// package.json
{
  // omitted...
  "dependenciesMeta": {
    "msw": {
      "built": true
    }
  }
}
```

I didn't build or start any of the samples. So if they're having trouble running after this change, then a package post likely needs to be whitelisted. We then need to decide if we trust that package and whitelist it.