### PR TITLE
fix(core): Add esbuild external option for getMutatorInfo

### DIFF
--- a/packages/core/src/generators/__tests__/mutator-test-files/external-module-tests/external-module.ts
+++ b/packages/core/src/generators/__tests__/mutator-test-files/external-module-tests/external-module.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import lib from './non-existent-file';
+console.log(lib);

--- a/packages/core/src/generators/__tests__/mutator-test-files/external-module-tests/mutation.ts
+++ b/packages/core/src/generators/__tests__/mutator-test-files/external-module-tests/mutation.ts
@@ -1,0 +1,4 @@
+import './external-module';
+
+/* eslint-disable unicorn/no-anonymous-default-export, @typescript-eslint/no-empty-function */
+export default function () {}

--- a/packages/core/src/generators/mutator-info.test.ts
+++ b/packages/core/src/generators/mutator-info.test.ts
@@ -250,4 +250,13 @@ describe('getMutatorInfo', () => {
       expect(result).toEqual({ numberOfParams: 0, returnNumberOfParams: 2 });
     });
   });
+
+  describe('external module', () => {
+    it('should work even if there are imports that cannot be resolved in external modules', async () => {
+      const result = await getMutatorInfo(
+        path.join(basePath, 'external-module-tests', 'mutation.ts'),
+      );
+      expect(result).toEqual({ numberOfParams: 0 });
+    });
+  });
 });

--- a/packages/core/src/generators/mutator-info.ts
+++ b/packages/core/src/generators/mutator-info.ts
@@ -62,6 +62,7 @@ async function bundleFile(
     treeShaking: false,
     keepNames: false,
     alias,
+    external: ['*'],
   } satisfies BuildOptions);
   const { text } = result.outputFiles[0];
 


### PR DESCRIPTION
## Related
Fix #2682

## Overview
During the processing of getMutatorInfo, bundling using esbuild includes external modules as well, resulting in unnecessary module resolution processing.

To resolve this, all modules are now marked as external modules, ensuring only mutation code is transpilated.