### PR TITLE
fix(docs): GeneratorVerbOptions type permalink

### DIFF
--- a/docs/src/pages/reference/configuration/output.mdx
+++ b/docs/src/pages/reference/configuration/output.mdx
@@ -744,7 +744,7 @@ Type: `String` or `Function`.
 
 Valid values: path or implementation of the transformer function.
 
-This function is executed for each call when you generate and take in argument a <a href="https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L823" target="_blank">GeneratorVerbOptions</a> and should return a <a href="https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L823" target="_blank">GeneratorVerbOptions</a>
+This function is executed for each call when you generate and take in argument a <a href="https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L857" target="_blank">GeneratorVerbOptions</a> and should return a <a href="https://github.com/orval-labs/orval/blob/master/packages/core/src/types.ts#L857" target="_blank">GeneratorVerbOptions</a>
 
 ```js
 import { defineConfig } from 'orval';


### PR DESCRIPTION
Hi, Team
This PR corrects `GeneratorVerbOptions` type permalink.

Happy Christmas! 🎄