### PR TITLE
fix(zod): avoid trailing commas in additionalProperties consts

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -861,7 +861,11 @@ ${Object.entries(mergedProperties)
         .map((prop: any) => parseProperty(prop))
         .join('');
       const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
-      consts += args.consts;
+      if (typeof args.consts === 'string') {
+        consts += args.consts;
+      } else if (Array.isArray(args.consts)) {
+        consts += args.consts.join('\n');
+      }
       return `zod.record(zod.string(), ${valueWithZod})`;
     }
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -141,6 +141,14 @@ const additionalPropertiesSchema: OpenApiSchemaObject = {
   },
 };
 
+const additionalPropertiesMaxLengthSchema: OpenApiSchemaObject = {
+  type: 'object',
+  additionalProperties: {
+    type: 'string',
+    maxLength: 253,
+  },
+};
+
 describe('generateZodValidationSchemaDefinition`', () => {
   it('required', () => {
     const result = generateZodValidationSchemaDefinition(
@@ -308,6 +316,43 @@ describe('generateZodValidationSchemaDefinition`', () => {
       ],
       consts: [],
     });
+  });
+
+  it('additionalProperties with maxLength', () => {
+    const result = generateZodValidationSchemaDefinition(
+      additionalPropertiesMaxLengthSchema,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'additionalPropertiesMaxLength',
+      true,
+      false,
+      {
+        required: true,
+      },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('zod.record(zod.string(), zod.string().max(');
+    expect(parsed.consts).toContain('= 253;');
+    expect(parsed.consts).not.toContain(';,');
   });
 
   it('handles allOf with base type string', () => {


### PR DESCRIPTION
## Summary

This fixes an issue where generated zod types would contain trailing commas and thereby be syntactically invalid.

- join additionalProperties consts to avoid comma stringification
- add regression assertion for maxLength additionalProperties
