### PR TITLE
chore: restore deleted comments during yarn update

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,7 @@
+# https://yarnpkg.com/features/catalogs
 catalog:
   '@scalar/openapi-types': 0.5.3
-  '@types/node': 22.18.12
+  '@types/node': 22.18.12 # pinned to minimum supported version by orval
   eslint: 10.0.2
   globals: 17.4.0
   npm-run-all2: 8.0.4
@@ -13,11 +14,11 @@ catalog:
   vite: 7.2.2
   vitest: 4.0.18
 
+# using named catalogs to align packages in /tests with /samples
 catalogs:
   angular:
+    # Runtime packages kept in sync (https://github.com/angular/angular/blob/main/tools/bazel/npm_packages.bzl)
     '@angular/animations': 21.1.4
-    '@angular/build': 21.1.4
-    '@angular/cli': 21.1.4
     '@angular/common': 21.1.4
     '@angular/compiler': 21.1.4
     '@angular/compiler-cli': 21.1.4
@@ -26,6 +27,9 @@ catalogs:
     '@angular/platform-browser': 21.1.4
     '@angular/router': 21.1.4
     rxjs: 7.8.2
+    # Build tooling uses last available patch
+    '@angular/build': 21.1.4
+    '@angular/cli': 21.1.4
   axios:
     axios: 1.13.6
   hono:
@@ -62,6 +66,8 @@ npmPublishAccess: public
 npmRegistryServer: 'https://registry.npmjs.org'
 
 packageExtensions:
+  # issue with @vue/test-utils@2.4.6
+  # https://github.com/vuejs/test-utils/issues/2581
   '@vue/test-utils@*':
     peerDependencies:
       vue: '*'


### PR DESCRIPTION
Running `yarn set version latest` apparently removes comments. Rather annoying!

This PR restores them.

Related PR
- #3070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized and annotated package management configuration with clarifying comments for dependency tracking and tooling synchronization. No functional changes to dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->