### PR TITLE
refactor(fetch): break long ternary expressions into multiple lines

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -388,6 +388,11 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   const reviver = fetchReviver ? `, ${fetchReviver.name}` : '';
   const schemaValueRef =
     responseType === 'Error' ? 'ErrorSchema' : responseType;
+  const fetchResponseType =
+    override.fetch.forceSuccessResponse && hasSuccess
+      ? successName
+      : responseTypeName;
+
   const throwOnErrorImplementation = `if (!${isNdJson ? 'stream' : 'res'}.ok) {
     ${isNdJson ? 'const body = [204, 205, 304].includes(stream.status) ? null : await stream.text();' : ''}
     const err: globalThis.Error & {info?: ${hasError ? `${errorName}${override.fetch.includeHttpResponseReturnType ? "['data']" : ''}` : 'any'}, status?: number} = new globalThis.Error();
@@ -399,7 +404,11 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   const fetchResponseImplementation = isNdJson
     ? `  const stream = await fetch(${fetchFnOptions});
   ${override.fetch.forceSuccessResponse ? throwOnErrorImplementation : ''}
-  ${override.fetch.includeHttpResponseReturnType ? `return { status: stream.status, stream, headers: stream.headers } as ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}` : `return stream`}
+  ${
+    override.fetch.includeHttpResponseReturnType
+      ? `return { status: stream.status, stream, headers: stream.headers } as ${fetchResponseType}`
+      : `return stream`
+  }
   `
     : `const res = await fetch(${fetchFnOptions})
 
@@ -409,11 +418,15 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
     isValidateResponse
       ? `const parsedBody = body ? JSON.parse(body${reviver}) : {}
   const data = ${schemaValueRef}.parse(parsedBody)`
-      : `const data: ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = body ? JSON.parse(body${reviver}) : {}`
+      : `const data: ${fetchResponseType}${override.fetch.includeHttpResponseReturnType ? `['data']` : ''} = body ? JSON.parse(body${reviver}) : {}`
   }
-  ${override.fetch.includeHttpResponseReturnType ? `return { data, status: res.status, headers: res.headers } as ${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}` : 'return data'}
+  ${
+    override.fetch.includeHttpResponseReturnType
+      ? `return { data, status: res.status, headers: res.headers } as ${fetchResponseType}`
+      : 'return data'
+  }
 `;
-  let customFetchResponseImplementation = `return ${mutator?.name}<${override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName}>(${fetchFnOptions});`;
+  let customFetchResponseImplementation = `return ${mutator?.name}<${fetchResponseType}>(${fetchFnOptions});`;
 
   const bodyForm = generateFormDataAndUrlEncodedFunction({
     formData,


### PR DESCRIPTION
## Summary
- Extract repeated conditional `override.fetch.forceSuccessResponse && hasSuccess ? successName : responseTypeName` into a `fetchResponseType` variable (used 4 times)
- Break long single-line ternary expressions in `fetchResponseImplementation` and `customFetchResponseImplementation` into multiple lines for improved readability
- Pure refactor with no behavioral changes to generated output

## Test plan
- [x] ESLint passes
- [x] Prettier formatting verified (unchanged)
- [x] Full build succeeds (12/12 packages)
- [x] TypeScript typecheck passes
- [x] Unit tests pass (no new failures)
- [x] Snapshot tests show no regressions (all failures are pre-existing vitest infra issues)

Closes #3087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code generation logic for consistency and maintainability across fetch implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->