### PR TITLE
chore(http): Add rejectUnauthorized option to fetch requests

### DIFF
--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -503,6 +503,7 @@ async function resolveFirstValidTarget(
             method: 'HEAD',
             headers,
             signal: controller.signal,
+            rejectUnauthorized: false,
           });
 
           if (response.ok) return target;
@@ -512,6 +513,7 @@ async function resolveFirstValidTarget(
               method: 'GET',
               headers,
               signal: controller.signal,
+              rejectUnauthorized: false,
             });
             if (getResponse.ok) return target;
           }


### PR DESCRIPTION
So if you are accessing an internal OpenAPI URL in your company and it has self signed or bad certs it fails.  This would basically ignore SSL/TLS errors. I thought this was a safe default vs making it yet again another configuration?

@snebjorn @anymaniax @soartec-lab @ScriptType @the-ult  any thoughts on this?  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL resolution to support skipping TLS certificate verification for requests during target validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->