### PR TITLE
chore: upgrade lib from es2023 to esnext, allows for modern js api usage

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["es2023"],
+    "lib": ["esnext"],
     "moduleDetection": "force",
     "module": "preserve",
     "moduleResolution": "bundler",


### PR DESCRIPTION
Allows for modern js api usage.

Node 22.18 (our current minimum required) have rather good compliance with esnext
https://node.green/

I tested with `using` (not supported in node 22.18) and it got downleveled*,  so this should have little risk

_*) tsdown is set to target node 22.18_