### PR TITLE
fix(core): dedupeUnionType only splits on top-level | #2880

### DIFF
--- a/packages/core/src/utils/string.test.ts
+++ b/packages/core/src/utils/string.test.ts
@@ -22,4 +22,27 @@ describe('dedupeUnionType', () => {
       expect(dedupeUnionType('A | B | A | C | B')).toBe('A | B | C');
     });
   });
+
+  describe('nested structures', () => {
+    it('should only split on top-level |', () => {
+      expect(dedupeUnionType("{ a: 'x' | 'y' } | { b: 'z' }")).toBe(
+        "{ a: 'x' | 'y' } | { b: 'z' }",
+      );
+      expect(dedupeUnionType("('a' | 'b')[] | string")).toBe(
+        "('a' | 'b')[] | string",
+      );
+      expect(dedupeUnionType("Array<'a' | 'b'> | string")).toBe(
+        "Array<'a' | 'b'> | string",
+      );
+      expect(dedupeUnionType('[string | number, boolean] | null')).toBe(
+        '[string | number, boolean] | null',
+      );
+    });
+
+    it('should dedupe identical complex types', () => {
+      expect(dedupeUnionType("{ a: 'x' | 'y' } | { a: 'x' | 'y' }")).toBe(
+        "{ a: 'x' | 'y' }",
+      );
+    });
+  });
 });

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -255,9 +255,24 @@ export function jsStringEscape(input: string) {
 /**
  * Deduplicates a TypeScript union type string.
  * Handles types like "A | B | B" → "A | B" and "null | null" → "null".
+ * Only splits on top-level | (not inside {} () [] <>).
  */
 export function dedupeUnionType(unionType: string): string {
-  const parts = unionType.split('|').map((part) => part.trim());
-  const unique = [...new Set(parts)];
-  return unique.join(' | ');
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (const c of unionType) {
+    if ('{([<'.includes(c)) depth++;
+    if ('})]>'.includes(c)) depth--;
+    if (c === '|' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+    } else {
+      current += c;
+    }
+  }
+  if (current.trim()) parts.push(current.trim());
+
+  return [...new Set(parts)].join(' | ');
 }


### PR DESCRIPTION
Previously, dedupeUnionType split on all | characters, corrupting inline combined types containing nested unions like { a: 'x' | 'y' }. Now tracks bracket depth to only split at the top level.

Fixes #2880
