### PR TITLE
add aliasCombinedTypes documentation and rename option

### DIFF
--- a/docs/src/pages/guides/migration-v8.mdx
+++ b/docs/src/pages/guides/migration-v8.mdx
@@ -184,3 +184,23 @@ export default {
   },
 };
 ```
+
+## 7. Changed combined types generation (anyOf/oneOf/allOf)
+
+Combined types (`anyOf`, `oneOf`, `allOf`) are now inlined by default instead of creating intermediate type aliases.
+
+### How to maintain compatibility
+
+Use `aliasCombinedTypes`.
+
+```diff:orval.config.ts
+export default {
+  petstore: {
+    output: {
+      override: {
++       aliasCombinedTypes: true,
+      },
+    },
+  },
+};
+```

--- a/docs/src/pages/reference/configuration/output.mdx
+++ b/docs/src/pages/reference/configuration/output.mdx
@@ -2933,6 +2933,57 @@ Result when `enumGenerationType` is `union`:
 export const Example = 'foo' | 'bar' | 'baz';
 ```
 
+### aliasCombinedTypes
+
+Type: `Boolean`
+
+Default Value: `false`.
+
+Creates intermediate type aliases for combined types (`anyOf`, `oneOf`, `allOf`) instead of inlining them. This restores v7 behavior.
+
+```js
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  petstore: {
+    output: {
+      override: {
+        aliasCombinedTypes: true,
+      },
+    },
+  },
+});
+```
+
+Result when `aliasCombinedTypes` is `false` (default):
+
+```ts
+// Primitives - inlined directly
+// Objects - creates one named type
+export interface Pet {
+  status?: string | number;
+  category?: PetCategory;
+}
+export type PetCategory = { id?: number; name?: string } | { code?: string };
+```
+
+Result when `aliasCombinedTypes` is `true`:
+
+```ts
+// Primitives - creates named type
+export type PetStatus = string | number;
+
+// Objects - creates intermediate types with OneOf/OneOfTwo suffixes
+export type PetCategoryOneOf = { id?: number; name?: string };
+export type PetCategoryOneOfTwo = { code?: string };
+export type PetCategory = PetCategoryOneOf | PetCategoryOneOfTwo;
+
+export interface Pet {
+  status?: PetStatus;
+  category?: PetCategory;
+}
+```
+
 ### suppressReadonlyModifier
 
 Type: `Boolean`

--- a/packages/core/src/generators/schema-definition.test.ts
+++ b/packages/core/src/generators/schema-definition.test.ts
@@ -165,7 +165,7 @@ describe('generateSchemasDefinition', () => {
     ['oneOf', '|', 'OneOf'],
     ['allOf', '&', 'AllOf'],
   ] as const)(
-    'should generate %s with inline objects: type aliases when useCombinedTypeAliases is true, inlined by default',
+    'should generate %s with inline objects: type aliases when aliasCombinedTypes is true, inlined by default',
     (combiner, operator, combinerName) => {
       const schemas: OpenApiSchemasObject = {
         Response: {
@@ -176,14 +176,14 @@ describe('generateSchemasDefinition', () => {
         },
       };
 
-      // With useCombinedTypeAliases: true - creates intermediate type aliases
+      // With aliasCombinedTypes: true - creates intermediate type aliases
       const aliasContext: ContextSpec = {
         ...context,
         output: {
           ...context.output,
           override: {
             ...context.output.override,
-            useCombinedTypeAliases: true,
+            aliasCombinedTypes: true,
           },
         },
       };
@@ -202,7 +202,7 @@ describe('generateSchemasDefinition', () => {
         `export type Response = Response${combinerName} ${operator} Response${combinerName}Two;\n`,
       );
 
-      // Default behavior (useCombinedTypeAliases defaults to false) - inlines everything
+      // Default behavior (aliasCombinedTypes defaults to false) - inlines everything
       const inlineResult = generateSchemasDefinition(schemas, context, '');
       expect(inlineResult).toHaveLength(1);
       expect(inlineResult[0].name).toBe('Response');

--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -143,10 +143,10 @@ export function combineSchemas({
 
   const resolvedData = items.reduce<CombinedData>(
     (acc, subSchema) => {
-      // useCombinedTypeAliases (v7 compat): create intermediate types like ResponseAnyOf
+      // aliasCombinedTypes (v7 compat): create intermediate types like ResponseAnyOf
       // v8 default: propName stays undefined so combined types are inlined directly
       let propName: string | undefined = undefined;
-      if (context.output.override.useCombinedTypeAliases) {
+      if (context.output.override.aliasCombinedTypes) {
         propName = name ? name + pascal(separator) : undefined;
         if (propName && acc.schemas.length > 0) {
           propName = propName + pascal(getNumberWord(acc.schemas.length + 1));

--- a/packages/core/src/resolvers/object.ts
+++ b/packages/core/src/resolvers/object.ts
@@ -28,14 +28,14 @@ function resolveObjectOriginal({
   });
   const doc = jsDoc(resolvedValue.originalSchema ?? {});
 
-  // useCombinedTypeAliases (v7 compat): match '|' and '&' so 'string | number' creates named type
+  // aliasCombinedTypes (v7 compat): match '|' and '&' so 'string | number' creates named type
   // v8 default: only match '{' so combined primitives are inlined
   if (
     propName &&
     !resolvedValue.isEnum &&
     resolvedValue?.type === 'object' &&
     new RegExp(
-      context.output.override.useCombinedTypeAliases ? '{|&|\\|' : '{',
+      context.output.override.aliasCombinedTypes ? '{|&|\\|' : '{',
     ).test(resolvedValue.value)
   ) {
     let model = '';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,7 +106,7 @@ export type NormalizedOverrideOutput = {
   enumGenerationType: EnumGeneration;
   suppressReadonlyModifier?: boolean;
   jsDoc: NormalizedJsDocOptions;
-  useCombinedTypeAliases: boolean;
+  aliasCombinedTypes: boolean;
 };
 
 export type NormalizedMutator = {
@@ -459,7 +459,7 @@ export type OverrideOutput = {
   enumGenerationType?: EnumGeneration;
   suppressReadonlyModifier?: boolean;
   jsDoc?: JsDocOptions;
-  useCombinedTypeAliases?: boolean;
+  aliasCombinedTypes?: boolean;
 };
 
 export type JsDocOptions = {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -383,8 +383,7 @@ export async function normalizeOptions(
           outputOptions.override?.enumGenerationType ?? 'const',
         suppressReadonlyModifier:
           outputOptions.override?.suppressReadonlyModifier || false,
-        useCombinedTypeAliases:
-          outputOptions.override?.useCombinedTypeAliases ?? false,
+        aliasCombinedTypes: outputOptions.override?.aliasCombinedTypes ?? false,
       },
       allParamsOptional: outputOptions.allParamsOptional ?? false,
       urlEncodeParameters: outputOptions.urlEncodeParameters ?? false,


### PR DESCRIPTION
- Add documentation to output.mdx with usage examples
- Add migration guide section 7 for v7 to v8 upgrade
- Rename useCombinedTypeAliases to aliasCombinedTypes for clarity
- Add test for object types with OneOf/OneOfTwo pattern
