### PR TITLE
fix(core): support contentMediaType for array items in multipart/form-data (#2864)

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -24,6 +24,12 @@ const context: ContextSpec = {
     override: {
       formData: { arrayHandling: 'serialize', disabled: false },
       enumGenerationType: 'const',
+      components: {
+        schemas: { suffix: '', itemSuffix: 'Item' },
+        responses: { suffix: '' },
+        parameters: { suffix: '' },
+        requestBodies: { suffix: 'RequestBody' },
+      },
     },
   },
   target: 'spec',
@@ -322,5 +328,41 @@ describe('getResReqTypes (formData $ref with file properties)', () => {
 
     // Schema name 'FileUpload' → param 'fileUpload' (not 'uploadRequestBody')
     expect(result.formData).toContain('fileUpload.file');
+  });
+});
+
+describe('getResReqTypes (formData array of files)', () => {
+  it('should generate Blob[] for array items with contentMediaType', () => {
+    const reqBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'multipart/form-data': {
+              schema: {
+                type: 'object',
+                properties: {
+                  photos: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                      contentMediaType: 'application/octet-stream',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(reqBody, 'PostPhotos', context)[0];
+    const schema = result.schemas.find(
+      (s) => s.name === 'PostPhotosRequestBody',
+    );
+
+    expect(schema).toBeDefined();
+    expect(schema?.model).toContain('photos?: Blob[]');
   });
 });


### PR DESCRIPTION
The @scalar/openapi-upgrader transforms OAS 3.0 format: binary to OAS 3.1
contentMediaType: application/octet-stream. The existing scalar.ts has a
format: binary check, but it never runs in production because the upgrader
removes format before type generation.

The multipart/form-data handler (resolveFormDataRootObject) was added to
handle contentMediaType for top-level strings, but not arrays, causing
arrays of files to generate string[] instead of Blob[].

Extended resolveFormDataRootObject to handle arrays, respecting OAS 3.1
precedence rules (encoding.contentType > items.contentMediaType). This is
the correct location because only the multipart handler has access to
Encoding Object settings for precedence checking.

Fixes https://github.com/orval-labs/orval/issues/2864