### PR TITLE
docs: add `Angular` to using `paramsSerializerOptions` clients

### DIFF
--- a/docs/src/pages/reference/configuration/output.mdx
+++ b/docs/src/pages/reference/configuration/output.mdx
@@ -2688,7 +2688,7 @@ export const customParamsSerializerFn = (
 
 Type: `Object`
 
-IMPORTANT: This is only valid when using Axios.
+IMPORTANT: This is only valid when using Axios or Angular.
 
 Use this property to specify how parameters are serialized. This is only taken into account when `paramsSerializer` is not defined.
 Currently, `qs` is the only available option. Read more about `qs` and its settings [here](https://www.npmjs.com/package/qs).


### PR DESCRIPTION
Originally, it was stated that only `Axios` uses `paramsSerializerOptions`, but in fact `Angular` is used.

https://github.com/orval-labs/orval/issues/434#issuecomment-3448422295

The following PR will be closed, and we will correct the documentation and mark the issue as resolved.

https://github.com/orval-labs/orval/pull/2483