### PR TITLE
chore(deps): replace chalk with native util.styleText

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@scalar/openapi-types": "catalog:",
     "acorn": "^8.15.0",
-    "chalk": "^5.6.2",
     "compare-versions": "^6.1.1",
     "debug": "^4.4.3",
     "esbuild": "^0.27.3",

--- a/packages/core/src/generators/mutator.ts
+++ b/packages/core/src/generators/mutator.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
-import chalk from 'chalk';
 import fs from 'fs-extra';
 
 import type { GeneratorMutator, NormalizedMutator, Tsconfig } from '../types';
@@ -44,7 +44,10 @@ export async function generateMutator({
 
   if (mutatorInfoName === undefined) {
     throw new Error(
-      chalk.red(`Mutator ${importPath} must have a named or default export.`),
+      styleText(
+        'red',
+        `Mutator ${importPath} must have a named or default export.`,
+      ),
     );
   }
 
@@ -77,7 +80,8 @@ export async function generateMutator({
 
   if (!mutatorInfo) {
     throw new Error(
-      chalk.red(
+      styleText(
+        'red',
         `Your mutator file doesn't have the ${mutatorInfoName} exported function`,
       ),
     );

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,6 +1,5 @@
 import readline from 'node:readline';
-
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 import { isString } from './assertion';
 
@@ -29,7 +28,7 @@ export function startMessage({
   version: string;
   description: string;
 }): string {
-  return `🍻 ${chalk.cyan.bold(name)} ${chalk.green(`v${version}`)}${
+  return `🍻 ${styleText(['cyan', 'bold'], name)} ${styleText('green', `v${version}`)}${
     description ? ` - ${description}` : ''
   }`;
 }
@@ -53,7 +52,8 @@ export function logError(err: unknown, tag?: string) {
   }
 
   log(
-    chalk.red(
+    styleText(
+      'red',
       ['🛑', tag ? `${tag} -` : undefined, message].filter(Boolean).join(' '),
     ),
   );
@@ -61,7 +61,8 @@ export function logError(err: unknown, tag?: string) {
 
 export function mismatchArgsMessage(mismatchArgs: string[]) {
   log(
-    chalk.yellow(
+    styleText(
+      'yellow',
       `${mismatchArgs.join(', ')} ${
         mismatchArgs.length === 1 ? 'is' : 'are'
       } not defined in your configuration!`,
@@ -72,7 +73,7 @@ export function mismatchArgsMessage(mismatchArgs: string[]) {
 export function createSuccessMessage(backend?: string) {
   log(
     `🎉 ${
-      backend ? `${chalk.green(backend)} - ` : ''
+      backend ? `${styleText('green', backend)} - ` : ''
     }Your OpenAPI spec has been converted into ready to use orval!`,
   );
 }
@@ -138,11 +139,11 @@ export function createLogger(
         if (options.timestamp) {
           const tag =
             type === 'info'
-              ? chalk.cyan.bold(prefix)
+              ? styleText(['cyan', 'bold'], prefix)
               : type === 'warn'
-                ? chalk.yellow.bold(prefix)
-                : chalk.red.bold(prefix);
-          return `${chalk.dim(new Date().toLocaleTimeString())} ${tag} ${msg}`;
+                ? styleText(['yellow', 'bold'], prefix)
+                : styleText(['red', 'bold'], prefix);
+          return `${styleText('dim', new Date().toLocaleTimeString())} ${tag} ${msg}`;
         } else {
           return msg;
         }
@@ -150,7 +151,7 @@ export function createLogger(
       if (type === lastType && msg === lastMsg) {
         sameCount++;
         clear();
-        console[method](format(), chalk.yellow(`(x${sameCount + 1})`));
+        console[method](format(), styleText('yellow', `(x${sameCount + 1})`));
       } else {
         sameCount = 0;
         lastMsg = msg;

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -75,7 +75,6 @@
     "@scalar/json-magic": "^0.11.4",
     "@scalar/openapi-parser": "^0.24.13",
     "@scalar/openapi-types": "catalog:",
-    "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
     "commander": "^14.0.2",
     "enquirer": "^2.4.1",

--- a/packages/orval/src/formatters/prettier.ts
+++ b/packages/orval/src/formatters/prettier.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { log } from '@orval/core';
-import chalk from 'chalk';
 import { execa } from 'execa';
 
 /**
@@ -37,14 +37,16 @@ export async function formatWithPrettier(
               // https://prettier.io/docs/options#parser
             } else {
               log(
-                chalk.yellow(
+                styleText(
+                  'yellow',
                   `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}Failed to format file ${filePath}: ${error.toString()}`,
                 ),
               );
             }
           } else {
             log(
-              chalk.yellow(
+              styleText(
+                'yellow',
                 `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}Failed to format file ${filePath}: unknown error}`,
               ),
             );
@@ -61,7 +63,8 @@ export async function formatWithPrettier(
     await execa('prettier', ['--write', ...paths]);
   } catch {
     log(
-      chalk.yellow(
+      styleText(
+        'yellow',
         `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}prettier not found. Install it as a project dependency or globally.`,
       ),
     );

--- a/packages/orval/src/utils/execute-hook.ts
+++ b/packages/orval/src/utils/execute-hook.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import {
   type Hook,
   type HookOption,
@@ -8,7 +10,6 @@ import {
   logError,
   type NormalizedHookCommand,
 } from '@orval/core';
-import chalk from 'chalk';
 import { execa } from 'execa';
 import { parseArgsStringToArgv } from 'string-argv';
 
@@ -17,7 +18,7 @@ export const executeHook = async (
   commands: NormalizedHookCommand = [],
   args: string[] = [],
 ) => {
-  log(chalk.white(`Running ${name} hook...`));
+  log(styleText('white', `Running ${name} hook...`));
 
   for (const command of commands) {
     try {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import {
   type ClientMockBuilder,
   type ConfigExternal,
@@ -42,7 +44,6 @@ import {
   upath,
 } from '@orval/core';
 import { DEFAULT_MOCK_OPTIONS } from '@orval/mock';
-import chalk from 'chalk';
 
 import pkg from '../../package.json';
 import { loadPackageJson } from './package-json';
@@ -122,11 +123,11 @@ export async function normalizeOptions(
     : optionsExport);
 
   if (!options.input) {
-    throw new Error(chalk.red(`Config require an input`));
+    throw new Error(styleText('red', `Config require an input`));
   }
 
   if (!options.output) {
-    throw new Error(chalk.red(`Config require an output`));
+    throw new Error(styleText('red', `Config require an output`));
   }
 
   const inputOptions = isString(options.input)
@@ -410,11 +411,13 @@ export async function normalizeOptions(
   };
 
   if (!normalizedOptions.input.target) {
-    throw new Error(chalk.red(`Config require an input target`));
+    throw new Error(styleText('red', `Config require an input target`));
   }
 
   if (!normalizedOptions.output.target && !normalizedOptions.output.schemas) {
-    throw new Error(chalk.red(`Config require an output target or schemas`));
+    throw new Error(
+      styleText('red', `Config require an output target or schemas`),
+    );
   }
 
   return normalizedOptions;
@@ -426,7 +429,7 @@ function normalizeMutator(
 ): NormalizedMutator | undefined {
   if (isObject(mutator)) {
     if (!mutator.path) {
-      throw new Error(chalk.red(`Mutator need a path`));
+      throw new Error(styleText('red', `Mutator need a path`));
     }
 
     return {
@@ -599,7 +602,9 @@ function normalizeOutputMode(mode?: OutputMode): OutputMode {
   }
 
   if (!Object.values(OutputMode).includes(mode)) {
-    createLogger().warn(chalk.yellow(`Unknown the provided mode => ${mode}`));
+    createLogger().warn(
+      styleText('yellow', `Unknown the provided mode => ${mode}`),
+    );
     return OutputMode.SINGLE;
   }
 

--- a/packages/orval/src/utils/package-json.ts
+++ b/packages/orval/src/utils/package-json.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import {
   dynamicImport,
   isObject,
@@ -7,7 +9,6 @@ import {
   type PackageJson,
   resolveInstalledVersions,
 } from '@orval/core';
-import chalk from 'chalk';
 import { findUp, findUpMultiple } from 'find-up';
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
@@ -81,7 +82,10 @@ const resolveAndAttachVersions = (
     resolvedCache.set(cacheKey, resolved);
     for (const [name, version] of Object.entries(resolved)) {
       logVerbose(
-        chalk.dim(`Detected ${chalk.white(name)} v${chalk.white(version)}`),
+        styleText(
+          'dim',
+          `Detected ${styleText('white', name)} v${styleText('white', version)}`,
+        ),
       );
     }
   }
@@ -168,7 +172,7 @@ const maybeReplaceCatalog = async (
 
   if (!catalogData) {
     log(
-      `⚠️  ${chalk.yellow('package.json contains catalog: references, but no catalog source was found (checked: pnpm-workspace.yaml, package.json, .yarnrc.yml).')}`,
+      `⚠️  ${styleText('yellow', 'package.json contains catalog: references, but no catalog source was found (checked: pnpm-workspace.yaml, package.json, .yarnrc.yml).')}`,
     );
     return pkg;
   }
@@ -189,14 +193,14 @@ const performSubstitution = (
     if (version === 'catalog:' || version === 'catalog:default') {
       if (!catalogData.catalog) {
         log(
-          `⚠️  ${chalk.yellow(`catalog: substitution for the package '${packageName}' failed as there is no default catalog.`)}`,
+          `⚠️  ${styleText('yellow', `catalog: substitution for the package '${packageName}' failed as there is no default catalog.`)}`,
         );
         continue;
       }
       const sub = catalogData.catalog[packageName];
       if (!sub) {
         log(
-          `⚠️  ${chalk.yellow(`catalog: substitution for the package '${packageName}' failed as there is no matching package in the default catalog.`)}`,
+          `⚠️  ${styleText('yellow', `catalog: substitution for the package '${packageName}' failed as there is no matching package in the default catalog.`)}`,
         );
         continue;
       }
@@ -206,14 +210,14 @@ const performSubstitution = (
       const catalog = catalogData.catalogs?.[catalogName];
       if (!catalog) {
         log(
-          `⚠️  ${chalk.yellow(`'${version}' substitution for the package '${packageName}' failed as there is no matching catalog named '${catalogName}'. (available named catalogs are: ${Object.keys(catalogData.catalogs ?? {}).join(', ')})`)}`,
+          `⚠️  ${styleText('yellow', `'${version}' substitution for the package '${packageName}' failed as there is no matching catalog named '${catalogName}'. (available named catalogs are: ${Object.keys(catalogData.catalogs ?? {}).join(', ')})`)}`,
         );
         continue;
       }
       const sub = catalog[packageName];
       if (!sub) {
         log(
-          `⚠️  ${chalk.yellow(`'${version}' substitution for the package '${packageName}' failed as there is no package in the catalog named '${catalogName}'. (packages in the catalog are: ${Object.keys(catalog).join(', ')})`)}`,
+          `⚠️  ${styleText('yellow', `'${version}' substitution for the package '${packageName}' failed as there is no package in the catalog named '${catalogName}'. (packages in the catalog are: ${Object.keys(catalog).join(', ')})`)}`,
         );
         continue;
       }

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import {
   createSuccessMessage,
   fixCrossDirectoryImports,
@@ -20,7 +22,6 @@ import {
   writeSplitTagsMode,
   writeTagsMode,
 } from '@orval/core';
-import chalk from 'chalk';
 import { execa, ExecaError } from 'execa';
 import fs from 'fs-extra';
 import { unique } from 'remeda';
@@ -388,7 +389,7 @@ export async function writeSpecs(
       if (error instanceof ExecaError && error.exitCode === 1)
         message = error.message;
 
-      log(chalk.yellow(message));
+      log(styleText('yellow', message));
     }
   }
 
@@ -440,7 +441,7 @@ export async function writeSpecs(
           ? error.message
           : `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}Unable to generate docs`;
 
-      log(chalk.yellow(message));
+      log(styleText('yellow', message));
     }
   }
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@orval/core": "workspace:*",
     "@orval/fetch": "workspace:*",
-    "chalk": "^5.6.2",
     "remeda": "^2.33.6"
   },
   "devDependencies": {

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import {
   type GetterProps,
   GetterPropType,
@@ -12,7 +14,6 @@ import {
   TEMPLATE_TAG_REGEX,
   upath,
 } from '@orval/core';
-import chalk from 'chalk';
 
 export const normalizeQueryOptions = (
   queryOptions: QueryOptions = {},
@@ -72,7 +73,7 @@ const normalizeMutator = (
 ): NormalizedMutator | undefined => {
   if (isObject(mutator)) {
     if (!mutator.path) {
-      throw new Error(chalk.red(`Mutator need a path`));
+      throw new Error(styleText('red', `Mutator need a path`));
     }
 
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6098,7 +6098,6 @@ __metadata:
     "@types/esutils": "npm:^2.0.2"
     "@types/fs-extra": "npm:^11.0.4"
     acorn: "npm:^8.15.0"
-    chalk: "npm:^5.6.2"
     compare-versions: "npm:^6.1.1"
     debug: "npm:^4.4.3"
     esbuild: "npm:^0.27.3"
@@ -6187,7 +6186,6 @@ __metadata:
   dependencies:
     "@orval/core": "workspace:*"
     "@orval/fetch": "workspace:*"
-    chalk: "npm:^5.6.2"
     eslint: "catalog:"
     remeda: "npm:^2.33.6"
     rimraf: "catalog:"
@@ -21405,7 +21403,6 @@ __metadata:
     "@scalar/openapi-types": "catalog:"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/js-yaml": "npm:^4.0.9"
-    chalk: "npm:^5.6.2"
     chokidar: "npm:^5.0.0"
     commander: "npm:^14.0.2"
     enquirer: "npm:^2.4.1"


### PR DESCRIPTION
## Summary
- Replace the `chalk` dependency with Node.js built-in `util.styleText` across all three packages (`core`, `orval`, `query`)
- `styleText` is stable in Node >=22.18.0, which is already the minimum engine version for orval
- Removes one external dependency from the dependency tree

## Changes
- 8 source files updated: migrate all `chalk.<color>()` calls to `styleText('<color>', ...)`
- Chained styles use array syntax: `chalk.cyan.bold(x)` → `styleText(['cyan', 'bold'], x)`
- 3 package.json files: removed `chalk` from dependencies
- yarn.lock updated accordingly

## Test plan
- [x] All 336 tests pass
- [x] All 22 lint tasks pass
- [x] `NO_COLOR` behavior preserved (`styleText` respects `NO_COLOR` env var)
- [x] Zero remaining chalk references in source packages

Closes #2982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal logging stack by transitioning to Node.js built-in text styling utilities, reducing external dependencies while maintaining consistent console output and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->