### PR TITLE
fix(core): add fileExtension to schemas barrel import in tags-split mode

### DIFF
--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -61,7 +61,10 @@ export async function writeSplitMode({
             { extension: output.fileExtension },
           ).dirname,
         )
-      : './' + filename + '.schemas';
+      : './' +
+        filename +
+        '.schemas' +
+        (extension.endsWith('.ts') ? extension.slice(0, -3) : extension);
 
     const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(
       output.tsconfig,

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -82,7 +82,10 @@ export async function writeSplitTagsMode({
                 { extension: output.fileExtension },
               ).dirname,
             )
-          : '../' + filename + '.schemas';
+          : '../' +
+            filename +
+            '.schemas' +
+            (extension.endsWith('.ts') ? extension.slice(0, -3) : extension);
 
         const importsForBuilder = generateImportsForBuilder(
           output,

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -69,7 +69,10 @@ export async function writeTagsMode({
                 { extension: output.fileExtension },
               ).dirname,
             )
-          : './' + filename + '.schemas';
+          : './' +
+            filename +
+            '.schemas' +
+            (extension.endsWith('.ts') ? extension.slice(0, -3) : extension);
 
         const implementationImports = imports.filter((imp) => {
           const searchWords = [imp.alias, imp.name]


### PR DESCRIPTION
## Summary
- Fixes #3092
- Added `fileExtension` to schemas file import paths in `tags-split`, `split`, and `tags` modes
- When using a custom `fileExtension` (e.g., `.generated.ts`), the generated import for the inline schemas file was missing the extension suffix — e.g., `import { Source } from "../myAPI.schemas"` instead of `import { Source } from "../myAPI.schemas.generated"`
- Follows the same pattern as previous fixes in #2826 and #2906

## Test plan
- [ ] Verify schemas imports include `fileExtension` in tags-split mode
- [ ] Verify schemas imports include `fileExtension` in split mode
- [ ] Verify schemas imports include `fileExtension` in tags mode
- [ ] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected schema import path generation across split-mode, split-tags-mode, and tags-mode to properly respect configured output file extensions instead of using a fixed suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->