### PR TITLE
fix(core): handle \$ref responses without content property

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type {
   ContextSpec,
+  OpenApiReferenceObject,
   OpenApiRequestBodyObject,
   OpenApiResponseObject,
   OpenApiSchemaObject,
@@ -492,5 +493,35 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
       // allOf with $ref: intersection type (not union)
       expect(schema?.model).toContain('ClientUpdateDto & {');
     });
+  });
+});
+
+describe('getResReqTypes ($ref response without content)', () => {
+  it('should not crash when a $ref response has no content property', () => {
+    const ctxWithResponses: ContextSpec = {
+      ...context,
+      spec: {
+        components: {
+          schemas: {},
+          responses: {
+            OK: {
+              description: 'OK',
+            },
+          },
+        },
+      },
+    };
+
+    const responses: [
+      string,
+      OpenApiReferenceObject | OpenApiResponseObject,
+    ][] = [['200', { $ref: '#/components/responses/OK' }]];
+
+    const result = getResReqTypes(responses, 'Response', ctxWithResponses);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('Ok');
+    expect(result[0].isRef).toBe(true);
+    expect(result[0].originalSchema).toBeUndefined();
   });
 });

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -122,8 +122,28 @@ export function getResReqTypes(
           context,
         );
 
-        const [contentType, mediaType] =
-          Object.entries(bodySchema.content ?? {})[0] ?? [];
+        const firstEntry = Object.entries(bodySchema.content ?? {}).at(0);
+
+        if (!firstEntry) {
+          return [
+            {
+              value: name,
+              imports: [{ name, schemaName }],
+              schemas: [],
+              type: 'unknown',
+              isEnum: false,
+              isRef: true,
+              hasReadonlyProps: false,
+              originalSchema: undefined,
+              example: undefined,
+              examples: undefined,
+              key,
+              contentType: undefined,
+            },
+          ] as ResReqTypesValue[];
+        }
+
+        const [contentType, mediaType] = firstEntry;
 
         const isFormData = formDataContentTypes.has(contentType);
         const isFormUrlEncoded = formUrlEncodedContentTypes.has(contentType);


### PR DESCRIPTION
Fixes #2966 

$ref responses without a content property crash with TypeError: Cannot read properties of undefined (reading 'schema').

This is probably the same bug that was previously reported in #2681 / #2688 and fixed in #2686. PR #2937 reverted that fix.