### PR TITLE
chore: removes the last require() usages

### DIFF
--- a/.github/workflows/deploy-doc.yaml
+++ b/.github/workflows/deploy-doc.yaml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           # https://github.com/actions/setup-node/issues/1357
           package-manager-cache: false
       - name: Install Vercel CLI

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.35.0",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "esbuild-plugin-alias": "^0.2.1",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/core/src/generators/mutator.ts
+++ b/packages/core/src/generators/mutator.ts
@@ -63,12 +63,10 @@ export const generateMutator = async ({
     ? `${pascal(name)}${BODY_TYPE_NAME}`
     : BODY_TYPE_NAME;
 
-  const { file, cached } = await loadFile<string>(importPath, {
-    isDefault: false,
+  const { file, cached } = await loadFile(importPath, {
     root: workspace,
     alias: mutator.alias,
     tsconfig,
-    load: false,
   });
 
   if (file) {

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -15,6 +15,9 @@
       "default": "./dist/index.js"
     }
   },
+  "engines": {
+    "node": ">=22.18.0"
+  },
   "keywords": [
     "rest",
     "client",

--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -1,3 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import url from 'node:url';
+
 import {
   asyncReduce,
   type ConfigExternal,
@@ -6,13 +11,11 @@ import {
   type GlobalOptions,
   isFunction,
   isString,
-  loadFile,
   log,
   logError,
   type NormalizedConfig,
   type NormalizedOptions,
   removeFilesAndEmptyFolders,
-  upath,
 } from '@orval/core';
 
 import { importSpecs } from './import-specs';
@@ -90,23 +93,47 @@ export const generateSpecs = async (
     throw new Error('One or more project failed, see above for details');
 };
 
+function findConfigFile(configFilePath?: string) {
+  if (configFilePath) {
+    if (!fs.existsSync(configFilePath))
+      throw new Error(`Config file ${configFilePath} does not exist`);
+
+    return configFilePath;
+  }
+
+  const root = process.cwd();
+  const exts = ['.ts', '.js', '.mjs', '.cjs'];
+  for (const ext of exts) {
+    const fullPath = path.resolve(root, `orval.config${ext}`);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  throw new Error(`No config file found in ${root}`);
+}
+
 export const generateConfig = async (
   configFile?: string,
   options?: GlobalOptions,
 ) => {
-  const {
-    path,
-    file: configExternal,
-    error,
-  } = await loadFile<ConfigExternal>(configFile, {
-    defaultFileName: 'orval.config',
-  });
-
-  if (!configExternal) {
-    throw new Error(`failed to load from ${path} => ${error}`);
+  const configFilePath = findConfigFile(configFile);
+  let configExternal: ConfigExternal;
+  try {
+    const importPath = url.pathToFileURL(configFilePath).href;
+    const importedModule = (await import(importPath)) as {
+      default?: ConfigExternal;
+    };
+    if (importedModule.default === undefined) {
+      throw new Error(`${configFilePath} doesn't have a default export`);
+    }
+    configExternal = importedModule.default;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : 'unknown error';
+    throw new Error(`failed to load from ${configFilePath} => ${errorMsg}`);
   }
 
-  const workspace = upath.dirname(path);
+  const workspace = path.dirname(configFilePath);
 
   const config = await (isFunction(configExternal)
     ? configExternal()

--- a/packages/tsdown.base.ts
+++ b/packages/tsdown.base.ts
@@ -2,7 +2,7 @@ import type { UserConfig } from 'tsdown';
 
 export const baseOptions: UserConfig = {
   entry: ['src/index.ts'],
-  target: 'node18',
+  target: 'node22.18',
   format: 'cjs',
   tsconfig: 'tsconfig.build.json',
   sourcemap: true,

--- a/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/endpoints/pets/pets.msw.ts
@@ -57,7 +57,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getShowPetTextResponseMock = (): string => faker.word.sample();

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -140,7 +140,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/hono/hono-with-fetch-client/next-app/package.json
+++ b/samples/hono/hono-with-fetch-client/next-app/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "postcss": "8.5.6",

--- a/samples/mcp/petstore/package.json
+++ b/samples/mcp/petstore/package.json
@@ -12,7 +12,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "orval": "workspace:*",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3"

--- a/samples/next-app-with-fetch/package.json
+++ b/samples/next-app-with-fetch/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "eslint": "^9.35.0",

--- a/samples/react-app-with-swr/basic/package.json
+++ b/samples/react-app-with-swr/basic/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@faker-js/faker": "^9.9.0",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "axios": "^1.12.2",

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -44,7 +44,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-app/package.json
+++ b/samples/react-app/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.9.0",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "axios": "^1.12.2",

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-query/basic/package.json
+++ b/samples/react-query/basic/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.9.0",
     "@tanstack/react-query": "~5.62.16",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "ajv": "^8.17.1",

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -77,7 +77,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-query/custom-client/package.json
+++ b/samples/react-query/custom-client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.9.0",
     "@types/faker": "^5.5.9",
-    "@types/node": "^20.19.14",
+    "@types/node": "^22.18.10",
     "@types/react": "^18.3.24",
     "@types/react-dom": "^18.3.7",
     "axios": "^1.12.2",

--- a/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/custom-client/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -77,7 +77,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -45,7 +45,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -7510,12 +7510,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.19.14":
-  version: 20.19.14
-  resolution: "@types/node@npm:20.19.14"
+"@types/node@npm:^22.18.10":
+  version: 22.18.10
+  resolution: "@types/node@npm:22.18.10"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/cb6a1e3eda43056bf3135d46affbbe5883600adc1928f99247dd9b1a5254823174a91e2d7c6734c2c247a4eb889cb81b0113306e61bf8f4a709b55e86a325f79
+  checksum: 10c0/37b34553f1953ab8fc25b7467d44701446400f62547adb62c842cebac091350985470aeed87acd60f5295778c370d9721d477310e643677a7eab03a8dc6ed74f
   languageName: node
   linkType: hard
 
@@ -17065,7 +17065,7 @@ __metadata:
   resolution: "mcp-petstore@workspace:samples/mcp/petstore"
   dependencies:
     "@modelcontextprotocol/sdk": "npm:1.18.0"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     orval: "workspace:*"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.8.3"
@@ -17754,7 +17754,7 @@ __metadata:
   resolution: "next-app-with-fetch@workspace:samples/next-app-with-fetch"
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
     eslint: "npm:^9.35.0"
@@ -17778,7 +17778,7 @@ __metadata:
   resolution: "next-app@workspace:samples/hono/hono-with-fetch-client/next-app"
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
     next: "npm:^15.5.3"
@@ -18625,7 +18625,7 @@ __metadata:
     "@commitlint/cli": "npm:^19.8.1"
     "@commitlint/config-conventional": "npm:^19.8.1"
     "@eslint/js": "npm:^9.35.0"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     esbuild-plugin-alias: "npm:^0.2.1"
     eslint: "npm:^9.35.0"
     eslint-config-prettier: "npm:^10.1.8"
@@ -20389,7 +20389,7 @@ __metadata:
   resolution: "react-app@workspace:samples/react-app"
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
     axios: "npm:^1.12.2"
@@ -20484,7 +20484,7 @@ __metadata:
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
     "@tanstack/react-query": "npm:~5.62.16"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
     ajv: "npm:^8.17.1"
@@ -20507,7 +20507,7 @@ __metadata:
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
     "@types/faker": "npm:^5.5.9"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
     axios: "npm:^1.12.2"
@@ -23245,7 +23245,7 @@ __metadata:
   resolution: "swr-basic@workspace:samples/react-app-with-swr/basic"
   dependencies:
     "@faker-js/faker": "npm:^9.9.0"
-    "@types/node": "npm:^20.19.14"
+    "@types/node": "npm:^22.18.10"
     "@types/react": "npm:^18.3.24"
     "@types/react-dom": "npm:^18.3.7"
     axios: "npm:^1.12.2"


### PR DESCRIPTION
This removes the last usages of legacy `require` paving the way for ESM

I had to bump the minimum required node version to 22.18.0. This is a **breaking change**.

Even though tests pass and no meaningful changes to samples were made, I doubt this will work for all users.