### PR TITLE
Features/2182 zod exclusive

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -199,17 +199,25 @@ export const generateZodValidationSchemaDefinition = (
     (Array.isArray(schema.type) && schema.type.includes('null'));
   const min = schema.minimum ?? schema.minLength ?? schema.minItems;
   const max = schema.maximum ?? schema.maxLength ?? schema.maxItems;
-  
+
   // Handle exclusiveMinimum and exclusiveMaximum (OpenAPI 3.0 vs 3.1 compatibility)
   // OpenAPI 3.0: exclusiveMinimum/exclusiveMaximum are booleans indicating if minimum/maximum is exclusive
   // OpenAPI 3.1: exclusiveMinimum/exclusiveMaximum are numbers (the value itself)
-  const exclusiveMinRaw = 'exclusiveMinimum' in schema ? schema.exclusiveMinimum : undefined;
-  const exclusiveMaxRaw = 'exclusiveMaximum' in schema ? schema.exclusiveMaximum : undefined;
-  
+  const exclusiveMinRaw =
+    'exclusiveMinimum' in schema ? schema.exclusiveMinimum : undefined;
+  const exclusiveMaxRaw =
+    'exclusiveMaximum' in schema ? schema.exclusiveMaximum : undefined;
+
   // Convert boolean to number if using OpenAPI 3.0 format
-  const exclusiveMin = typeof exclusiveMinRaw === 'boolean' && exclusiveMinRaw ? min : exclusiveMinRaw;
-  const exclusiveMax = typeof exclusiveMaxRaw === 'boolean' && exclusiveMaxRaw ? max : exclusiveMaxRaw;
-  
+  const exclusiveMin =
+    typeof exclusiveMinRaw === 'boolean' && exclusiveMinRaw
+      ? min
+      : exclusiveMinRaw;
+  const exclusiveMax =
+    typeof exclusiveMaxRaw === 'boolean' && exclusiveMaxRaw
+      ? max
+      : exclusiveMaxRaw;
+
   const multipleOf = schema.multipleOf;
   const matches = schema.pattern ?? undefined;
 
@@ -543,7 +551,7 @@ export const generateZodValidationSchemaDefinition = (
     // Check if exclusive flag was set (boolean format in OpenAPI 3.0) or a different value (OpenAPI 3.1)
     const shouldUseExclusiveMin = exclusiveMinRaw !== undefined;
     const shouldUseExclusiveMax = exclusiveMaxRaw !== undefined;
-    
+
     if (shouldUseExclusiveMin && exclusiveMin !== undefined) {
       consts.push(
         `export const ${name}ExclusiveMin${constsCounterValue} = ${exclusiveMin};`,
@@ -558,7 +566,7 @@ export const generateZodValidationSchemaDefinition = (
         functions.push(['min', `${name}Min${constsCounterValue}`]);
       }
     }
-    
+
     // Handle maximum constraints: exclusiveMaximum (<.lt()) takes priority over maximum (.max())
     if (shouldUseExclusiveMax && exclusiveMax !== undefined) {
       consts.push(
@@ -570,7 +578,7 @@ export const generateZodValidationSchemaDefinition = (
       consts.push(`export const ${name}Max${constsCounterValue} = ${max};`);
       functions.push(['max', `${name}Max${constsCounterValue}`]);
     }
-    
+
     if (multipleOf !== undefined) {
       consts.push(
         `export const ${name}MultipleOf${constsCounterValue} = ${multipleOf.toString()};`,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -954,7 +954,10 @@ describe('generateZodValidationSchemaDefinition`', () => {
             ['gt', 'testNumberExclusiveMinExclusiveMin'],
             ['optional', undefined],
           ],
-          consts: ['export const testNumberExclusiveMinExclusiveMin = 5;', '\n'],
+          consts: [
+            'export const testNumberExclusiveMinExclusiveMin = 5;',
+            '\n',
+          ],
         });
 
         const parsed = parseZodValidationSchemaDefinition(
@@ -990,7 +993,10 @@ describe('generateZodValidationSchemaDefinition`', () => {
             ['lt', 'testNumberExclusiveMaxExclusiveMax'],
             ['optional', undefined],
           ],
-          consts: ['export const testNumberExclusiveMaxExclusiveMax = 100;', '\n'],
+          consts: [
+            'export const testNumberExclusiveMaxExclusiveMax = 100;',
+            '\n',
+          ],
         });
 
         const parsed = parseZodValidationSchemaDefinition(
@@ -1074,7 +1080,10 @@ describe('generateZodValidationSchemaDefinition`', () => {
             ['gt', 'testNumberExclusiveMinOAS30ExclusiveMin'],
             ['optional', undefined],
           ],
-          consts: ['export const testNumberExclusiveMinOAS30ExclusiveMin = 10;', '\n'],
+          consts: [
+            'export const testNumberExclusiveMinOAS30ExclusiveMin = 10;',
+            '\n',
+          ],
         });
 
         const parsed = parseZodValidationSchemaDefinition(
@@ -1111,7 +1120,10 @@ describe('generateZodValidationSchemaDefinition`', () => {
             ['lt', 'testNumberExclusiveMaxOAS30ExclusiveMax'],
             ['optional', undefined],
           ],
-          consts: ['export const testNumberExclusiveMaxOAS30ExclusiveMax = 100;', '\n'],
+          consts: [
+            'export const testNumberExclusiveMaxOAS30ExclusiveMax = 100;',
+            '\n',
+          ],
         });
 
         const parsed = parseZodValidationSchemaDefinition(


### PR DESCRIPTION
## Fix: Support for `exclusiveMinimum` and `exclusiveMaximum` in Zod schema generation

Fixes #2182

### Problem

Currently, Orval's Zod client generates only basic primitives (`z.number()`, `z.string()`, etc.) and does not translate JSON Schema numeric constraints (`minimum`, `exclusiveMinimum`, `maximum`, `exclusiveMaximum`) into Zod refinements. This means numeric constraints declared in OpenAPI definitions are lost in the generated schemas, creating gaps between backend validation (e.g., Pydantic's `gt=0`) and frontend validation in libraries like React Hook Form.

**Example:**
Given an OpenAPI schema with `exclusiveMinimum: 0`, the current implementation generates:
```typescript
export const BaseBidSchema = z.object({
  price: z.number(), // Missing .gt(0) constraint
});
```

Instead of:
```typescript
export const BaseBidSchema = z.object({
  price: z.number().gt(0), // Correct exclusive constraint
});
```

### Solution

Added support for both OpenAPI 3.0 and 3.1 formats:

- **OpenAPI 3.0**: `exclusiveMinimum` and `exclusiveMaximum` are boolean flags indicating whether `minimum`/`maximum` should be exclusive
- **OpenAPI 3.1**: `exclusiveMinimum` and `exclusiveMaximum` are numeric values themselves

The implementation automatically detects the format and generates the appropriate Zod constraints:
- `minimum: n` → `.min(n)` (inclusive)
- `exclusiveMinimum: n` or `exclusiveMinimum: true` → `.gt(n)` (exclusive)
- `maximum: n` → `.max(n)` (inclusive)
- `exclusiveMaximum: n` or `exclusiveMaximum: true` → `.lt(n)` (exclusive)

### Changes

1. **Enhanced field extraction** in `generateZodValidationSchemaDefinition()`:
   - Extract `exclusiveMinimum` and `exclusiveMaximum` from schema
   - Handle both boolean (OpenAPI 3.0) and numeric (OpenAPI 3.1) formats
   - Convert boolean flags to numeric values when needed

2. **Updated constraint generation logic**:
   - When exclusive minimum/maximum are present, generate `.gt()` and `.lt()` instead of `.min()` and `.max()`
   - Added comprehensive inline comments explaining the logic

3. **Comprehensive test coverage**:
   - Created 6 new tests organized in two groups:
     - OpenAPI 3.1 format tests (numeric exclusiveMinimum/exclusiveMaximum)
     - OpenAPI 3.0 format tests (boolean exclusiveMinimum/exclusiveMaximum)
   - Each group covers: single exclusiveMinimum, single exclusiveMaximum, and both combined
