### PR TITLE
fix(zod): add line breaks to export constants

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -545,6 +545,9 @@ export const generateZodValidationSchemaDefinition = (
       );
       functions.push(['multipleOf', `${name}MultipleOf${constsCounterValue}`]);
     }
+    if (min !== undefined || multipleOf !== undefined || max !== undefined) {
+      consts.push(`\n`);
+    }
   }
 
   if (matches) {
@@ -1086,7 +1089,7 @@ const generateZodRoute = async (
     | PathItemObject
     | undefined;
 
-  if (spec == null) {
+  if (spec == undefined) {
     throw new Error(`No such path ${pathRoute} in ${context.specKey}`);
   }
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -930,7 +930,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['min', 'testNumberMinMin'],
           ['optional', undefined],
         ],
-        consts: ['export const testNumberMinMin = 10;'],
+        consts: ['export const testNumberMinMin = 10;', '\n'],
       });
 
       const parsed = parseZodValidationSchemaDefinition(
@@ -963,7 +963,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['max', 'testNumberMaxMax'],
           ['optional', undefined],
         ],
-        consts: ['export const testNumberMaxMax = 99;'],
+        consts: ['export const testNumberMaxMax = 99;', '\n'],
       });
 
       const parsed = parseZodValidationSchemaDefinition(
@@ -1002,6 +1002,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         consts: [
           'export const testNumberMinMaxMin = 10;',
           'export const testNumberMinMaxMax = 99;',
+          '\n',
         ],
       });
 
@@ -1045,6 +1046,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           'export const testNumberMinMaxMultipleMin = 10;',
           'export const testNumberMinMaxMultipleMax = 99;',
           'export const testNumberMinMaxMultipleMultipleOf = 2;',
+          '\n',
         ],
       });
 


### PR DESCRIPTION
Fix #2451
