### PR TITLE
fix(import-specs): prevent injection of components into swagger 2.0 spec when no external refs

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -726,4 +726,17 @@ describe('dereferenceExternalRefs', () => {
 
     expect(result).not.toHaveProperty('x-ext');
   });
+
+  it('should not inject components into Swagger 2.0 spec when no external refs exist', () => {
+    const input = {
+      swagger: '2.0',
+      info: { title: 'Test', version: '1.0' },
+      paths: {},
+      definitions: { Foo: { type: 'object' } },
+    };
+
+    const result = dereferenceExternalRef(input);
+
+    expect(result).not.toHaveProperty('components');
+  });
 });

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -105,6 +105,8 @@ function mergeExternalSchemas(
 ): Record<string, Record<string, string>> {
   const schemaNameMappings: Record<string, Record<string, string>> = {};
 
+  if (Object.keys(extensions).length === 0) return schemaNameMappings;
+
   data.components ??= {};
   const mainComponents = data.components as Record<string, unknown>;
   mainComponents.schemas ??= {};


### PR DESCRIPTION
Closes https://github.com/orval-labs/orval/issues/3036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case validating correct handling of Swagger 2.0 specifications without external references, ensuring components are not incorrectly injected.

* **Chores**
  * Optimized schema merging to short-circuit when no external extensions are present, improving performance by eliminating unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->