### PR TITLE
feat(orval): adds defineTransformer to support type-safe transformers

### DIFF
--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -41,7 +41,21 @@ export default defineConfig({
 });
 ```
 
-The transformer function receives an [`OpenAPIObject`](https://github.com/metadevpro/openapi3-ts/blob/master/src/model/openapi30.ts#L12) and should return a transformed `OpenAPIObject`. See [example transformer](https://github.com/orval-labs/orval/blob/master/samples/basic/api/transformer/add-version.js).
+The transformer function receives an `OpenApiDocument` and should return a transformed `OpenApiDocument`. You can use the `defineTransformer` helper from `orval` for type inference.
+
+```ts title="transformer.ts"
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => ({
+  ...inputSchema,
+  info: {
+    ...inputSchema.info,
+    title: `${inputSchema.info?.title} - Custom`,
+  },
+}));
+```
+
+See [example transformer](https://github.com/orval-labs/orval/blob/master/samples/basic/api/transformer/add-version.js).
 
 ## filters
 

--- a/packages/orval/src/index.ts
+++ b/packages/orval/src/index.ts
@@ -1,4 +1,4 @@
 export { generate as default, generate } from './generate';
-export { defineConfig } from './utils/options';
+export { defineConfig, defineTransformer } from './utils/options';
 export type { Options } from '@orval/core';
 export * from '@orval/core';

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -10,6 +10,7 @@ import {
   type HookFunction,
   type HookOption,
   type HooksOptions,
+  type InputTransformerFn,
   isBoolean,
   isFunction,
   isNullish,
@@ -53,6 +54,16 @@ import { loadTsconfig } from './tsconfig';
  */
 export function defineConfig(options: ConfigExternal): ConfigExternal {
   return options;
+}
+
+/**
+ * Type helper to make it easier to write input transformers.
+ * accepts a direct {@link InputTransformerFn} function.
+ */
+export function defineTransformer(
+  transformer: InputTransformerFn,
+): InputTransformerFn {
+  return transformer;
 }
 
 function createFormData(

--- a/samples/angular-app/src/orval/transformer/add-version.ts
+++ b/samples/angular-app/src/orval/transformer/add-version.ts
@@ -1,4 +1,4 @@
-import { InputTransformerFn } from '@orval/core';
+import { defineTransformer } from 'orval';
 
 type OperationParameter = {
   name?: string;
@@ -16,7 +16,7 @@ const HTTP_VERBS = new Set([
   'trace',
 ]);
 
-const transformer: InputTransformerFn = (inputSchema) => ({
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.entries(inputSchema.paths ?? {}).reduce(
     (acc, [path, pathItem]) => ({
@@ -63,6 +63,4 @@ const transformer: InputTransformerFn = (inputSchema) => ({
     }),
     {},
   ),
-});
-
-export default transformer;
+}));

--- a/samples/angular-query/src/api/transformer/add-version.js
+++ b/samples/angular-query/src/api/transformer/add-version.js
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => {
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => {
   const transformedPaths = {};
 
   Object.entries(inputSchema.paths).forEach(([path, pathItem]) => {
@@ -35,4 +31,4 @@ export default (inputSchema) => {
     ...inputSchema,
     paths: transformedPaths,
   };
-};
+});

--- a/samples/basic/api/transformer/add-version.js
+++ b/samples/basic/api/transformer/add-version.js
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} inputSchema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => ({
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.entries(inputSchema.paths).reduce(
     (acc, [path, pathItem]) => ({
@@ -33,4 +29,4 @@ export default (inputSchema) => ({
     }),
     {},
   ),
-});
+}));

--- a/samples/react-app-with-swr/basic/src/api/transformer/add-version.js
+++ b/samples/react-app-with-swr/basic/src/api/transformer/add-version.js
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => ({
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.entries(inputSchema.paths).reduce(
     (acc, [path, pathItem]) => ({
@@ -33,4 +29,4 @@ export default (inputSchema) => ({
     }),
     {},
   ),
-});
+}));

--- a/samples/react-app/src/api/transformer/add-version.js
+++ b/samples/react-app/src/api/transformer/add-version.js
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => ({
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.entries(inputSchema.paths).reduce(
     (acc, [path, pathItem]) => ({
@@ -33,4 +29,4 @@ export default (inputSchema) => ({
     }),
     {},
   ),
-});
+}));

--- a/samples/react-query/basic/src/api/transformer/add-version.js
+++ b/samples/react-query/basic/src/api/transformer/add-version.js
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => ({
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.entries(inputSchema.paths).reduce(
     (acc, [path, pathItem]) => ({
@@ -33,4 +29,4 @@ export default (inputSchema) => ({
     }),
     {},
   ),
-});
+}));

--- a/samples/svelte-query/basic/src/api/transformer/add-version.mjs
+++ b/samples/svelte-query/basic/src/api/transformer/add-version.mjs
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => ({
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.entries(inputSchema.paths).reduce(
     (acc, [path, pathItem]) => ({
@@ -33,4 +29,4 @@ export default (inputSchema) => ({
     }),
     {},
   ),
-});
+}));

--- a/samples/vue-query/vue-query-basic/src/api/transformer/add-version.js
+++ b/samples/vue-query/vue-query-basic/src/api/transformer/add-version.js
@@ -1,10 +1,6 @@
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => {
+import { defineTransformer } from 'orval';
+
+export default defineTransformer((inputSchema) => {
   const transformedPaths = {};
 
   Object.entries(inputSchema.paths).forEach(([path, pathItem]) => {
@@ -41,4 +37,4 @@ export default (inputSchema) => {
     ...inputSchema,
     paths: transformedPaths,
   };
-};
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -43,7 +43,6 @@
     "hono": "catalog:hono",
     "msw": "catalog:tooling",
     "npm-run-all2": "catalog:",
-    "openapi3-ts": "^4.5.0",
     "orval": "workspace:*",
     "prettier": "catalog:",
     "react": "catalog:react",

--- a/tests/transformers/add-version.js
+++ b/tests/transformers/add-version.js
@@ -1,14 +1,6 @@
-/**
- * @import { OpenAPIObject } from 'openapi3-ts/oas30'
- */
+import { defineTransformer } from 'orval';
 
-/**
- * Transformer function for orval.
- *
- * @param {OpenAPIObject} schema
- * @return {OpenAPIObject}
- */
-export default (inputSchema) => ({
+export default defineTransformer((inputSchema) => ({
   ...inputSchema,
   paths: Object.fromEntries(
     Object.entries(inputSchema.paths).map(([path, pathItem]) => [
@@ -35,4 +27,4 @@ export default (inputSchema) => ({
       ),
     ]),
   ),
-});
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -18808,15 +18808,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openapi3-ts@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "openapi3-ts@npm:4.5.0"
-  dependencies:
-    yaml: "npm:^2.8.0"
-  checksum: 10c0/97de2d24e9ceffb89e1388e137e4a6e17ee57a02dce0c938a5e98b1338ac72b31e8b2ce8dd28945ad43fae8bee2a145892cb548ba5ae60b0930f1b6b79b0747d
-  languageName: node
-  linkType: hard
-
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -18872,7 +18863,6 @@ __metadata:
     hono: "catalog:hono"
     msw: "catalog:tooling"
     npm-run-all2: "catalog:"
-    openapi3-ts: "npm:^4.5.0"
     orval: "workspace:*"
     prettier: "catalog:"
     react: "catalog:react"


### PR DESCRIPTION
Adds an optional helper to write type-safe transformers.
There are no changes to the transformer api or behavior. It's simply a helper.

```ts
import { defineTransformer } from 'orval';

export default defineTransformer((inputSchema) => ({
  ...inputSchema,
  info: {
    ...inputSchema.info,
    title: `${inputSchema.info?.title} - Custom`,
  },
}));
```