### PR TITLE
fix: avoid literal index signatures for propertyNames enum

### DIFF
--- a/packages/core/src/generators/interface.test.ts
+++ b/packages/core/src/generators/interface.test.ts
@@ -268,7 +268,7 @@ export type ConstEnum = typeof ConstEnumValue;
     const want: GeneratorSchema[] = [
       {
         name: 'MyObject',
-        model: `export interface MyObject {[key: 'foo' | 'bar']: string}\n`,
+        model: `export type MyObject = Partial<Record<'foo' | 'bar', string>>;\n`,
         imports: [],
         dependencies: [],
         schema,
@@ -295,7 +295,7 @@ export type ConstEnum = typeof ConstEnumValue;
     const want: GeneratorSchema[] = [
       {
         name: 'MyObject',
-        model: `export interface MyObject { [key: 'key1' | 'key2' | 'key3']: unknown }\n`,
+        model: `export type MyObject = Partial<Record<'key1' | 'key2' | 'key3', unknown>>;\n`,
         imports: [],
         dependencies: [],
         schema,
@@ -324,7 +324,7 @@ export type ConstEnum = typeof ConstEnumValue;
     const want: GeneratorSchema[] = [
       {
         name: 'MyObject',
-        model: `export interface MyObject {[key: 'id' | 'name']: number}\n`,
+        model: `export type MyObject = Partial<Record<'id' | 'name', number>>;\n`,
         imports: [],
         dependencies: [],
         schema,
@@ -389,7 +389,9 @@ export type ConstEnum = typeof ConstEnumValue;
     expect(got).toHaveLength(1);
     expect(got[0].name).toBe('MyObject');
     expect(got[0].model).toContain('existingProp: string');
-    expect(got[0].model).toContain("[key: 'allowed' | 'values']: number");
+    expect(got[0].model).toContain(
+      "} & Partial<Record<'allowed' | 'values', number>>",
+    );
   });
 
   it.each([

--- a/packages/core/src/generators/interface.ts
+++ b/packages/core/src/generators/interface.ts
@@ -26,6 +26,8 @@ export function generateInterface({
     context,
   });
   const isEmptyObject = scalar.value === '{}';
+  const shouldUseTypeAlias =
+    context?.output.override?.useTypeOverInterfaces || scalar.useTypeAlias;
 
   let model = '';
 
@@ -36,10 +38,7 @@ export function generateInterface({
       '// eslint-disable-next-line @typescript-eslint/no-empty-interface\n';
   }
 
-  if (
-    scalar.type === 'object' &&
-    !context?.output.override?.useTypeOverInterfaces
-  ) {
+  if (scalar.type === 'object' && !shouldUseTypeAlias) {
     if (
       scalar.type === 'object' &&
       schema.properties &&

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -44,6 +44,19 @@ function getIndexSignatureKey(item: OpenApiSchemaObject): string {
   return 'string';
 }
 
+function getPropertyNamesRecordType(
+  item: OpenApiSchemaObject,
+  valueType: string,
+): string | undefined {
+  const enumValues = getPropertyNamesEnum(item);
+  if (!enumValues || enumValues.length === 0) {
+    return undefined;
+  }
+
+  const keyType = enumValues.map((val) => `'${val}'`).join(' | ');
+  return `Partial<Record<${keyType}, ${valueType}>>`;
+}
+
 interface GetObjectOptions {
   item: OpenApiSchemaObject;
   name?: string;
@@ -216,16 +229,34 @@ export function getObject({
 
         if (arr.length - 1 === index) {
           if (item.additionalProperties) {
-            const keyType = getIndexSignatureKey(item);
             if (isBoolean(item.additionalProperties)) {
-              acc.value += `\n  [key: ${keyType}]: unknown;\n }`;
+              const recordType = getPropertyNamesRecordType(item, 'unknown');
+              if (recordType) {
+                acc.value += '\n}';
+                acc.value += ` & ${recordType}`;
+                acc.useTypeAlias = true;
+              } else {
+                const keyType = getIndexSignatureKey(item);
+                acc.value += `\n  [key: ${keyType}]: unknown;\n }`;
+              }
             } else {
               const resolvedValue = resolveValue({
                 schema: item.additionalProperties,
                 name,
                 context,
               });
-              acc.value += `\n  [key: ${keyType}]: ${resolvedValue.value};\n}`;
+              const recordType = getPropertyNamesRecordType(
+                item,
+                resolvedValue.value,
+              );
+              if (recordType) {
+                acc.value += '\n}';
+                acc.value += ` & ${recordType}`;
+                acc.useTypeAlias = true;
+              } else {
+                const keyType = getIndexSignatureKey(item);
+                acc.value += `\n  [key: ${keyType}]: ${resolvedValue.value};\n}`;
+              }
               acc.dependencies.push(...resolvedValue.dependencies);
             }
           } else {
@@ -246,6 +277,7 @@ export function getObject({
         isRef: false,
         schema: {},
         hasReadonlyProps: false,
+        useTypeAlias: false,
         dependencies: [],
         example: item.example,
         examples: resolveExampleRefs(item.examples, context),
@@ -254,8 +286,22 @@ export function getObject({
   }
 
   if (item.additionalProperties) {
-    const keyType = getIndexSignatureKey(item);
     if (isBoolean(item.additionalProperties)) {
+      const recordType = getPropertyNamesRecordType(item, 'unknown');
+      if (recordType) {
+        return {
+          value: recordType + nullable,
+          imports: [],
+          schemas: [],
+          isEnum: false,
+          type: 'object',
+          isRef: false,
+          hasReadonlyProps: item.readOnly || false,
+          useTypeAlias: true,
+          dependencies: [],
+        };
+      }
+      const keyType = getIndexSignatureKey(item);
       return {
         value: `{ [key: ${keyType}]: unknown }` + nullable,
         imports: [],
@@ -264,6 +310,7 @@ export function getObject({
         type: 'object',
         isRef: false,
         hasReadonlyProps: item.readOnly || false,
+        useTypeAlias: false,
         dependencies: [],
       };
     }
@@ -272,6 +319,21 @@ export function getObject({
       name,
       context,
     });
+    const recordType = getPropertyNamesRecordType(item, resolvedValue.value);
+    if (recordType) {
+      return {
+        value: recordType + nullable,
+        imports: resolvedValue.imports ?? [],
+        schemas: resolvedValue.schemas ?? [],
+        isEnum: false,
+        type: 'object',
+        isRef: false,
+        hasReadonlyProps: resolvedValue.hasReadonlyProps,
+        useTypeAlias: true,
+        dependencies: resolvedValue.dependencies,
+      };
+    }
+    const keyType = getIndexSignatureKey(item);
     return {
       value: `{[key: ${keyType}]: ${resolvedValue.value}}` + nullable,
       imports: resolvedValue.imports ?? [],
@@ -280,6 +342,7 @@ export function getObject({
       type: 'object',
       isRef: false,
       hasReadonlyProps: resolvedValue.hasReadonlyProps,
+      useTypeAlias: false,
       dependencies: resolvedValue.dependencies,
     };
   }
@@ -300,6 +363,20 @@ export function getObject({
 
   const keyType =
     item.type === 'object' ? getIndexSignatureKey(item) : 'string';
+  const recordType = getPropertyNamesRecordType(item, 'unknown');
+  if (item.type === 'object' && recordType) {
+    return {
+      value: recordType + nullable,
+      imports: [],
+      schemas: [],
+      isEnum: false,
+      type: 'object',
+      isRef: false,
+      hasReadonlyProps: item.readOnly || false,
+      useTypeAlias: true,
+      dependencies: [],
+    };
+  }
   return {
     value:
       (item.type === 'object' ? `{ [key: ${keyType}]: unknown }` : 'unknown') +
@@ -310,6 +387,7 @@ export function getObject({
     type: 'object',
     isRef: false,
     hasReadonlyProps: item.readOnly || false,
+    useTypeAlias: false,
     dependencies: [],
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1137,6 +1137,7 @@ export const SchemaType = {
 
 export type ScalarValue = {
   value: string;
+  useTypeAlias?: boolean;
   isEnum: boolean;
   hasReadonlyProps: boolean;
   type: SchemaType;


### PR DESCRIPTION
## Problem

Schemas with `propertyNames.enum` generate literal-union index signatures, which triggers TS1337. This is reported in
- #2824

Fixes #2824

## Approach
  
- Emit `Partial<Record<...>>` when `propertyNames.enum` is present
- Use type aliases for those cases to keep output valid TypeScript
- Update related tests

## Reproduction

- Repo: https://github.com/froggy1014/orval-reproduction

## Impact

Type output switches from interface to type alias for `propertyNames.enum` cases (no declaration merging), but type safety is preserved.