### PR TITLE
fix(fetch): preserve mutator options parameter when custom mutator has second arg

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -5,6 +5,7 @@ import {
   type ClientHeaderBuilder,
   generateBodyOptions,
   generateFormDataAndUrlEncodedFunction,
+  generateMutatorRequestOptions,
   generateVerbImports,
   type GeneratorDependency,
   type GeneratorOptions,
@@ -308,7 +309,11 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
     })
     .join(',');
 
-  const args = `${toObjectString(props, 'implementation')} ${isRequestOptions ? `options?: RequestInit` : ''}`;
+  const mutatorOptions =
+    isRequestOptions && mutator?.hasSecondArg
+      ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}>,`
+      : '';
+  const args = `${toObjectString(props, 'implementation')} ${mutatorOptions || (isRequestOptions ? `options?: RequestInit` : '')}`;
   const returnType =
     override.fetch.forceSuccessResponse && hasSuccess
       ? `Promise<${successName}>`
@@ -357,9 +362,10 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   } else {
     globalFetchOptions = '';
   }
+  const hasMutatorSecondArg = mutator?.hasSecondArg ?? false;
   const fetchHeadersOption =
     headersToAdd.length > 0
-      ? `headers: { ${headersToAdd.join(',')}, ...options?.headers }`
+      ? `headers: { ${headersToAdd.join(',')}${hasMutatorSecondArg ? '' : ', ...options?.headers'} }`
       : '';
   const requestBodyParams = generateBodyOptions(
     body,
@@ -373,9 +379,10 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
       ? `body: ${requestBodyParams}`
       : `body: JSON.stringify(${requestBodyParams})`
     : '';
+  const shouldSpreadOptions = isRequestOptions && !mutator?.hasSecondArg;
   const fetchFnOptions = `${getUrlFnName}(${getUrlFnProperties}),
   {${globalFetchOptions ? '\n' : ''}      ${globalFetchOptions}
-    ${isRequestOptions ? '...options,' : ''}
+    ${shouldSpreadOptions ? '...options,' : ''}
     ${fetchMethodOption}${fetchHeadersOption ? ',' : ''}
     ${fetchHeadersOption}${fetchBodyOption ? ',' : ''}
     ${fetchBodyOption}
@@ -409,7 +416,14 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   }
   ${override.fetch.includeHttpResponseReturnType ? `return { data, status: res.status, headers: res.headers } as ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}` : 'return data'}
 `;
-  let customFetchResponseImplementation = `return ${mutator?.name}<${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}>(${fetchFnOptions});`;
+  const mutatorRequestOptions =
+    isRequestOptions && mutator?.hasSecondArg
+      ? generateMutatorRequestOptions(
+          override.requestOptions,
+          mutator.hasSecondArg,
+        )
+      : '';
+  let customFetchResponseImplementation = `return ${mutator?.name}<${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}>(${fetchFnOptions}${mutatorRequestOptions ? `, ${mutatorRequestOptions}` : ''});`;
 
   const bodyForm = generateFormDataAndUrlEncodedFunction({
     formData,
@@ -431,7 +445,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
       const ${formattedDeconstructor} = ${mutator.name}();
       return (${args}) => {
         ${bodyForm}
-        return ${fetchExportName}(${fetchFnOptions});
+        return ${fetchExportName}(${fetchFnOptions}${mutatorRequestOptions ? `, ${mutatorRequestOptions}` : ''});
       }
   `;
   }
@@ -528,9 +542,17 @@ export const generateFetchHeader: ClientHeaderBuilder = ({
   return needsStatusCodeTypes ? getHTTPStatusCodes() : '';
 };
 
+const generateFetchClientHeader: ClientHeaderBuilder = (params) => {
+  const secondParameterType =
+    params.isRequestOptions && params.isMutator
+      ? `type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];\n\n`
+      : '';
+  return secondParameterType + generateFetchHeader(params);
+};
+
 const fetchClientBuilder: ClientGeneratorsBuilder = {
   client: generateClient,
-  header: generateFetchHeader,
+  header: generateFetchClientHeader,
   dependencies: getFetchDependencies,
 };
 


### PR DESCRIPTION
## Summary
- Fixes #2146
- The fetch client's `generateRequestFunction` did not handle `mutator.hasSecondArg`, so custom mutators expecting a second `options` parameter never received it
- When using the fetch httpClient (now the default) with a custom mutator that accepts two arguments (e.g., config + options), the generated function signature omitted the `options` parameter entirely and did not pass it to the mutator call
- Fixed by using `SecondParameter<typeof mutator>` for the options type, passing options as a separate second argument to the mutator, and emitting the `SecondParameter` helper type in the standalone fetch client header

## Test plan
- [x] Existing tests pass (59 query tests, 13 axios tests, 588+ other tests)
- [x] Type checking passes
- [ ] Verify generated functions retain the options parameter with a custom mutator that has a second argument
- [ ] Verify `optionsParamRequired` controls the optionality of the parameter
- [ ] Verify fetch client without custom mutator still uses `options?: RequestInit` as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mutators now support accepting a second argument for advanced request customization.

* **Refactor**
  * Enhanced request parameter handling with improved type safety for request options.
  * Optimized header generation for better fetch client builder compatibility.
  * Improved conditional request construction to better handle mutator configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->