### PR TITLE
fix(zod): update type handling from 'any' to 'unknown' in schema definitions

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -86,7 +86,7 @@ const resolveZodType = (schema: SchemaObject | SchemaObject31) => {
       return 'number';
     }
     default: {
-      return type ?? 'any';
+      return type ?? 'unknown';
     }
   }
 };

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -55,7 +55,7 @@ const record: ZodValidationSchemaDefinition = {
             [
               'additionalProperties',
               {
-                functions: [['any', undefined]],
+                functions: [['unknown', undefined]],
                 consts: [],
               },
             ],
@@ -129,7 +129,7 @@ describe('parseZodValidationSchemaDefinition', () => {
     );
 
     expect(parseResult.zod).toBe(
-      'zod.object({\n  "queryParams": zod.record(zod.string(), zod.any())\n})',
+      'zod.object({\n  "queryParams": zod.record(zod.string(), zod.unknown())\n})',
     );
   });
 });
@@ -323,7 +323,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
                 [
                   'additionalProperties',
                   {
-                    functions: [['any', undefined]],
+                    functions: [['unknown', undefined]],
                     consts: [],
                   },
                 ],
@@ -336,7 +336,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
                 [
                   'additionalProperties',
                   {
-                    functions: [['any', undefined]],
+                    functions: [['unknown', undefined]],
                     consts: [],
                   },
                 ],
@@ -1422,7 +1422,7 @@ describe('parsePrefixItemsArrayAsTupleZod', () => {
             },
             {
               consts: [],
-              functions: [['any', undefined]],
+              functions: [['unknown', undefined]],
             },
           ],
         ],
@@ -1475,7 +1475,7 @@ describe('parsePrefixItemsArrayAsTupleZod', () => {
             },
             {
               consts: [],
-              functions: [['any', undefined]],
+              functions: [['unknown', undefined]],
             },
           ],
         ],


### PR DESCRIPTION
Sometime ago someone changed the behaviour of not-defined types generation e.g. additionalProperties, that are now defaulting to `unknow` types and not `any` which is the most correct and safe option ✔️ . However zod schemas are still being generating `zod.any()` instead of `zod.unknow()`. This PR fixes it.

With this PR now:
- TypeScript types (from core) and Zod schemas (from zod package) are consistent;
- Both use the safer unknown approach for untyped schemas;

Thank you! Happy to discuss any alternative option!
