### PR TITLE
fix: broken model imports

### DIFF
--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -218,12 +218,11 @@ function normalizeCanonicalImportPaths(
       const canonical = canonicalByName ?? canonicalByPath;
       if (!canonical?.importPath) return imp;
 
-      const importPath = removeFileExtension(
+      const importPath = removeTSExtension(
         upath.relativeSafe(
           schemaPath,
           canonical.importPath.replaceAll('\\', '/'),
         ),
-        fileExtension,
       );
 
       return { ...imp, importPath };
@@ -264,10 +263,8 @@ function resolveImportKey(
     .replaceAll('\\', '/');
 }
 
-function removeFileExtension(path: string, fileExtension: string) {
-  return path.endsWith(fileExtension)
-    ? path.slice(0, path.length - fileExtension.length)
-    : path;
+function removeTSExtension(path: string) {
+  return path.endsWith('.ts') ? path.slice(0, -3) : path;
 }
 
 interface GetSchemaOptions {


### PR DESCRIPTION
Close #3212 

Remove `.ts` extension instead of `fileExtension`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal path handling logic for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->