### PR TITLE
fix(useOperationIdAsQueryKey): make sure operationName is returned as string

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1372,7 +1372,7 @@ ${
 
         // Use operation ID as query key if enabled, otherwise use route string
         const queryKeyIdentifier = override.query.useOperationIdAsQueryKey
-          ? operationName
+          ? `"${operationName}"`
           : routeString;
 
         // Note: do not unref() params in Vue - this will make key lose reactivity


### PR DESCRIPTION
It seems like i missed in my change in #2314 to make sure the operationName is returned as a string.