### PR TITLE
fix(core): handle string literals in dedupeUnionType

### DIFF
--- a/packages/core/src/utils/string.test.ts
+++ b/packages/core/src/utils/string.test.ts
@@ -24,18 +24,31 @@ describe('dedupeUnionType', () => {
   });
 
   describe('nested structures', () => {
-    it('should only split on top-level |', () => {
-      expect(dedupeUnionType("{ a: 'x' | 'y' } | { b: 'z' }")).toBe(
-        "{ a: 'x' | 'y' } | { b: 'z' }",
+    it('should not corrupt objects with similar nested unions', () => {
+      // If we incorrectly split on inner |, "{ a: 'x'" would appear twice and get deduped
+      expect(dedupeUnionType("{ a: 'x' | 'y' } | { a: 'x' | 'z' }")).toBe(
+        "{ a: 'x' | 'y' } | { a: 'x' | 'z' }",
       );
-      expect(dedupeUnionType("('a' | 'b')[] | string")).toBe(
-        "('a' | 'b')[] | string",
+    });
+
+    it('should not corrupt parenthesized unions with similar content', () => {
+      // If we incorrectly split on inner |, "'a'" would appear twice and get deduped
+      expect(dedupeUnionType("('a' | 'b')[] | ('a' | 'c')[]")).toBe(
+        "('a' | 'b')[] | ('a' | 'c')[]",
       );
-      expect(dedupeUnionType("Array<'a' | 'b'> | string")).toBe(
-        "Array<'a' | 'b'> | string",
+    });
+
+    it('should not corrupt generics with similar type parameters', () => {
+      // If we incorrectly split on inner |, "Array<'a'" would appear twice and get deduped
+      expect(dedupeUnionType("Array<'a' | 'b'> | Array<'a' | 'c'>")).toBe(
+        "Array<'a' | 'b'> | Array<'a' | 'c'>",
       );
-      expect(dedupeUnionType('[string | number, boolean] | null')).toBe(
-        '[string | number, boolean] | null',
+    });
+
+    it('should not corrupt tuples with similar element types', () => {
+      // If we incorrectly split on inner |, "[string" would appear twice and get deduped
+      expect(dedupeUnionType('[string | number] | [string | boolean]')).toBe(
+        '[string | number] | [string | boolean]',
       );
     });
 
@@ -43,6 +56,31 @@ describe('dedupeUnionType', () => {
       expect(dedupeUnionType("{ a: 'x' | 'y' } | { a: 'x' | 'y' }")).toBe(
         "{ a: 'x' | 'y' }",
       );
+      expect(dedupeUnionType("('a' | 'b')[] | ('a' | 'b')[]")).toBe(
+        "('a' | 'b')[]",
+      );
+      expect(dedupeUnionType("Array<'a' | 'b'> | Array<'a' | 'b'>")).toBe(
+        "Array<'a' | 'b'>",
+      );
+    });
+
+    it('should not split on | inside string literals', () => {
+      // If we incorrectly split inside the string, "'a" would appear twice and get deduped
+      expect(dedupeUnionType("'a | a' | 'a | b'")).toBe("'a | a' | 'a | b'");
+      expect(dedupeUnionType('"a | a" | "a | b"')).toBe('"a | a" | "a | b"');
+      // Verify deduping still works for identical string literals
+      expect(dedupeUnionType("'a | a' | 'a | a'")).toBe("'a | a'");
+      // Without escape handling, \' would close the string, trapping | inside
+      expect(dedupeUnionType("'it\\'s' | 'it\\'s'")).toBe("'it\\'s'");
+    });
+
+    it('should not be confused by unbalanced brackets inside string literals', () => {
+      // The duplicate 'a' should be deduped. If the '(' inside the string
+      // incorrectly affects bracket depth, deduping wouldn't happen.
+      expect(dedupeUnionType("a | '(' | a")).toBe("a | '('");
+      expect(dedupeUnionType("a | '{' | a")).toBe("a | '{'");
+      expect(dedupeUnionType("a | '[' | a")).toBe("a | '['");
+      expect(dedupeUnionType("a | '<' | a")).toBe("a | '<'");
     });
   });
 });


### PR DESCRIPTION
Extends the union type parser to correctly handle:
- | characters inside string literals ('a|b')
- Escaped quotes inside strings ('it\'s')
- Unbalanced brackets inside strings ('(')

Adds comprehensive tests that would fail if parsing is broken.

This completes fix for #2880


<!-- A few sentences describing the overall goals of the pull request's commits. -->
