### PR TITLE
docs(llms): add llms.txt build step

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,4 @@ packages/hono/src/zValidator.ts
 # https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx#prettier
 *.mdx
 .github/ISSUE_TEMPLATE
+docs/public/llms.txt

--- a/docs/.wrangler/deploy/config.json
+++ b/docs/.wrangler/deploy/config.json
@@ -1,0 +1,1 @@
+{ "configPath": "../../dist/server/wrangler.json", "auxiliaryWorkers": [] }

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "sideEffects": false,
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "yarn llms && vite build",
     "start": "node .output/server/index.mjs",
     "types:check": "fumadocs-mdx && tsc --noEmit",
     "postinstall": "fumadocs-mdx",
@@ -13,7 +13,8 @@
     "format": "biome format --write",
     "deploy": "yarn build && wrangler deploy",
     "preview": "yarn build && vite preview",
-    "cf-typegen": "wrangler types"
+    "cf-typegen": "wrangler types",
+    "llms": "node scripts/build-llms.js"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,74 @@
+# Documentation
+
+# Orval Documentation
+
+[Orval Website](https://orval.dev)
+
+## Overview
+
+- [Overview](https://orval.dev/docs): Generate type-safe TypeScript clients from OpenAPI specifications
+- [Installation](https://orval.dev/docs/installation): Install Orval in your project
+- [Quick Start](https://orval.dev/docs/quick-start): Generate your first type-safe API client in seconds
+
+## Getting Started
+
+- [Basics](https://orval.dev/docs/guides/basics): Learn the fundamentals of configuring Orval
+
+## HTTP Clients
+
+- [Fetch](https://orval.dev/docs/guides/fetch): Generate Fetch API clients from OpenAPI
+- [Fetch Client](https://orval.dev/docs/guides/fetch-client): Configure Fetch as HTTP client for SWR and TanStack Query
+- [Custom HTTP Client](https://orval.dev/docs/guides/custom-client): Configure a custom HTTP client with mutators
+- [Custom Axios Instance](https://orval.dev/docs/guides/custom-axios): Configure a custom Axios instance
+- [Custom Base URL](https://orval.dev/docs/guides/set-base-url): Configure base URLs for your API clients
+
+## Data Fetching
+
+- [React Query](https://orval.dev/docs/guides/react-query): Generate type-safe React Query hooks from OpenAPI
+- [Vue Query](https://orval.dev/docs/guides/vue-query): Generate type-safe Vue Query composables from OpenAPI
+- [Svelte Query](https://orval.dev/docs/guides/svelte-query): Generate type-safe Svelte Query stores from OpenAPI
+- [Solid Query](https://orval.dev/docs/guides/solid-query): Generate type-safe Solid Query primitives from OpenAPI
+- [Angular Query](https://orval.dev/docs/guides/angular-query): Generate TanStack Query for Angular
+- [SWR](https://orval.dev/docs/guides/swr): Generate type-safe SWR hooks from OpenAPI
+
+## Frameworks
+
+- [Angular](https://orval.dev/docs/guides/angular): Generate Angular services with HttpClient from OpenAPI
+- [SolidStart](https://orval.dev/docs/guides/solid-start): Generate type-safe SolidStart primitives from OpenAPI
+- [Hono](https://orval.dev/docs/guides/hono): Generate Hono server templates from OpenAPI
+
+## Validation & Mocking
+
+- [Zod](https://orval.dev/docs/guides/zod): Generate Zod schemas from OpenAPI
+- [Client with Zod](https://orval.dev/docs/guides/client-with-zod): Combine Zod validation with HTTP clients
+- [MSW](https://orval.dev/docs/guides/msw): Generate Mock Service Worker handlers from OpenAPI
+
+## Advanced
+
+- [Enum Names](https://orval.dev/docs/guides/enums): Generate named enums from OpenAPI extensions
+- [Stream NDJSON](https://orval.dev/docs/guides/stream-ndjson): Type-safe streaming with Newline Delimited JSON
+- [MCP Server](https://orval.dev/docs/guides/mcp): Generate Model Context Protocol servers from OpenAPI
+
+## Guides
+
+- [CLI](https://orval.dev/docs/reference/cli): Command line interface reference
+- [Programmatic API](https://orval.dev/docs/reference/integration): Use Orval programmatically in your build scripts
+- [Configuration](https://orval.dev/docs/reference/configuration): Overview of Orval configuration options
+- [Input](https://orval.dev/docs/reference/configuration/input): Input configuration options
+- [Output](https://orval.dev/docs/reference/configuration/output): Output configuration options
+- [Hooks](https://orval.dev/docs/reference/configuration/hooks): Run scripts on generation events
+- [Full Example](https://orval.dev/docs/reference/configuration/full-example): Complete configuration example
+
+## Reference
+
+- [Upgrading to v8](https://orval.dev/docs/versions/v8): Migration guide for Orval v8
+
+## Playground
+
+- [Playground - Orval](https://orval.dev/playground): Try Orval in your browser. Generate type-safe TypeScript clients from OpenAPI specifications instantly.
+
+## Optional
+
+- [GitHub Repository](https://github.com/orval-labs/orval)
+- [Discord](https://discord.gg/6fC2sjDU7w)
+- [Sponsor](https://opencollective.com/orval)

--- a/docs/scripts/build-llms.js
+++ b/docs/scripts/build-llms.js
@@ -1,0 +1,310 @@
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import siteConfig from '../site.config.json' with { type: 'json' };
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DOCS_ROOT = path.resolve(__dirname, '..');
+const CONTENT_ROOT = path.join(DOCS_ROOT, 'content', 'docs');
+const OUTPUT_PATH = path.join(DOCS_ROOT, 'public', 'llms.txt');
+const BASE_URL = 'https://orval.dev';
+
+const DOC_EXTENSIONS = new Set(['.mdx', '.md']);
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n/;
+const SEPARATOR_REGEX = /^---(?:\[[^\]]+])?(?<name>.+)---|^---$/;
+
+const stripQuotes = (value) => {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+};
+
+const parseFrontmatter = (content) => {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return {};
+  }
+
+  const data = {};
+  for (const rawLine of match[1].split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    if (key !== 'title' && key !== 'description') {
+      continue;
+    }
+
+    const value = line.slice(separatorIndex + 1).trim();
+    data[key] = stripQuotes(value);
+  }
+
+  return data;
+};
+
+const getSeparatorTitle = (value) => {
+  const match = SEPARATOR_REGEX.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const name = match.groups?.name?.trim();
+  return name && name.length > 0 ? name : null;
+};
+
+const toPosixPath = (value) => value.split(path.sep).join('/');
+
+const toDocId = (filePath) => {
+  const relativePath = toPosixPath(path.relative(CONTENT_ROOT, filePath));
+  return relativePath.replace(/\.(mdx|md)$/, '');
+};
+
+const toRoutePath = (docId) => {
+  const normalized = docId.replace(/\/index$/, '');
+  const trimmed = normalized === 'index' ? '' : normalized;
+  const segments = trimmed.length > 0 ? trimmed.split('/').map(encodeURI) : [];
+  return `/docs${segments.length ? `/${segments.join('/')}` : ''}`;
+};
+
+const toAbsoluteUrl = (value) => new URL(value, BASE_URL).toString();
+
+const collectDocFiles = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectDocFiles(entryPath)));
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (DOC_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+const buildDocsIndex = async () => {
+  const files = await collectDocFiles(CONTENT_ROOT);
+  const docs = new Map();
+
+  await Promise.all(
+    files.map(async (filePath) => {
+      const docId = toDocId(filePath);
+      const content = await readFile(filePath, 'utf8');
+      const { title, description } = parseFrontmatter(content);
+      docs.set(docId, {
+        title: title?.trim() || docId,
+        description: description?.trim() || '',
+        url: toAbsoluteUrl(toRoutePath(docId)),
+      });
+    }),
+  );
+
+  return docs;
+};
+
+const readMeta = async (dir) => {
+  try {
+    const metaPath = path.join(dir, 'meta.json');
+    const content = await readFile(metaPath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+};
+
+const resolveDocId = (dir, name) => {
+  const relativeDir = toPosixPath(path.relative(CONTENT_ROOT, dir));
+  const cleanName = name.replace(/\.(mdx|md)$/, '');
+  return relativeDir ? `${relativeDir}/${cleanName}` : cleanName;
+};
+
+const buildLinkLine = (entry) =>
+  `- [${entry.title}](${entry.url}): ${entry.description ?? ''}`;
+
+const pushHeading = (lines, title) => {
+  if (!title) {
+    return;
+  }
+
+  if (lines.length > 0 && lines[lines.length - 1] !== '') {
+    lines.push('');
+  }
+
+  lines.push(`## ${title}`, '');
+};
+
+const pushDocLine = (lines, entry) => {
+  lines.push(buildLinkLine(entry));
+};
+
+const getRootDocIds = (docsIndex) =>
+  Array.from(docsIndex.keys()).filter((docId) => !docId.includes('/'));
+
+const getOrderedRootDocIds = (rootPages, docsIndex) => {
+  const rootDocIds = getRootDocIds(docsIndex);
+  const rootDocSet = new Set(rootDocIds);
+  const ordered = [];
+  const seen = new Set();
+
+  if (Array.isArray(rootPages)) {
+    for (const item of rootPages) {
+      if (typeof item !== 'string') {
+        continue;
+      }
+
+      if (item.startsWith('!') || item.startsWith('...')) {
+        continue;
+      }
+
+      if (getSeparatorTitle(item)) {
+        continue;
+      }
+
+      const docId = resolveDocId(CONTENT_ROOT, item);
+      if (!rootDocSet.has(docId) || seen.has(docId) || !docsIndex.has(docId)) {
+        continue;
+      }
+
+      ordered.push(docId);
+      seen.add(docId);
+    }
+  }
+
+  const remaining = rootDocIds
+    .filter((docId) => !seen.has(docId))
+    .sort((a, b) => a.localeCompare(b));
+
+  ordered.push(...remaining);
+  return ordered;
+};
+
+const collectMetaLines = async (dir, items, docsIndex, seenDocIds, lines) => {
+  if (!Array.isArray(items)) {
+    return;
+  }
+
+  for (const item of items) {
+    if (typeof item !== 'string') {
+      continue;
+    }
+
+    if (item.startsWith('!')) {
+      continue;
+    }
+
+    const separatorTitle = getSeparatorTitle(item);
+    if (separatorTitle) {
+      pushHeading(lines, separatorTitle);
+      continue;
+    }
+
+    if (item.startsWith('...') && item.length > 3) {
+      const target = item.slice(3);
+      const targetDir = path.join(dir, target);
+      const meta = await readMeta(targetDir);
+      await collectMetaLines(
+        targetDir,
+        meta?.pages,
+        docsIndex,
+        seenDocIds,
+        lines,
+      );
+      continue;
+    }
+
+    const docId = resolveDocId(dir, item);
+    if (seenDocIds.has(docId)) {
+      continue;
+    }
+
+    const entry = docsIndex.get(docId);
+    if (!entry) {
+      continue;
+    }
+
+    pushDocLine(lines, entry);
+    seenDocIds.add(docId);
+  }
+};
+
+const docsIndex = await buildDocsIndex();
+const rootMeta = await readMeta(CONTENT_ROOT);
+const rootTitle = rootMeta?.title ?? 'Documentation';
+
+const lines = [
+  `# ${rootTitle}`,
+  '',
+  `# Orval Documentation`,
+  '',
+  `[Orval Website](${BASE_URL})`,
+  '',
+];
+
+const rootDocIds = getOrderedRootDocIds(rootMeta?.pages, docsIndex);
+if (rootDocIds.length > 0) {
+  pushHeading(lines, 'Overview');
+  for (const docId of rootDocIds) {
+    const entry = docsIndex.get(docId);
+    if (!entry) {
+      continue;
+    }
+    pushDocLine(lines, entry);
+  }
+}
+
+const seenDocIds = new Set(rootDocIds);
+await collectMetaLines(
+  CONTENT_ROOT,
+  rootMeta?.pages,
+  docsIndex,
+  seenDocIds,
+  lines,
+);
+
+pushHeading(lines, 'Playground');
+pushDocLine(lines, {
+  title: siteConfig.playground.title,
+  url: toAbsoluteUrl('/playground'),
+  description: siteConfig.playground.description,
+});
+
+const repoUrl = siteConfig.repoUrl;
+const discordUrl = siteConfig.discordUrl;
+const sponsorUrl = siteConfig.openCollectiveUrl;
+
+if (repoUrl || discordUrl || sponsorUrl) {
+  pushHeading(lines, 'Optional');
+  if (repoUrl) {
+    lines.push(`- [GitHub Repository](${repoUrl})`);
+  }
+  if (discordUrl) {
+    lines.push(`- [Discord](${discordUrl})`);
+  }
+  if (sponsorUrl) {
+    lines.push(`- [Sponsor](${sponsorUrl})`);
+  }
+}
+
+const content = lines.join('\n').trimEnd();
+await writeFile(OUTPUT_PATH, `${content}\n`, 'utf8');

--- a/docs/site.config.json
+++ b/docs/site.config.json
@@ -1,0 +1,12 @@
+{
+  "name": "Orval",
+  "description": "Generate type-safe API clients from OpenAPI specifications. TypeScript, React Query, Angular, Vue Query, SWR, and more.",
+  "playground": {
+    "title": "Playground - Orval",
+    "description": "Try Orval in your browser. Generate type-safe TypeScript clients from OpenAPI specifications instantly."
+  },
+  "repoUrl": "https://github.com/orval-labs/orval",
+  "discordUrl": "https://discord.gg/6fC2sjDU7w",
+  "openCollectiveUrl": "https://opencollective.com/orval",
+  "editUrl": "https://github.com/orval-labs/orval/edit/master/docs/content/docs"
+}

--- a/docs/src/lib/layout.shared.tsx
+++ b/docs/src/lib/layout.shared.tsx
@@ -1,14 +1,5 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-
-export const siteConfig = {
-  name: 'Orval',
-  description:
-    'Generate type-safe API clients from OpenAPI specifications. TypeScript, React Query, Angular, Vue Query, SWR, and more.',
-  repoUrl: 'https://github.com/orval-labs/orval',
-  discordUrl: 'https://discord.gg/6fC2sjDU7w',
-  openCollectiveUrl: 'https://opencollective.com/orval',
-  editUrl: 'https://github.com/orval-labs/orval/edit/master/docs/content/docs',
-};
+import * as siteConfig from 'site.config.json';
 
 export function baseOptions(): BaseLayoutProps {
   return {

--- a/docs/src/routes/playground.tsx
+++ b/docs/src/routes/playground.tsx
@@ -3,17 +3,17 @@ import { HomeLayout } from 'fumadocs-ui/layouts/home';
 
 import { Playground } from '@/components/playground/Playground';
 import { baseOptions } from '@/lib/layout.shared';
+import * as siteConfig from '../../site.config.json';
 
 export const Route = createFileRoute('/playground')({
   head: () => ({
     meta: [
       {
-        title: 'Playground - Orval',
+        title: siteConfig.playground.title,
       },
       {
         name: 'description',
-        content:
-          'Try Orval in your browser. Generate type-safe TypeScript clients from OpenAPI specifications instantly.',
+        content: siteConfig.playground.description,
       },
     ],
   }),


### PR DESCRIPTION
## Summary

I've [propose the adding llms.txt on discord](https://discord.com/channels/1081916174486478988/1464546422316859412) for orval official website. 

- Add automatic `/llms.txt` generation for the docs site.
- Keep the file in sync with the docs `meta.json`

If I'm missing something lmk 

## Reference

- https://vercel.com/llms.txt
- https://vitest.dev/llms.txt
- https://llmstxt.org