### PR TITLE
fix(core): add type guards for 'in' operator on schema objects (#2540)

### DIFF
--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -44,7 +44,7 @@ export function generateInterface({
       scalar.type === 'object' &&
       schema.properties &&
       Object.values(schema.properties).length > 0 &&
-      Object.values(schema.properties).every((item) => 'const' in item)
+      Object.values(schema.properties).every((item) => typeof item === 'object' && item !== null && 'const' in item)
     ) {
       const mappedScalarValue = scalar.value
         .replaceAll(';', ',')

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -167,7 +167,7 @@ export function getObject({
 
         acc.hasReadonlyProps ||= isReadOnly || false;
 
-        const constValue = 'const' in schema ? schema.const : undefined;
+        const constValue = typeof schema === 'object' && schema !== null && 'const' in schema ? schema.const : undefined;
         const hasConst = constValue !== undefined;
         let constLiteral: string | undefined;
 

--- a/packages/core/src/resolvers/object.ts
+++ b/packages/core/src/resolvers/object.ts
@@ -39,9 +39,9 @@ function resolveObjectOriginal({
     ).test(resolvedValue.value)
   ) {
     let model = '';
-    const isConstant = 'const' in schema;
+    const isConstant = typeof schema === 'object' && schema !== null && 'const' in schema;
     const constantIsString =
-      'type' in schema &&
+      typeof schema === 'object' && schema !== null && 'type' in schema &&
       (schema.type === 'string' ||
         (Array.isArray(schema.type) && schema.type.includes('string')));
 

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -68,9 +68,11 @@ function normalizeCanonicalImportPaths(
 ) {
   for (const schema of schemas) {
     schema.imports = schema.imports.map((imp) => {
+      // Always use the schema name (imp.name) to look up the canonical path,
+      // not imp.importPath which might be incorrect for external file references
       const resolvedImportKey = resolveImportKey(
         schemaPath,
-        imp.importPath ?? `./${conventionName(imp.name, namingConvention)}`,
+        `./${conventionName(imp.name, namingConvention)}`,
         fileExtension,
       );
       const canonical = canonicalPathMap.get(resolvedImportKey);


### PR DESCRIPTION
## Summary
Fixes #2540 by adding type guards before using the \`in\` operator on schema objects.

## Problem
When external YAML references are not properly resolved, primitive values (like strings) can be passed where schema objects are expected. This causes \`Cannot use 'in' operator to search for 'const' in <value>\` errors.

For example:
```
🛑 uzone_user - Cannot use 'in' operator to search for 'const' in リクエストは正常に完了しました。
```

## Changes
- Add type guards (\`typeof X === 'object' && X !== null\`) before using \`in\` operator in:
  - \`packages/core/src/generators/interface.ts:47\`
  - \`packages/core/src/getters/object.ts:170\`
  - \`packages/core/src/resolvers/object.ts:42,44\`
- Update \`packages/core/src/writers/schemas.ts\` to always use schema name for canonical path lookup instead of potentially incorrect importPath from external file references

## Testing
Tested with a real-world OpenAPI spec containing external YAML references and Japanese characters in example values. Code generation now succeeds without errors.

## Related
- Fixes #2540