### PR TITLE
fix(mock): generate null instead of undefined for nullable with ref

### DIFF
--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -128,6 +128,8 @@ export function getMockObject({
             mockOptions?.required ??
             (Array.isArray(item.required) ? item.required : []).includes(key);
 
+          const hasNullable = 'nullable' in prop && prop.nullable === true;
+
           // Check to see if the property is a reference to an existing property
           // Fixes issue #910
           if (
@@ -160,7 +162,8 @@ export function getMockObject({
           const keyDefinition = getKey(key);
 
           if (!isRequired && !resolvedValue.overrided) {
-            return `${keyDefinition}: faker.helpers.arrayElement([${resolvedValue.value}, undefined])`;
+            const nullValue = hasNullable ? 'null' : 'undefined';
+            return `${keyDefinition}: faker.helpers.arrayElement([${resolvedValue.value}, ${nullValue}])`;
           }
 
           const isNullable =

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -102,6 +102,7 @@ export function resolveMockValue({
       path: schema.path,
       isRef: true,
       required: [...(schemaRef?.required ?? []), ...(schema.required ?? [])],
+      ...(schema.nullable !== undefined ? { nullable: schema.nullable } : {}),
     };
 
     const newSeparator = newSchema.allOf


### PR DESCRIPTION
### Summary

Fixed `nullable: true` with `$ref` to generate `null` instead of `undefined` in mock values.

### Changes

[`packages/mock/src/faker/resolvers/value.ts`](packages/mock/src/faker/resolvers/value.ts)
- Preserve `nullable` specified alongside `$ref`

[`packages/mock/src/faker/getters/object.ts`](packages/mock/src/faker/getters/object.ts)
- Check `nullable` property when combined with `$ref`
- Use `null` instead of `undefined` for `nullable: true` fields

### Before

```yaml
ReservationData:
  properties:
    guest:
      nullable: true
      $ref: '#/components/schemas/ReservationData_guest'
  required:
    - guest
```

Generated MSW:
```typescript
{
  guest: faker.helpers.arrayElement([
    faker.helpers.arrayElement([
      { ...getGetAdminReservationsResponseUserMock() },
      faker.string.alpha({ length: { min: 10, max: 20 } }),
    ]),
    undefined,  // nullable: true but generates undefined
  ]),
}
```

Type error: `Type 'undefined' is not assignable to type 'ReservationDataGuest | null'.`

### After

Generated MSW:
```typescript
{
  guest: faker.helpers.arrayElement([
    faker.helpers.arrayElement([
      { ...getGetAdminReservationsResponseUserMock() },
      faker.string.alpha({ length: { min: 10, max: 20 } }),
    ]),
    null,  // nullable: true generates null
  ]),
}
```