### PR TITLE
chore(deps): bump yarn from v4.11.0 to v4.13.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,71 +1,67 @@
-nodeLinker: node-modules
-
-packageExtensions:
-  # issue with @vue/test-utils@2.4.6
-  # https://github.com/vuejs/test-utils/issues/2581
-  '@vue/test-utils@*':
-    peerDependencies:
-      vue: '*'
-
-enableScripts: false
-npmPublishAccess: public
-npmRegistryServer: https://registry.npmjs.org
-
-# https://yarnpkg.com/features/catalogs
 catalog:
+  '@scalar/openapi-types': 0.5.3
+  '@types/node': 22.18.12
   eslint: 10.0.2
+  globals: 17.4.0
+  npm-run-all2: 8.0.4
   prettier: 3.8.1
   rimraf: 6.1.2
-  tslib: 2.8.1
   tsdown: 0.20.3
+  tslib: 2.8.1
   typescript: 5.9.3
-  npm-run-all2: 8.0.4
+  typescript-eslint: 8.56.1
   vite: 7.2.2
   vitest: 4.0.18
-  '@types/node': 22.18.12 # pinned to minimum supported version by orval
-  '@scalar/openapi-types': 0.5.3
-  'typescript-eslint': 8.56.1
-  globals: 17.4.0
 
-# using named catalogs to align packages in /tests with /samples
 catalogs:
   angular:
-    # Runtime packages kept in sync (https://github.com/angular/angular/blob/main/tools/bazel/npm_packages.bzl)
-    '@angular/core': 21.1.4
+    '@angular/animations': 21.1.4
+    '@angular/build': 21.1.4
+    '@angular/cli': 21.1.4
     '@angular/common': 21.1.4
     '@angular/compiler': 21.1.4
     '@angular/compiler-cli': 21.1.4
-    '@angular/animations': 21.1.4
-    '@angular/platform-browser': 21.1.4
+    '@angular/core': 21.1.4
     '@angular/forms': 21.1.4
+    '@angular/platform-browser': 21.1.4
     '@angular/router': 21.1.4
     rxjs: 7.8.2
-    # Build tooling uses last available patch
-    '@angular/build': 21.1.4
-    '@angular/cli': 21.1.4
   axios:
     axios: 1.13.6
+  hono:
+    '@hono/zod-validator': 0.7.6
+    hono: 4.11.9
+  mcp:
+    '@modelcontextprotocol/sdk': 1.26.0
+  react:
+    '@tanstack/react-query': 5.62.16
+    '@types/react': 18.3.24
+    react: 18.3.1
+  svelte:
+    '@tanstack/svelte-query': 4.41.0
+    svelte: 5.53.0
+    svelte-check: 3.8.6
+  swr:
+    swr: 2.3.6
   tooling:
     '@faker-js/faker': 10.3.0
     msw: 2.12.10
-  hono:
-    hono: 4.11.9
-    '@hono/zod-validator': 0.7.6
-  zod3:
-    zod: 3.25.76
-  swr:
-    swr: 2.3.6
   vue:
+    '@tanstack/vue-query': 5.92.7
     vue: 3.5.26
     vue-tsc: 3.2.4
-    '@tanstack/vue-query': 5.92.7
-  svelte:
-    svelte: 5.53.0
-    svelte-check: 3.8.6
-    '@tanstack/svelte-query': 4.41.0
-  react:
-    react: 18.3.1
-    '@types/react': 18.3.24
-    '@tanstack/react-query': 5.62.16
-  mcp:
-    '@modelcontextprotocol/sdk': 1.26.0
+  zod3:
+    zod: 3.25.76
+
+enableScripts: false
+
+nodeLinker: node-modules
+
+npmPublishAccess: public
+
+npmRegistryServer: 'https://registry.npmjs.org'
+
+packageExtensions:
+  '@vue/test-utils@*':
+    peerDependencies:
+      vue: '*'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "tests"
   ],
   "private": true,
-  "packageManager": "yarn@4.11.0",
+  "packageManager": "yarn@4.13.0",
   "devEngines": {
     "runtime": {
       "name": "node",
@@ -61,6 +61,6 @@
   },
   "volta": {
     "node": "24.13.0",
-    "yarn": "4.11.0"
+    "yarn": "4.13.0"
   }
 }


### PR DESCRIPTION
Running `yarn set version latest` shuffled things around in yarnrc. So I guess it's the way it's supposed to be.

No package were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Yarn package manager to 4.13.0.
  * Reorganized package catalogs and consolidated framework/tooling dependency entries (React, Vue, Svelte, Angular, mcp, tooling).
  * Restored and adjusted global Yarn settings (scripts, node linker, registry/publish access).
  * Added a package extension to address Vue Test Utils peer dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->