### PR TITLE
Fix overview following recent changes v8

### DIFF
--- a/docs/src/pages/overview.mdx
+++ b/docs/src/pages/overview.mdx
@@ -15,7 +15,7 @@ Main goals:
 - Generate HTTP request functions
 - Generate mocks with <a href="https://mswjs.io/" target="_blank">MSW</a>
 
-The default generated clients use <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API" target="_blank">Fetch API</a>. You may configure any client(e.g. axios), depending on your project needs. Orval supports most major JavaScript frameworks such as Angular, React or Vue. [Learn more about configuring Orval](./guides/basics)
+The default generated clients use <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API" target="_blank">Fetch API</a>. You may configure any client (e.g. axios), depending on your project needs. Orval supports most major JavaScript frameworks such as Angular, React or Vue. [Learn more about configuring Orval](./guides/basics)
 
 Orval can also generate the following clients:
 


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->

From v8, default HTTP client is fetch API, not axios. I change the overview to follow recent update. 

https://orval.dev/versions/v8#-default-http-client-changed