### PR TITLE
docs: add x-enum-descriptions documentation to enums guide

### DIFF
--- a/docs/content/docs/guides/enums.mdx
+++ b/docs/content/docs/guides/enums.mdx
@@ -51,6 +51,8 @@ export const MyEnum = {
   /** Represents the fourth value */
   Four: 4,
 } as const;
+
+export type MyEnum = typeof MyEnum[keyof typeof MyEnum];
 ```
 
 ## Supported Extensions


### PR DESCRIPTION
Add documentation for the `x-enumDescriptions` OpenAPI extension to the enums guide.

 ## Changes
 - Rename page title from "Enum Names" to "Enum Extensions" to reflect broader scope
 - Add `x-enumDescriptions` usage example in the OpenAPI schema and generated output sections
 - Add a callout noting that enum descriptions only work with `const`

## References
- #2071
- #2072