### PR TITLE
chore(ci): slightly optimized pull-request CI script

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,15 +1,16 @@
-name: tests
+name: PR checks
 
 on:
   pull_request:
     branches:
       - 'master'
       - 'next'
+
 permissions:
   contents: read
 
 jobs:
-  tests:
+  pr-checks:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -29,16 +30,29 @@ jobs:
       # until setup-node have better support for corepack we have to setup yarn in 2 steps
       # https://github.com/actions/setup-node/issues/531
       - uses: actions/setup-node@v6
-      - name: install
-        run: yarn
-      - name: build
-        run: yarn build
-      - name: lint
-        # not all packages pass linting yet - ongoing work
-        run: yarn lint
-      - name: snapshot tests
-        run: yarn test:snapshots
-      - name: formatting
+        with:
+          node-version: ${{ matrix.node-version }}
+          # yarn is now installed so we can enable caching
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Check formatting
         run: yarn format:check
-      - name: unit tests
-        run: yarn test:ci
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Lint packages
+        run: yarn lint
+
+      - name: Test packages
+        run: yarn test
+
+      - name: Verify snapshot
+        # this step also runs the generate-api task
+        run: yarn test:snapshots
+
+      - name: Verify generated code can build
+        run: yarn workspace orval-tests build

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ This project uses [Yarn](https://yarnpkg.com/) for package management and buildi
 
 - **`yarn test`** - Run unit tests in all packages.
 
-- **`yarn test:ci`** - Run the CI-equivalent checks locally (`lint`, package tests, `test:cli`, and `test:samples`).
-
 - **`yarn update-samples`** - Generate sample outputs using the newly built version of Orval. This regenerates the sample code based on the current build.
 
 - **`yarn test:samples`** - Run tests in the samples directory using the newly generated output from `update-samples`.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "test:samples": "turbo test --filter='./samples/**' --filter=!react-query-form-data --filter=!react-query-form-url-encoded --filter=!react-query-form-url-encoded-mutator --filter=!react-query-form-data-mutator --filter=!react-query-hook-mutator-axios --filter=!react-query-hook-mutator-fetch",
     "test:snapshots": "turbo run test:snapshots --filter='./samples/**' --filter=orval-tests",
     "test:snapshots:update": "turbo run test:snapshots:update --filter='./samples/**' --filter=orval-tests",
-    "test:ci": "CI=true yarn lint && CI=true yarn test && yarn test:cli && yarn test:samples",
     "lint": "turbo run lint --filter='./packages/*' --filter=!@orval/mock --filter=!@orval/zod",
     "lint:samples": "turbo run lint --filter='./samples/**'",
     "dev": "turbo run dev --filter='./packages/*'",

--- a/turbo.json
+++ b/turbo.json
@@ -12,12 +12,9 @@
     "dev": {
       "cache": false
     },
-    // https://turborepo.com/docs/crafting-your-repository/configuring-tasks#dependent-tasks-that-can-be-run-in-parallel
-    "transit": {
-      "dependsOn": ["^transit"]
-    },
     "lint": {
-      "dependsOn": ["transit"]
+      // linting will fail if the packages are not built
+      "dependsOn": ["build"]
     },
     "test": {
       "outputs": []


### PR DESCRIPTION
Findings:

- `package-manager-cache: false` does not work, but `cache: 'yarn'` does.
- Apparently packages must be built for linting to pass.
- Github seems to be working on parallel steps. This would be a big speedup. Revisit when/if that is released.

https://github.blog/news-insights/product-news/lets-talk-about-github-actions/
> Moreover, we’ll start work on [parallel steps](https://github.com/orgs/community/discussions/14484), one of the most requested features across GitHub Actions. Our goal is to ship it before mid-2026.
