### PR TITLE
fix(core): normalize allOf schemas with inline objects (#2458)

### DIFF
--- a/packages/core/src/getters/combine.test.ts
+++ b/packages/core/src/getters/combine.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContextSpec, OpenApiSchemaObject } from '../types';
+import { combineSchemas } from './combine';
+
+const petSchema: OpenApiSchemaObject = {
+  type: 'object',
+  required: ['id', 'name', 'petType'],
+  properties: {
+    id: { type: 'integer' },
+    name: { type: 'string' },
+    petType: { type: 'string' },
+  },
+};
+
+const context: ContextSpec = {
+  output: {
+    override: {
+      enumGenerationType: 'const',
+      components: {
+        schemas: { suffix: '', itemSuffix: 'Item' },
+        responses: { suffix: '' },
+        parameters: { suffix: '' },
+        requestBodies: { suffix: 'RequestBody' },
+      },
+    },
+    unionAddMissingProperties: false,
+  },
+  target: 'spec',
+  workspace: '',
+  spec: {
+    components: {
+      schemas: {
+        Pet: petSchema,
+        Base: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+} as ContextSpec;
+
+describe('combineSchemas (allOf required handling)', () => {
+  it('does not add Required<Pick> when required properties are defined on parent', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['name', 'sound'],
+      properties: {
+        name: { type: 'string' },
+        sound: { type: 'string' },
+      },
+      allOf: [{ $ref: '#/components/schemas/Pet' }],
+    };
+
+    const result = combineSchemas({
+      schema,
+      name: 'Dog',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('Pet &');
+    expect(result.value).not.toContain('Required<Pick');
+  });
+
+  it('keeps Required<Pick> when parent requires properties defined only in subschemas', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['name'],
+      allOf: [{ $ref: '#/components/schemas/Base' }],
+    };
+
+    const result = combineSchemas({
+      schema,
+      name: 'PetWrapper',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('Required<Pick');
+  });
+
+  it('normalizes inline object in allOf to match parent object form', () => {
+    const variantA: OpenApiSchemaObject = {
+      allOf: [
+        { $ref: '#/components/schemas/Pet' },
+        {
+          type: 'object',
+          required: ['name', 'sound'],
+          properties: {
+            name: { type: 'string' },
+            sound: { type: 'string' },
+          },
+        },
+      ],
+    };
+
+    const variantB: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['name', 'sound'],
+      properties: {
+        name: { type: 'string' },
+        sound: { type: 'string' },
+      },
+      allOf: [{ $ref: '#/components/schemas/Pet' }],
+    };
+
+    const resultA = combineSchemas({
+      schema: variantA,
+      name: 'DogA',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    const resultB = combineSchemas({
+      schema: variantB,
+      name: 'DogB',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    expect(resultA.value).toBe(resultB.value);
+  });
+});

--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -1,4 +1,4 @@
-import { unique } from 'remeda';
+import { isNullish, unique } from 'remeda';
 
 import { resolveExampleRefs, resolveObject } from '../resolvers';
 import {
@@ -6,6 +6,7 @@ import {
   EnumGeneration,
   type GeneratorImport,
   type GeneratorSchema,
+  type OpenApiReferenceObject,
   type OpenApiSchemaObject,
   type ScalarValue,
   SchemaType,
@@ -35,12 +36,77 @@ type CombinedData = {
 };
 
 type Separator = 'allOf' | 'anyOf' | 'oneOf';
+const mergeableAllOfKeys = new Set(['type', 'properties', 'required']);
+
+function isMergeableAllOfObject(schema: OpenApiSchemaObject): boolean {
+  // Must have properties to be worth merging
+  if (isNullish(schema.properties)) {
+    return false;
+  }
+
+  // Cannot merge if it contains nested composition
+  if (schema.allOf || schema.anyOf || schema.oneOf) {
+    return false;
+  }
+
+  // Only object types can be merged
+  if (!isNullish(schema.type) && schema.type !== 'object') {
+    return false;
+  }
+
+  // Only merge schemas with safe keys (type, properties, required)
+  return Object.keys(schema).every((key) => mergeableAllOfKeys.has(key));
+}
+
+function normalizeAllOfSchema(
+  schema: OpenApiSchemaObject,
+): OpenApiSchemaObject {
+  if (!schema.allOf) {
+    return schema;
+  }
+
+  let didMerge = false;
+  const mergedProperties = { ...schema.properties };
+  const mergedRequired = new Set(schema.required);
+  const remainingAllOf: (OpenApiSchemaObject | OpenApiReferenceObject)[] = [];
+
+  for (const subSchema of schema.allOf) {
+    if (isSchema(subSchema) && isMergeableAllOfObject(subSchema)) {
+      didMerge = true;
+      if (subSchema.properties) {
+        Object.assign(mergedProperties, subSchema.properties);
+      }
+      if (subSchema.required) {
+        for (const prop of subSchema.required) {
+          mergedRequired.add(prop);
+        }
+      }
+      continue;
+    }
+
+    remainingAllOf.push(subSchema);
+  }
+
+  if (!didMerge || remainingAllOf.length === 0) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    ...(Object.keys(mergedProperties).length > 0 && {
+      properties: mergedProperties,
+    }),
+    ...(mergedRequired.size > 0 && { required: [...mergedRequired] }),
+    ...(remainingAllOf.length > 0 && { allOf: remainingAllOf }),
+  };
+}
 
 interface CombineValuesOptions {
   resolvedData: CombinedData;
   resolvedValue?: ScalarValue;
   separator: Separator;
   context: ContextSpec;
+  parentSchema?: OpenApiSchemaObject;
 }
 
 function combineValues({
@@ -48,6 +114,7 @@ function combineValues({
   resolvedValue,
   separator,
   context,
+  parentSchema,
 }: CombineValuesOptions) {
   const isAllEnums = resolvedData.isEnum.every(Boolean);
 
@@ -89,6 +156,10 @@ function combineValues({
         !resolvedData.originalSchema.some(
           (schema) =>
             schema?.properties?.[prop] && schema.required?.includes(prop),
+        ) &&
+        !(
+          parentSchema?.properties?.[prop] &&
+          parentSchema.required?.includes(prop)
         ),
     );
     if (overrideRequiredProperties.length > 0) {
@@ -147,9 +218,21 @@ export function combineSchemas({
   nullable: string;
   formDataContext?: FormDataContext;
 }): ScalarValue {
-  const items = schema[separator] ?? [];
+  // Normalize allOf schemas by merging inline objects into parent (fixes #2458)
+  // Only applies when: using allOf, not in v7 compat mode, no sibling oneOf/anyOf
+  const canMergeInlineAllOf =
+    separator === 'allOf' &&
+    !context.output.override.aliasCombinedTypes &&
+    !schema.oneOf &&
+    !schema.anyOf;
 
-  const resolvedData: CombinedData[] = items.reduce<CombinedData>(
+  const normalizedSchema = canMergeInlineAllOf
+    ? normalizeAllOfSchema(schema)
+    : schema;
+
+  const items = normalizedSchema[separator] ?? [];
+
+  const resolvedData: CombinedData = items.reduce<CombinedData>(
     (acc, subSchema) => {
       // aliasCombinedTypes (v7 compat): create intermediate types like ResponseAnyOf
       // v8 default: propName stays undefined so combined types are inlined directly
@@ -283,13 +366,14 @@ export function combineSchemas({
 
   let resolvedValue: ScalarValue | undefined;
 
-  if (schema.properties) {
+  if (normalizedSchema.properties) {
     resolvedValue = getScalar({
       item: Object.fromEntries(
-        Object.entries(schema).filter(([key]) => key !== separator),
+        Object.entries(normalizedSchema).filter(([key]) => key !== separator),
       ),
       name,
       context,
+      formDataContext,
     });
   } else if (separator === 'allOf' && (schema.oneOf || schema.anyOf)) {
     // Handle sibling pattern: allOf + oneOf/anyOf at same level
@@ -309,6 +393,7 @@ export function combineSchemas({
     separator,
     resolvedValue,
     context,
+    parentSchema: normalizedSchema,
   });
 
   return {
@@ -326,9 +411,7 @@ export function combineSchemas({
     type: 'object' as SchemaType,
     isRef: false,
     hasReadonlyProps:
-      resolvedData?.hasReadonlyProps ||
-      resolvedValue?.hasReadonlyProps ||
-      false,
+      resolvedData.hasReadonlyProps || resolvedValue?.hasReadonlyProps || false,
     example: schema.example,
     examples: resolveExampleRefs(schema.examples, context),
   };


### PR DESCRIPTION
## Description

Normalizes allOf schemas to generate consistent types regardless of property definition order.

## Problem

- Fixes #2458 
- [reproduction](https://github.com/froggy1014/orval-2458)

## Solution

Merge inline object schemas into parent before processing via normalizeAllOfSchema().
