### PR TITLE
fix(angular): use null literal in filterParams to fix TypeScript error

### DIFF
--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -31,7 +31,7 @@ export const getAngularFilteredParamsExpression = (
   const filteredParamValueType = `string | number | boolean${preserveRequiredNullables ? ' | null' : ''} | Array<string | number | boolean>`;
   const preserveNullableBranch = preserveRequiredNullables
     ? `    } else if (value === null && requiredNullableParamKeys.has(key)) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
 `
     : '';
   const scalarBranch = `    } else if (
@@ -106,7 +106,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -106,7 +106,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -105,7 +105,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -105,7 +105,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -81,7 +81,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -80,7 +80,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -106,7 +106,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -105,7 +105,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -105,7 +105,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -81,7 +81,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -80,7 +80,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -77,7 +77,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -76,7 +76,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -73,7 +73,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -79,7 +79,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -77,7 +77,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -76,7 +76,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -73,7 +73,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -79,7 +79,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
@@ -101,7 +101,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
@@ -101,7 +101,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/named-parameters/endpoints.ts
@@ -110,7 +110,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/petstore/endpoints.ts
+++ b/tests/__snapshots__/angular/petstore/endpoints.ts
@@ -111,7 +111,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/split/endpoints.service.ts
+++ b/tests/__snapshots__/angular/split/endpoints.service.ts
@@ -104,7 +104,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
@@ -104,7 +104,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/tags/pets.ts
+++ b/tests/__snapshots__/angular/tags/pets.ts
@@ -111,7 +111,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
@@ -111,7 +111,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
+++ b/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
@@ -102,7 +102,7 @@ function filterParams(
       value === null &&
       requiredNullableKeys.has(key)
     ) {
-      filteredParams[key] = value;
+      filteredParams[key] = null;
     } else if (
       value != null &&
       (typeof value === 'string' ||


### PR DESCRIPTION
## Summary

Closes #3104

The generated `filterParams` function assigns `filteredParams[key] = value` in the null-check branch, where `value` is typed as `unknown` from `Object.entries()`. TypeScript may not reliably narrow `unknown` to `null` in compound `&&` conditions, causing:

> Type 'unknown' is not assignable to type 'string | number | boolean | Array<string | number | boolean>'

Since `value === null` is already asserted in the condition, this PR replaces `filteredParams[key] = value` with `filteredParams[key] = null` — semantically equivalent but avoids the narrowing dependency.

## Changes

- `getAngularFilteredParamsExpression()` (IIFE version)
- `getAngularFilteredParamsHelperBody()` (standalone function version)
- Updated all affected snapshots and samples (27 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of null values in required nullable query parameters to ensure they are properly preserved in HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->