### PR TITLE
chore: fixes angular sample failing to start

### DIFF
--- a/samples/angular-app/tsconfig.app.json
+++ b/samples/angular-app/tsconfig.app.json
@@ -7,5 +7,5 @@
     "types": []
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts", "src/orval/**/*.ts"]
 }


### PR DESCRIPTION
fixes `bun run start` in the angular sample was failing due to angular-compiler not being happy with code in orval packages

```
X [ERROR] TS4111: Property 'contentEncoding' comes from an index signature, so it must be accessed with ['contentEncoding']. [plugin angular-compiler]

    ../../packages/zod/src/index.ts:540:18:
      540 │           !schema.contentEncoding
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation configuration in the sample Angular project build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->