### PR TITLE
fix: respect single schema file configuration in import generation

### DIFF
--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -11,7 +11,7 @@ export function generateImportsForBuilder(
   const isZodSchemaOutput =
     isObject(output.schemas) && output.schemas.type === 'zod';
 
-  if (!output.indexFiles) {
+  if (!output.indexFiles && !output.schemas) {
     return uniqueBy(imports, (x) => x.name).map((i) => {
       const baseName = i.schemaName || i.name;
       const name = conventionName(baseName, output.namingConvention);


### PR DESCRIPTION
## Problem

When using Orval with a configuration that outputs all schemas to a single file, the generated controller files were importing types from non-existent individual schema file paths.

For example, instead of:
```typescript
import type { ActionTypeRequest, GetDeliveryCardParams } from '../orchestrator.schemas';
```
It was generating:
```typescript
import type { ActionTypeRequest } from '../orchestrator.schemas/actionTypeRequest';
import type { GetDeliveryCardParams } from '../orchestrator.schemas/getDeliveryCardParams';
```

This caused TypeScript errors: Cannot find module `'../orchestrator.schemas/actionTypeRequest'`

## Solution
Modified `generateImportsForBuilder()` to detect when schemas are configured as a single file and treat them the same way as index files - importing all types from the single schema file