### PR TITLE
fix(swr): duplicate union types in error type generation

### DIFF
--- a/packages/swr/src/client.ts
+++ b/packages/swr/src/client.ts
@@ -168,20 +168,37 @@ export const getSwrRequestOptions = (
   }
 };
 
+// Helper to deduplicate union type string: "A | B | B" -> "A | B"
+const dedupeUnionTypes = (types: string): string => {
+  if (!types) return types;
+  // Split by '|', trim spaces, filter out empty, and dedupe using a Set
+  const unique = [
+    ...new Set(
+      types
+        .split('|')
+        .map((t) => t.trim())
+        .filter(Boolean),
+    ),
+  ];
+  return unique.join(' | ');
+};
+
 export const getSwrErrorType = (
   response: GetterResponse,
   httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
 ) => {
+  const errorsType = dedupeUnionTypes(response.definition.errors || 'unknown');
+
   if (mutator) {
     return mutator.hasErrorType
-      ? `ErrorType<${response.definition.errors || 'unknown'}>`
-      : response.definition.errors || 'unknown';
+      ? `ErrorType<${errorsType}>`
+      : errorsType;
   } else {
     const errorType =
       httpClient === OutputHttpClient.AXIOS ? 'AxiosError' : 'Promise';
 
-    return `${errorType}<${response.definition.errors || 'unknown'}>`;
+    return `${errorType}<${errorsType}>`;
   }
 };
 


### PR DESCRIPTION
## Summary

This PR applies the same deduplication fix from #2471 to the SWR package.

The @orval/query package already has dedupeUnionTypes helper to remove duplicate types in generated error union types, but @orval/swr was missing this fix.
