### PR TITLE
feat(query): add support for invalidating queries in other files

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -630,6 +630,7 @@ export default defineConfig({
               invalidates: [
                 'listPets',
                 { query: 'showPetById', params: ['petId'], invalidationMode: 'reset' },
+                { query: 'adminPets', file: './admin' },
               ],
             },
           ],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -606,6 +606,7 @@ export type InvalidateTarget =
       query: string;
       params?: string[] | Record<string, string>;
       invalidateMode?: 'invalidate' | 'reset';
+      file?: string;
     };
 
 export type MutationInvalidatesRule = {

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -89,17 +89,20 @@ export const generateQuery: ClientBuilder = async (
     normalizedVerbOptions,
     options,
   );
-  const { implementation: hookImplementation, mutators } =
-    await generateQueryHook(
-      normalizedVerbOptions,
-      options,
-      outputClient,
-      adapter,
-    );
+  const {
+    implementation: hookImplementation,
+    imports: hookImports,
+    mutators,
+  } = await generateQueryHook(
+    normalizedVerbOptions,
+    options,
+    outputClient,
+    adapter,
+  );
 
   return {
     implementation: `${functionImplementation}\n\n${hookImplementation}`,
-    imports,
+    imports: [...imports, ...hookImports],
     mutators,
   };
 };

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -1,6 +1,7 @@
 import {
   camel,
   generateMutator,
+  type GeneratorImport,
   type GeneratorMutator,
   type GeneratorOptions,
   type GeneratorVerbOptions,
@@ -806,6 +807,8 @@ ${queryKeyFns}`;
         : undefined;
   }
 
+  let imports: GeneratorImport[] = [];
+
   if (isMutation) {
     const mutationResult = await generateMutationHook({
       verbOptions: { ...verbOptions, props },
@@ -820,10 +823,12 @@ ${queryKeyFns}`;
     mutators = mutationResult.mutators
       ? [...(mutators ?? []), ...mutationResult.mutators]
       : mutators;
+    imports = mutationResult.imports;
   }
 
   return {
     implementation,
     mutators,
+    imports,
   };
 };

--- a/tests/configs/svelte-query.config.ts
+++ b/tests/configs/svelte-query.config.ts
@@ -200,4 +200,42 @@ export default defineConfig({
       target: '../specifications/petstore.yaml',
     },
   },
+  invalidatesOtherFile: {
+    output: {
+      target: '../generated/svelte-query/invalidates-other-file',
+      schemas: '../generated/svelte-query/invalidates-other-file/model',
+      client: 'svelte-query',
+      mode: 'tags',
+      mock: true,
+      headers: true,
+      override: {
+        query: {
+          mutationInvalidates: [
+            {
+              onMutations: ['createPets'],
+              invalidates: [
+                'listPets',
+                { query: 'healthCheck', file: './health' },
+              ],
+            },
+            {
+              onMutations: ['deletePetById'],
+              invalidates: [
+                { query: 'listPets', invalidateMode: 'reset' },
+                { query: 'healthCheck', file: './health' },
+                {
+                  query: 'showPetById',
+                  params: ['petId'],
+                  invalidateMode: 'reset',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    input: {
+      target: '../specifications/petstore.yaml',
+    },
+  },
 });


### PR DESCRIPTION
fixes #2949 

Currently, when using a mode that splits the output file in multiple files, there is no way to invalidate a query in another file. With this, the user can specify that the query to invalidate is located in another file. Example with healthcheck below:

```diff
{
  onMutations: ['deletePetById'],
  invalidates: [
    { query: 'listPets', invalidateMode: 'reset' },
+   { query: 'healthCheck', file: './health' },
    {
      query: 'showPetById',
      params: ['petId'],
      invalidateMode: 'reset',
    },
  ],
},
```