### PR TITLE
docs: fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 
 `orval` generates type-safe JS clients (TypeScript) from any valid OpenAPI v3 or Swagger v2 specification, either in `yaml` or `json` formats.
 
-> [!IMPORTANT]  
-> Version [8.0.0+](https://orval.dev/versions/v8) comes with a lot of improvements and changes please see the [Migration Guide](https://orval.dev/versions/v8)
+> [!IMPORTANT]
+> Version [8.0.0+](https://orval.dev/docs/versions/v8) comes with a lot of improvements and changes please see the [Migration Guide](https://orval.dev/docs/versions/v8)
 
 ### Supported clients
 


### PR DESCRIPTION
 ## Summary

  Fixes broken documentation links in README that were pointing to incorrect URLs after the documentation restructure.

  The v8 migration guide links were missing the /docs prefix in the URL path, causing 404 errors when users tried to access the
  migration documentation.

 ## Problem

  After the documentation site was migrated from Next.js to TanStack Start + Fumadocs (PR #2856), the URL structure changed from `orval.dev/versions/v8` to `orval.dev/docs/versions/v8.`

  The README.md in the root directory still contained the old links without the /docs prefix, resulting in broken links that led to
  404 pages instead of the v8 migration guide.
  
  <img width="1912" height="1045" alt="image" src="https://github.com/user-attachments/assets/c9a2f879-584f-47d8-856d-3a623166bf5c" />

 ## Changes

  - Updated 2 broken links in README.md:
    - https://orval.dev/versions/v8 → https://orval.dev/docs/versions/v8