### PR TITLE
fix: remove unused axiosInstance parameter when using mutator

### DIFF
--- a/packages/axios/src/index.test.ts
+++ b/packages/axios/src/index.test.ts
@@ -156,12 +156,46 @@ describe('generateAxiosHeader', () => {
       ...baseMockParams,
       isRequestOptions: true,
       isMutator: true,
+      isGlobalMutator: true,
       noFunction: false,
     });
 
     expect(header).toContain('type SecondParameter<T extends (...args: never)');
     expect(header).toContain('export const getPetsApi = () => {');
     expect(header).not.toContain('axiosInstance');
+  });
+
+  it('should not include axiosInstance when tags-level mutator is present', () => {
+    const header = generateAxiosHeader({
+      ...baseMockParams,
+      isRequestOptions: true,
+      isMutator: false,
+      isGlobalMutator: false,
+      noFunction: false,
+      verbOptions: {
+        getPets: {
+          mutator: { name: 'customInstance' },
+        } as never,
+      },
+    });
+
+    expect(header).toContain('export const getPetsApi = () => {');
+    expect(header).not.toContain('axiosInstance');
+    expect(header).not.toContain('AxiosInstance');
+  });
+
+  it('should not include axiosInstance when global mutator is present', () => {
+    const header = generateAxiosHeader({
+      ...baseMockParams,
+      isRequestOptions: false,
+      isMutator: false,
+      isGlobalMutator: true,
+      noFunction: false,
+    });
+
+    expect(header).toContain('export const getPetsApi = () => {');
+    expect(header).not.toContain('axiosInstance');
+    expect(header).not.toContain('AxiosInstance');
   });
 });
 

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -225,12 +225,15 @@ export const generateAxiosTitle: ClientTitleBuilder = (title) => {
 };
 
 // Header for factory mode - axios is optional parameter with default value
+// When using mutator (global or tags-level), axiosInstance parameter is not needed
 export const generateAxiosHeader: ClientHeaderBuilder = ({
   title,
   isRequestOptions,
   isMutator,
+  isGlobalMutator,
   noFunction,
   output,
+  verbOptions,
 }) => {
   const isSyntheticDefaultImportsAllowed = isSyntheticDefaultImportsAllow(
     output.tsconfig,
@@ -239,13 +242,18 @@ export const generateAxiosHeader: ClientHeaderBuilder = ({
     ? 'axios'
     : 'axios.default';
 
+  // Check if any operation uses a mutator (either global or tags-level)
+  const hasAnyMutator =
+    isGlobalMutator ||
+    Object.values(verbOptions).some((verbOption) => !!verbOption.mutator);
+
   return `
 ${
   isRequestOptions && isMutator
     ? `type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];\n\n`
     : ''
 }
-  ${noFunction ? '' : isMutator ? `export const ${title} = () => {\n` : `export const ${title} = (axiosInstance: AxiosInstance = ${axiosDefault}) => {\n`}`;
+  ${noFunction ? '' : hasAnyMutator ? `export const ${title} = () => {\n` : `export const ${title} = (axiosInstance: AxiosInstance = ${axiosDefault}) => {\n`}`;
 };
 
 export const generateAxiosFooter: ClientFooterBuilder = ({


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->

Fixes #2877

When `override.mutator` is configured, generated factory functions had an unused `axiosInstance` parameter that caused TypeScript errors with `noUnusedParameters: true`.

**Before:**
```typescript
export const getPetsApi = (axiosInstance: AxiosInstance = axios) => ({
  listPets: () => customMutator({ url: '/pets' })
});
// axiosInstance is never used - compilation error
```

**After:**
```typescript
export const getPetsApi = () => ({
  listPets: () => customMutator({ url: '/pets' })
});
// No unused parameter
```

All tests passed(added tests for global and tags mutator scenario)