### PR TITLE
[WIP] fix(core): use parameter name in formData for $ref schemas (#2814)

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -282,3 +282,82 @@ formData.append(\`wildcardFile\`, bodyRequestBody.wildcardFile);
     });
   });
 });
+
+// When requestBody uses $ref, the generated function parameter name varies:
+// - If schema properties have file types (contentMediaType), the type is rewritten
+//   as inline, so param becomes operation-based: uploadFile() → uploadFileBody
+// - If schema has no file types, the $ref type is preserved,
+//   so param uses schema name: uploadFile() → mySchemaName
+// formData variable must match whichever naming is used.
+describe('getResReqTypes (formData $ref variable name)', () => {
+  it('uses operation-based name when schema has file properties', () => {
+    // contentMediaType: 'application/octet-stream' marks this as a file field
+    const ctx: ContextSpec = {
+      ...context,
+      spec: {
+        components: {
+          schemas: {
+            FileUpload: {
+              type: 'object',
+              properties: {
+                file: {
+                  type: 'string',
+                  contentMediaType: 'application/octet-stream',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const reqBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'multipart/form-data': {
+              schema: { $ref: '#/components/schemas/FileUpload' },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+
+    expect(result.formData).toContain('uploadRequestBody.file');
+  });
+
+  it('uses schema name when no file properties', () => {
+    // No file fields, so $ref type is preserved and param uses schema name
+    const ctx: ContextSpec = {
+      ...context,
+      spec: {
+        components: {
+          schemas: {
+            FileUpload: {
+              type: 'object',
+              properties: { name: { type: 'string' } },
+            },
+          },
+        },
+      },
+    };
+    const reqBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'multipart/form-data': {
+              schema: { $ref: '#/components/schemas/FileUpload' },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+
+    expect(result.formData).toContain('fileUpload.name');
+  });
+});

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -239,6 +239,7 @@ export function getResReqTypes(
                   context,
                   isRequestBodyOptional:
                     'required' in res && res.required === false,
+                  isRef: !resolvedValue.isRef,
                   encoding: mediaType.encoding,
                 })
               : undefined;
@@ -251,6 +252,7 @@ export function getResReqTypes(
                   isUrlEncoded: true,
                   isRequestBodyOptional:
                     'required' in res && res.required === false,
+                  isRef: !resolvedValue.isRef,
                   encoding: mediaType.encoding,
                 })
               : undefined;


### PR DESCRIPTION
Pass `isRef: true` when calling `getSchemaFormDataAndUrlEncoded` from inline `requestBody` path, ensuring `formData` variable uses parameter name instead of schema name.

Fix #2814
