### PR TITLE
fix(resolveMockValue): use `name` instead of `pascalCase(originalName)` to prevent dropped suffix

### DIFF
--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -86,7 +86,7 @@ export function resolveMockValue({
   allowOverride,
 }: ResolveMockValueOptions): MockDefinition & { type?: string } {
   if (isReference(schema)) {
-    const { originalName, refPaths } = getRefInfo(schema.$ref, context);
+    const { name, refPaths } = getRefInfo(schema.$ref, context);
 
     const schemaRef = Array.isArray(refPaths)
       ? (prop(
@@ -98,7 +98,7 @@ export function resolveMockValue({
 
     const newSchema = {
       ...schemaRef,
-      name: pascal(originalName),
+      name,
       path: schema.path,
       isRef: true,
       required: [...(schemaRef?.required ?? []), ...(schema.required ?? [])],


### PR DESCRIPTION
## Summary

When `override.components.schemas.suffix` is configured, Orval correctly appends the suffix to generated types (e.g., TypeA → TypeADto). However, `resolveMockValue` in `@orval/mock` is calling `getRefInfo` and re-deriving the schema name via `pascal(originalName)`, which omitted the configured suffix. This caused generated mock factory functions to reference the unsuffixed type names.

## Resolution

Use the `name` field returned by `getRefInfo` directly, which already includes the suffix, instead of re-computing it from `originalName`.

## Minimal Reproduction

https://github.com/chrislambe/orval-ref-suffix-bug-repro

## Caveat

While I ran into this bug in a real world use case, the debugging steps and fix were implemented by Claude. I've applied this fix as a patch in my codebase and it seems to have resolved the issue. I'm not certain whether or not this is the "right" fix, just that it works for my use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reference name resolution in mock data generation to preserve the original naming convention without applying automatic case transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->