### PR TITLE
fix(hono): zValidator not imported consistently

### DIFF
--- a/tests/configs/hono.config.ts
+++ b/tests/configs/hono.config.ts
@@ -10,4 +10,12 @@ export default defineConfig({
       client: 'hono',
     },
   },
+  examples: {
+    input: '../specifications/examples.yaml',
+    output: {
+      target: '../generated/hono/examples/endpoints.ts',
+      mode: 'tags-split',
+      client: 'hono',
+    },
+  },
 });

--- a/tests/specifications/examples.yaml
+++ b/tests/specifications/examples.yaml
@@ -9,6 +9,7 @@ info:
 paths:
   /users:
     get:
+      tags: [users]
       operationId: 'get-users'
       responses:
         '200':
@@ -24,6 +25,7 @@ paths:
                   $ref: '#/components/examples/GetUsersResponseExample'
   /users2:
     get:
+      tags: [users2]
       operationId: 'get-users-2'
       responses:
         '200':


### PR DESCRIPTION
The branches in `generateHandlers` independently compute whether the generated code requires the zValidator import. This code hasn't been kept in sync, however, notably for the `tags` and `tags-split` modes. In this case, `generateHandlers` assesses that `zValidator` isn't needed, but `getHonoHandlers` produces code that validates the response body anyway, resulting in a Typescript compilation error for first-time users of orval.

I don't prefer code generation with string manipulation but don't want to make any drastic changes to someone else's codebase. Instead, have `getHonoHandlers` itself report whether `zValidator` is required by bundling this flag alongside the generated code in a tuple. Also, handle the one verb and many verbs per file cases uniformly by making `getHonoHandlers` variadic. It performs the same kind of reduction that was used before, but also reduces over the zValidator flag.

Add tests for this condition to the hono configs. Tag the verbs in `examples.yaml` to trigger the behavior.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
