### PR TITLE
fix(core): replace `camel` with `conventionName` in writers to follow consistent naming conventions

### DIFF
--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import { OutputClient, type WriteModeProps } from '../types';
 import {
-  camel,
+  conventionName,
   getFileInfo,
   isFunction,
   isSyntheticDefaultImportsAllow,
@@ -23,7 +23,7 @@ export async function writeSplitTagsMode({
   needSchema,
 }: WriteModeProps): Promise<string[]> {
   const { filename, dirname, extension } = getFileInfo(output.target, {
-    backupFilename: camel(builder.info.title),
+    backupFilename: conventionName(builder.info.title, output.namingConvention),
     extension: output.fileExtension,
   });
 

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import type { WriteModeProps } from '../types';
 import {
-  camel,
+  conventionName,
   getFileInfo,
   isFunction,
   isSyntheticDefaultImportsAllow,
@@ -22,7 +22,7 @@ export async function writeTagsMode({
   needSchema,
 }: WriteModeProps): Promise<string[]> {
   const { filename, dirname, extension } = getFileInfo(output.target, {
-    backupFilename: camel(builder.info.title),
+    backupFilename: conventionName(builder.info.title, output.namingConvention),
     extension: output.fileExtension,
   });
 


### PR DESCRIPTION
Update `tags-mode` and `split-tags-mode` writers to use the provided naming convention from the config file instead of using camel case always.

Example configuration used in `samples/react-query/basic/orval.config.ts`:

```ts
import { defineConfig } from 'orval';

export default defineConfig({
  petstore: {
    output: {
      mode: 'tags-split',
      target: 'src/api/endpoints',
      client: 'react-query',
      httpClient: 'axios',
      mock: true,
      prettier: true,
      clean: true,
      namingConvention: 'kebab-case'
    },
    input: {
      target: './petstore.yaml',
    },
  },
});
```

Result previous to this fix:
<img width="346" height="145" alt="image" src="https://github.com/user-attachments/assets/3874e254-e96e-4d77-9fce-fdaafb41612d" />

Result after this fix:
<img width="349" height="147" alt="image" src="https://github.com/user-attachments/assets/8ac14bf2-bee4-4982-b20c-1473bf08277f" />

Closes #2253