### PR TITLE
fix(svelte): don't use accessor for prefetch options

### DIFF
--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -582,7 +582,7 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
     queryProps,
     dataType,
     errorType,
-    queryArguments,
+    queryArguments: queryArgumentsForOptions,
     queryOptionsVarName,
     queryOptionsFnName,
     queryProperties,

--- a/packages/query/src/query-options.ts
+++ b/packages/query/src/query-options.ts
@@ -188,8 +188,7 @@ export const generateQueryArguments = ({
   initialData?: 'defined' | 'undefined';
   httpClient: OutputHttpClient;
   isAngularClient: boolean;
-  /** When true, include http: HttpClient parameter (for getQueryOptions/getMutationOptions).
-   *  When false, don't include it (for inject* functions which inject internally). */
+  /** When true, don't make options an Accessor for svelte-query v6 */
   forQueryOptions?: boolean;
   /** When true, wrap options type in getter alternative for Angular reactive support. */
   forAngularInject?: boolean;

--- a/samples/svelte-query/v6-custom-fetch/orval.config.ts
+++ b/samples/svelte-query/v6-custom-fetch/orval.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
           name: 'customFetch',
         },
         query: {
+          usePrefetch: true,
           mutationInvalidates: [
             {
               onMutations: ['createPets'],

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -209,6 +209,29 @@ export function createListPets<
 }
 
 /**
+ * @summary List all pets
+ */
+export const prefetchListPetsQuery = async <
+  TData = Awaited<ReturnType<typeof listPets>>,
+  TError = unknown,
+>(
+  queryClient: QueryClient,
+  params?: ListPetsParams,
+  options?: {
+    query?: Partial<
+      CreateQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getListPetsQueryOptions(params, options);
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};
+
+/**
  * @summary Create a pet
  */
 export type createPetsResponse200 = {
@@ -550,3 +573,26 @@ export function createShowPetById<
 
   return query;
 }
+
+/**
+ * @summary Info for a specific pet
+ */
+export const prefetchShowPetByIdQuery = async <
+  TData = Awaited<ReturnType<typeof showPetById>>,
+  TError = Error,
+>(
+  queryClient: QueryClient,
+  petId: string,
+  options?: {
+    query?: Partial<
+      CreateQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof customFetch>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getShowPetByIdQueryOptions(petId, options);
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};


### PR DESCRIPTION
Makes sure svelte query v6 generates prefetch functions without accessors, just plain object
```diff
export const prefetchListPetsQuery = async <
  TData = Awaited<ReturnType<typeof listPets>>,
  TError = unknown,
>(
  queryClient: QueryClient,
  params?: ListPetsParams,
-  options?: () => {
+  options?: {
    query?: Partial<
      CreateQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>
    >;
    request?: SecondParameter<typeof customFetch>;
  },
): Promise<QueryClient> => {
  const queryOptions = getListPetsQueryOptions(params, options);

  await queryClient.prefetchQuery(queryOptions);

  return queryClient;
};
```