### PR TITLE
Fix prototype pollution vulnerability in js-yaml

### DIFF
--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -91,7 +91,7 @@
     "find-up": "8.0.0",
     "fs-extra": "^11.3.2",
     "jiti": "^2.6.1",
-    "js-yaml": "4.1.0",
+    "js-yaml": "4.1.1",
     "openapi3-ts": "4.5.0",
     "remeda": "^2.32.0",
     "string-argv": "^0.3.2",


### PR DESCRIPTION
**Summary**
This PR updates the js-yaml dependency from version 4.1.0 to 4.1.1 to address a prototype pollution vulnerability discovered in the YAML merge functionality.

**Security Advisory**
CVE-2025-64718 / GHSA-mh29-5h37-fv8m

**Severity**: Moderate (CVSS 5.3)
Impact: Prototype pollution via __proto__ in parsed YAML documents
Affected: js-yaml < 4.1.1
Patched: js-yaml 4.1.1
Reference: [https://github.com/advisories/GHSA-mh29-5h37-fv8m](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Changes**
This pull request updates a dependency version to ensure the project uses the latest patch release. The change is minor and only affects the `js-yaml` package version in `packages/orval/package.json`.
Low Risk Update: Patch version that only contains the security fix
Recent Discovery: Vulnerability was disclosed just 3 days ago (November 12, 2025)