### PR TITLE
fix-(cli): exit with code 1 when project generation fails

### DIFF
--- a/packages/orval/src/bin/orval.ts
+++ b/packages/orval/src/bin/orval.ts
@@ -172,8 +172,10 @@ cli
         }
       }
 
-      if (hasErrors)
+      if (hasErrors) {
         logError('One or more project failed, see above for details');
+        process.exit(1);
+      }
     }
   });
 


### PR DESCRIPTION
## Problem
When running yarn test:ci, if one or more projects fail during generation, the CLI logs the error but exits with code 0 (success). This causes CI pipelines to incorrectly pass despite errors like Maximum call stack size exceeded.

## Solution
Added process.exit(1) after logging "One or more project failed" to ensure the CLI exits with a non-zero code when any project fails.

## Impact
- CI workflows (like update-samples) will now properly fail when generation errors occur
- No breaking changes to normal usage