### PR TITLE
Fix(zod) Schema Generation

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -616,11 +616,14 @@ export const generateZodValidationSchemaDefinition = (
     }
   }
 
-  if (minAndMaxTypes.has(type)) {
+  if (minAndMaxTypes.has(type) && !schema.enum) {
     // Handle minimum constraints: exclusiveMinimum (>.gt()) takes priority over minimum (.min())
     // Check if exclusive flag was set (boolean format in OpenAPI 3.0) or a different value (OpenAPI 3.1)
-    const shouldUseExclusiveMin = exclusiveMinRaw !== undefined;
-    const shouldUseExclusiveMax = exclusiveMaxRaw !== undefined;
+    // Only use .gt()/.lt() for numbers since these methods don't exist on ZodString/ZodArray
+    const shouldUseExclusiveMin =
+      exclusiveMinRaw !== undefined && type === 'number';
+    const shouldUseExclusiveMax =
+      exclusiveMaxRaw !== undefined && type === 'number';
 
     if (shouldUseExclusiveMin && exclusiveMin !== undefined) {
       consts.push(
@@ -649,7 +652,7 @@ export const generateZodValidationSchemaDefinition = (
       functions.push(['max', `${name}Max${constsCounterValue}`]);
     }
 
-    if (multipleOf !== undefined) {
+    if (multipleOf !== undefined && type === 'number') {
       consts.push(
         `export const ${name}MultipleOf${constsCounterValue} = ${multipleOf.toString()};`,
       );
@@ -666,7 +669,7 @@ export const generateZodValidationSchemaDefinition = (
     }
   }
 
-  if (matches) {
+  if (matches && type === 'string' && !schema.enum) {
     const isStartWithSlash = matches.startsWith('/');
     const isEndWithSlash = matches.endsWith('/');
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1498,6 +1498,109 @@ describe('generateZodValidationSchemaDefinition`', () => {
         "zod.array(zod.enum(['A', 'B', 'C'])).default([`A`])",
       );
     });
+
+    it('ignores minLength on string enum (issue #2630)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['value1', 'value2'],
+        minLength: 1,
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumMinLength',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['value1', 'value2']"],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe("zod.enum(['value1', 'value2']).optional()");
+    });
+
+    it('ignores maxLength on string enum (issue #2634)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['order.status.pending', 'order.status.confirmed'],
+        maxLength: 30,
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumMaxLength',
+        false,
+        false,
+        { required: true },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['order.status.pending', 'order.status.confirmed']"],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe(
+        "zod.enum(['order.status.pending', 'order.status.confirmed'])",
+      );
+    });
+
+    it('ignores pattern on string enum', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['cat', 'dog'],
+        pattern: '^[a-z]+$',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumPattern',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['cat', 'dog']"],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe("zod.enum(['cat', 'dog']).optional()");
+    });
   });
   describe('number handling', () => {
     const context: ContextSpec = {
@@ -1539,6 +1642,40 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
       expect(parsed.zod).toBe('zod.number().optional()');
     });
+
+    it('ignores pattern on number (issue #2634)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'number',
+        pattern: '^[0-9]+$',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testNumberPattern',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['number', undefined],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toBe('zod.number().optional()');
+    });
+
     it('generates an number with min', () => {
       const schema: OpenApiSchemaObject = {
         type: 'number',


### PR DESCRIPTION
## Summary

Fix invalid Zod schema generation when type-specific constraints are applied to incompatible types.

Fixes #2634
Fixes #2630

Also some other cases.
Thought about handling incorrect OpenAPI Schema like using pattern on number, but the best way to handle it is to ignore it simply, other tools handling it also like this.

## Changes

- Skip `min`/`max` constraints when schema has an enum (enums have fixed values, length constraints don't apply)
- Only apply `.regex()` for string types (not numbers or enums)
- Only apply `.multipleOf()` for number types
- Only apply `.gt()`/`.lt()` for number types (strings/arrays fall back to `.min()`/`.max()`)

## Before

```typescript
// String enum with maxLength generated invalid code:
zod.max(30).enum(['pending', 'confirmed'])  // Error: zod.max() doesn't exist

// Number with pattern generated invalid code:
zod.number().regex(/^[0-9]+$/)  // Error: .regex() doesn't exist on ZodNumber
```

## after
```typescript
// String enum correctly ignores maxLength:
zod.enum(['pending', 'confirmed'])

// Number correctly ignores pattern:
zod.number()
```

## Testing

Added 4 new unit tests covering:

- String enum with minLength
- String enum with maxLength
- String enum with pattern
- Number with pattern
