### PR TITLE
[doc] Restore URL normalization for Algolia search results

### DIFF
--- a/docs/src/components/useSearch.tsx
+++ b/docs/src/components/useSearch.tsx
@@ -118,7 +118,15 @@ export function SearchProvider({
                     return null;
                   }
 
-                  return item;
+                  const url = new URL(item.url);
+                  return {
+                    ...item,
+                    url: item.url
+                      .replace(url.origin, '')
+                      .replace('#__next', '')
+                      .replace('/docs/#', '/docs/overview#')
+                      .replace(/#([^/]+)$/, '/$1'),
+                  };
                 })
                 .filter((item) => item !== null);
             }}


### PR DESCRIPTION
## Summary

This PR restores the URL normalization logic that was previously removed in PR #2733. In PR #2733, the implementation worked correctly in the local environment. However, this was because the local Algolia index did not include URLs with hash fragments (e.g., `/reference/configuration#input`), while the production Algolia index does. As a result, the URL normalization logic was mistakenly removed, thinking it was unnecessary. This PR restores the logic to handle production environments where the Algolia index contains URLs with hash fragments.

## Problem and Solution

The production Algolia index contains URLs with hash fragments (e.g., `/reference/configuration#input`), while the local Algolia index does not. Without URL normalization, search results with hash fragments cause navigation issues in production.

This PR restores the URL normalization logic in `transformItems` to:
- Remove hash fragments from URLs (e.g., `/reference/configuration#input` → `/reference/configuration/input`)

---

<img width="588" height="285" alt="image" src="https://github.com/user-attachments/assets/47ca5a86-feb6-4aae-806a-7dfb027ff199" />

http://localhost:3000/reference/configuration/input