### PR TITLE
docs: modernize Axios examples to remove deprecated CancelToken

### DIFF
--- a/docs/src/pages/guides/custom-axios.mdx
+++ b/docs/src/pages/guides/custom-axios.mdx
@@ -36,17 +36,10 @@ export const customInstance = <T>(
   config: AxiosRequestConfig,
   options?: AxiosRequestConfig,
 ): Promise<T> => {
-  const source = Axios.CancelToken.source();
   const promise = AXIOS_INSTANCE({
     ...config,
     ...options,
-    cancelToken: source.token,
   }).then(({ data }) => data);
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled');
-  };
 
   return promise;
 };

--- a/docs/src/pages/reference/configuration/output.mdx
+++ b/docs/src/pages/reference/configuration/output.mdx
@@ -815,15 +815,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by React Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };
@@ -845,15 +837,7 @@ import config from '@config';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '', ...config });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by React Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };
@@ -917,19 +901,12 @@ export const useCustomInstance = <T>(): ((
   const token = useToken(); // Do what you want
 
   return (config: AxiosRequestConfig) => {
-    const source = Axios.CancelToken.source();
     const promise = AXIOS_INSTANCE({
       ...config,
       headers: {
-        Authorization: `Bearer ${token}`
-      }
-      cancelToken: source.token,
+        Authorization: `Bearer ${token}`,
+      },
     }).then(({ data }) => data);
-
-    // @ts-ignore
-    promise.cancel = () => {
-      source.cancel('Query was cancelled by React Query');
-    };
 
     return promise;
   };

--- a/samples/react-app-with-swr/basic/src/api/mutator/custom-instance.ts
+++ b/samples/react-app-with-swr/basic/src/api/mutator/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by React Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/samples/react-query/basic/src/api/mutator/custom-instance.ts
+++ b/samples/react-query/basic/src/api/mutator/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosError, AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by Vue Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/samples/react-query/form-data-mutator/custom-instance.ts
+++ b/samples/react-query/form-data-mutator/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by Vue Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/samples/react-query/form-data/custom-instance.ts
+++ b/samples/react-query/form-data/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by Vue Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/samples/react-query/form-url-encoded-mutator/custom-instance.ts
+++ b/samples/react-query/form-url-encoded-mutator/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by Vue Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/samples/react-query/form-url-encoded/custom-instance.ts
+++ b/samples/react-query/form-url-encoded/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by Vue Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/samples/react-query/hook-mutator/use-custom-instance.ts
+++ b/samples/react-query/hook-mutator/use-custom-instance.ts
@@ -6,16 +6,7 @@ export const useCustomInstance = <T>(): ((
   config: AxiosRequestConfig,
 ) => Promise<T>) => {
   return (config: AxiosRequestConfig) => {
-    const source = Axios.CancelToken.source();
-    const promise = AXIOS_INSTANCE({
-      ...config,
-      cancelToken: source.token,
-    }).then(({ data }) => data);
-
-    // @ts-ignore
-    promise.cancel = () => {
-      source.cancel('Query was cancelled by React Query');
-    };
+    const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
     return promise;
   };

--- a/samples/vue-query/vue-query-basic/src/api/mutator/custom-instance.ts
+++ b/samples/vue-query/vue-query-basic/src/api/mutator/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by Vue Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/tests/mutators/custom-instance.ts
+++ b/tests/mutators/custom-instance.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by React Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/tests/mutators/error-type.ts
+++ b/tests/mutators/error-type.ts
@@ -3,15 +3,7 @@ import Axios, { AxiosError, AxiosRequestConfig } from 'axios';
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 
 export const customInstance = <T>(config: AxiosRequestConfig): Promise<T> => {
-  const source = Axios.CancelToken.source();
-  const promise = AXIOS_INSTANCE({ ...config, cancelToken: source.token }).then(
-    ({ data }) => data,
-  );
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by React Query');
-  };
+  const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
   return promise;
 };

--- a/tests/mutators/multi-arguments.ts
+++ b/tests/mutators/multi-arguments.ts
@@ -6,20 +6,13 @@ export const customInstance = <T>(
   config: AxiosRequestConfig,
   token?: string,
 ): Promise<T> => {
-  const source = Axios.CancelToken.source();
   const promise = AXIOS_INSTANCE({
     ...config,
-    cancelToken: source.token,
     headers: {
       ...config?.headers,
       ...(token ? { Authorization: token } : {}),
     },
   }).then(({ data }) => data);
-
-  // @ts-ignore
-  promise.cancel = () => {
-    source.cancel('Query was cancelled by React Query');
-  };
 
   return promise;
 };

--- a/tests/mutators/use-custom-instance-with-second-parameter.ts
+++ b/tests/mutators/use-custom-instance-with-second-parameter.ts
@@ -10,17 +10,10 @@ export const useCustomInstance = <T>() => {
   queryClient.isFetching();
 
   return (config: AxiosRequestConfig, headers?: { token: string }) => {
-    const source = Axios.CancelToken.source();
     const promise = AXIOS_INSTANCE({
       ...config,
-      cancelToken: source.token,
       headers: headers,
     }).then(({ data }) => data);
-
-    // @ts-ignore
-    promise.cancel = () => {
-      source.cancel('Query was cancelled by React Query');
-    };
 
     return promise;
   };

--- a/tests/mutators/use-custom-instance.ts
+++ b/tests/mutators/use-custom-instance.ts
@@ -12,16 +12,7 @@ export const useCustomInstance = <T>(): ((
   queryClient.isFetching();
 
   return (config: AxiosRequestConfig) => {
-    const source = Axios.CancelToken.source();
-    const promise = AXIOS_INSTANCE({
-      ...config,
-      cancelToken: source.token,
-    }).then(({ data }) => data);
-
-    // @ts-ignore
-    promise.cancel = () => {
-      source.cancel('Query was cancelled by React Query');
-    };
+    const promise = AXIOS_INSTANCE({ ...config }).then(({ data }) => data);
 
     return promise;
   };


### PR DESCRIPTION
## Summary
Updated documentation and sample code to remove deprecated `CancelToken` (deprecated since Axios 0.22.0) and unnecessary `promise.cancel()` implementation (not needed in TanStack Query v4+), modernizing examples to follow current best practices.

## Changes

### Removed deprecated code
- ❌ `Axios.CancelToken.source()` usage (deprecated since Axios 0.22.0)
- ❌ `cancelToken: source.token` configuration
- ❌ `promise.cancel()` implementation (unnecessary in TanStack Query v4+)
- ❌ `@ts-ignore` comments

### Modified files (15 files total)

**Documentation:**
- `docs/src/pages/guides/custom-axios.mdx`
- `docs/src/pages/reference/configuration/output.mdx` (3 code examples)

**Test mutators:**
- `tests/mutators/custom-instance.ts`
- `tests/mutators/use-custom-instance.ts`
- `tests/mutators/error-type.ts`
- `tests/mutators/multi-arguments.ts`
- `tests/mutators/use-custom-instance-with-second-parameter.ts`

**Sample code:**
- `samples/react-query/basic/src/api/mutator/custom-instance.ts`
- `samples/react-query/hook-mutator/use-custom-instance.ts`
- `samples/react-query/form-data/custom-instance.ts`
- `samples/react-query/form-data-mutator/custom-instance.ts`
- `samples/react-query/form-url-encoded/custom-instance.ts`
- `samples/react-query/form-url-encoded-mutator/custom-instance.ts`
- `samples/vue-query/vue-query-basic/src/api/mutator/custom-instance.ts`
- `samples/react-app-with-swr/basic/src/api/mutator/custom-instance.ts`

## Rationale

- **Axios 1.x+**: `CancelToken` is deprecated in favor of standard `AbortController` / `signal`
- **TanStack Query v4+**: Query cancellation is handled internally via `signal`, making custom `promise.cancel()` implementation unnecessary
- **Modern implementation**: Axios automatically supports `signal` passed in `config`, so simpler implementation is sufficient

## Impact
- Documentation and sample code now compatible with modern Axios and TanStack Query
- Provides simpler and more maintainable code examples
- Avoids future compatibility issues by not using deprecated APIs

