### PR TITLE
fix(msw): handle void response type in mock handlers with multiple status codes

### DIFF
--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -1039,7 +1039,47 @@ describe('generateMSW', () => {
       expect(result.implementation.handler).not.toContain('JSON.stringify');
     });
 
-    it('Test L: should not treat type names containing "string" as string return types', () => {
+    it('Test L: should handle void in return type union (issue #3026)', () => {
+      const voidUnionVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          ...mockVerbOptions.response,
+          definition: { success: 'ResourceResponse | void' },
+          types: {
+            success: [
+              {
+                key: '200',
+                value: 'ResourceResponse',
+                originalSchema: {
+                  type: 'object',
+                  properties: { id: { type: 'string' } },
+                },
+              },
+              { key: '204', value: 'void' },
+            ],
+          },
+          contentTypes: ['application/json'],
+        },
+      } as unknown as GeneratorVerbOptions;
+
+      const result = generateMSW(voidUnionVerbOptions, baseOptions);
+
+      // Should use runtime branching to handle the void case
+      expect(result.implementation.handler).toContain('const resolvedBody =');
+      expect(result.implementation.handler).toContain(
+        'resolvedBody === undefined',
+      );
+      expect(result.implementation.handler).toContain(
+        'new HttpResponse(null, { status: 204 })',
+      );
+      expect(result.implementation.handler).toContain('HttpResponse.json(');
+      // Should NOT have a bare HttpResponse.json that would reject void
+      expect(result.implementation.handler).not.toMatch(
+        /return\s+HttpResponse\.json\(overrideResponse/,
+      );
+    });
+
+    it('Test M: should not treat type names containing "string" as string return types', () => {
       const mixedVerbOptions = {
         ...mockVerbOptions,
         response: {

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -110,6 +110,11 @@ function generateDefinition(
       .split('|')
       .map((part) => part.trim().replaceAll(/^\(+|\)+$/g, ''))
       .includes('string');
+  const isUnionContainingVoid = (typeExpr: string) =>
+    typeExpr
+      .split('|')
+      .map((part) => part.trim().replaceAll(/^\(+|\)+$/g, ''))
+      .includes('void');
   const isBinaryLikeContentType = (ct: string) =>
     ct === 'application/octet-stream' ||
     ct === 'application/pdf' ||
@@ -186,6 +191,11 @@ function generateDefinition(
     hasStringReturnType &&
     mockReturnType !== 'string';
 
+  // When the return type is a union containing void (e.g. `ResourceResponse | void`),
+  // HttpResponse.json() will reject the void type. We need runtime branching to
+  // return `new HttpResponse(null, { status: 204 })` for the void/undefined case.
+  const hasVoidInReturnType = isUnionContainingVoid(mockReturnType);
+
   const mockImplementation = isReturnHttpResponse
     ? `${mockImplementations}export const ${getResponseMockFunctionName} = (${
         isResponseOverridable
@@ -236,6 +246,8 @@ function generateDefinition(
   let responsePrelude = '';
   if (isBinaryResponse) {
     responsePrelude = `const binaryBody = ${resolvedResponseExpr};`;
+  } else if (hasVoidInReturnType && isReturnHttpResponse) {
+    responsePrelude = `const resolvedBody = ${resolvedResponseExpr};`;
   } else if (needsRuntimeContentTypeSwitch) {
     responsePrelude = `const resolvedBody = ${resolvedResponseExpr};`;
   } else if (isTextResponse && !shouldPreferJsonResponse) {
@@ -254,6 +266,12 @@ function generateDefinition(
       { status: ${statusCode},
         headers: { 'Content-Type': '${binaryContentType}' }
       })`;
+  } else if (hasVoidInReturnType) {
+    // Runtime branching: when the resolved value is undefined (void),
+    // return a no-content response; otherwise use HttpResponse.json().
+    responseBody = `resolvedBody === undefined
+      ? new HttpResponse(null, { status: 204 })
+      : HttpResponse.json(resolvedBody, { status: ${statusCode} })`;
   } else if (needsRuntimeContentTypeSwitch) {
     // Runtime branching: when the resolved value is a string, use the
     // appropriate text helper; otherwise fall back to HttpResponse.json()


### PR DESCRIPTION
## Summary
- Fixes #3026
- When an endpoint has both 200 and 204 responses, the generated mock handler had a type error because `HttpResponse.json()` rejects `void`
- Fixed by detecting `void` in the return type union and generating a runtime check: if the resolved value is `undefined`, return `new HttpResponse(null, { status: 204 })`; otherwise use `HttpResponse.json()`

## Test plan
- [x] Added unit test for void union return type scenario
- [x] All 104 existing mock package tests pass
- [ ] Verify mock generation for endpoints with both 200 and 204 responses
- [ ] Verify no type errors in generated MSW handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for union return types containing `void` in MSW handler generation. Void responses now correctly return 204 No Content status with proper runtime branching to handle both void and non-void cases.

* **Tests**
  * Enhanced test coverage for void union return type handling to verify correct 204 responses and non-void case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->