### PR TITLE
fix(zod): add offset support to zod.iso.datetime for date-time format

### DIFF
--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -112,7 +112,7 @@ export function createTestContextSpec({
           response: false,
         },
         generateEachHttpStatus: false,
-        dateTimeOptions: {},
+        dateTimeOptions: { offset: true },
         timeOptions: { precision: 3 },
       },
       fetch: {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -387,7 +387,9 @@ export async function normalizeOptions(
           },
           generateEachHttpStatus:
             outputOptions.override?.zod?.generateEachHttpStatus ?? false,
-          dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {},
+          dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {
+            offset: true,
+          },
           timeOptions: outputOptions.override?.zod?.timeOptions ?? {},
         },
         swr: {
@@ -708,7 +710,9 @@ function normalizeOperationsAndTags(
                         : {}),
                     },
                     generateEachHttpStatus: zod.generateEachHttpStatus ?? false,
-                    dateTimeOptions: zod.dateTimeOptions ?? {},
+                    dateTimeOptions: zod.dateTimeOptions ?? {
+                      offset: true,
+                    },
                     timeOptions: zod.timeOptions ?? {},
                   },
                 }

--- a/samples/mcp/petstore/src/tool-schemas.zod.ts
+++ b/samples/mcp/petstore/src/tool-schemas.zod.ts
@@ -160,7 +160,7 @@ export const GetOrderByIdResponse = zod.object({
   id: zod.number().optional(),
   petId: zod.number().optional(),
   quantity: zod.number().optional(),
-  shipDate: zod.string().datetime({}).optional(),
+  shipDate: zod.string().datetime({ offset: true }).optional(),
   status: zod
     .enum(['placed', 'approved', 'delivered'])
     .optional()

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
@@ -55,7 +55,7 @@ export const ListPetsByAgeQueryParams = zod.object({
     .describe('How many items to return at one time (max 100)'),
   latestBirthdate: zod
     .string()
-    .datetime({})
+    .datetime({"offset":true})
     .optional()
     .describe('Filter by latest birthdate.\nExample: 2020-01-01T00:00:00Z\n'),
 });

--- a/tests/__snapshots__/zod/time-options/time-options.ts
+++ b/tests/__snapshots__/zod/time-options/time-options.ts
@@ -17,7 +17,7 @@ export const ShowPetByIdParams = zod.object({
 export const ShowPetByIdResponse = zod.object({
   id: zod.number().optional(),
   birthDate: zod.string().date(),
-  createdAt: zod.string().datetime({}),
+  createdAt: zod.string().datetime({"offset":true}),
   age: zod.number().optional(),
   legCount: zod.number().optional(),
   weight: zod.number().optional(),


### PR DESCRIPTION
## Summary
- Fixes #3124
- OpenAPI `format: date-time` follows RFC 3339 which allows timezone offsets
- Changed default `dateTimeOptions` from `{}` to `{ offset: true }` so generated Zod schemas accept valid offset-based date-time strings (e.g. `2026-03-27T12:00:00+01:00`)
- Users can still override this by explicitly setting `dateTimeOptions` in their config

## Test plan
- [x] All 139 existing zod package tests pass
- [ ] Verify generated Zod schemas accept date-time strings with timezone offsets
- [ ] Existing snapshot tests updated to reflect new default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated default datetime validation configuration across generated schemas and test utilities to require timezone offset information in datetime strings, changing from empty options to `{ offset: true }` in Zod datetime validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->