### PR TITLE
fix(query): include path params info query key when `useOperationIdAsQueryKey` enabled

### DIFF
--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1478,6 +1478,18 @@ ${
           ? `"${operationName}"`
           : routeString;
 
+        // Use all params in query key when useOperationIdAsQueryKey=true, otherwise use only query param
+        // All params sorted by required first
+        const queryKeyParams = props
+          .filter((p) =>
+            override.query.useOperationIdAsQueryKey
+              ? true
+              : p.type === GetterPropType.QUERY_PARAM,
+          )
+          .toSorted((a) => (a.required ? -1 : 1))
+          .map((p) => `...(${p.name} ? [${p.name}] : [])`)
+          .join(', ');
+
         // Note: do not unref() params in Vue - this will make key lose reactivity
         const queryKeyFn = `
 ${override.query.shouldExportQueryKey ? 'export ' : ''}const ${queryOption.queryKeyFnName} = (${queryKeyProps}) => {
@@ -1488,7 +1500,7 @@ ${override.query.shouldExportQueryKey ? 'export ' : ''}const ${queryOption.query
         ? `'infinite'`
         : '',
       queryKeyIdentifier,
-      queryParams ? '...(params ? [params]: [])' : '',
+      queryKeyParams,
       body.implementation,
     ]
       .filter((x) => !!x)


### PR DESCRIPTION
Fix https://github.com/orval-labs/orval/issues/2505

Explanation:

- drop hardcoded query Params insertion
- when useOperationIdAsQueryKey=true query param use all parameters 
- when useOperationIdAsQueryKey=false only query params (because path params included in path)
- all params sorted by `required` first 

Below are screenshots with diffs:
<img width="1534" height="470" alt="Снимок экрана от 2025-11-28 22-24-17" src="https://github.com/user-attachments/assets/16f1d250-031b-434f-ac8a-ab1c6eb19000" />

<img width="1534" height="234" alt="Снимок экрана от 2025-11-28 22-24-06" src="https://github.com/user-attachments/assets/08f95c21-828e-4fba-af9e-3a67144696e5" />

<img width="1514" height="175" alt="Снимок экрана от 2025-11-28 22-23-39" src="https://github.com/user-attachments/assets/b6d82b9f-c4f5-43ff-be1a-09dfa3322c08" />
