### PR TITLE
fix(core): preserve ./ prefix in operation schema import paths

### DIFF
--- a/packages/core/src/writers/schemas.test.ts
+++ b/packages/core/src/writers/schemas.test.ts
@@ -433,7 +433,7 @@ describe('fixRegularSchemaImports', () => {
       { name: 'Context' },
       {
         name: 'PythonExecutionWebRequestParams',
-        importPath: 'operations/pythonExecutionWebRequestParams',
+        importPath: './operations/pythonExecutionWebRequestParams',
       },
     ]);
   });
@@ -451,7 +451,7 @@ describe('fixRegularSchemaImports', () => {
     );
 
     expect(regularSchemas[0].imports[0].importPath).toBe(
-      'api/params/getUserParams',
+      './api/params/getUserParams',
     );
   });
 
@@ -468,7 +468,7 @@ describe('fixRegularSchemaImports', () => {
     );
 
     expect(regularSchemas[0].imports[0].importPath).toBe(
-      'operations/GetUserParams',
+      './operations/GetUserParams',
     );
   });
 
@@ -517,12 +517,12 @@ describe('fixRegularSchemaImports', () => {
       { name: 'Context' },
       {
         name: 'ExecutionRequestParams',
-        importPath: 'operations/executionRequestParams',
+        importPath: './operations/executionRequestParams',
       },
     ]);
     expect(regularSchemas[1].imports).toEqual([
       { name: 'User' },
-      { name: 'BatchRequestBody', importPath: 'operations/batchRequestBody' },
+      { name: 'BatchRequestBody', importPath: './operations/batchRequestBody' },
     ]);
   });
 });

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -75,7 +75,7 @@ function fixSchemaImports(
         const fileName = conventionName(imp.name, namingConvention);
         return {
           ...imp,
-          importPath: upath.join(relativePath, fileName),
+          importPath: upath.joinSafe(relativePath, fileName),
         };
       }
       return imp;


### PR DESCRIPTION
## Summary

Fixes a bug in the `operationSchemas` feature where import paths for regular schemas referencing operation schemas were missing the `./` prefix, causing TypeScript module resolution to fail.

**Before:** `import type { MLHyperparameter } from 'operations/mLHyperparameter';`
**After:** `import type { MLHyperparameter } from './operations/mLHyperparameter';`

## Problem

When using `operationSchemas` config option (added in #2785), regular schemas that import operation schemas generate incorrect import paths:

```
TS2307: Cannot find module 'operations/mLHyperparameter' or its corresponding type declarations.
```

TypeScript interprets `operations/...` as a package name instead of a relative path because the `./` prefix is missing.

## Root Cause

In `packages/core/src/writers/schemas.ts`, the `fixSchemaImports` function used `upath.join()` to build import paths:

```typescript
importPath: upath.join(relativePath, fileName),
```

Node's `path.join('./operations', 'file')` returns `operations/file` - it strips the `./` prefix.

## Fix

Changed to use `upath.joinSafe()` which preserves the `./` prefix:

```typescript
importPath: upath.joinSafe(relativePath, fileName),
```

## Related

- #2783 - Original feature request for operationSchemas
- #2785 - Added operationSchemas config option
- #2788 - Fixed bidirectional imports (this bug was introduced/missed here)

## Test plan

- [x] All existing tests pass (164 tests)
- [x] Updated test expectations to reflect correct `./` prefix
- [x] Verified with real-world OpenAPI spec - TypeScript compiles without module resolution errors