### PR TITLE
fix(zod): handle falsy default values in schema generation

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -584,7 +584,7 @@ export const generateZodValidationSchemaDefinition = (
     }
   }
 
-  if (!required && schema.default) {
+  if (!required && schema.default !== undefined) {
     functions.push(['default', defaultVarName]);
   } else if (!required && nullable) {
     functions.push(['nullish', undefined]);

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -434,7 +434,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(parsed.consts).toBe('export const testNumberDefaultDefault = 42;');
     });
 
-    it('generates a default value for a boolean schema', () => {
+    it('generates a default value for a boolean schema with default: true', () => {
       const schemaWithBooleanDefault: SchemaObject30 = {
         type: 'boolean',
         default: true,
@@ -443,7 +443,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       const result = generateZodValidationSchemaDefinition(
         schemaWithBooleanDefault,
         context,
-        'testBooleanDefault',
+        'testBooleanDefaultTrue',
         false,
         false,
         { required: false },
@@ -452,9 +452,9 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(result).toEqual({
         functions: [
           ['boolean', undefined],
-          ['default', 'testBooleanDefaultDefault'],
+          ['default', 'testBooleanDefaultTrueDefault'],
         ],
-        consts: ['export const testBooleanDefaultDefault = true;'],
+        consts: ['export const testBooleanDefaultTrueDefault = true;'],
       });
 
       const parsed = parseZodValidationSchemaDefinition(
@@ -465,11 +465,83 @@ describe('generateZodValidationSchemaDefinition`', () => {
         false,
       );
       expect(parsed.zod).toBe(
-        'zod.boolean().default(testBooleanDefaultDefault)',
+        'zod.boolean().default(testBooleanDefaultTrueDefault)',
       );
       expect(parsed.consts).toBe(
-        'export const testBooleanDefaultDefault = true;',
+        'export const testBooleanDefaultTrueDefault = true;',
       );
+    });
+
+    it('generates a default value for a boolean schema with default: false', () => {
+      const schemaWithBooleanDefault: SchemaObject30 = {
+        type: 'boolean',
+        default: false,
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithBooleanDefault,
+        context,
+        'testBooleanDefaultFalse',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['boolean', undefined],
+          ['default', 'testBooleanDefaultFalseDefault'],
+        ],
+        consts: ['export const testBooleanDefaultFalseDefault = false;'],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe(
+        'zod.boolean().default(testBooleanDefaultFalseDefault)',
+      );
+      expect(parsed.consts).toBe(
+        'export const testBooleanDefaultFalseDefault = false;',
+      );
+    });
+
+    it('generates a boolean schema without default (undefined)', () => {
+      const schemaWithoutDefault: SchemaObject30 = {
+        type: 'boolean',
+        // default property is undefined (not set)
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithoutDefault,
+        context,
+        'testBooleanNoDefault',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['boolean', undefined],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe('zod.boolean().optional()');
+      expect(parsed.consts).toBe('');
     });
 
     it('generates a default value for an array schema', () => {


### PR DESCRIPTION
## Fix: Handle falsy default values in Zod schema generation

### Problem

When a schema has `default: false` (or other falsy values like `0`, `''`, or `null`), the generated Zod schema incorrectly omits the `.default()` method and uses `.optional()` instead. This occurs because the condition `if (!required && schema.default)` treats falsy values as falsy in JavaScript.

**Example from issue #2222:**

```yaml
schema:
  type: object
  properties:
    primary:
      type: boolean
      default: false
```

**Before:**
```typescript
export const patchV2OrganisationsOrganisationIdSchemesSchemeIdPrimaryBody = zod.object({
  "primary": zod.boolean().optional()  // ❌ Missing default
})
```

**Expected:**
```typescript
export const patchV2OrganisationsOrganisationIdSchemesSchemeIdPrimaryBody = zod.object({
  "primary": zod.boolean().default(patchV2OrganisationsOrganisationIdSchemesSchemeIdPrimaryBodyPrimaryDefault)
})
```

### Solution

Changed the condition from `schema.default` to `schema.default !== undefined` to properly detect when a default value is set, regardless of whether it's a falsy value.

```typescript
// Changed from:
if (!required && schema.default) {

// To:
if (!required && schema.default !== undefined) {
```

This ensures that all default values, including falsy ones, are properly applied to the Zod schema.
