### PR TITLE
fix(2629): Fix Zod conversion when the default value contains a line …

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -329,7 +329,7 @@ export const generateZodValidationSchemaDefinition = (
       defaultValue =
         rawStringified === undefined
           ? 'null'
-          : rawStringified.replaceAll("'", '"');
+          : rawStringified.replaceAll("'", '`');
 
       // If the schema is an array with enum items, inject inplace to avoid issues with default values
       const isArrayWithEnumItems =

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -850,7 +850,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['default', 'testStringDescriptionDefault'],
           ['describe', "'This is a test description'"],
         ],
-        consts: ['export const testStringDescriptionDefault = "hello";'],
+        consts: ['export const testStringDescriptionDefault = \`hello\`;'],
       });
 
       const parsed = parseZodValidationSchemaDefinition(
@@ -895,7 +895,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['string', undefined],
           ['default', 'testStringDefaultDefault'],
         ],
-        consts: [`export const testStringDefaultDefault = "hello";`],
+        consts: [`export const testStringDefaultDefault = \`hello\`;`],
       });
 
       const parsed = parseZodValidationSchemaDefinition(
@@ -907,7 +907,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
       expect(parsed.zod).toBe('zod.string().default(testStringDefaultDefault)');
       expect(parsed.consts).toBe(
-        'export const testStringDefaultDefault = "hello";',
+        'export const testStringDefaultDefault = `hello`;',
       );
     });
 
@@ -1076,7 +1076,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['array', { functions: [['string', undefined]], consts: [] }],
           ['default', 'testArrayDefaultDefault'],
         ],
-        consts: ['export const testArrayDefaultDefault = ["a", "b"];'],
+        consts: ['export const testArrayDefaultDefault = [`a`, `b`];'],
       });
 
       const parsed = parseZodValidationSchemaDefinition(
@@ -1090,7 +1090,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'zod.array(zod.string()).default(testArrayDefaultDefault)',
       );
       expect(parsed.consts).toBe(
-        'export const testArrayDefaultDefault = ["a", "b"];',
+        'export const testArrayDefaultDefault = [`a`, `b`];',
       );
     });
 
@@ -1436,7 +1436,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
               consts: [],
             },
           ],
-          ['default', '["A"]'],
+          ['default', '[`A`]'],
         ],
         consts: [],
       });
@@ -1449,7 +1449,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         false,
       );
       expect(parsed.zod).toBe(
-        "zod.array(zod.enum(['A', 'B', 'C'])).default([\"A\"])",
+        "zod.array(zod.enum(['A', 'B', 'C'])).default([`A`])",
       );
     });
 
@@ -1495,7 +1495,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
 
       expect(parsed.zod).toBe(
-        "zod.array(zod.enum(['A', 'B', 'C'])).default([\"A\"])",
+        "zod.array(zod.enum(['A', 'B', 'C'])).default([`A`])",
       );
     });
   });

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -229,4 +229,11 @@ export default defineConfig({
       target: '../specifications/nullable-oneof-enums.yaml',
     },
   },
+  'multiline-default': {
+    output: {
+      target: '../generated/zod/multiline-default.ts',
+      client: 'zod',
+    },
+    input: '../specifications/multiline-default.yaml',
+  },
 });

--- a/tests/specifications/multiline-default.yaml
+++ b/tests/specifications/multiline-default.yaml
@@ -1,0 +1,41 @@
+openapi: 3.1.0
+info:
+  title: Orval Multiline Default Repro
+  version: '1.0.0'
+servers:
+  - url: https://example.com/api
+paths:
+  /multiline-default:
+    post:
+      summary: Endpoint demonstrating multiline default value
+      operationId: createMultilineDefault
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MultilineExampleRequest'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    MultilineExampleRequest:
+      type: object
+      properties:
+        rerank_prompt:
+          anyOf:
+            - type: string
+            - type: 'null'
+          title: Rerank Prompt
+          description: Prompt text with a multiline default value.
+          default: |-
+            # Task
+            You are a helpful assistant. Rerank the following information blocks according to their relevance to the given question.
+            Return only the indices of the most relevant blocks in descending order of relevance, using the exact response format specified below.
+
+            # Question
+            {question}
+
+            # Information Blocks
+            {blocks}


### PR DESCRIPTION
This fixes #2629

<!-- A few sentences describing the overall goals of the pull request's commits. -->

It replaces the `"` character with a ` character so multiline strings don't create invalid typescript.