### PR TITLE
fix: disable development export condition in tsdown base config

### DIFF
--- a/packages/tsdown.base.ts
+++ b/packages/tsdown.base.ts
@@ -9,5 +9,5 @@ export const baseConfig: UserConfig = {
   dts: {
     sourcemap: true,
   },
-  exports: { devExports: 'development' },
+  exports: true,
 };


### PR DESCRIPTION
Fixes #3216

This reverts `packages/tsdown.base.ts` to `exports: true`, which stops generating a `development` export condition that points to `src/index.ts` in published packages. With this change, package exports resolve to built `dist` output in consumers even when `development` custom conditions are active.

Greetings, saschabuehrle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated base configuration export settings to use default export mechanism instead of development-specific mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->