### PR TITLE
fix(zod): guard enum constraints for non-array schemas

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -254,6 +254,7 @@ export const generateZodValidationSchemaDefinition = (
 
   const multipleOf = schema.multipleOf;
   const matches = schema.pattern ?? undefined;
+  const hasNonArrayEnum = !!schema.enum && type !== 'array';
 
   // Check for allOf/oneOf/anyOf BEFORE processing by type
   // This ensures these constraints work with any base type (string, number, object, etc.)
@@ -700,7 +701,7 @@ export const generateZodValidationSchemaDefinition = (
     }
   }
 
-  if (isString(type) && minAndMaxTypes.has(type)) {
+  if (!hasNonArrayEnum && isString(type) && minAndMaxTypes.has(type)) {
     // Handle minimum constraints: exclusiveMinimum (>.gt()) takes priority over minimum (.min())
     // Check if exclusive flag was set (boolean format in OpenAPI 3.0) or a different value (OpenAPI 3.1)
     const shouldUseExclusiveMin = exclusiveMinRaw !== undefined;
@@ -750,7 +751,7 @@ export const generateZodValidationSchemaDefinition = (
     }
   }
 
-  if (matches) {
+  if (matches && !hasNonArrayEnum) {
     const isStartWithSlash = matches.startsWith('/');
     const isEndWithSlash = matches.endsWith('/');
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -254,6 +254,9 @@ export const generateZodValidationSchemaDefinition = (
 
   const multipleOf = schema.multipleOf;
   const matches = schema.pattern ?? undefined;
+  // Enum-based schemas are emitted as `zod.enum(...)` or literal unions, so
+  // chaining scalar constraints onto the parent schema would generate invalid
+  // Zod output. Arrays are handled separately via their item schema.
   const hasNonArrayEnum = !!schema.enum && type !== 'array';
 
   // Check for allOf/oneOf/anyOf BEFORE processing by type

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1750,6 +1750,179 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(parsed.zod).toBe("zod.enum(['+33', '+420']).optional()");
     });
 
+    it('skips string constraints for direct enums with minLength/maxLength (#3024)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['cat', 'dog'],
+        minLength: 2,
+        maxLength: 3,
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumStringMinLength',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['cat', 'dog']"],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+
+      expect(parsed.zod).toBe("zod.enum(['cat', 'dog']).optional()");
+      expect(parsed.zod).not.toContain('zod.min(');
+      expect(parsed.zod).not.toContain('.min(');
+      expect(parsed.zod).not.toContain('.max(');
+    });
+
+    it('skips constraints for dereferenced enum schemas with sibling minLength (#3024)', () => {
+      const dereferenceContext = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              PetStatus: {
+                type: 'string',
+                enum: ['available', 'sold'],
+              },
+            },
+          },
+        },
+      } as ContextSpec;
+
+      const resolvedSchema = dereference(
+        {
+          $ref: '#/components/schemas/PetStatus',
+          minLength: 1,
+        },
+        dereferenceContext,
+      );
+
+      const result = generateZodValidationSchemaDefinition(
+        resolvedSchema,
+        dereferenceContext,
+        'testDereferencedEnumStringMinLength',
+        false,
+        false,
+        { required: true },
+      );
+
+      expect(result).toEqual({
+        functions: [['enum', "['available', 'sold']"]],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        dereferenceContext,
+        false,
+        false,
+        false,
+      );
+
+      expect(parsed.zod).toBe("zod.enum(['available', 'sold'])");
+      expect(parsed.zod).not.toContain('zod.min(');
+      expect(parsed.zod).not.toContain('.min(');
+    });
+
+    it('skips pattern chains for enums to avoid invalid regex-enum output (#3024)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['cat', 'dog'],
+        pattern: '^[a-z]+$',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumStringPattern',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['cat', 'dog']"],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+
+      expect(parsed.zod).toBe("zod.enum(['cat', 'dog']).optional()");
+      expect(parsed.zod).not.toContain('.regex(');
+      expect(parsed.consts).toBe('');
+    });
+
+    it('preserves default while skipping min/max on enums (#3024)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['EUR', 'USD'],
+        minLength: 3,
+        maxLength: 3,
+        default: 'EUR',
+        description: 'Currency code for the order.',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumStringDefault',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['EUR', 'USD']"],
+          ['default', 'testEnumStringDefaultDefault'],
+          ['describe', "'Currency code for the order.'"],
+        ],
+        consts: ['export const testEnumStringDefaultDefault = `EUR`;'],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+
+      expect(parsed.zod).toBe(
+        "zod.enum(['EUR', 'USD']).default(testEnumStringDefaultDefault).describe('Currency code for the order.')",
+      );
+      expect(parsed.zod).not.toContain('zod.min(');
+      expect(parsed.zod).not.toContain('.min(');
+      expect(parsed.zod).not.toContain('.max(');
+      expect(parsed.consts).toBe(
+        'export const testEnumStringDefaultDefault = `EUR`;',
+      );
+    });
+
     it('generates an enum for a number', () => {
       const schema: OpenApiSchemaObject = {
         type: 'number',

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1876,6 +1876,45 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(parsed.consts).toBe('');
     });
 
+    it('skips stringFormat emission for enums in Zod v4 when format and pattern are both present (#3024)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'string',
+        enum: ['cat', 'dog'],
+        format: 'pet-kind',
+        pattern: '^[a-z]+$',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumStringPatternV4',
+        false,
+        true,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          ['enum', "['cat', 'dog']"],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        true,
+      );
+
+      expect(parsed.zod).toBe("zod.enum(['cat', 'dog']).optional()");
+      expect(parsed.zod).not.toContain('.regex(');
+      expect(parsed.zod).not.toContain('.stringFormat(');
+      expect(parsed.consts).toBe('');
+    });
+
     it('preserves default while skipping min/max on enums (#3024)', () => {
       const schema: OpenApiSchemaObject = {
         type: 'string',
@@ -1921,6 +1960,55 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(parsed.consts).toBe(
         'export const testEnumStringDefaultDefault = `EUR`;',
       );
+    });
+
+    it('skips numeric constraints for enum literal unions (#3024)', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'number',
+        enum: [1, 2],
+        minimum: 1,
+        maximum: 2,
+        multipleOf: 1,
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testEnumNumberConstraints',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result).toEqual({
+        functions: [
+          [
+            'oneOf',
+            [
+              { functions: [['literal', 1]], consts: [] },
+              { functions: [['literal', 2]], consts: [] },
+            ],
+          ],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+
+      expect(parsed.zod).toBe(
+        'zod.union([zod.literal(1),zod.literal(2)]).optional()',
+      );
+      expect(parsed.zod).not.toContain('.min(');
+      expect(parsed.zod).not.toContain('.max(');
+      expect(parsed.zod).not.toContain('.multipleOf(');
+      expect(parsed.consts).toBe('');
     });
 
     it('generates an enum for a number', () => {


### PR DESCRIPTION
Fixes a Zod regression where OpenAPI enum schemas can still pick up incompatible
string constraints, producing invalid output like:

```ts
zod.min(...).enum([...])
zod.min(...).max(...).enum([...])
zod.regex(...).enum([...])
```

Closes #3024

## Why this happens

Some OpenAPI generators emit enum schemas with string constraints, for example:

```yaml
type: string
enum: ["project", "room"]
minLength: 1
```

and in real-world cases:

```yaml
type: string
enum: ["EUR", "USD", ...]
minLength: 3
maxLength: 3
default: "EUR"
description: "Currency code for the order."
```

Those constraints are valid in OpenAPI, but they are not valid enum construction
paths in Zod.

## What changed

In `generateZodValidationSchemaDefinition`, this PR adds a scoped guard for
enum-bearing **non-array** schemas so we do **not** emit:

- `min` / `max` / `multipleOf`
- `pattern` / `regex`

We still preserve:

- normal enum emission
- `.default(...)`
- `.describe(...)`

We also keep the existing array-specific behavior from `#2765` unchanged.

## Before / after

### Before

```ts
zod.min(currencyMin).max(currencyMax).enum(['EUR', 'USD'])
```

### After

```ts
zod.enum(['EUR', 'USD']).default(currencyDefault)
```

## Reviewer notes

This is intentionally a **narrow fix**:

- no change to enum generation strategy
- no change to split writer behavior
- no change to array-parent enum handling

That is important because the earlier broader fix was reverted after causing
other regressions around split-mode/schema output (`#2793`, `#2801`, `#2817`).

## Test coverage added

Added focused regressions in `packages/zod/src/zod.test.ts` for:

- direct enum + `minLength` / `maxLength`
- dereferenced `$ref` enum + sibling `minLength`
- enum + `pattern`
- enum + `minLength` / `maxLength` + `default: 'EUR'`

I used a reduced EUR/USD-style case instead of copying the full FastAPI fixture,
since the important behavior is the combination of:

- enum
- min/max length
- default
- description

without the maintenance cost of a very large fixture.

## Scope

Included:

- enum constraint compatibility for non-array schemas
- regression coverage for direct, dereferenced, and default-bearing enum cases

Not included:

- `nativeEnum` or alternate enum generation strategies
- broader schema compatibility abstractions
- unrelated split writer changes already handled elsewhere


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enum types now skip incompatible string and numeric constraints (min/max, exclusive bounds, pattern/format, multipleOf), avoiding invalid schema combinations while preserving defaults and descriptions.

* **Tests**
  * Added extensive tests covering enum handling across direct, dereferenced, composed (allOf/oneOf/anyOf) and literal-union scenarios to prevent constraint/regex chaining regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->