### PR TITLE
chore: set published packages to access=public

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,3 +8,5 @@ packageExtensions:
       vue: '*'
 
 enableScripts: false
+npmPublishAccess: public
+npmRegistryServer: https://registry.npmjs.org


### PR DESCRIPTION
when publishing `@scoped` packages, like `@orval/...`, they default to restricted and must be manually set to public

https://yarnpkg.com/configuration/yarnrc#npmPublishAccess