### PR TITLE
fix(orval): prevent unnecessary regeneration on watch mode launch

### DIFF
--- a/packages/orval/src/bin/orval.ts
+++ b/packages/orval/src/bin/orval.ts
@@ -102,6 +102,17 @@ cli
         },
       });
 
+      try {
+        await generateSpec(process.cwd(), normalizedOptions);
+      } catch (error) {
+        if (error instanceof ErrorWithTag) {
+          logError(error.cause, error.tag);
+        } else {
+          logError(error);
+        }
+        process.exit(1);
+      }
+
       if (options.watch) {
         await startWatcher(
           options.watch,
@@ -115,17 +126,6 @@ cli
           },
           normalizedOptions.input.target as string,
         );
-      } else {
-        try {
-          await generateSpec(process.cwd(), normalizedOptions);
-        } catch (error) {
-          if (error instanceof ErrorWithTag) {
-            logError(error.cause, error.tag);
-          } else {
-            logError(error);
-          }
-          process.exit(1);
-        }
       }
     } else {
       const configFilePath = findConfigFile(options.config);
@@ -156,14 +156,14 @@ cli
           options,
         );
 
-        if (options.watch === undefined) {
-          try {
-            await generateSpec(workspace, normalizedOptions, projectName);
-          } catch (error) {
-            hasErrors = true;
-            logError(error, projectName);
-          }
-        } else {
+        try {
+          await generateSpec(workspace, normalizedOptions, projectName);
+        } catch (error) {
+          hasErrors = true;
+          logError(error, projectName);
+        }
+
+        if (options.watch !== undefined) {
           const fileToWatch = isString(normalizedOptions.input.target)
             ? normalizedOptions.input.target
             : undefined;

--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -32,14 +32,14 @@ export async function generate(
         options,
       );
 
-      if (options?.watch === undefined) {
-        try {
-          await generateSpec(workspace, normalizedOptions, projectName);
-        } catch (error) {
-          hasErrors = true;
-          logError(error, projectName);
-        }
-      } else {
+      try {
+        await generateSpec(workspace, normalizedOptions, projectName);
+      } catch (error) {
+        hasErrors = true;
+        logError(error, projectName);
+      }
+
+      if (options?.watch !== undefined) {
         const fileToWatch = isString(normalizedOptions.input.target)
           ? normalizedOptions.input.target
           : undefined;
@@ -70,6 +70,12 @@ export async function generate(
     options,
   );
 
+  try {
+    await generateSpec(workspace, normalizedOptions);
+  } catch (error) {
+    logError(error);
+  }
+
   if (options?.watch) {
     await startWatcher(
       options.watch,
@@ -82,11 +88,5 @@ export async function generate(
       },
       normalizedOptions.input.target as string,
     );
-  } else {
-    try {
-      await generateSpec(workspace, normalizedOptions);
-    } catch (error) {
-      logError(error);
-    }
   }
 }

--- a/packages/orval/src/utils/watcher.ts
+++ b/packages/orval/src/utils/watcher.ts
@@ -40,11 +40,14 @@ export async function startWatcher(
     ignorePermissionErrors: true,
     ignored,
   });
-  watcher.on('all', (type, file) => {
-    log(`Change detected: ${type} ${file}`);
+  watcher.on('ready', () => {
+    log('Initial scan complete. Watching for changes...');
+    watcher.on('all', (type, file) => {
+      log(`Change detected: ${type} ${file}`);
 
-    watchFn().catch((error: unknown) => {
-      logError(error);
+      watchFn().catch((error: unknown) => {
+        logError(error);
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes #2975

When starting orval in watch mode, chokidar's initial file scan emits `add` events for every existing file, each triggering a full `generateSpec()` call. This causes multiple unnecessary regenerations on startup.

### Changes

- **watcher.ts**: Attach `all` event listener only after chokidar's `ready` event, skipping initial scan events
- **orval.ts / generate.ts**: Run `generateSpec()` explicitly once before starting the watcher, ensuring initial generation happens exactly once regardless of watch mode

### Behavior

| | Before | After |
|---|---|---|
| Non-watch mode | 1 generation | 1 generation (unchanged) |
| Watch mode startup | N generations (per discovered file) | 1 explicit generation |
| Watch file change | Regeneration | Regeneration (unchanged) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Spec generation now consistently executes regardless of watch mode status.
  * Improved file watcher initialization with clearer completion feedback when the initial filesystem scan finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->