### PR TITLE
fix: support OpenAPI 3.1 type arrays with $ref

### DIFF
--- a/packages/core/src/resolvers/ref.ts
+++ b/packages/core/src/resolvers/ref.ts
@@ -96,8 +96,15 @@ function getSchema<
 
   let currentSchema = schemaByRefPaths ? schemaByRefPaths : context.spec;
 
+  // Handle OpenAPI 3.0 nullable property
   if ('nullable' in schema) {
     currentSchema = { ...currentSchema, nullable: schema.nullable };
+  }
+
+  // Handle OpenAPI 3.1 type array (e.g., type: ["object", "null"])
+  // This preserves nullable information when using direct $ref with types array
+  if ('type' in schema && Array.isArray(schema.type)) {
+    currentSchema = { ...currentSchema, type: schema.type };
   }
 
   return {


### PR DESCRIPTION
# Fix: Support OpenAPI 3.1 type arrays with $ref

## Problem

OpenAPI 3.1 introduced the `type` array feature (per JSON Schema 2020-12) that allows specifying multiple types, commonly used for nullable types:

```yaml
billingAddress:
  type:
    - object
    - "null"
  $ref: "#/components/schemas/BillingAddressDto"
  description: Billing address - can be an address object or null
```

**Currently**, Orval only handles the OpenAPI 3.0 `nullable` property but doesn't recognize the OpenAPI 3.1 `type` array when resolving `$ref`. This results in incorrect TypeScript type generation:

```typescript
// Generated (incorrect):
billingAddress?: BillingAddressDto;  // Only optional, not nullable

// Expected (correct):
billingAddress?: BillingAddressDto | null;  // Optional AND nullable
```

## Solution

This PR adds support for the OpenAPI 3.1 `type` array in the `resolveRef` function. When a schema has both `$ref` and `type: ["object", "null"]`, the `type` array is now preserved and passed to the nullable detection logic.

### Code Changes

**File**: `packages/core/src/resolvers/ref.ts`

Added handling for the `type` array alongside the existing `nullable` property handling:

```typescript
// Handle OpenAPI 3.0 nullable property
if ('nullable' in schema) {
  currentSchema = { ...currentSchema, nullable: schema.nullable };
}

// Handle OpenAPI 3.1 type array (e.g., type: ["object", "null"])
// This preserves nullable information when using direct $ref with types array
if ('type' in schema && Array.isArray(schema.type)) {
  currentSchema = { ...currentSchema, type: schema.type };
}
```

The existing nullable detection in `resolveValue` (line 48-52) already handles type arrays:

```typescript
const nullable =
  (Array.isArray(schemaObject.type) &&
    schemaObject.type.includes('null')) ||
  schemaObject.nullable === true
    ? ' | null'
    : '';
```

## Testing

Tested with a real-world OpenAPI 3.1 spec from a Spring Boot 4 application using swagger-core 2.2.41.

### Test Case 1: Direct $ref with type array (Pattern 3)
**OpenAPI Spec:**
```yaml
billingAddress:
  type:
    - object
    - "null"
  $ref: "#/components/schemas/BillingAddressDto"
```

**Before Fix:**
```typescript
billingAddress?: BillingAddressDto;
```

**After Fix:**
```typescript
billingAddress?: BillingAddressDto | null;
```

### Test Case 2: oneOf with type array (Pattern 1 & 2 - Already Working)
**OpenAPI Spec:**
```yaml
paymentMethod:
  type:
    - object
    - "null"
  oneOf:
    - $ref: "#/components/schemas/CreditCardDto"
    - $ref: "#/components/schemas/BankTransferDto"
```

**Result (Already works, not affected by this change):**
```typescript
paymentMethod?: CreditCardDto | BankTransferDto | null;
```

## Impact

- ✅ **Backward Compatible**: Only affects schemas that have both `$ref` and `type` array
- ✅ **Minimal Change**: Single-line addition to preserve type information
- ✅ **Aligns with OpenAPI 3.1**: Properly supports JSON Schema 2020-12 features
- ✅ **No Breaking Changes**: Existing OpenAPI 3.0 `nullable` handling unchanged

## Related Issues

This fix addresses a common pain point when using OpenAPI 3.1 specs with modern frameworks like Spring Boot 4 that generate OpenAPI 3.1 by default.

## Demo Project

A complete demo showcasing this issue and the fix is available at:
https://github.com/bostrom/spring-4-openapi-3.1-demo

The demo includes:
- Spring Boot 4 application with OpenAPI 3.1
- Examples of all three patterns (polymorphic, single type with oneOf, typed property)
- TypeScript type generation showing the before/after behavior
