### PR TITLE
fix-(msw)-circular-error-in-ci-test

### DIFF
--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -374,6 +374,7 @@ describe('combineSchemasMock', () => {
 
     const item: MockSchemaObject = {
       name: 'Cat',
+      isRef: true,
       allOf: [
         { $ref: '#/components/schemas/Base' },
         {

--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -74,9 +74,14 @@ export function combineSchemasMock({
     (acc, val, _, arr) => {
       const refName =
         '$ref' in val ? pascal(val.$ref.split('/').pop() ?? '') : '';
+      // For allOf: skip if refName is in existingRefs AND this is an inline schema (not a top-level ref)
+      // This allows top-level schemas (item.isRef=true) to get base properties from allOf
+      // while preventing circular allOf chains in inline property schemas
       const shouldSkipRef =
         separator === 'allOf'
-          ? refName && refName === item.name
+          ? refName &&
+            (refName === item.name ||
+              (existingReferencedProperties.includes(refName) && !item.isRef))
           : refName && existingReferencedProperties.includes(refName);
       if (shouldSkipRef) {
         if (arr.length === 1) {


### PR DESCRIPTION
## Problem

yarn test:ci had an error
```bash
🛑 circular-v2 - Maximum call stack size exceeded
```

## Fix

For allOf, the skip logic now checks:

refName === item.name (self-reference guard), OR
refName is in existingReferencedProperties AND !item.isRef (inline property schema, not a top-level ref)
This allows:

Top-level schemas (like Cat with isRef=true): Get base properties from allOf even if the base was seen before
Inline property schemas (like Pet.tests with isRef=false/undefined): Check existingReferencedProperties to prevent circular allOf chains