### PR TITLE
fix: don't mangle external URL $ref

### DIFF
--- a/packages/core/src/getters/ref.ts
+++ b/packages/core/src/getters/ref.ts
@@ -87,9 +87,15 @@ export const getRefInfo = (
     };
   }
 
-  const path = isUrl(context.specKey)
-    ? resolveUrl(context.specKey, pathname)
-    : upath.resolve(getFileInfo(context.specKey).dirname, pathname);
+  let path: string;
+
+  if (isUrl($ref)) {
+    path = $ref;
+  } else if (isUrl(context.specKey)) {
+    path = resolveUrl(context.specKey, pathname);
+  } else {
+    path = upath.resolve(getFileInfo(context.specKey).dirname, pathname);
+  }
 
   return {
     name: sanitize(pascal(originalName) + suffix, {

--- a/packages/core/src/utils/path.ts
+++ b/packages/core/src/utils/path.ts
@@ -61,11 +61,7 @@ export const relativeSafe = (from: string, to: string) => {
 
 export const getSpecName = (specKey: string, target: string) => {
   if (isUrl(specKey)) {
-    const url = new URL(target);
-    return specKey
-      .replace(url.origin, '')
-      .replace(getFileInfo(url.pathname).dirname, '')
-      .replace(`.${getExtension(specKey)}`, '');
+    return specKey;
   }
 
   return (

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -17,7 +17,7 @@ import { importOpenApi } from './import-open-api';
 const resolveSpecs = async (
   path: string,
   { validate, ...options }: SwaggerParserOptions,
-  isUrl: boolean,
+  _isUrl: boolean,
   isOnlySchema: boolean,
 ) => {
   try {
@@ -37,7 +37,7 @@ const resolveSpecs = async (
 
     const data = (await SwaggerParser.resolve(path, options)).values();
 
-    if (isUrl) {
+    if (_isUrl) {
       return data;
     }
 
@@ -45,7 +45,7 @@ const resolveSpecs = async (
     return Object.fromEntries(
       Object.entries(data)
         .sort()
-        .map(([key, value]) => [upath.resolve(key), value]),
+        .map(([key, value]) => [isUrl(key) ? key : upath.resolve(key), value]),
     );
   } catch {
     const file = await fs.readFile(path, 'utf8');

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -458,4 +458,16 @@ export default defineConfig({
     },
     input: '../specifications/multi-files-with-same-import-names/api.yaml',
   },
+  'external-ref': {
+    input: {
+      target: '../specifications/external-ref.yaml',
+      parserOptions: {
+        resolve: {
+          external: true,
+          http: {},
+        },
+      },
+    },
+    output: '../generated/default/external-ref/endpoints.ts',
+  },
 });

--- a/tests/specifications/external-ref.yaml
+++ b/tests/specifications/external-ref.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 0.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+paths:
+  /points:
+    get:
+      operationId: 'get-points'
+      responses:
+        '200':
+          description: A JSON array of GeoJSON points
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'https://geojson.org/schema/Point.json'


### PR DESCRIPTION
It should be valid for a local file `target.yaml` to reference an external schema like GeoJSON. Preserve these URLs as-is and don't turn them into fake file paths.

Fix https://github.com/orval-labs/orval/issues/1557

