### PR TITLE
docs: fix configuration key reference from mode to client in guides

### DIFF
--- a/docs/src/pages/guides/angular.mdx
+++ b/docs/src/pages/guides/angular.mdx
@@ -3,7 +3,7 @@ id: angular
 title: Angular
 ---
 
-Start by providing an OpenAPI specification and an Orval config file. To use Angular, define the `mode` in the Orval config to be `angular`.
+Start by providing an OpenAPI specification and an Orval config file. To use Angular, define the `client` in the Orval config to be `angular`.
 
 ## Example with angular
 

--- a/docs/src/pages/guides/fetch.mdx
+++ b/docs/src/pages/guides/fetch.mdx
@@ -5,7 +5,7 @@ title: Fetch
 
 The Fetch API is a native browser API, and thus doesn't require bundling additional dependencies, as is the case with Axios. It can also act as an HTTP client in server-side frameworks and edge computing runtimes such as Cloudflare, Vercel Edge and Deno.
 
-Start by providing an OpenAPI specification and an Orval config where you define the `mode` as `fetch`.
+Start by providing an OpenAPI specification and an Orval config where you define the `client` as `fetch`.
 
 ## Example with Fetch
 

--- a/docs/src/pages/guides/react-query.mdx
+++ b/docs/src/pages/guides/react-query.mdx
@@ -3,7 +3,7 @@ id: react-query
 title: React Query
 ---
 
-Start by providing an OpenAPI specification and an Orval config file. To use React Query, define the `mode` in the Orval config to be `react-query`.
+Start by providing an OpenAPI specification and an Orval config file. To use React Query, define the `client` in the Orval config to be `react-query`.
 
 ## Example with React Query
 

--- a/docs/src/pages/guides/svelte-query.mdx
+++ b/docs/src/pages/guides/svelte-query.mdx
@@ -3,7 +3,7 @@ id: svelte-query
 title: Svelte Query
 ---
 
-Start by providing an OpenAPI specification and an Orval config file. To use React Query, define the `mode` in the Orval config to be `svelte-query`.
+Start by providing an OpenAPI specification and an Orval config file. To use React Query, define the `client` in the Orval config to be `svelte-query`.
 
 ## Example with Svelte Query
 

--- a/docs/src/pages/guides/vue-query.mdx
+++ b/docs/src/pages/guides/vue-query.mdx
@@ -3,7 +3,7 @@ id: vue-query
 title: Vue Query
 ---
 
-Start by providing an OpenAPI specification and an Orval config file. To use Vue Query, define the `mode` in the Orval config to be `vue-query`.
+Start by providing an OpenAPI specification and an Orval config file. To use Vue Query, define the `client` in the Orval config to be `vue-query`.
 
 ## Example with Vue Query
 


### PR DESCRIPTION
This updates the documentation in the Angular, Fetch, React Query, Svelte Query, and Vue Query guides to correctly refer to the `client` key instead of `mode` in the Orval config.