### PR TITLE
feat: change mock delay default from 1000 to false (BREAKING CHANGE)

### DIFF
--- a/packages/mock/src/delay.ts
+++ b/packages/mock/src/delay.ts
@@ -20,7 +20,7 @@ export const getDelay = (
       return overrideDelay;
     }
     default: {
-      return 1000;
+      return false;
     }
   }
 };


### PR DESCRIPTION
fix #2478

Changed the default mock delay from `1000` to `false` to disable delay by default.

## Summary
Changed the default value of `override.mock.delay` from `1000` to `false`.
Default delay creates noise for initial users. Disabling it by default provides a better out-of-the-box experience.
The default mock delay is now `false` (disabled) instead of `1000ms`. Users who want delay must explicitly set it.

```diff
// To maintain delay
export default {
  petstore: {
    output: {
+      mock: {
+        delay: 1000, // In milliseconds
+      },
    },
  },
};
