### PR TITLE
fix(core): strip trailing whitespace from generated code output

### DIFF
--- a/packages/core/src/writers/file.ts
+++ b/packages/core/src/writers/file.ts
@@ -1,0 +1,17 @@
+import fs from 'fs-extra';
+
+const TRAILING_WHITESPACE_RE = /[^\S\r\n]+$/gm;
+
+/**
+ * Write generated code to a file, stripping trailing whitespace from each line.
+ *
+ * Template literals in code generators can produce lines with only whitespace
+ * when conditional expressions evaluate to empty strings. This function
+ * ensures the output is always clean regardless of generator implementation.
+ */
+export async function writeGeneratedFile(
+  filePath: string,
+  content: string,
+): Promise<void> {
+  await fs.outputFile(filePath, content.replaceAll(TRAILING_WHITESPACE_RE, ''));
+}

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -10,6 +10,7 @@ import {
   NamingConvention,
 } from '../types';
 import { conventionName, upath } from '../utils';
+import { writeGeneratedFile } from './file';
 
 type CanonicalInfo = Pick<GeneratorImport, 'importPath' | 'name'>;
 
@@ -331,7 +332,7 @@ export async function writeSchema({
   const name = conventionName(schema.name, namingConvention);
 
   try {
-    await fs.outputFile(
+    await writeGeneratedFile(
       getPath(path, name, fileExtension),
       getSchema({
         schema,
@@ -443,7 +444,7 @@ export async function writeSchemas({
 
       const fileContent = `${header}\n${exports}\n`;
 
-      await fs.writeFile(schemaFilePath, fileContent, { encoding: 'utf8' });
+      await writeGeneratedFile(schemaFilePath, fileContent);
     } catch (error) {
       throw new Error(
         `Oups... 🍻. An Error occurred while writing schema index file ${schemaFilePath} => ${String(error)}`,

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -1,5 +1,3 @@
-import fs from 'fs-extra';
-
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import type { WriteModeProps } from '../types';
 import {
@@ -10,6 +8,7 @@ import {
   isSyntheticDefaultImportsAllow,
   upath,
 } from '../utils';
+import { writeGeneratedFile } from './file';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import { generateTarget } from './target';
 import { getOrvalGeneratedTypes, getTypedResponse } from './types';
@@ -144,7 +143,7 @@ export async function writeSingleMode({
       data += implementationMock;
     }
 
-    await fs.outputFile(path, data);
+    await writeGeneratedFile(path, data);
 
     return [path];
   } catch (error) {

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -1,7 +1,5 @@
 import path from 'node:path';
 
-import fs from 'fs-extra';
-
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import { OutputClient, type WriteModeProps } from '../types';
 import {
@@ -13,6 +11,7 @@ import {
   upath,
 } from '../utils';
 import { getMockFileExtensionByTypeName } from '../utils/file-extensions';
+import { writeGeneratedFile } from './file';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import { generateTarget } from './target';
 import { getOrvalGeneratedTypes, getTypedResponse } from './types';
@@ -112,7 +111,7 @@ export async function writeSplitMode({
     if (schemasPath && needSchema) {
       const schemasData = header + generateModelsInline(builder.schemas);
 
-      await fs.outputFile(schemasPath, schemasData);
+      await writeGeneratedFile(schemasPath, schemasData);
     }
 
     if (mutators) {
@@ -169,7 +168,7 @@ export async function writeSplitMode({
       extension;
 
     const implementationPath = path.join(dirname, implementationFilename);
-    await fs.outputFile(implementationPath, implementationData);
+    await writeGeneratedFile(implementationPath, implementationData);
 
     const mockPath = output.mock
       ? path.join(
@@ -182,7 +181,7 @@ export async function writeSplitMode({
       : undefined;
 
     if (mockPath) {
-      await fs.outputFile(mockPath, mockData);
+      await writeGeneratedFile(mockPath, mockData);
     }
 
     return [

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -14,6 +14,7 @@ import {
   upath,
 } from '../utils';
 import { getMockFileExtensionByTypeName } from '../utils/file-extensions';
+import { writeGeneratedFile } from './file';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import { generateTargetForTags } from './target-tags';
 import { getOrvalGeneratedTypes, getTypedResponse } from './types';
@@ -127,7 +128,7 @@ export async function writeSplitTagsMode({
         if (schemasPath && needSchema) {
           const schemasData = header + generateModelsInline(builder.schemas);
 
-          await fs.outputFile(schemasPath, schemasData);
+          await writeGeneratedFile(schemasPath, schemasData);
         }
 
         if (mutators) {
@@ -194,7 +195,7 @@ export async function writeSplitTagsMode({
           tag,
           implementationFilename,
         );
-        await fs.outputFile(implementationPath, implementationData);
+        await writeGeneratedFile(implementationPath, implementationData);
 
         const mockPath = output.mock
           ? path.join(
@@ -208,7 +209,7 @@ export async function writeSplitTagsMode({
           : undefined;
 
         if (mockPath) {
-          await fs.outputFile(mockPath, mockData);
+          await writeGeneratedFile(mockPath, mockData);
         }
 
         return [

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -1,7 +1,5 @@
 import path from 'node:path';
 
-import fs from 'fs-extra';
-
 import { generateModelsInline, generateMutatorImports } from '../generators';
 import type { WriteModeProps } from '../types';
 import {
@@ -13,6 +11,7 @@ import {
   kebab,
   upath,
 } from '../utils';
+import { writeGeneratedFile } from './file';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import { generateTargetForTags } from './target-tags';
 import { getOrvalGeneratedTypes, getTypedResponse } from './types';
@@ -119,7 +118,7 @@ export async function writeTagsMode({
         if (schemasPath && needSchema) {
           const schemasData = header + generateModelsInline(builder.schemas);
 
-          await fs.outputFile(schemasPath, schemasData);
+          await writeGeneratedFile(schemasPath, schemasData);
         }
 
         if (mutators) {
@@ -172,7 +171,7 @@ export async function writeTagsMode({
           dirname,
           `${kebab(tag)}${extension}`,
         );
-        await fs.outputFile(implementationPath, data);
+        await writeGeneratedFile(implementationPath, data);
 
         return [implementationPath, ...(schemasPath ? [schemasPath] : [])];
       } catch (error) {


### PR DESCRIPTION
### Problem

close https://github.com/orval-labs/orval/issues/3113

Generated `.ts` and `.msw.ts` files contain lines with trailing whitespace (spaces on otherwise blank lines). This triggers `no-trailing-spaces` linter warnings in downstream projects.

#### Root cause

Template literals in code generators produce lines with only whitespace when conditional expressions evaluate to empty strings. The indentation spaces remain on the line even though the content is empty.

```typescript
`  ${condition ? 'content' : ''}` // → "  " when falsy (trailing whitespace)
```

### Fix

Add a `writeGeneratedFile` utility in `packages/core/src/writers/` that strips trailing whitespace (`/[^\S\n]+$/gm`) at the file-write boundary. All writer modes (single, split, tags, split-tags) and the schema writer now use this utility instead of calling `fs.outputFile` directly.

This approach fixes the issue at the output layer regardless of which generator produces the content, without modifying individual template literals across multiple packages.

#### Changed files
- `packages/core/src/writers/file.ts` — new `writeGeneratedFile` utility
- `packages/core/src/writers/single-mode.ts`
- `packages/core/src/writers/split-mode.ts`
- `packages/core/src/writers/tags-mode.ts`
- `packages/core/src/writers/split-tags-mode.ts`
- `packages/core/src/writers/schemas.ts`

### Verification

Tested with a minimal OpenAPI spec (single GET endpoint). Before fix: trailing whitespace lines in generated `.ts` and `.msw.ts`. After fix: 0 in both files. All existing tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Generated code files now have trailing whitespace automatically normalized across all output modes for cleaner, more consistent code.

* **Refactor**
  * Centralized file writing logic into a dedicated utility module that handles all code generation file outputs. This improves consistency and maintainability across schema generation, implementation files, and mock outputs in all generation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->