### PR TITLE
feat(query): add reset queries option to invalidates

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -611,7 +611,7 @@ Generate query invalidation helpers.
 
 **Type:** `Array`
 
-Automatically invalidate queries on mutation success (Angular Query, React Query & Svelte Query):
+Automatically invalidate or reset queries on mutation success (Angular Query, React Query & Svelte Query):
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -629,7 +629,7 @@ export default defineConfig({
               onMutations: ['deletePet', 'updatePet'],
               invalidates: [
                 'listPets',
-                { query: 'showPetById', params: ['petId'] },
+                { query: 'showPetById', params: ['petId'], invalidationMode: 'reset' },
               ],
             },
           ],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -589,7 +589,8 @@ export type InvalidateTarget =
   | string
   | {
       query: string;
-      params: string[] | Record<string, string>;
+      params?: string[] | Record<string, string>;
+      invalidateMode?: 'invalidate' | 'reset';
     };
 
 export type MutationInvalidatesRule = {

--- a/packages/query/src/framework-adapter.ts
+++ b/packages/query/src/framework-adapter.ts
@@ -54,18 +54,18 @@ export interface QueryInvocationContext {
   optionalQueryClientArgument: string;
 }
 
+interface InvalidateTarget {
+  query: string;
+  params?: string[] | Record<string, string>;
+  invalidateMode: 'invalidate' | 'reset';
+}
+
 export interface MutationOnSuccessContext {
   operationName: string;
   definitions: string;
   isRequestOptions: boolean;
-  generateInvalidateCall: (target: {
-    query: string;
-    params?: string[] | Record<string, string>;
-  }) => string;
-  uniqueInvalidates: {
-    query: string;
-    params?: string[] | Record<string, string>;
-  }[];
+  generateInvalidateCall: (target: InvalidateTarget) => string;
+  uniqueInvalidates: InvalidateTarget[];
 }
 
 export interface MutationHookBodyContext {

--- a/tests/configs/svelte-query.config.ts
+++ b/tests/configs/svelte-query.config.ts
@@ -182,15 +182,15 @@ export default defineConfig({
               invalidates: ['listPets'],
             },
             {
-              onMutations: ['deletePet', 'updatePet', 'patchPet'],
+              onMutations: ['deletePetById'],
               invalidates: [
-                'listPets',
-                { query: 'showPetById', params: ['petId'] },
+                { query: 'listPets', invalidateMode: 'reset' },
+                {
+                  query: 'showPetById',
+                  params: ['petId'],
+                  invalidateMode: 'reset',
+                },
               ],
-            },
-            {
-              onMutations: ['uploadFile'],
-              invalidates: ['listPets'],
             },
           ],
         },


### PR DESCRIPTION
Adds the ability to generate `resetQueries` instead of `invalidateQueries`.
Controlled by the `invalidationMode` parameter