### PR TITLE
feat: option to generate query invalidations

### DIFF
--- a/docs/src/pages/reference/configuration/output.md
+++ b/docs/src/pages/reference/configuration/output.md
@@ -1209,6 +1209,25 @@ export const prefetchGetCategories = async <
 };
 ```
 
+#### useInvalidate
+
+Type: `Boolean`.
+
+Use to generate <a href="https://tanstack.com/query/latest/docs/framework/react/guides/query-invalidation" target="_blank">invalidation</a> functions.
+
+Example generated function:
+
+```js
+export const invalidateShowPetById = async (
+ queryClient: QueryClient, petId: string, options?: InvalidateOptions
+  ): Promise<QueryClient> => {
+
+  await queryClient.invalidateQueries({ queryKey: getShowPetByIdQueryKey(petId) }, options);
+
+  return queryClient;
+}
+```
+
 #### useInfiniteQueryParam
 
 Type: `String`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -578,6 +578,7 @@ export type NormalizedQueryOptions = {
   useSuspenseInfiniteQuery?: boolean;
   useInfiniteQueryParam?: string;
   usePrefetch?: boolean;
+  useInvalidate?: boolean;
   options?: any;
   queryKey?: NormalizedMutator;
   queryOptions?: NormalizedMutator;
@@ -599,6 +600,7 @@ export type QueryOptions = {
   useSuspenseInfiniteQuery?: boolean;
   useInfiniteQueryParam?: string;
   usePrefetch?: boolean;
+  useInvalidate?: boolean;
   options?: any;
   queryKey?: Mutator;
   queryOptions?: Mutator;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -648,6 +648,9 @@ const normalizeQueryOptions = (
     ...(isUndefined(queryOptions.usePrefetch)
       ? {}
       : { usePrefetch: queryOptions.usePrefetch }),
+    ...(isUndefined(queryOptions.useInvalidate)
+      ? {}
+      : { useInvalidate: queryOptions.useInvalidate }),
     ...(isUndefined(queryOptions.useQuery)
       ? {}
       : { useQuery: queryOptions.useQuery }),

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -22,6 +22,7 @@ export const normalizeQueryOptions = (
 ): NormalizedQueryOptions => {
   return {
     ...(queryOptions.usePrefetch ? { usePrefetch: true } : {}),
+    ...(queryOptions.useInvalidate ? { useInvalidate: true } : {}),
     ...(queryOptions.useQuery ? { useQuery: true } : {}),
     ...(queryOptions.useInfinite ? { useInfinite: true } : {}),
     ...(queryOptions.useInfiniteQueryParam

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -549,4 +549,19 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  useInvalidate: {
+    output: {
+      target: '../generated/react-query/use-invalidate/endpoints.ts',
+      schemas: '../generated/react-query/use-invalidate/model',
+      client: 'react-query',
+      override: {
+        query: {
+          useInvalidate: true,
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
 });


### PR DESCRIPTION
I implemented a new option `useInvalidate` to generate an invalidate function for query-based clients

closes #2442