### PR TITLE
fix(core): guard against undefinedItem from JS string coercion

### DIFF
--- a/packages/core/src/getters/array.test.ts
+++ b/packages/core/src/getters/array.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContextSpec, OpenApiSchemaObject } from '../types';
+import { getArray } from './array';
+
+describe('getArray', () => {
+  const context: ContextSpec = {
+    output: {
+      override: {
+        components: {
+          schemas: { suffix: '', itemSuffix: 'Item' },
+        },
+      },
+    },
+    target: 'typescript',
+    spec: { openapi: '3.1.0' },
+  };
+
+  it('should inline types when name is undefined (no schemas generated)', () => {
+    // When name is undefined, types should be inlined, not declared as schemas.
+    // Previously `undefined + "Item"` became "undefinedItem" via JS coercion.
+    const schema: OpenApiSchemaObject = {
+      type: 'array',
+      prefixItems: [
+        { type: 'string' },
+        { type: 'object', properties: { id: { type: 'number' } } },
+      ],
+    };
+
+    const result = getArray({
+      schema,
+      name: undefined,
+      context,
+    });
+
+    // No schemas generated - types are inlined
+    expect(result.schemas).toHaveLength(0);
+  });
+
+  it('should generate named schemas when name is provided', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'array',
+      prefixItems: [
+        { type: 'string' },
+        { type: 'object', properties: { id: { type: 'number' } } },
+      ],
+    };
+
+    const result = getArray({
+      schema,
+      name: 'MyTuple',
+      context,
+    });
+
+    expect(result.schemas).toHaveLength(1);
+    expect(result.schemas[0].name).toBe('MyTupleItem1');
+  });
+});

--- a/packages/core/src/getters/array.ts
+++ b/packages/core/src/getters/array.ts
@@ -28,22 +28,19 @@ export function getArray({
   formDataContext,
 }: GetArrayOptions): ScalarValue {
   const schema31 = schema as OpenApiSchemaObject;
+  const itemSuffix = context.output.override.components.schemas.itemSuffix;
   if (schema31.prefixItems) {
     const resolvedObjects = schema31.prefixItems.map((item, index) =>
       resolveObject({
         schema: item as OpenApiSchemaObject | OpenApiReferenceObject,
-        propName:
-          name + context.output.override.components.schemas.itemSuffix + index,
+        propName: name ? name + itemSuffix + index : undefined,
         context,
       }),
     );
     if (schema31.items) {
       const additional = resolveObject({
         schema: schema31.items as OpenApiSchemaObject | OpenApiReferenceObject,
-        propName:
-          name +
-          context.output.override.components.schemas.itemSuffix +
-          'Additional',
+        propName: name ? name + itemSuffix + 'Additional' : undefined,
         context,
       });
       resolvedObjects.push({
@@ -67,7 +64,7 @@ export function getArray({
   if (schema.items) {
     const resolvedObject = resolveObject({
       schema: schema.items,
-      propName: name + context.output.override.components.schemas.itemSuffix,
+      propName: name ? name + itemSuffix : undefined,
       context,
       formDataContext,
     });


### PR DESCRIPTION
When name is undefined in array.ts, `name + "Item"` produces "undefinedItem" via JS string coercion. This causes duplicate identifier errors in generated TypeScript when multiple schemas trigger this code path (e.g., prefixItems inside oneOf).

Fix: guard with `name ?` so undefined name → undefined propName → types are inlined instead of generating bogus declarations.

This fixes #2885

