### PR TITLE
fix(core): prevent enum key collisions from naming convention transforms

### DIFF
--- a/packages/core/src/getters/enum.test.ts
+++ b/packages/core/src/getters/enum.test.ts
@@ -21,8 +21,6 @@ describe('getEnumImplementation', () => {
         NamingConvention.PASCAL_CASE,
       );
 
-      // "-" is replaced with "Minus" before PascalCase, so both values
-      // produce distinct keys
       expect(result).toContain('CreatedAt');
       expect(result).toContain('MinusCreatedAt');
       expect(result).toContain('Email');
@@ -65,6 +63,20 @@ describe('getEnumImplementation', () => {
       expect(result).toContain('Active');
       expect(result).toContain('Inactive');
       expect(result).toContain('Pending');
+    });
+
+    it('should not change keys when dash values do not collide', () => {
+      // "-date" alone (no "date") should still produce "Date", not "MinusDate"
+      const result = getEnumImplementation(
+        "'-date' | 'name'",
+        undefined,
+        undefined,
+        NamingConvention.PASCAL_CASE,
+      );
+
+      expect(result).toContain('Date');
+      expect(result).toContain('Name');
+      expect(result).not.toContain('Minus');
     });
   });
 });

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -124,6 +124,44 @@ const getTypeConstEnum = (
   return enumValue;
 };
 
+/**
+ * Derive the object/enum key for a single enum value.
+ *
+ * Handles numeric prefixes, sanitization, and optional naming convention
+ * transforms.  When `disambiguate` is true, special characters (-/+) are
+ * replaced with semantic words before the convention transform to prevent
+ * key collisions.
+ */
+function deriveEnumKey(
+  val: string,
+  enumNamingConvention?: NamingConvention,
+  disambiguate = false,
+): string {
+  let key = val.startsWith("'") ? val.slice(1, -1) : val;
+
+  if (isNumeric(key)) {
+    key = toNumberKey(key);
+  }
+
+  if (key.length > 1) {
+    key = sanitize(key, {
+      whitespace: '_',
+      underscore: true,
+      dash: true,
+      special: true,
+    });
+  }
+
+  if (enumNamingConvention) {
+    if (disambiguate) {
+      key = replaceSpecialCharacters(key);
+    }
+    key = conventionName(key, enumNamingConvention);
+  }
+
+  return key;
+}
+
 export function getEnumImplementation(
   value: string,
   names?: string[],
@@ -134,6 +172,15 @@ export function getEnumImplementation(
   if (value === '') return '';
 
   const uniqueValues = [...new Set(value.split(' | '))];
+
+  // Check whether the naming convention produces duplicate keys.
+  // Only apply special-character disambiguation when it does,
+  // so that existing output is preserved for non-colliding enums.
+  const disambiguate =
+    !!enumNamingConvention &&
+    new Set(uniqueValues.map((v) => deriveEnumKey(v, enumNamingConvention)))
+      .size < uniqueValues.length;
+
   let result = '';
   for (const [index, val] of uniqueValues.entries()) {
     const name = names?.[index];
@@ -147,27 +194,7 @@ export function getEnumImplementation(
       continue;
     }
 
-    let key = val.startsWith("'") ? val.slice(1, -1) : val;
-
-    const isNumber = isNumeric(key);
-
-    if (isNumber) {
-      key = toNumberKey(key);
-    }
-
-    if (key.length > 1) {
-      key = sanitize(key, {
-        whitespace: '_',
-        underscore: true,
-        dash: true,
-        special: true,
-      });
-    }
-
-    if (enumNamingConvention) {
-      key = replaceSpecialCharacters(key);
-      key = conventionName(key, enumNamingConvention);
-    }
+    const key = deriveEnumKey(val, enumNamingConvention, disambiguate);
 
     result +=
       comment +
@@ -196,6 +223,12 @@ const getNativeEnumItems = (
   if (value === '') return '';
 
   const uniqueValues = [...new Set(value.split(' | '))];
+
+  const disambiguate =
+    !!enumNamingConvention &&
+    new Set(uniqueValues.map((v) => deriveEnumKey(v, enumNamingConvention)))
+      .size < uniqueValues.length;
+
   let result = '';
   for (const [index, val] of uniqueValues.entries()) {
     const name = names?.[index];
@@ -204,27 +237,7 @@ const getNativeEnumItems = (
       continue;
     }
 
-    let key = val.startsWith("'") ? val.slice(1, -1) : val;
-
-    const isNumber = isNumeric(key);
-
-    if (isNumber) {
-      key = toNumberKey(key);
-    }
-
-    if (key.length > 1) {
-      key = sanitize(key, {
-        whitespace: '_',
-        underscore: true,
-        dash: true,
-        special: true,
-      });
-    }
-
-    if (enumNamingConvention) {
-      key = replaceSpecialCharacters(key);
-      key = conventionName(key, enumNamingConvention);
-    }
+    const key = deriveEnumKey(val, enumNamingConvention, disambiguate);
 
     result += `  ${keyword.isIdentifierNameES5(key) ? key : `'${key}'`}= ${val},\n`;
   }


### PR DESCRIPTION
**Problem**

Fix #638 

When `enumNamingConvention` is set (e.g. PascalCase) and an enum contains values that differ only by a leading special character, the naming convention strips the character and both values map to the same key. The second silently overwrites the first in the generated const/enum object.

Example — an ordering parameter enum with `["created_at", "-created_at", "email", "-email"]`:

```ts
// Before (bug): "-created_at" overwrites "created_at"
export const OrderingEnum = {
  CreatedAt: 'created_at',
  CreatedAt: '-created_at',  // silent overwrite
  Email: 'email',
  Email: '-email',           // silent overwrite
} as const;
```

This is common with DRF (Django REST Framework) ordering filters which auto-generate both `field` and `-field` enum values, but affects any enum with `+`/`-` prefixed values.

**Fix**

Replace special characters (`-`, `+`) with semantic words (`minus`, `plus`) before the naming convention transform, with a trailing underscore as word boundary:

`-created_at` → `minus_created_at` → `MinusCreatedAt`

```ts
// After (fix): distinct keys
export const OrderingEnum = {
  CreatedAt: 'created_at',
  MinusCreatedAt: '-created_at',
  Email: 'email',
  MinusEmail: '-email',
} as const;
```

Applied to both `getEnumImplementation` (const enums) and `getNativeEnumItems` (native enums). Only runs when `enumNamingConvention` is set — no change for users without convention config.

**Character map** is intentionally conservative (only `-` and `+`), can be extended incrementally for other special chars if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in enum keys when naming conventions are applied, preventing duplicate or ambiguous keys and preserving original literals.

* **Tests**
  * Added comprehensive tests covering naming conventions (including PascalCase), collision disambiguation, uniqueness checks, and special-character cases (plus/minus and dash scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->