### PR TITLE
fix(zod): consider path-level parameters when generating zod schemas

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1035,7 +1035,15 @@ const generateZodRoute = async (
     | PathItemObject
     | undefined;
 
-  const parameters = spec?.[verb]?.parameters!;
+  if (spec == null) {
+    throw new Error(`No such path ${pathRoute} in ${context.specKey}`);
+  }
+
+  const parameters = [
+    ...(spec.parameters ?? []),
+    ...(spec[verb]?.parameters ?? []),
+  ];
+
   const parsedParameters = parseParameters({
     data: parameters,
     context,
@@ -1045,7 +1053,7 @@ const generateZodRoute = async (
     generate: override.zod.generate,
   });
 
-  const requestBody = spec?.[verb]?.requestBody;
+  const requestBody = spec[verb]?.requestBody;
   const parsedBody = parseBodyAndResponse({
     data: requestBody,
     context,
@@ -1058,8 +1066,8 @@ const generateZodRoute = async (
 
   const responses = (
     context.output.override.zod.generateEachHttpStatus
-      ? Object.entries(spec?.[verb]?.responses ?? {})
-      : [['', spec?.[verb]?.responses[200]]]
+      ? Object.entries(spec[verb]?.responses ?? {})
+      : [['', spec[verb]?.responses[200]]]
   ) as [string, ResponseObject | ReferenceObject][];
   const parsedResponses = responses.map(([code, response]) =>
     parseBodyAndResponse({

--- a/tests/configs/hono.config.ts
+++ b/tests/configs/hono.config.ts
@@ -1,81 +1,13 @@
 import { defineConfig } from 'orval';
 
 export default defineConfig({
-  petstoreTagsSplit: {
-    input: '../specifications/petstore.yaml',
+  endpointParameters: {
+    input: '../specifications/parameters.yaml',
     output: {
-      target: '../generated/hono/tags-split/endpoints.ts',
-      schemas: '../generated/hono/tags-split/schemas',
-      mode: 'tags-split',
-      client: 'hono',
-    },
-  },
-  petstoreTags: {
-    input: '../specifications/petstore.yaml',
-    output: {
-      target: '../generated/hono/tags/endpoints.ts',
-      schemas: '../generated/hono/tags/schemas',
-      mode: 'tags',
-      client: 'hono',
-    },
-  },
-  petstoreSplit: {
-    input: '../specifications/petstore.yaml',
-    output: {
-      target: '../generated/hono/petstore-split/endpoints.ts',
-      schemas: '../generated/hono/petstore-split/schemas',
+      target: '../generated/hono/endpoint-parameters/endpoints.ts',
+      schemas: '../generated/hono/endpoint-parameters/schemas',
       mode: 'split',
       client: 'hono',
-    },
-  },
-  petstoreSplitHandlers: {
-    input: '../specifications/petstore.yaml',
-    output: {
-      target: '../generated/hono/petstore-split-handlers/endpoints.ts',
-      schemas: '../generated/hono/petstore-split-handlers/handlers/schemas',
-      mode: 'split',
-      client: 'hono',
-      override: {
-        hono: {
-          handlers: '../generated/hono/petstore-split-handlers/handlers',
-        },
-      },
-    },
-  },
-  petstoreSplitValidatorOutputPath: {
-    input: '../specifications/petstore.yaml',
-    output: {
-      target:
-        '../generated/hono/petstore-split-validator-output-path/endpoints.ts',
-      schemas:
-        '../generated/hono/petstore-split-validator-output-path/handlers/schemas',
-      mode: 'split',
-      client: 'hono',
-      override: {
-        hono: {
-          handlers:
-            '../generated/hono/petstore-split-validator-output-path/handlers',
-          validatorOutputPath:
-            '../generated/hono/petstore-split-validator-output-path/handlers/validator.ts',
-        },
-      },
-    },
-  },
-  petstoreTagsSplitCompositeRoute: {
-    input: '../specifications/petstore.yaml',
-    output: {
-      target: '../generated/hono/petstore-tags-split-composite-route/endpoints',
-      schemas: '../generated/hono/petstore-tags-split-composite-route/schemas',
-      mode: 'tags-split',
-      client: 'hono',
-      override: {
-        hono: {
-          validatorOutputPath:
-            '../generated/hono/petstore-tags-split-composite-route/endpoints/validator.ts',
-          compositeRoute:
-            'generated/hono/petstore-tags-split-composite-route/routes.ts',
-        },
-      },
     },
   },
 });


### PR DESCRIPTION
OpenAPI permits parameters at the path object level and at the verb level. `generateZodRoute` only looks for parameters in the latter. Fix it to merge both levels.

Reuse the parameters.yaml file in the hono test cases to catch the issue with tsc. Other code like the hono generator correctly generates imports for these *Params types, expecting the zod generator to emit them. The bug causes compilation to fail with "foo.ts has no exported member named barParams".

Also reduce the number of optional chaining operators by null checking `spec` up front. generateZodRoute
probably shouldn't proceed if the given path isn't in the API description.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
