### PR TITLE
 fix(core): wrap union types in parens when combined with allOf

### DIFF
--- a/packages/core/src/generators/interface.test.ts
+++ b/packages/core/src/generators/interface.test.ts
@@ -491,4 +491,35 @@ export type ConstEnum = typeof ConstEnumValue;
       'export interface InlineObject {\n  field?: InlineObjectField;\n}\n',
     );
   });
+
+  // Comprehensive test: (a|b) & c & (d|e) & (f|g)
+  // Tests: nested oneOf, nested anyOf, sibling oneOf, different positions
+  it('allOf + union precedence: should wrap all unions in parens', () => {
+    const schema: OpenApiSchemaObject = {
+      allOf: [
+        {
+          oneOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'string' } } },
+          ],
+        },
+        { type: 'object', properties: { c: { type: 'string' } } },
+        {
+          anyOf: [
+            { type: 'object', properties: { d: { type: 'string' } } },
+            { type: 'object', properties: { e: { type: 'string' } } },
+          ],
+        },
+      ],
+      oneOf: [
+        { type: 'object', properties: { f: { type: 'string' } } },
+        { type: 'object', properties: { g: { type: 'string' } } },
+      ],
+    };
+
+    const result = generateInterface({ name: 'Test', context, schema });
+    expect(result[0].model).toBe(
+      'export interface Test ({\n  a?: string;\n} | {\n  b?: string;\n}) & {\n  c?: string;\n} & ({\n  d?: string;\n} | {\n  e?: string;\n}) & ({\n  f?: string;\n} | {\n  g?: string;\n})\n',
+    );
+  });
 });


### PR DESCRIPTION
When generating TypeScript for `allOf` + `oneOf`/`anyOf` combinations, union types were not wrapped in parentheses, causing incorrect operator precedence. For example:

```
{ allOf: [A, { oneOf: [B, C] }] }
```

Previously generated: `A & B | C`
Now generates: `A & (B | C)`

Also handles sibling pattern where `oneOf`/`anyOf` is at the same level as `allOf`, which was previously ignored entirely in v7:

```
{ allOf: [A], oneOf: [B, C] }
```

Previously generated: `A` (sibling `oneOf` completely ignored)
Now generates: `A & (B | C)`

This fixes #2791
