### PR TITLE
bugfix(core)!: faker is now an optional peerDependency instead of being inlined

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,5 +46,13 @@
     "remeda": "^2.33.6",
     "typedoc": "^0.28.15"
   },
+  "peerDependencies": {
+    "@faker-js/faker": ">=10"
+  },
+  "peerDependenciesMeta": {
+    "@faker-js/faker": {
+      "optional": true
+    }
+  },
   "module": "./dist/index.mjs"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5751,6 +5751,11 @@ __metadata:
     typedoc: "npm:^0.28.15"
     typescript: "catalog:"
     vitest: "catalog:"
+  peerDependencies:
+    "@faker-js/faker": ">=10"
+  peerDependenciesMeta:
+    "@faker-js/faker":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`@faker-js/faker` is now an optional peerDependency 

This is a **BREAKING CHANGE** for users using the [Mock Option](https://orval.dev/docs/reference/configuration/output#mock-options) `locale`

Migration:
add `@faker-js/faker` to your project