### PR TITLE
fix(core): add main and types fields for moduleResolution node compat…

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,8 @@
   "version": "8.0.0-rc.4",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",


### PR DESCRIPTION
Fixes #2279 - DeepNonNullable import fails with moduleResolution: node

With moduleResolution: 'node' (Angular 17-18 default), TypeScript ignores the exports field and only looks for top-level main/types fields. Adding these fields enables backwards compatibility while keeping modern bundler support via the exports field.

