### PR TITLE
feat: generate zod schema even with params type

### DIFF
--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -24,7 +24,7 @@ import { unique } from 'remeda';
 import type { TypeDocOptions } from 'typedoc';
 
 import { executeHook } from './utils';
-import { writeZodSchemas } from './write-zod-specs';
+import { writeZodSchemas, writeZodSchemasFromVerbs } from './write-zod-specs';
 
 function getHeader(
   option: false | ((info: OpenApiInfoObject) => string | string[]),
@@ -92,6 +92,22 @@ export async function writeSpecs(
             header,
             output,
           );
+
+          if (builder.verbOptions) {
+            await writeZodSchemasFromVerbs(
+              builder.verbOptions,
+              output.schemas.path,
+              fileExtension,
+              header,
+              output,
+              {
+                spec: builder.spec,
+                target: builder.target,
+                workspace,
+                output,
+              },
+            );
+          }
         }
       }
     }

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -1,7 +1,11 @@
 import {
   conventionName,
   type ContextSpec,
+  type GeneratorVerbOptions,
+  type NamingConvention,
   type NormalizedOutputOptions,
+  type OpenApiSchemaObject,
+  pascal,
   upath,
   type WriteSpecBuilder,
 } from '@orval/core';
@@ -13,6 +17,58 @@ import {
 } from '@orval/zod';
 import fs from 'fs-extra';
 
+function generateZodSchemaFileContent(
+  header: string,
+  schemaName: string,
+  zodContent: string,
+): string {
+  return `${header}import { z as zod } from 'zod';
+
+export const ${schemaName} = ${zodContent}
+
+export type ${schemaName} = zod.infer<typeof ${schemaName}>;
+`;
+}
+
+async function writeZodSchemaIndex(
+  schemasPath: string,
+  fileExtension: string,
+  header: string,
+  schemaNames: string[],
+  namingConvention: NamingConvention,
+  shouldMergeExisting: boolean = false,
+) {
+  const importFileExtension = fileExtension.replace(/\.ts$/, '');
+  const indexPath = upath.join(schemasPath, `index${fileExtension}`);
+
+  let existingExports = '';
+  if (shouldMergeExisting && (await fs.pathExists(indexPath))) {
+    const existingContent = await fs.readFile(indexPath, 'utf-8');
+    const headerMatch = existingContent.match(/^(\/\*\*[\s\S]*?\*\/\n)?/);
+    const headerPart = headerMatch ? headerMatch[0] : '';
+    existingExports = existingContent.substring(headerPart.length).trim();
+  }
+
+  const newExports = schemaNames
+    .map((schemaName) => {
+      const fileName = conventionName(schemaName, namingConvention);
+      return `export * from './${fileName}${importFileExtension}';`;
+    })
+    .sort()
+    .join('\n');
+
+  const allExports = existingExports
+    ? `${existingExports}\n${newExports}`
+    : newExports;
+
+  const uniqueExports = [...new Set(allExports.split('\n'))]
+    .filter((line) => line.trim())
+    .sort()
+    .join('\n');
+
+  await fs.outputFile(indexPath, `${header}\n${uniqueExports}\n`);
+}
+
 export async function writeZodSchemas(
   builder: WriteSpecBuilder,
   schemasPath: string,
@@ -21,7 +77,6 @@ export async function writeZodSchemas(
   output: NormalizedOutputOptions,
 ) {
   const schemasWithOpenApiDef = builder.schemas.filter((s) => s.schema);
-  const importFileExtension = fileExtension.replace(/\.ts$/, '');
 
   await Promise.all(
     schemasWithOpenApiDef.map(async (generatorSchema) => {
@@ -73,28 +128,178 @@ export async function writeZodSchemas(
         isZodV4,
       );
 
-      const fileContent = `${header}import { z as zod } from 'zod';
-${parsedZodDefinition.consts ? `\n${parsedZodDefinition.consts}\n` : ''}
-export const ${name}Schema = ${parsedZodDefinition.zod};
-export type ${name} = zod.infer<typeof ${name}Schema>;
-`;
+      const zodContent = parsedZodDefinition.consts
+        ? `${parsedZodDefinition.consts}\n${parsedZodDefinition.zod}`
+        : parsedZodDefinition.zod;
+
+      const fileContent = generateZodSchemaFileContent(
+        header,
+        name,
+        zodContent,
+      );
 
       await fs.outputFile(filePath, fileContent);
     }),
   );
 
   if (output.indexFiles) {
-    const schemaFilePath = upath.join(schemasPath, `/index${fileExtension}`);
+    const schemaNames = schemasWithOpenApiDef.map((schema) => schema.name);
+    await writeZodSchemaIndex(
+      schemasPath,
+      fileExtension,
+      header,
+      schemaNames,
+      output.namingConvention,
+      false,
+    );
+  }
+}
 
-    const exports = schemasWithOpenApiDef
-      .map((schema) => {
-        const fileName = conventionName(schema.name, output.namingConvention);
-        return `export * from './${fileName}${importFileExtension}';`;
-      })
-      .toSorted((a, b) => a.localeCompare(b))
-      .join('\n');
+export async function writeZodSchemasFromVerbs(
+  verbOptions: Record<string, GeneratorVerbOptions>,
+  schemasPath: string,
+  fileExtension: string,
+  header: string,
+  output: NormalizedOutputOptions,
+  context: ContextSpec,
+) {
+  const verbOptionsArray = Object.values(verbOptions);
 
-    const fileContent = `${header}\n${exports}`;
-    await fs.outputFile(schemaFilePath, fileContent);
+  if (verbOptionsArray.length === 0) {
+    return;
+  }
+
+  const isZodV4 = !!output.packageJson && isZodVersionV4(output.packageJson);
+  const strict =
+    typeof output.override?.zod?.strict === 'object'
+      ? (output.override.zod.strict.body ?? false)
+      : (output.override?.zod?.strict ?? false);
+  const coerce =
+    typeof output.override?.zod?.coerce === 'object'
+      ? (output.override.zod.coerce.body ?? false)
+      : (output.override?.zod?.coerce ?? false);
+
+  const generateVerbsSchemas = verbOptionsArray.flatMap((verbOption) => {
+    const operation = verbOption.originalOperation;
+
+    const bodySchema =
+      operation.requestBody && 'content' in operation.requestBody
+        ? operation.requestBody.content['application/json']?.schema
+        : undefined;
+
+    const bodySchemas = bodySchema
+      ? [
+          {
+            name: `${pascal(verbOption.operationName)}Body`,
+            schema: dereference(bodySchema as OpenApiSchemaObject, context),
+          },
+        ]
+      : [];
+
+    const queryParams = operation.parameters?.filter(
+      (p) => 'in' in p && p.in === 'query',
+    );
+
+    const queryParamsSchemas =
+      queryParams && queryParams.length > 0
+        ? [
+            {
+              name: `${pascal(verbOption.operationName)}Params`,
+              schema: {
+                type: 'object' as const,
+                properties: Object.fromEntries(
+                  queryParams
+                    .filter((p) => 'schema' in p && p.schema)
+                    .map((p) => [
+                      p.name,
+                      dereference(p.schema as OpenApiSchemaObject, context),
+                    ]),
+                ),
+                required: queryParams
+                  .filter((p) => p.required)
+                  .map((p) => p.name),
+              },
+            },
+          ]
+        : [];
+
+    const headerParams = operation.parameters?.filter(
+      (p) => 'in' in p && p.in === 'header',
+    );
+
+    const headerParamsSchemas =
+      headerParams && headerParams.length > 0
+        ? [
+            {
+              name: `${pascal(verbOption.operationName)}Headers`,
+              schema: {
+                type: 'object' as const,
+                properties: Object.fromEntries(
+                  headerParams
+                    .filter((p) => 'schema' in p && p.schema)
+                    .map((p) => [
+                      p.name,
+                      dereference(p.schema as OpenApiSchemaObject, context),
+                    ]),
+                ),
+                required: headerParams
+                  .filter((p) => p.required)
+                  .map((p) => p.name),
+              },
+            },
+          ]
+        : [];
+
+    return [...bodySchemas, ...queryParamsSchemas, ...headerParamsSchemas];
+  });
+
+  await Promise.all(
+    generateVerbsSchemas.map(async ({ name, schema }) => {
+      const fileName = conventionName(name, output.namingConvention);
+      const filePath = upath.join(schemasPath, `${fileName}${fileExtension}`);
+
+      const zodDefinition = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        name,
+        strict,
+        isZodV4,
+        {
+          required: true,
+        },
+      );
+
+      const parsedZodDefinition = parseZodValidationSchemaDefinition(
+        zodDefinition,
+        context,
+        coerce,
+        strict,
+        isZodV4,
+      );
+
+      const zodContent = parsedZodDefinition.consts
+        ? `${parsedZodDefinition.consts}\n${parsedZodDefinition.zod}`
+        : parsedZodDefinition.zod;
+
+      const fileContent = generateZodSchemaFileContent(
+        header,
+        name,
+        zodContent,
+      );
+
+      await fs.outputFile(filePath, fileContent);
+    }),
+  );
+
+  if (output.indexFiles && generateVerbsSchemas.length > 0) {
+    const schemaNames = generateVerbsSchemas.map((s) => s.name);
+    await writeZodSchemaIndex(
+      schemasPath,
+      fileExtension,
+      header,
+      schemaNames,
+      output.namingConvention,
+      true,
+    );
   }
 }


### PR DESCRIPTION
fix #2598

## Summary

Improved to generate `zod` schemas for request parameters (body, queryParams, headers).
Previously, only response schemas had `zod` schemas generated. Now, `zod` schemas are also generated for request parameters.

## Changes

### Before
```
model/
├── createPetsBody.ts
├── createPetsParams.ts
└── pet.zod.ts
```

### After
```
model/
├── createPetsBody.ts
├── createPetsBody.zod.ts
├── createPetsParams.ts
├── createPetsParams.zod.ts
├── createPetsHeaders.zod.ts
└── pet.zod.ts
```