### PR TITLE
fix(axios):  remove generic type parameter from generated axios functions

### DIFF
--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -202,13 +202,11 @@ const generateAxiosImplementation = (
     ? 'axiosInstance'
     : `axios${isSyntheticDefaultImportsAllowed ? '' : '.default'}`;
 
-  return `const ${operationName} = <TData = AxiosResponse<${
-    response.definition.success || 'unknown'
-  }>>(\n    ${toObjectString(props, 'implementation')} ${
+  return `const ${operationName} = (\n    ${toObjectString(props, 'implementation')} ${
     isRequestOptions
       ? `options${context.output.optionsParamRequired ? '' : '?'}: AxiosRequestConfig\n`
       : ''
-  } ): Promise<TData> => {${bodyForm}
+  } ): Promise<AxiosResponse<${response.definition.success || 'unknown'}>> => {${bodyForm}
     return ${axiosRef}.${verb}(${options});
   }
 `;

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -131,12 +131,12 @@ describe('optionsParamRequired', () => {
     const expectedImplementation = `/**
  * @summary Single endpoint with optional inputs
  */
-export const handleResource = <TData = AxiosResponse<void>>(
+export const handleResource = (
     workspaceId: string,
     id: string,
     handleResourceBody?: HandleResourceBody,
     params?: HandleResourceParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
+ ): Promise<AxiosResponse<void>> => {
     return axios.post(
       \`/\${workspaceId}/resource/\${id}\`,
       handleResourceBody,{
@@ -200,12 +200,12 @@ export const handleResource = <TData = AxiosResponse<void>>(
     const expectedImplementation = `/**
  * @summary Single endpoint with optional inputs
  */
-export const handleResource = <TData = AxiosResponse<void>>(
+export const handleResource = (
     workspaceId: string,
     id: string,
     handleResourceBody: HandleResourceBody,
     params: HandleResourceParams, options: AxiosRequestConfig
- ): Promise<TData> => {
+ ): Promise<AxiosResponse<void>> => {
     return axios.post(
       \`/\${workspaceId}/resource/\${id}\`,
       handleResourceBody,{

--- a/samples/angular-query/src/api/node.ts
+++ b/samples/angular-query/src/api/node.ts
@@ -1,6 +1,23 @@
 import { setupServer } from 'msw/node';
-import { getPetsMock } from './endpoints/pets/pets.msw';
+import { http, HttpResponse } from 'msw';
+import {
+  getPetsMock,
+  getListPetsResponseMock,
+  getSearchPetsResponseMock,
+} from './endpoints/pets/pets.msw';
 
-const server = setupServer(...getPetsMock());
+// Additional handlers for non-versioned endpoints (no-transformer and custom-instance)
+const nonVersionedHandlers = [
+  // Handler for /pets (no version prefix)
+  http.get('*/pets', () => {
+    return HttpResponse.json(getListPetsResponseMock());
+  }),
+  // Handler for /search (no version prefix)
+  http.get('*/search', () => {
+    return HttpResponse.json(getSearchPetsResponseMock());
+  }),
+];
+
+const server = setupServer(...getPetsMock(), ...nonVersionedHandlers);
 
 export { server };

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithConfig.ts
@@ -82,10 +82,10 @@ export type ListPetsNestedArrayParams = {
 /**
  * @summary List all pets
  */
-export const listPets = <TData = AxiosResponse<PetsArray>>(
+export const listPets = (
   params?: ListPetsParams,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<PetsArray>> => {
   return axios.get(`/pets`, {
     ...options,
     params: { ...params, ...options?.params },
@@ -95,20 +95,20 @@ export const listPets = <TData = AxiosResponse<PetsArray>>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = (
   createPetsBody: CreatePetsBody,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
 
 /**
  * @summary List all pets as nested array
  */
-export const listPetsNestedArray = <TData = AxiosResponse<PetsNestedArray>>(
+export const listPetsNestedArray = (
   params?: ListPetsNestedArrayParams,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<PetsNestedArray>> => {
   return axios.get(`/pets-nested-array`, {
     ...options,
     params: { ...params, ...options?.params },
@@ -118,10 +118,10 @@ export const listPetsNestedArray = <TData = AxiosResponse<PetsNestedArray>>(
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = <TData = AxiosResponse<Pet>>(
+export const showPetById = (
   petId: string,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
 

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -35,22 +35,22 @@ export const listPets = (params?: ListPetsParams, version: number = 1) => {
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = (
   createPetsBody: CreatePetsBody,
   version: number = 1,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<void>> => {
   return axios.post(`/v${version}/pets`, createPetsBody, options);
 };
 
 /**
  * @summary List all pets as nested array
  */
-export const listPetsNestedArray = <TData = AxiosResponse<PetsNestedArray>>(
+export const listPetsNestedArray = (
   params?: ListPetsNestedArrayParams,
   version: number = 1,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<PetsNestedArray>> => {
   return axios.get(`/v${version}/pets-nested-array`, {
     ...options,
     params: { ...params, ...options?.params },
@@ -60,11 +60,11 @@ export const listPetsNestedArray = <TData = AxiosResponse<PetsNestedArray>>(
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = <TData = AxiosResponse<Pet>>(
+export const showPetById = (
   petId: string,
   version: number = 1,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/v${version}/pets/${petId}`, options);
 };
 

--- a/samples/react-app/docs-html-plugin/functions/createPets.html
+++ b/samples/react-app/docs-html-plugin/functions/createPets.html
@@ -88,22 +88,6 @@
             <li class="">
               <div class="tsd-signature tsd-anchor-link" id="createpets">
                 <span class="tsd-kind-call-signature">createPets</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#createpetstdata"
-                  >TData</a
-                >
-                <span class="tsd-signature-symbol">=</span>
-                <span class="tsd-signature-type">AxiosResponse</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">void</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-symbol">{}</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">(</span><br />    <span
                   class="tsd-kind-parameter"
                   >createPetsBody</span
@@ -126,10 +110,14 @@
                 ><span class="tsd-signature-symbol">:</span>
                 <span class="tsd-signature-type">Promise</span
                 ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#createpetstdata"
-                  >TData</a
+                ><span class="tsd-signature-type">AxiosResponse</span
+                ><span class="tsd-signature-symbol">&lt;</span
+                ><span class="tsd-signature-type">void</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-type">any</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-symbol">{}</span
+                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">&gt;</span
                 ><a
                   href="#createpets"
@@ -140,24 +128,6 @@
                 ></a>
               </div>
               <div class="tsd-description">
-                <section class="tsd-panel">
-                  <h4>Type Parameters</h4>
-                  <ul class="tsd-type-parameter-list">
-                    <li>
-                      <span id="createpetstdata"
-                        ><span class="tsd-kind-type-parameter">TData</span> =
-                        <span class="tsd-signature-type">AxiosResponse</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><span class="tsd-signature-type">void</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-symbol">{}</span
-                        ><span class="tsd-signature-symbol">&gt;</span></span
-                      >
-                    </li>
-                  </ul>
-                </section>
                 <div class="tsd-parameters">
                   <h4 class="tsd-parameters-title">Parameters</h4>
                   <ul class="tsd-parameter-list">
@@ -187,10 +157,14 @@
                 <h4 class="tsd-returns-title">
                   Returns <span class="tsd-signature-type">Promise</span
                   ><span class="tsd-signature-symbol">&lt;</span
-                  ><a
-                    class="tsd-signature-type tsd-kind-type-parameter"
-                    href="#createpetstdata"
-                    >TData</a
+                  ><span class="tsd-signature-type">AxiosResponse</span
+                  ><span class="tsd-signature-symbol">&lt;</span
+                  ><span class="tsd-signature-type">void</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-type">any</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-symbol">{}</span
+                  ><span class="tsd-signature-symbol">&gt;</span
                   ><span class="tsd-signature-symbol">&gt;</span>
                 </h4>
               </div>

--- a/samples/react-app/docs-html-plugin/functions/listPets.html
+++ b/samples/react-app/docs-html-plugin/functions/listPets.html
@@ -88,25 +88,6 @@
             <li class="">
               <div class="tsd-signature tsd-anchor-link" id="listpets">
                 <span class="tsd-kind-call-signature">listPets</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#listpetstdata"
-                  >TData</a
-                >
-                <span class="tsd-signature-symbol">=</span>
-                <span class="tsd-signature-type">AxiosResponse</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  href="../types/Pets.html"
-                  class="tsd-signature-type tsd-kind-type-alias"
-                  >Pets</a
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-symbol">{}</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">(</span><br />    <span
                   class="tsd-kind-parameter"
                   >params</span
@@ -129,10 +110,17 @@
                 ><span class="tsd-signature-symbol">:</span>
                 <span class="tsd-signature-type">Promise</span
                 ><span class="tsd-signature-symbol">&lt;</span
+                ><span class="tsd-signature-type">AxiosResponse</span
+                ><span class="tsd-signature-symbol">&lt;</span
                 ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#listpetstdata"
-                  >TData</a
+                  href="../types/Pets.html"
+                  class="tsd-signature-type tsd-kind-type-alias"
+                  >Pets</a
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-type">any</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-symbol">{}</span
+                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">&gt;</span
                 ><a
                   href="#listpets"
@@ -143,27 +131,6 @@
                 ></a>
               </div>
               <div class="tsd-description">
-                <section class="tsd-panel">
-                  <h4>Type Parameters</h4>
-                  <ul class="tsd-type-parameter-list">
-                    <li>
-                      <span id="listpetstdata"
-                        ><span class="tsd-kind-type-parameter">TData</span> =
-                        <span class="tsd-signature-type">AxiosResponse</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><a
-                          href="../types/Pets.html"
-                          class="tsd-signature-type tsd-kind-type-alias"
-                          >Pets</a
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-symbol">{}</span
-                        ><span class="tsd-signature-symbol">&gt;</span></span
-                      >
-                    </li>
-                  </ul>
-                </section>
                 <div class="tsd-parameters">
                   <h4 class="tsd-parameters-title">Parameters</h4>
                   <ul class="tsd-parameter-list">
@@ -194,10 +161,17 @@
                 <h4 class="tsd-returns-title">
                   Returns <span class="tsd-signature-type">Promise</span
                   ><span class="tsd-signature-symbol">&lt;</span
+                  ><span class="tsd-signature-type">AxiosResponse</span
+                  ><span class="tsd-signature-symbol">&lt;</span
                   ><a
-                    class="tsd-signature-type tsd-kind-type-parameter"
-                    href="#listpetstdata"
-                    >TData</a
+                    href="../types/Pets.html"
+                    class="tsd-signature-type tsd-kind-type-alias"
+                    >Pets</a
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-type">any</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-symbol">{}</span
+                  ><span class="tsd-signature-symbol">&gt;</span
                   ><span class="tsd-signature-symbol">&gt;</span>
                 </h4>
               </div>

--- a/samples/react-app/docs-html-plugin/functions/showPetById.html
+++ b/samples/react-app/docs-html-plugin/functions/showPetById.html
@@ -88,25 +88,6 @@
             <li class="">
               <div class="tsd-signature tsd-anchor-link" id="showpetbyid">
                 <span class="tsd-kind-call-signature">showPetById</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#showpetbyidtdata"
-                  >TData</a
-                >
-                <span class="tsd-signature-symbol">=</span>
-                <span class="tsd-signature-type">AxiosResponse</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  href="../interfaces/Pet.html"
-                  class="tsd-signature-type tsd-kind-interface"
-                  >Pet</a
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-symbol">{}</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">(</span><br />    <span
                   class="tsd-kind-parameter"
                   >petId</span
@@ -126,10 +107,17 @@
                 ><span class="tsd-signature-symbol">:</span>
                 <span class="tsd-signature-type">Promise</span
                 ><span class="tsd-signature-symbol">&lt;</span
+                ><span class="tsd-signature-type">AxiosResponse</span
+                ><span class="tsd-signature-symbol">&lt;</span
                 ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#showpetbyidtdata"
-                  >TData</a
+                  href="../interfaces/Pet.html"
+                  class="tsd-signature-type tsd-kind-interface"
+                  >Pet</a
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-type">any</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-symbol">{}</span
+                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">&gt;</span
                 ><a
                   href="#showpetbyid"
@@ -140,27 +128,6 @@
                 ></a>
               </div>
               <div class="tsd-description">
-                <section class="tsd-panel">
-                  <h4>Type Parameters</h4>
-                  <ul class="tsd-type-parameter-list">
-                    <li>
-                      <span id="showpetbyidtdata"
-                        ><span class="tsd-kind-type-parameter">TData</span> =
-                        <span class="tsd-signature-type">AxiosResponse</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><a
-                          href="../interfaces/Pet.html"
-                          class="tsd-signature-type tsd-kind-interface"
-                          >Pet</a
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-symbol">{}</span
-                        ><span class="tsd-signature-symbol">&gt;</span></span
-                      >
-                    </li>
-                  </ul>
-                </section>
                 <div class="tsd-parameters">
                   <h4 class="tsd-parameters-title">Parameters</h4>
                   <ul class="tsd-parameter-list">
@@ -186,10 +153,17 @@
                 <h4 class="tsd-returns-title">
                   Returns <span class="tsd-signature-type">Promise</span
                   ><span class="tsd-signature-symbol">&lt;</span
+                  ><span class="tsd-signature-type">AxiosResponse</span
+                  ><span class="tsd-signature-symbol">&lt;</span
                   ><a
-                    class="tsd-signature-type tsd-kind-type-parameter"
-                    href="#showpetbyidtdata"
-                    >TData</a
+                    href="../interfaces/Pet.html"
+                    class="tsd-signature-type tsd-kind-interface"
+                    >Pet</a
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-type">any</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-symbol">{}</span
+                  ><span class="tsd-signature-symbol">&gt;</span
                   ><span class="tsd-signature-symbol">&gt;</span>
                 </h4>
               </div>

--- a/samples/react-app/docs-html/functions/createPets.html
+++ b/samples/react-app/docs-html/functions/createPets.html
@@ -88,22 +88,6 @@
             <li class="">
               <div class="tsd-signature tsd-anchor-link" id="createpets">
                 <span class="tsd-kind-call-signature">createPets</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#createpetstdata"
-                  >TData</a
-                >
-                <span class="tsd-signature-symbol">=</span>
-                <span class="tsd-signature-type">AxiosResponse</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><span class="tsd-signature-type">void</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-symbol">{}</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">(</span><br />    <span
                   class="tsd-kind-parameter"
                   >createPetsBody</span
@@ -126,10 +110,14 @@
                 ><span class="tsd-signature-symbol">:</span>
                 <span class="tsd-signature-type">Promise</span
                 ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#createpetstdata"
-                  >TData</a
+                ><span class="tsd-signature-type">AxiosResponse</span
+                ><span class="tsd-signature-symbol">&lt;</span
+                ><span class="tsd-signature-type">void</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-type">any</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-symbol">{}</span
+                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">&gt;</span
                 ><a
                   href="#createpets"
@@ -140,24 +128,6 @@
                 ></a>
               </div>
               <div class="tsd-description">
-                <section class="tsd-panel">
-                  <h4>Type Parameters</h4>
-                  <ul class="tsd-type-parameter-list">
-                    <li>
-                      <span id="createpetstdata"
-                        ><span class="tsd-kind-type-parameter">TData</span> =
-                        <span class="tsd-signature-type">AxiosResponse</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><span class="tsd-signature-type">void</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-symbol">{}</span
-                        ><span class="tsd-signature-symbol">&gt;</span></span
-                      >
-                    </li>
-                  </ul>
-                </section>
                 <div class="tsd-parameters">
                   <h4 class="tsd-parameters-title">Parameters</h4>
                   <ul class="tsd-parameter-list">
@@ -187,10 +157,14 @@
                 <h4 class="tsd-returns-title">
                   Returns <span class="tsd-signature-type">Promise</span
                   ><span class="tsd-signature-symbol">&lt;</span
-                  ><a
-                    class="tsd-signature-type tsd-kind-type-parameter"
-                    href="#createpetstdata"
-                    >TData</a
+                  ><span class="tsd-signature-type">AxiosResponse</span
+                  ><span class="tsd-signature-symbol">&lt;</span
+                  ><span class="tsd-signature-type">void</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-type">any</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-symbol">{}</span
+                  ><span class="tsd-signature-symbol">&gt;</span
                   ><span class="tsd-signature-symbol">&gt;</span>
                 </h4>
               </div>

--- a/samples/react-app/docs-html/functions/listPets.html
+++ b/samples/react-app/docs-html/functions/listPets.html
@@ -88,25 +88,6 @@
             <li class="">
               <div class="tsd-signature tsd-anchor-link" id="listpets">
                 <span class="tsd-kind-call-signature">listPets</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#listpetstdata"
-                  >TData</a
-                >
-                <span class="tsd-signature-symbol">=</span>
-                <span class="tsd-signature-type">AxiosResponse</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  href="../types/Pets.html"
-                  class="tsd-signature-type tsd-kind-type-alias"
-                  >Pets</a
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-symbol">{}</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">(</span><br />    <span
                   class="tsd-kind-parameter"
                   >params</span
@@ -129,10 +110,17 @@
                 ><span class="tsd-signature-symbol">:</span>
                 <span class="tsd-signature-type">Promise</span
                 ><span class="tsd-signature-symbol">&lt;</span
+                ><span class="tsd-signature-type">AxiosResponse</span
+                ><span class="tsd-signature-symbol">&lt;</span
                 ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#listpetstdata"
-                  >TData</a
+                  href="../types/Pets.html"
+                  class="tsd-signature-type tsd-kind-type-alias"
+                  >Pets</a
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-type">any</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-symbol">{}</span
+                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">&gt;</span
                 ><a
                   href="#listpets"
@@ -143,27 +131,6 @@
                 ></a>
               </div>
               <div class="tsd-description">
-                <section class="tsd-panel">
-                  <h4>Type Parameters</h4>
-                  <ul class="tsd-type-parameter-list">
-                    <li>
-                      <span id="listpetstdata"
-                        ><span class="tsd-kind-type-parameter">TData</span> =
-                        <span class="tsd-signature-type">AxiosResponse</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><a
-                          href="../types/Pets.html"
-                          class="tsd-signature-type tsd-kind-type-alias"
-                          >Pets</a
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-symbol">{}</span
-                        ><span class="tsd-signature-symbol">&gt;</span></span
-                      >
-                    </li>
-                  </ul>
-                </section>
                 <div class="tsd-parameters">
                   <h4 class="tsd-parameters-title">Parameters</h4>
                   <ul class="tsd-parameter-list">
@@ -194,10 +161,17 @@
                 <h4 class="tsd-returns-title">
                   Returns <span class="tsd-signature-type">Promise</span
                   ><span class="tsd-signature-symbol">&lt;</span
+                  ><span class="tsd-signature-type">AxiosResponse</span
+                  ><span class="tsd-signature-symbol">&lt;</span
                   ><a
-                    class="tsd-signature-type tsd-kind-type-parameter"
-                    href="#listpetstdata"
-                    >TData</a
+                    href="../types/Pets.html"
+                    class="tsd-signature-type tsd-kind-type-alias"
+                    >Pets</a
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-type">any</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-symbol">{}</span
+                  ><span class="tsd-signature-symbol">&gt;</span
                   ><span class="tsd-signature-symbol">&gt;</span>
                 </h4>
               </div>

--- a/samples/react-app/docs-html/functions/showPetById.html
+++ b/samples/react-app/docs-html/functions/showPetById.html
@@ -88,25 +88,6 @@
             <li class="">
               <div class="tsd-signature tsd-anchor-link" id="showpetbyid">
                 <span class="tsd-kind-call-signature">showPetById</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#showpetbyidtdata"
-                  >TData</a
-                >
-                <span class="tsd-signature-symbol">=</span>
-                <span class="tsd-signature-type">AxiosResponse</span
-                ><span class="tsd-signature-symbol">&lt;</span
-                ><a
-                  href="../interfaces/Pet.html"
-                  class="tsd-signature-type tsd-kind-interface"
-                  >Pet</a
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-type">any</span
-                ><span class="tsd-signature-symbol">,</span>
-                <span class="tsd-signature-symbol">{}</span
-                ><span class="tsd-signature-symbol">&gt;</span
-                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">(</span><br />    <span
                   class="tsd-kind-parameter"
                   >petId</span
@@ -126,10 +107,17 @@
                 ><span class="tsd-signature-symbol">:</span>
                 <span class="tsd-signature-type">Promise</span
                 ><span class="tsd-signature-symbol">&lt;</span
+                ><span class="tsd-signature-type">AxiosResponse</span
+                ><span class="tsd-signature-symbol">&lt;</span
                 ><a
-                  class="tsd-signature-type tsd-kind-type-parameter"
-                  href="#showpetbyidtdata"
-                  >TData</a
+                  href="../interfaces/Pet.html"
+                  class="tsd-signature-type tsd-kind-interface"
+                  >Pet</a
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-type">any</span
+                ><span class="tsd-signature-symbol">,</span>
+                <span class="tsd-signature-symbol">{}</span
+                ><span class="tsd-signature-symbol">&gt;</span
                 ><span class="tsd-signature-symbol">&gt;</span
                 ><a
                   href="#showpetbyid"
@@ -140,27 +128,6 @@
                 ></a>
               </div>
               <div class="tsd-description">
-                <section class="tsd-panel">
-                  <h4>Type Parameters</h4>
-                  <ul class="tsd-type-parameter-list">
-                    <li>
-                      <span id="showpetbyidtdata"
-                        ><span class="tsd-kind-type-parameter">TData</span> =
-                        <span class="tsd-signature-type">AxiosResponse</span
-                        ><span class="tsd-signature-symbol">&lt;</span
-                        ><a
-                          href="../interfaces/Pet.html"
-                          class="tsd-signature-type tsd-kind-interface"
-                          >Pet</a
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-type">any</span
-                        ><span class="tsd-signature-symbol">,</span>
-                        <span class="tsd-signature-symbol">{}</span
-                        ><span class="tsd-signature-symbol">&gt;</span></span
-                      >
-                    </li>
-                  </ul>
-                </section>
                 <div class="tsd-parameters">
                   <h4 class="tsd-parameters-title">Parameters</h4>
                   <ul class="tsd-parameter-list">
@@ -186,10 +153,17 @@
                 <h4 class="tsd-returns-title">
                   Returns <span class="tsd-signature-type">Promise</span
                   ><span class="tsd-signature-symbol">&lt;</span
+                  ><span class="tsd-signature-type">AxiosResponse</span
+                  ><span class="tsd-signature-symbol">&lt;</span
                   ><a
-                    class="tsd-signature-type tsd-kind-type-parameter"
-                    href="#showpetbyidtdata"
-                    >TData</a
+                    href="../interfaces/Pet.html"
+                    class="tsd-signature-type tsd-kind-interface"
+                    >Pet</a
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-type">any</span
+                  ><span class="tsd-signature-symbol">,</span>
+                  <span class="tsd-signature-symbol">{}</span
+                  ><span class="tsd-signature-symbol">&gt;</span
                   ><span class="tsd-signature-symbol">&gt;</span>
                 </h4>
               </div>

--- a/samples/react-app/docs-markdown/functions/createPets.html
+++ b/samples/react-app/docs-markdown/functions/createPets.html
@@ -1,6 +1,6 @@
 [**react-app**](../README.md) *** [react-app](../index.html) / createPets #
-Function: createPets() > **createPets**\<`TData`\>(`createPetsBody`,
-`options?`): `Promise`\<`TData`\> ## Type Parameters ### TData `TData` =
-`AxiosResponse`\<`void`, `any`, \{ \}\> ## Parameters ### createPetsBody
-[`CreatePetsBody`](../types/CreatePetsBody.html) ### options?
-`AxiosRequestConfig`\<`any`\> ## Returns `Promise`\<`TData`\>
+Function: createPets() > **createPets**(`createPetsBody`, `options?`):
+`Promise`\<`AxiosResponse`\<`void`, `any`, \{ \}\>\> ## Parameters ###
+createPetsBody [`CreatePetsBody`](../types/CreatePetsBody.html) ### options?
+`AxiosRequestConfig`\<`any`\> ## Returns `Promise`\<`AxiosResponse`\<`void`,
+`any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/functions/listPets.html
+++ b/samples/react-app/docs-markdown/functions/listPets.html
@@ -1,6 +1,6 @@
 [**react-app**](../README.md) *** [react-app](../index.html) / listPets #
-Function: listPets() > **listPets**\<`TData`\>(`params?`, `options?`):
-`Promise`\<`TData`\> ## Type Parameters ### TData `TData` =
-`AxiosResponse`\<[`Pets`](../types/Pets.html), `any`, \{ \}\> ## Parameters ###
-params? [`ListPetsParams`](../types/ListPetsParams.html) ### options?
-`AxiosRequestConfig`\<`any`\> ## Returns `Promise`\<`TData`\>
+Function: listPets() > **listPets**(`params?`, `options?`):
+`Promise`\<`AxiosResponse`\<[`Pets`](../types/Pets.html), `any`, \{ \}\>\> ##
+Parameters ### params? [`ListPetsParams`](../types/ListPetsParams.html) ###
+options? `AxiosRequestConfig`\<`any`\> ## Returns
+`Promise`\<`AxiosResponse`\<[`Pets`](../types/Pets.html), `any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/functions/showPetById.html
+++ b/samples/react-app/docs-markdown/functions/showPetById.html
@@ -1,6 +1,6 @@
 [**react-app**](../README.md) *** [react-app](../index.html) / showPetById #
-Function: showPetById() > **showPetById**\<`TData`\>(`petId`, `options?`):
-`Promise`\<`TData`\> ## Type Parameters ### TData `TData` =
-`AxiosResponse`\<[`Pet`](../interfaces/Pet.html), `any`, \{ \}\> ## Parameters
-### petId `string` ### options? `AxiosRequestConfig`\<`any`\> ## Returns
-`Promise`\<`TData`\>
+Function: showPetById() > **showPetById**(`petId`, `options?`):
+`Promise`\<`AxiosResponse`\<[`Pet`](../interfaces/Pet.html), `any`, \{ \}\>\> ##
+Parameters ### petId `string` ### options? `AxiosRequestConfig`\<`any`\> ##
+Returns `Promise`\<`AxiosResponse`\<[`Pet`](../interfaces/Pet.html), `any`, \{
+\}\>\>

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithDocsHtml.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithDocsHtml.ts
@@ -35,10 +35,10 @@ export type CreatePetsBody = {
 /**
  * @summary List all pets
  */
-export const listPets = <TData = AxiosResponse<Pets>>(
+export const listPets = (
   params?: ListPetsParams,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets`, {
     ...options,
     params: { ...params, ...options?.params },
@@ -48,20 +48,20 @@ export const listPets = <TData = AxiosResponse<Pets>>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = (
   createPetsBody: CreatePetsBody,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
 
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = <TData = AxiosResponse<Pet>>(
+export const showPetById = (
   petId: string,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
 

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithDocsHtmlPlugin.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithDocsHtmlPlugin.ts
@@ -35,10 +35,10 @@ export type CreatePetsBody = {
 /**
  * @summary List all pets
  */
-export const listPets = <TData = AxiosResponse<Pets>>(
+export const listPets = (
   params?: ListPetsParams,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets`, {
     ...options,
     params: { ...params, ...options?.params },
@@ -48,20 +48,20 @@ export const listPets = <TData = AxiosResponse<Pets>>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = (
   createPetsBody: CreatePetsBody,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
 
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = <TData = AxiosResponse<Pet>>(
+export const showPetById = (
   petId: string,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
 

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithDocsMarkdown.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithDocsMarkdown.ts
@@ -35,10 +35,10 @@ export type CreatePetsBody = {
 /**
  * @summary List all pets
  */
-export const listPets = <TData = AxiosResponse<Pets>>(
+export const listPets = (
   params?: ListPetsParams,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets`, {
     ...options,
     params: { ...params, ...options?.params },
@@ -48,20 +48,20 @@ export const listPets = <TData = AxiosResponse<Pets>>(
 /**
  * @summary Create a pet
  */
-export const createPets = <TData = AxiosResponse<void>>(
+export const createPets = (
   createPetsBody: CreatePetsBody,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
 
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = <TData = AxiosResponse<Pet>>(
+export const showPetById = (
   petId: string,
   options?: AxiosRequestConfig,
-): Promise<TData> => {
+): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
 


### PR DESCRIPTION
## Summary

Fix #952 

- Remove generic type parameter from generated axios functions in favor of concrete return types

## Changes

### Axios Type Signature Change

**Before:**
```typescript
const listPets = <TData = AxiosResponse<PetsArray>>(
  params?: ListPetsParams,
  options?: AxiosRequestConfig,
): Promise<TData> => { ... }
```

**After:**
```typescript
const listPets = (
  params?: ListPetsParams,
  options?: AxiosRequestConfig,
): Promise<AxiosResponse<PetsArray>> => { ... }
```

### Why this change?

The generic `<TData = AxiosResponse<...>>` pattern allowed callers to override the return type (e.g., `listPets<MyCustomType>()`), but this flexibility:
1. Is rarely used in practice
2. Can mask type errors by allowing arbitrary type assertions
3. Makes the generated code more complex than necessary

Using concrete return types provides stronger type safety and clearer API contracts.
