### PR TITLE
docs: add `hono` and `mcp` to valid client values

### DIFF
--- a/docs/src/pages/reference/configuration/output.mdx
+++ b/docs/src/pages/reference/configuration/output.mdx
@@ -25,7 +25,7 @@ export default defineConfig({
 
 Type: `String | Function`.
 
-Valid values: `angular`, `axios`, `axios-functions`, `react-query`, `svelte-query`, `vue-query`, `swr`, `zod`, `fetch`.
+Valid values: `angular`, `axios`, `axios-functions`, `react-query`, `svelte-query`, `vue-query`, `swr`, `zod`, `hono`, `fetch`, `mcp`.
 
 Default Value: `axios-functions`.
 


### PR DESCRIPTION
## Summary

Add `hono` and `mcp` to the valid client values in the documentation.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
