### PR TITLE
bugfix(mock): remeda was not listed as a dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "esutils": "2.0.3",
     "fs-extra": "^11.3.2",
     "globby": "16.1.0",
-    "remeda": "^2.32.0",
+    "remeda": "^2.33.6",
     "typedoc": "^0.28.15"
   },
   "module": "./dist/index.mjs"

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -23,7 +23,7 @@
     "@orval/core": "workspace:*",
     "@orval/zod": "workspace:*",
     "fs-extra": "^11.3.2",
-    "remeda": "^2.32.0"
+    "remeda": "^2.33.6"
   },
   "devDependencies": {
     "@hono/zod-validator": "catalog:hono",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -21,7 +21,8 @@
     "nuke": "rimraf .turbo dist node_modules"
   },
   "dependencies": {
-    "@orval/core": "workspace:*"
+    "@orval/core": "workspace:*",
+    "remeda": "^2.33.6"
   },
   "devDependencies": {
     "eslint": "catalog:",

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -93,7 +93,7 @@
     "fs-extra": "^11.3.2",
     "jiti": "^2.6.1",
     "js-yaml": "4.1.1",
-    "remeda": "^2.32.0",
+    "remeda": "^2.33.6",
     "string-argv": "^0.3.2",
     "tsconfck": "^3.1.6",
     "typedoc": "^0.28.15",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -24,7 +24,7 @@
     "@orval/core": "workspace:*",
     "@orval/fetch": "workspace:*",
     "chalk": "^5.6.2",
-    "remeda": "^2.32.0"
+    "remeda": "^2.33.6"
   },
   "devDependencies": {
     "eslint": "catalog:",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@orval/core": "workspace:*",
-    "remeda": "^2.32.0"
+    "remeda": "^2.33.6"
   },
   "devDependencies": {
     "eslint": "catalog:",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,7 +5745,7 @@ __metadata:
     esutils: "npm:2.0.3"
     fs-extra: "npm:^11.3.2"
     globby: "npm:16.1.0"
-    remeda: "npm:^2.32.0"
+    remeda: "npm:^2.33.6"
     rimraf: "catalog:"
     tsdown: "catalog:"
     typedoc: "npm:^0.28.15"
@@ -5777,7 +5777,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     eslint: "catalog:"
     fs-extra: "npm:^11.3.2"
-    remeda: "npm:^2.32.0"
+    remeda: "npm:^2.33.6"
     rimraf: "catalog:"
     tsdown: "catalog:"
     typescript: "catalog:"
@@ -5804,6 +5804,7 @@ __metadata:
   dependencies:
     "@orval/core": "workspace:*"
     eslint: "catalog:"
+    remeda: "npm:^2.33.6"
     rimraf: "catalog:"
     tsdown: "catalog:"
     typescript: "catalog:"
@@ -5819,7 +5820,7 @@ __metadata:
     "@orval/fetch": "workspace:*"
     chalk: "npm:^5.6.2"
     eslint: "catalog:"
-    remeda: "npm:^2.32.0"
+    remeda: "npm:^2.33.6"
     rimraf: "catalog:"
     tsdown: "catalog:"
     vitest: "catalog:"
@@ -5857,7 +5858,7 @@ __metadata:
   dependencies:
     "@orval/core": "workspace:*"
     eslint: "catalog:"
-    remeda: "npm:^2.32.0"
+    remeda: "npm:^2.33.6"
     rimraf: "catalog:"
     tsdown: "catalog:"
     vitest: "catalog:"
@@ -18935,7 +18936,7 @@ __metadata:
     fs-extra: "npm:^11.3.2"
     jiti: "npm:^2.6.1"
     js-yaml: "npm:4.1.1"
-    remeda: "npm:^2.32.0"
+    remeda: "npm:^2.33.6"
     rimraf: "catalog:"
     string-argv: "npm:^0.3.2"
     tsconfck: "npm:^3.1.6"
@@ -21167,12 +21168,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remeda@npm:^2.32.0":
-  version: 2.32.0
-  resolution: "remeda@npm:2.32.0"
-  dependencies:
-    type-fest: "npm:^4.41.0"
-  checksum: 10c0/890ce245dac492eacffc657d6976680a6de8c9f96a5a1e86c37d91795e5209a62e6912dceeda20685f03d26bb5d54805c8c7a9ad0e91b16f1fcfacd70452ab00
+"remeda@npm:^2.33.6":
+  version: 2.33.6
+  resolution: "remeda@npm:2.33.6"
+  checksum: 10c0/b85d9e041e03153c5f6a3c8eec36c843e4a3dd6aebfbe1528d353654befc53b9fac18c399e8e36b8571acd54e836cd31ef7bd8240980b3134488e6ccff84c31b
   languageName: node
   linkType: hard
 
@@ -24205,13 +24204,6 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^4.41.0":
-  version: 4.41.0
-  resolution: "type-fest@npm:4.41.0"
-  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@orval/mock` had remeda listed as a devDependency but was using it runtime. So tsdown bundles it inline into the output. This is not the way.
Packages used runtime should be listed under dependencies.

Update remeda while I was at it.