### PR TITLE
fix(zod): fixed an issue where `oneOf` was missing additional properties

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -254,8 +254,8 @@ export const generateZodValidationSchemaDefinition = (
       ),
     );
 
-    // Handle allOf/oneOf/anyOf with additional properties
-    if (schema.properties && Object.keys(schema.properties).length > 0) {
+    // Handle allOf/oneOf/anyOf with additional properties - merge additional properties into the schema
+    if ((schema.allOf || schema.oneOf || schema.anyOf) && schema.properties) {
       const additionalPropertiesSchema = {
         properties: schema.properties,
         required: schema.required,


### PR DESCRIPTION


Follow-up to #2672
I had the same problem with `oneOf`, so I fixed it.