### PR TITLE
fix: update GitHub security advisory URL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ If you discover a security vulnerability in Orval, **please do not open a public
 ### How to Report
 
 - Report security issues via **GitHub Security Advisories**:  
-  https://github.com/orval/orval/security/advisories
+  https://github.com/orval-labs/orval/security/advisories
 - Alternatively, you may contact the maintainers privately via email if listed in the repository.
 
 ### What to Include


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->
Fixes #2870 

This PR fixes the incorrect GitHub Security Advisories URL in `SECURITY.md`.

The security advisory link was pointing to the old repository path (`orval/orval`), which has been updated to the correct organization path (`orval-labs/orval`). 
