### PR TITLE
Docs: Update output.md

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -119,7 +119,7 @@ Default Value: `camelCase`.
 
 Specify the naming convention for the generated **files**.
 
-If you're looking for **property keys** naming convention, see [namingConvention](#namingconvention-for-property-keys).
+If you're looking for **property keys** naming convention, see [namingConvention](#namingconvention-property-keys).
 
 ```js
 module.exports = {


### PR DESCRIPTION
The link anchor in naming conventions (file names) that should point to the naming convention section for property keys, was incorrectly specified. It is now fixed.
