### PR TITLE
chore(core) Maximum call stack size exceeded for circular references

### DIFF
--- a/packages/core/src/resolvers/value.ts
+++ b/packages/core/src/resolvers/value.ts
@@ -30,14 +30,15 @@ export function resolveValue({
 
     let hasReadonlyProps = false;
 
-    // Avoid infinite loop
-    if (!name || !context.parents?.includes(name)) {
+    // Avoid infinite loop - use resolvedImport.name for tracking since name may be undefined
+    const refName = resolvedImport.name;
+    if (!context.parents?.includes(refName)) {
       const scalar = getScalar({
         item: schemaObject,
-        name: resolvedImport.name,
+        name: refName,
         context: {
           ...context,
-          ...(name ? { parents: [...(context.parents ?? []), name] } : {}),
+          parents: [...(context.parents ?? []), refName],
         },
       });
 


### PR DESCRIPTION
### Problem
#2669
After the v8 default change to inline combined types (`aliasCombinedTypes: false`), processing schemas with circular references through `allOf` causes a "Maximum call stack size exceeded" error.

**Affected tests:**
- `circular-v2`
- `deeply-nested-refs`

**Affected versions:**
- 8.0.0-rc.4 and later
- Works in 8.0.0-rc.3

### Root Cause

The issue was introduced in #2654 which changed the default behavior to inline combined types. This caused `propName` to be `undefined` in `combineSchemas`, which propagates as `name = undefined` to `resolveValue`.

In `packages/core/src/resolvers/value.ts`, the circular reference detection logic was:

```typescript
if (!name || !context.parents?.includes(name)) {
  const scalar = getScalar({
    item: schemaObject,
    name: resolvedImport.name,
    context: {
      ...context,
      ...(name ? { parents: [...(context.parents ?? []), name] } : {}),
    },
  });
  hasReadonlyProps = scalar.hasReadonlyProps;
}
```

When `name` is `undefined`:
1. `!name` is always `true`, so the recursive call was **always** made
2. `parents` was **never** updated (due to `name ? ... : {}`)

This caused infinite recursion for circular references.

### Solution

Changed the tracking to use `resolvedImport.name` (the actual referenced schema name) instead of the incoming `name` parameter:

```typescript
const refName = resolvedImport.name;
if (!context.parents?.includes(refName)) {
  const scalar = getScalar({
    item: schemaObject,
    name: refName,
    context: {
      ...context,
      parents: [...(context.parents ?? []), refName],
    },
  });
  hasReadonlyProps = scalar.hasReadonlyProps;
}
```

This ensures:
- Circular references are properly detected using the actual schema name (e.g., `Pet`, `Parent`)
- The `parents` array is always updated correctly
- Works regardless of whether `name` is defined or not

### Testing

- All 215 CLI tests pass
- All 133 unit tests pass
- Specifically verified `circular-v2` and `deeply-nested-refs` tests now pass
- Generated output for circular reference schemas is correct

Fixes #2669
