### PR TITLE
docs: change sponsor to open collective

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Support us with a one-time donation and help us continue our activities on [Open
   <img src="https://orval.dev/images/emblem.svg" width="50" height="50" alt="Backer" />
 </a>
 
+**Note:** After becoming a sponsor or backer, please contact us on [Discord](https://discord.gg/6fC2sjDU7w) to upload your logo.
+
 ## Star History
 
 <a href="https://star-history.com/#orval-labs/orval&Date">

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -344,6 +344,19 @@ my-app
                 Support us on Open Collective
               </a>
             </div>
+
+            <p className="mt-6 text-sm text-gray-600">
+              After becoming a sponsor or backer, please contact us on{' '}
+              <a
+                href={siteConfig.discordUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-coral-default hover:text-coral-light underline"
+              >
+                Discord
+              </a>{' '}
+              to upload your logo.
+            </p>
           </div>
         </div>
         <div className="bg-gray-50 border-b border-gray-100">


### PR DESCRIPTION
# Ref

https://opencollective.com/orval

# Summary

To further sustainability and give back to developers, we are opening OpenCollective. 
For this PR, we have made some changes to ensure there is space for sponsors. The new display will look like this:

### Top page

<img width="842" height="666" alt="スクリーンショット 2025-12-07 12 30 34" src="https://github.com/user-attachments/assets/0c4b1cd1-4311-43e1-a170-130f08915d09" />

### README

<img width="887" height="491" alt="スクリーンショット 2025-12-07 12 39 40" src="https://github.com/user-attachments/assets/5fac2692-fb5e-46fb-bc07-33be35eac85c" />
