### PR TITLE
feat: allow mts config file extension

### DIFF
--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -102,7 +102,7 @@ function findConfigFile(configFilePath?: string) {
   }
 
   const root = process.cwd();
-  const exts = ['.ts', '.js', '.mjs'];
+  const exts = ['.ts', '.js', '.mjs', '.mts'];
   for (const ext of exts) {
     const fullPath = path.resolve(root, `orval.config${ext}`);
     if (fs.existsSync(fullPath)) {


### PR DESCRIPTION
Using a TS config file without `"type": "module"` in a `package.json` produces the warning that it's a module.

<img width="1437" height="127" alt="image" src="https://github.com/user-attachments/assets/b16b1398-6ad1-4594-b9e2-63b019310d4b" />

Tested this with `orval --config orval.config.mts` and warning is not present when using `.mts` extension.
