### PR TITLE
feat(fetch): add plain text support

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -192,7 +192,6 @@ ${
   const isNdJson = response.contentTypes.some((contentType) =>
     isContentTypeNdJson(contentType),
   );
-
   const responseTypeName = fetchResponseTypeName(
     override.fetch.includeHttpResponseReturnType,
     isNdJson ? 'Response' : response.definition.success,
@@ -387,7 +386,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   const throwOnErrorImplementation = `if (!${isNdJson ? 'stream' : 'res'}.ok) {
     ${isNdJson ? 'const body = [204, 205, 304].includes(stream.status) ? null : await stream.text();' : ''}
     const err: globalThis.Error & {info?: ${hasError ? `${errorName}${override.fetch.includeHttpResponseReturnType ? "['data']" : ''}` : 'any'}, status?: number} = new globalThis.Error();
-    const data ${hasError ? `: ${errorName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''}` : ''} = ${`body ? JSON.parse(body${reviver}) : {}`}
+    const data ${hasError ? `: ${errorName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''}` : ''} = body ? JSON.parse(body${reviver}) : {}
     err.info = data;
     err.status = ${isNdJson ? 'stream' : 'res'}.status;
     throw err;
@@ -403,7 +402,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   ${override.fetch.forceSuccessResponse ? throwOnErrorImplementation : ''}
   ${
     isValidateResponse
-      ? `const parsedBody = ${`body ? JSON.parse(body${reviver}) : {}`};
+      ? `const parsedBody = body ? JSON.parse(body${reviver}) : {}
   const data = ${schemaValueRef}.parse(parsedBody)`
       : `
       const resContentType = res.headers.get("content-type") ?? "";

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -189,9 +189,13 @@ ${
   const isContentTypeNdJson = (contentType: string) =>
     contentType === 'application/nd-json' ||
     contentType === 'application/x-ndjson';
-
   const isNdJson = response.contentTypes.some((contentType) =>
     isContentTypeNdJson(contentType),
+  );
+
+  const isTextPlain = (contentType: string) => contentType === 'text/plain';
+  const isPlainText = response.contentTypes.some((contentType) =>
+    isTextPlain(contentType),
   );
   const responseTypeName = fetchResponseTypeName(
     override.fetch.includeHttpResponseReturnType,
@@ -387,7 +391,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   const throwOnErrorImplementation = `if (!${isNdJson ? 'stream' : 'res'}.ok) {
     ${isNdJson ? 'const body = [204, 205, 304].includes(stream.status) ? null : await stream.text();' : ''}
     const err: globalThis.Error & {info?: ${hasError ? `${errorName}${override.fetch.includeHttpResponseReturnType ? "['data']" : ''}` : 'any'}, status?: number} = new globalThis.Error();
-    const data ${hasError ? `: ${errorName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''}` : ''} = body ? JSON.parse(body${reviver}) : {}
+    const data ${hasError ? `: ${errorName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''}` : ''} = ${isPlainText ? `body ?? ''` : `body ? JSON.parse(body${reviver}) : {}`}
     err.info = data;
     err.status = ${isNdJson ? 'stream' : 'res'}.status;
     throw err;
@@ -403,9 +407,9 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   ${override.fetch.forceSuccessResponse ? throwOnErrorImplementation : ''}
   ${
     isValidateResponse
-      ? `const parsedBody = body ? JSON.parse(body${reviver}) : {}
+      ? `const parsedBody = ${isPlainText ? `body ?? ''` : `body ? JSON.parse(body${reviver}) : {}`};
   const data = ${schemaValueRef}.parse(parsedBody)`
-      : `const data: ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = body ? JSON.parse(body${reviver}) : {}`
+      : `const data: ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = ${isPlainText ? `body ?? ''` : `body ? JSON.parse(body${reviver}) : {}`}`
   }
   ${override.fetch.includeHttpResponseReturnType ? `return { data, status: res.status, headers: res.headers } as ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}` : 'return data'}
 `;

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -193,17 +193,6 @@ ${
     isContentTypeNdJson(contentType),
   );
 
-  const isTextPlain = (contentType: string) => contentType === 'text/plain';
-  // Prefer deriving plain-text behavior from success responses only, so that
-  // text/plain error responses do not force successful JSON responses to be
-  // treated as plain text.
-  const successContentTypes = response.types.success
-    .map((r) => r.contentType)
-    .filter((ct) => typeof ct === 'string' && ct.length > 0);
-  const isPlainText =
-    successContentTypes.length > 0
-      ? successContentTypes.some((contentType) => isTextPlain(contentType))
-      : response.contentTypes.some((contentType) => isTextPlain(contentType));
   const responseTypeName = fetchResponseTypeName(
     override.fetch.includeHttpResponseReturnType,
     isNdJson ? 'Response' : response.definition.success,
@@ -398,7 +387,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   const throwOnErrorImplementation = `if (!${isNdJson ? 'stream' : 'res'}.ok) {
     ${isNdJson ? 'const body = [204, 205, 304].includes(stream.status) ? null : await stream.text();' : ''}
     const err: globalThis.Error & {info?: ${hasError ? `${errorName}${override.fetch.includeHttpResponseReturnType ? "['data']" : ''}` : 'any'}, status?: number} = new globalThis.Error();
-    const data ${hasError ? `: ${errorName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''}` : ''} = ${isPlainText ? `body ?? ''` : `body ? JSON.parse(body${reviver}) : {}`}
+    const data ${hasError ? `: ${errorName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''}` : ''} = ${`body ? JSON.parse(body${reviver}) : {}`}
     err.info = data;
     err.status = ${isNdJson ? 'stream' : 'res'}.status;
     throw err;
@@ -414,9 +403,11 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   ${override.fetch.forceSuccessResponse ? throwOnErrorImplementation : ''}
   ${
     isValidateResponse
-      ? `const parsedBody = ${isPlainText ? `body ?? ''` : `body ? JSON.parse(body${reviver}) : {}`};
+      ? `const parsedBody = ${`body ? JSON.parse(body${reviver}) : {}`};
   const data = ${schemaValueRef}.parse(parsedBody)`
-      : `const data: ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = ${isPlainText ? `body ?? ''` : `body ? JSON.parse(body${reviver}) : {}`}`
+      : `
+      const resContentType = res.headers.get("content-type") ?? "";
+      const data: ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = resContentType.startsWith('text/') ? body ?? '' : body ? JSON.parse(body${reviver}) : {}`
   }
   ${override.fetch.includeHttpResponseReturnType ? `return { data, status: res.status, headers: res.headers } as ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}` : 'return data'}
 `;

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -194,9 +194,16 @@ ${
   );
 
   const isTextPlain = (contentType: string) => contentType === 'text/plain';
-  const isPlainText = response.contentTypes.some((contentType) =>
-    isTextPlain(contentType),
-  );
+  // Prefer deriving plain-text behavior from success responses only, so that
+  // text/plain error responses do not force successful JSON responses to be
+  // treated as plain text.
+  const successContentTypes = response.types.success
+    .map((r) => r.contentType)
+    .filter((ct) => typeof ct === 'string' && ct.length > 0);
+  const isPlainText =
+    successContentTypes.length > 0
+      ? successContentTypes.some((contentType) => isTextPlain(contentType))
+      : response.contentTypes.some((contentType) => isTextPlain(contentType));
   const responseTypeName = fetchResponseTypeName(
     override.fetch.includeHttpResponseReturnType,
     isNdJson ? 'Response' : response.definition.success,

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -94,7 +94,12 @@ export const listPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: listPetsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: listPetsResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
@@ -139,7 +144,12 @@ export const createPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: createPetsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: createPetsResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -188,7 +198,12 @@ export const updatePets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: updatePetsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: updatePetsResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -235,7 +250,12 @@ export const showPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: showPetByIdResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -130,7 +130,14 @@ export const findPetsByStatus = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: findPetsByStatusResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: findPetsByStatusResponse['data'] = resContentType.startsWith(
+    'text/',
+  )
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -207,7 +214,14 @@ export const findPetsByTags = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: findPetsByTagsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: findPetsByTagsResponse['data'] = resContentType.startsWith(
+    'text/',
+  )
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -273,7 +287,12 @@ export const getPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: getPetByIdResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: getPetByIdResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -349,7 +368,14 @@ export const updatePetWithForm = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: updatePetWithFormResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: updatePetWithFormResponse['data'] = resContentType.startsWith(
+    'text/',
+  )
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -401,7 +427,12 @@ export const deletePet = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: deletePetResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: deletePetResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -444,7 +475,12 @@ export const getInventory = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: getInventoryResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: getInventoryResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -510,7 +546,12 @@ export const getOrderById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: getOrderByIdResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: getOrderByIdResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -568,7 +609,12 @@ export const deleteOrder = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: deleteOrderResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: deleteOrderResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -640,7 +686,12 @@ export const loginUser = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: loginUserResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: loginUserResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -683,7 +734,12 @@ export const logoutUser = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: logoutUserResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: logoutUserResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -749,7 +805,12 @@ export const getUserByName = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: getUserByNameResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: getUserByNameResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -807,7 +868,12 @@ export const deleteUser = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: deleteUserResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: deleteUserResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -48,7 +48,12 @@ export const listPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: Pets = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: Pets = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return data;
 };
 
@@ -111,7 +116,12 @@ export const createPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: Pet = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: Pet = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return data;
 };
 
@@ -171,7 +181,12 @@ export const showPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: Pet = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: Pet = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return data;
 };
 

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -128,7 +128,12 @@ export const listPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: listPetsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: listPetsResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
@@ -211,7 +216,12 @@ export const createPets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: createPetsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: createPetsResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -297,7 +307,12 @@ export const updatePets = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: updatePetsResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: updatePetsResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,
@@ -381,7 +396,12 @@ export const showPetById = async (
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: showPetByIdResponse['data'] = body ? JSON.parse(body) : {};
+  const resContentType = res.headers.get('content-type') ?? '';
+  const data: showPetByIdResponse['data'] = resContentType.startsWith('text/')
+    ? (body ?? '')
+    : body
+      ? JSON.parse(body)
+      : {};
   return {
     data,
     status: res.status,


### PR DESCRIPTION
**Summary**

There is already an open issue describing a problem with the **Orval fetch client**: it **always parses responses as JSON**, even when the response may be **`text/plain`**.

Currently, the generated code reads the response with `res.text()` and then immediately calls `JSON.parse(...)`. When an endpoint returns `text/plain`, this results in a **runtime error**, since plain text is not valid JSON.

Another contributor already reported this behavior and explained that the generated client does not take the response `content-type` into account. A collaborator acknowledged the issue and indicated that **a pull request would be welcome**, but the preferred implementation approach has not yet been decided.

**In short:**
The fetch client should allow handling **`text/plain` responses** without forcing JSON parsing.

Issue: https://github.com/orval-labs/orval/issues/3088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for text/* responses (raw text) in the fetch client and related endpoints alongside JSON.

* **Bug Fixes**
  * Ensured response parsing now respects Content-Type, avoiding incorrect JSON parsing of text responses and improving consistent success/error handling across clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->