### PR TITLE
fix: generate models for swagger 2.0 responses

### DIFF
--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -275,6 +275,31 @@ export function getResReqTypes(
           .filter(Boolean)
           .map((x) => ({ ...x, key })) as ResReqTypesValue[];
       }
+      const swaggerSchema =
+        'schema' in res
+          ? (
+              res as {
+                schema?: OpenApiSchemaObject | OpenApiReferenceObject;
+              }
+            ).schema
+          : undefined;
+
+      if (swaggerSchema) {
+        const propName = key ? pascal(name) + pascal(key) : undefined;
+        const resolvedValue = resolveObject({
+          schema: swaggerSchema,
+          propName,
+          context,
+        });
+
+        return [
+          {
+            ...resolvedValue,
+            contentType: 'application/json',
+            key,
+          },
+        ] as ResReqTypesValue[];
+      }
 
       return [
         {

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -7,6 +7,7 @@ import {
   type ImportOpenApi,
   type InputOptions,
   type NormalizedOutputOptions,
+  type OpenApiComponentsObject,
   type OpenApiDocument,
   type OverrideInput,
   type WriteSpecBuilder,
@@ -118,6 +119,14 @@ function getApiSchemas({
     output.override.components.responses.suffix,
   );
 
+  const swaggerResponseDefinition = generateComponentDefinition(
+    'responses' in spec
+      ? (spec as { responses?: OpenApiComponentsObject['responses'] }).responses
+      : undefined,
+    context,
+    '',
+  );
+
   const bodyDefinition = generateComponentDefinition(
     spec.components?.requestBodies,
     context,
@@ -133,6 +142,7 @@ function getApiSchemas({
   const schemas = [
     ...schemaDefinition,
     ...responseDefinition,
+    ...swaggerResponseDefinition,
     ...bodyDefinition,
     ...parameters,
   ];


### PR DESCRIPTION

- Problem/Root cause: In Swagger 2.0, responses are defined at the top level, not under components.responses.  so #/responses/* references were skipped during model generation. This caused import errors.
  
- What changed
     - orval/src/import-open-api.ts: include Swagger 2.0 top‑level responses in component model generation.
     - core/src/getters/res-req-types.ts: add a fallback to resolve response.schema when content is absent (Swagger 2.0).
     
     
Fixes #2751
     
- you can test it out [here](https://github.com/froggy1014/orval-version-2.0-fix)