### PR TITLE
fix(faker): regexp must be escaped

### DIFF
--- a/packages/core/src/utils/string.test.ts
+++ b/packages/core/src/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { dedupeUnionType, jsStringEscape } from './string';
+import { dedupeUnionType, escape, jsStringEscape } from './string';
 
 describe('dedupeUnionType', () => {
   describe('edge cases', () => {
@@ -203,5 +203,21 @@ describe('jsStringEscape', () => {
       expect(jsStringEscape('/*')).toBe(String.raw`\/\*`);
       expect(jsStringEscape('*/')).toBe(String.raw`\*\/`);
     });
+  });
+});
+
+describe('escape', () => {
+  it('should escape a single occurrence of the character', () => {
+    expect(escape("don't")).toBe(String.raw`don\'t`);
+  });
+
+  it('should escape all occurrences of the character', () => {
+    expect(escape("it's John's car")).toBe(String.raw`it\'s John\'s car`);
+  });
+
+  it('should escape all occurrences of a custom character', () => {
+    expect(escape('say "hello" and "goodbye"', '"')).toBe(
+      String.raw`say \"hello\" and \"goodbye\"`,
+    );
   });
 });

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -201,17 +201,19 @@ export function getNumberWord(num: number) {
 }
 
 /**
- * Escapes a specific character in a string by prefixing it with a backslash.
+ * Escapes a specific character in a string by prefixing all of its occurrences with a backslash.
  *
  * @param str - The string to escape, or null.
  * @param char - The character to escape. Defaults to single quote (').
  * @returns The escaped string, or null if the input is null.
  * @example
  * escape("don't") // returns "don\'t"
+ * escape("it's John's") // returns "it\'s John\'s"
  * escape('say "hello"', '"') // returns 'say \\"hello\\"'
+ * escape("a'''b", "'") // returns "a\'\'\'b"
  */
 export function escape(str: string | null, char = "'") {
-  return str?.replace(char, `\\${char}`);
+  return str?.replaceAll(char, `\\${char}`);
 }
 
 /**

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -510,8 +510,6 @@ describe('getMockScalar (pattern escaping)', () => {
       },
     });
 
-    expect(result.value).toBe(
-      String.raw`faker.helpers.fromRegExp('a\'\'\'b')`,
-    );
+    expect(result.value).toBe(String.raw`faker.helpers.fromRegExp('a\'\'\'b')`);
   });
 });

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable unicorn/no-null */
 import type { ContextSpec, OpenApiSchemaObjectType } from '@orval/core';
 import { describe, expect, it } from 'vitest';
@@ -473,5 +472,31 @@ describe('getMockScalar (@-prefixed property names)', () => {
     // Property key should be quoted as '@type', not sanitized to '_type' or 'type'
     expect(result.value).toContain("'@type'");
     expect(result.value).not.toContain('_type');
+  });
+});
+
+describe('getMockScalar (pattern escaping)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+    context: { output: { override: {} } } as ContextSpec,
+  };
+
+  it('should escape single quotes in pattern when generating faker.helpers.fromRegExp call', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as const,
+        name: 'pattern-item',
+        pattern: "^[a-zA-Z0-9']*$",
+      },
+    });
+
+    expect(result.value).toBe(
+      String.raw`faker.helpers.fromRegExp('^[a-zA-Z0-9\']*$')`,
+    );
   });
 });

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -499,4 +499,19 @@ describe('getMockScalar (pattern escaping)', () => {
       String.raw`faker.helpers.fromRegExp('^[a-zA-Z0-9\']*$')`,
     );
   });
+
+  it('should escape multiple single quotes in pattern when generating faker.helpers.fromRegExp call', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as const,
+        name: 'pattern-item-multiple',
+        pattern: "a'''b",
+      },
+    });
+
+    expect(result.value).toBe(
+      String.raw`faker.helpers.fromRegExp('a\'\'\'b')`,
+    );
+  });
 });

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -313,7 +313,7 @@ export function getMockScalar({
           'string',
         );
       } else if (item.pattern) {
-        value = `faker.helpers.fromRegExp('${item.pattern}')`;
+        value = `faker.helpers.fromRegExp('${escape(item.pattern)}')`;
       } else if ('const' in item) {
         value = JSON.stringify((item as OpenApiSchemaObject).const);
       }


### PR DESCRIPTION
Fix #3064 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying escaping of special characters in string patterns and the new escaping utility behavior.

* **Bug Fixes**
  * Corrected pattern escaping used during mock data generation so string patterns with quotes are handled safely.

* **Documentation**
  * Updated docs/examples for the string-escaping utility to show escaping all occurrences and relevant edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->