### PR TITLE
chore: auto mark isssues as stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,30 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale issues
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 365
+          days-before-issue-close: 20
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          exempt-issue-labels: 'help wanted'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had
+            no activity for 1 year. It will be closed in 20 days if no further
+            activity occurs.
+          close-issue-message: >
+            This issue was automatically closed after being marked stale for
+            20 days with no further activity.


### PR DESCRIPTION
Issues older than 1 year will be marked as stale with a label.
When marked it'll be closed after 20 days of no activity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated issue lifecycle management: issues inactive for 365 days are marked stale and closed after 20 more days. Pull requests are exempt. The process runs daily at 02:00 UTC and can be triggered manually. Issues labeled "help wanted" are excluded. Custom notifications are sent when marking stale and when closing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->