### PR TITLE
fix: clean workspace directory when clean option is enabled

### DIFF
--- a/packages/orval/src/generate-spec.ts
+++ b/packages/orval/src/generate-spec.ts
@@ -41,6 +41,12 @@ export async function generateSpec(
         getFileInfo(options.output.schemas).dirname,
       );
     }
+    if (options.output.workspace) {
+      await removeFilesAndEmptyFolders(
+        ['**/*', '!**/*.d.ts', ...extraPatterns],
+        options.output.workspace,
+      );
+    }
     log(`${projectName} Cleaning output folder`);
   }
 


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->
## Problem
When `clean: true` is set, the `workspace` directory was not being cleaned up, which caused `index.ts` files in the workspace directory to persist after regeneration.

## Solution
Added cleanup for the `workspace` directory similar to how `target` and `schemas` directories are cleaned. This ensures that all generated files, including `index.ts` in the workspace directory, are properly removed before regeneration.

## Changes
- Added cleanup logic for `options.output.workspace` in `generate-spec.ts`
- Uses the same pattern as `target` and `schemas` cleanup (`**/*` with `!**/*.d.ts` exclusion)