### PR TITLE
fix(core): strip const from discriminator merged property (#3139)

### DIFF
--- a/packages/core/src/getters/discriminators.test.ts
+++ b/packages/core/src/getters/discriminators.test.ts
@@ -136,6 +136,59 @@ describe('resolveDiscriminators getter', () => {
     }
   });
 
+  it('strips const from discriminator property to prevent DogValue object bug (#3139)', () => {
+    const schemas: OpenApiSchemasObject = {
+      Pet: {
+        oneOf: [
+          { $ref: '#/components/schemas/Cat' },
+          { $ref: '#/components/schemas/Dog' },
+        ],
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            cat: '#/components/schemas/Cat',
+            dog: '#/components/schemas/Dog',
+          },
+        },
+      },
+      Cat: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type', 'name'],
+        properties: {
+          type: { const: 'cat' },
+          name: { type: 'string' },
+        },
+      },
+      Dog: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['type'],
+        properties: {
+          type: { const: 'dog', description: 'animal type' },
+        },
+      },
+    };
+
+    const result = resolveDiscriminators(structuredClone(schemas), context);
+    const dogSchema = result.Dog as NonNullable<OpenApiSchemasObject[string]>;
+    const dogProps = dogSchema.properties as
+      | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
+      | undefined;
+    const typeProp = dogProps?.type as OpenApiSchemaObject | undefined;
+
+    // The merged property must NOT retain `const` — otherwise interface.ts
+    // generates `const DogValue = { type: DogType }` where DogType is the
+    // runtime enum object instead of the string literal.
+    expect(typeProp).toBeDefined();
+    expect(typeProp).not.toHaveProperty('const');
+    expect(typeProp?.enum).toEqual(['dog']);
+    expect(typeProp?.type).toBe('string');
+    expect((typeProp as Record<string, unknown>).description).toBe(
+      'animal type',
+    );
+  });
+
   it('hoists oneOf from discriminator when nested incorrectly', () => {
     const schemas: OpenApiSchemasObject = {
       Animal: {

--- a/packages/core/src/getters/discriminators.ts
+++ b/packages/core/src/getters/discriminators.ts
@@ -66,11 +66,13 @@ export function resolveDiscriminators(
           mappingKey,
         ];
 
+        // @see https://github.com/orval-labs/orval/issues/3139
         const mergedProperty = {
           ...schemaProperty,
           type: 'string',
           enum: mergedEnumValues,
         };
+        delete (mergedProperty as Record<string, unknown>).const;
 
         subTypeSchema.properties = {
           ...subTypeSchema.properties,


### PR DESCRIPTION
## Summary

- Strip `const` keyword when merging discriminator properties to prevent broken type generation
- Objects with only a `const` discriminator property (no additional fields) were generating `const DogValue = { type: DogType }` instead of `interface Dog { type: DogType }`

## Problem

Fixes #3139

When a discriminator variant has only a `const` property and no extra fields:
```json
{
  "Dog": {
    "type": "object",
    "additionalProperties": false,
    "required": ["type"],
    "properties": {
      "type": { "const": "dog" }
    }
  }
}
```

**Before (broken):**
```ts
import { DogType } from './dogType';

export const DogValue = {
  type: DogType,    // runtime object { dog: 'dog' } ❌
} as const;
export type Dog = typeof DogValue;
```

**After (fixed):**
```ts
import type { DogType } from './dogType';

export interface Dog {
  type: DogType;    // type alias = 'dog' ✅
}
```

## Context

In #2897, `resolveDiscriminators` was changed to spread the existing property (`...schemaProperty`) to preserve metadata like `description`. This also preserved `const`, which triggered the all-const-properties check in `interface.ts` — generating a `const XValue` pattern where the enum object was used as a runtime value instead of a type.

No side effects: all downstream consumers (zod, mock) already prioritize `enum` over `const`, so the removed `const` was only affecting `interface.ts`.

## Testing

- [Reproduction](https://github.com/froggy1014/3139)
- `bun vitest run src/getters/discriminators.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed discriminator-driven schema merging so target properties no longer retain overly restrictive constant values; merged discriminator properties are represented as string enums with correct values and preserved descriptions.
* **Tests**
  * Added a test validating discriminator resolution for oneOf-style schemas (e.g., Pet → Cat/Dog) to ensure correct merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->