### PR TITLE
fix(svelte): prefetch correctly

### DIFF
--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -96,7 +96,6 @@ const generatePrefetch = ({
   queryOptionsFnName,
   queryProperties,
   isRequestOptions,
-  hasSvelteQueryV6,
 }: {
   operationName: string;
   mutator?: GeneratorMutator;
@@ -113,7 +112,6 @@ const generatePrefetch = ({
   queryOptionsFnName: string;
   queryProperties: string;
   isRequestOptions: boolean;
-  hasSvelteQueryV6: boolean;
 }) => {
   const shouldGeneratePrefetch =
     usePrefetch &&
@@ -154,11 +152,7 @@ const generatePrefetch = ({
     queryProperties ? ',' : ''
   }${isRequestOptions ? 'options' : 'queryOptions'})
 
-  await queryClient.${prefetchFnName}(${
-    hasSvelteQueryV6
-      ? `() => ({ ...${queryOptionsVarName} })`
-      : queryOptionsVarName
-  });
+  await queryClient.${prefetchFnName}(${queryOptionsVarName});
 
   return queryClient;
 }\n`;
@@ -523,12 +517,9 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
     useInfinite,
     operationName,
     mutator,
-    queryProps: hasSvelteQueryV6
-      ? queryProps.replace(':', ': () => ')
-      : queryProps,
+    queryProps,
     dataType,
     errorType,
-    hasSvelteQueryV6,
     queryArguments,
     queryOptionsVarName,
     queryOptionsFnName,


### PR DESCRIPTION
In Svelte Query v6/svelte5, prefetch queries don't happen reactively and thus should not take functions as arguments