### PR TITLE
Fix TypeScript type error for arrays with enum and default values (#2427)

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -238,6 +238,17 @@ export const generateZodValidationSchemaDefinition = (
         rawStringified === undefined
           ? 'null'
           : rawStringified.replaceAll("'", '"');
+
+      // If the schema is an array with enum items, add 'as const' for proper TypeScript typing
+      const isArrayWithEnumItems =
+        Array.isArray(schema.default) &&
+        type === 'array' &&
+        schema.items &&
+        'enum' in schema.items;
+
+      if (isArrayWithEnumItems) {
+        defaultValue = `${defaultValue} as const`;
+      }
     }
     consts.push(`export const ${defaultVarName} = ${defaultValue};`);
   }

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -824,6 +824,92 @@ describe('generateZodValidationSchemaDefinition`', () => {
         "zod.union([zod.literal('cat'),zod.literal(1),zod.literal(true)]).optional()",
       );
     });
+
+    it('generates a default value for an array with enum items using "as const"', () => {
+      const schemaWithEnumArrayDefault: SchemaObject30 = {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['A', 'B', 'C'],
+        },
+        default: ['A'],
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithEnumArrayDefault,
+        context,
+        'testEnumArrayDefault',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          [
+            'array',
+            {
+              functions: [['enum', "['A', 'B', 'C']"]],
+              consts: [],
+            },
+          ],
+          ['default', 'testEnumArrayDefaultDefault'],
+        ],
+        consts: ['export const testEnumArrayDefaultDefault = ["A"] as const;'],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe(
+        "zod.array(zod.enum(['A', 'B', 'C'])).default(testEnumArrayDefaultDefault)",
+      );
+      expect(parsed.consts).toBe(
+        'export const testEnumArrayDefaultDefault = ["A"] as const;',
+      );
+    });
+
+    it('generates a default value for nested enum arrays in objects', () => {
+      const schemaWithNestedEnumArray: SchemaObject30 = {
+        type: 'object',
+        properties: {
+          some_enum: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['A', 'B', 'C'],
+            },
+            default: ['A'],
+          },
+        },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithNestedEnumArray,
+        context,
+        'postEnumBody',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.functions[0][0]).toBe('object');
+
+      // Check that the nested array default has 'as const'
+      const objectProperties = result.functions[0][1] as Record<
+        string,
+        ZodValidationSchemaDefinition
+      >;
+      const someEnumProperty = objectProperties['some_enum'];
+
+      expect(someEnumProperty.consts).toEqual(
+        expect.arrayContaining([expect.stringContaining('as const')]),
+      );
+    });
   });
   describe('number handling', () => {
     const context: ContextSpecs = {


### PR DESCRIPTION
## Fix TypeScript type error for arrays with enum and default values (#2427)

### Problem

When generating Zod validators for arrays of string enums with default values, TypeScript reports type incompatibility errors. The generated default variable is typed as `string[]` instead of the expected `("A" | "B" | "C")[]`.

**Before:**
```typescript
export const postEnumBodySomeEnumDefault = ["A"];

export const postEnumBody = zod.object({
  "some_enum": zod.array(zod.enum(['A', 'B', 'C'])).default(postEnumBodySomeEnumDefault)
  // Type error: Type 'string[]' is not assignable to type '("A" | "B" | "C")[]'
})
```

### Solution

Added type inference logic to detect when a schema is an array with enum items. When this condition is met, the default value is suffixed with `as const` to ensure proper TypeScript typing:

```typescript
const isArrayWithEnumItems = 
  Array.isArray(schema.default) && 
  type === 'array' && 
  schema.items && 
  'enum' in schema.items;

if (isArrayWithEnumItems) {
  defaultValue = `${defaultValue} as const`;
}
```

**After:**
```typescript
export const postEnumBodySomeEnumDefault = ["A"] as const;
// Now TypeScript correctly types this as ("A")[]
```