### PR TITLE
docs: fix typo - React Query → Svelte Query

### DIFF
--- a/docs/src/pages/guides/svelte-query.mdx
+++ b/docs/src/pages/guides/svelte-query.mdx
@@ -3,7 +3,7 @@ id: svelte-query
 title: Svelte Query
 ---
 
-Start by providing an OpenAPI specification and an Orval config file. To use React Query, define the `client` in the Orval config to be `svelte-query`.
+Start by providing an OpenAPI specification and an Orval config file. To use Svelte Query, define the `client` in the Orval config to be `svelte-query`.
 
 ## Example with Svelte Query
 


### PR DESCRIPTION
Fix typo: incorrect reference to "React Query" should be "Svelte Query" in the svelte-query documentation.