### PR TITLE
fix(query): respect global useQuery override for POST endpoints

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -683,6 +683,8 @@ export interface NormalizedQueryOptions {
   version?: 3 | 4 | 5;
   mutationInvalidates?: MutationInvalidatesConfig;
   runtimeValidation?: boolean;
+  /** @internal Indicates that the user explicitly set query hook options in the global config */
+  _explicitQueryHookOptions?: boolean;
 }
 
 export interface QueryOptions {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -177,6 +177,15 @@ export async function normalizeOptions(
 
   const defaultFileExtension = '.ts';
 
+  const userQueryOptions = outputOptions.override?.query;
+  const hasExplicitQueryHookOptions = !!(
+    userQueryOptions &&
+    (!isNullish(userQueryOptions.useQuery) ||
+      !isNullish(userQueryOptions.useSuspenseQuery) ||
+      !isNullish(userQueryOptions.useInfinite) ||
+      !isNullish(userQueryOptions.useSuspenseInfiniteQuery))
+  );
+
   const globalQueryOptions: NormalizedQueryOptions = {
     useQuery: true,
     useMutation: true,
@@ -186,6 +195,7 @@ export async function normalizeOptions(
     shouldExportQueryKey: true,
     shouldSplitQueryKey: false,
     ...normalizeQueryOptions(outputOptions.override?.query, workspace),
+    ...(hasExplicitQueryHookOptions ? { _explicitQueryHookOptions: true } : {}),
   };
 
   const normalizedOptions: NormalizedOptions = {

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -586,14 +586,16 @@ export const generateQueryHook = async (
     operationQueryOptions?.useSuspenseInfiniteQuery,
   ].some(Boolean);
 
+  const hasGlobalQueryOption = [
+    override.query.useQuery,
+    override.query.useSuspenseQuery,
+    override.query.useInfinite,
+    override.query.useSuspenseInfiniteQuery,
+  ].some(Boolean);
+
   let isQuery =
-    (Verbs.GET === verb &&
-      [
-        override.query.useQuery,
-        override.query.useSuspenseQuery,
-        override.query.useInfinite,
-        override.query.useSuspenseInfiniteQuery,
-      ].some(Boolean)) ||
+    ((Verbs.GET === verb || override.query._explicitQueryHookOptions) &&
+      hasGlobalQueryOption) ||
     hasOperationQueryOption;
 
   let isMutation = override.query.useMutation && verb !== Verbs.GET;


### PR DESCRIPTION
## Summary
- Fixes #2376
- Global `override.query.useQuery: true` was not being applied to POST endpoints because the query generator only checked global query options for `GET` verbs
- Added an `_explicitQueryHookOptions` internal flag to `NormalizedQueryOptions` that tracks whether the user explicitly set query hook options (useQuery, useSuspenseQuery, useInfinite, useSuspenseInfiniteQuery) in the global config
- When this flag is set, global query options are applied regardless of HTTP verb, not just for GET

## Details
The root cause was in `packages/query/src/query-generator.ts` where `isQuery` was guarded by `Verbs.GET === verb` for global options. Per-operation overrides (`override.operations[id].query`) worked correctly because they bypassed this guard.

The challenge is that `useQuery: true` is the **default** value, so we can't simply remove the GET guard — that would make all POST endpoints generate query hooks by default. Instead, we detect when the user has explicitly provided query hook options in their config and only then apply them to non-GET verbs.

## Test plan
- [x] Existing 850 tests pass (3 pre-existing failures in `resolve-version.test.ts` unrelated to this change)
- [ ] Verify POST endpoints generate query hooks with global `useQuery: true`
- [ ] Verify per-operation override still works
- [ ] Verify default behavior (no explicit `useQuery` in config) is unchanged — POST still generates mutations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal tracking of explicitly configured query hook options for more reliable configuration handling and query generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->