### PR TITLE
fix(mock): handle boolean exclusiveMinimum/exclusiveMaximum from OpenAPI 3.0

### DIFF
--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -151,10 +151,14 @@ export function getMockScalar({
         (item.format === 'int64' || item.format === 'uint64')
           ? 'bigInt'
           : 'int';
-      const numMin = (item.exclusiveMinimum ??
+      const numMin = ((typeof item.exclusiveMinimum === 'number'
+        ? item.exclusiveMinimum
+        : undefined) ??
         item.minimum ??
         safeMockOptions.numberMin) as number | undefined;
-      const numMax = (item.exclusiveMaximum ??
+      const numMax = ((typeof item.exclusiveMaximum === 'number'
+        ? item.exclusiveMaximum
+        : undefined) ??
         item.maximum ??
         safeMockOptions.numberMax) as number | undefined;
       const intParts: string[] = [];


### PR DESCRIPTION
## Summary
- Fixes #3058
- In OpenAPI 3.0, `exclusiveMinimum` and `exclusiveMaximum` are booleans, but the mock generator passed them directly as numbers to faker via nullish coalescing (`??`)
- Added `typeof` checks to only use these values when they are numbers (OpenAPI 3.1 format), falling back to `minimum`/`maximum` otherwise

## Test plan
- [ ] Verify mock generation with OpenAPI 3.0 specs using `exclusiveMinimum: true`
- [ ] Verify mock generation with OpenAPI 3.1 specs using `exclusiveMinimum: 0`
- [ ] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mock data generation to properly handle exclusive minimum and maximum bounds for numeric fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->