### PR TITLE
chore: fixes dependabot not updating bun.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm'
+  - package-ecosystem: bun
     directory: '/'
     schedule:
       interval: 'monthly'


### PR DESCRIPTION
https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use the Bun package ecosystem with a monthly update schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->