### PR TITLE
fix(mock): handle boolean exclusiveMinimum/exclusiveMaximum from OpenAPI 3.0 schemas

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -446,6 +446,122 @@ describe('getMockScalar (undefined filtering)', () => {
   });
 });
 
+describe('getMockScalar (exclusiveMinimum/exclusiveMaximum handling)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+    context: { output: { override: {} } } as ContextSpec,
+  };
+
+  describe('OpenAPI 3.0 (boolean exclusiveMinimum/exclusiveMaximum)', () => {
+    it('should omit min when exclusiveMinimum is true but minimum is absent', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'integer' as const,
+          exclusiveMinimum: true as unknown as number,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.int()');
+      expect(result.value).not.toContain('true');
+    });
+
+    it('should use minimum when exclusiveMinimum is true for integer type', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'integer' as const,
+          minimum: 0,
+          exclusiveMinimum: true as unknown as number,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.int({min: 0})');
+      expect(result.value).not.toContain('true');
+    });
+
+    it('should use maximum when exclusiveMaximum is true for integer type', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'integer' as const,
+          maximum: 100,
+          exclusiveMaximum: true as unknown as number,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.int({max: 100})');
+      expect(result.value).not.toContain('true');
+    });
+
+    it('should use minimum and maximum when both exclusive flags are true for number type', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'number' as const,
+          minimum: 0,
+          maximum: 100,
+          exclusiveMinimum: true as unknown as number,
+          exclusiveMaximum: true as unknown as number,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.float({min: 0, max: 100})');
+      expect(result.value).not.toContain('true');
+    });
+  });
+
+  describe('OpenAPI 3.1 (numeric exclusiveMinimum/exclusiveMaximum)', () => {
+    it('should use exclusiveMinimum value directly for integer type', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'integer' as const,
+          exclusiveMinimum: 5,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.int({min: 5})');
+    });
+
+    it('should use exclusiveMaximum value directly for integer type', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'integer' as const,
+          exclusiveMaximum: 100,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.int({max: 100})');
+    });
+
+    it('should use exclusiveMinimum and exclusiveMaximum values directly for number type', () => {
+      const result = getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'number' as const,
+          exclusiveMinimum: 0,
+          exclusiveMaximum: 100,
+          name: 'test-item',
+        },
+      });
+
+      expect(result.value).toBe('faker.number.float({min: 0, max: 100})');
+    });
+  });
+});
+
 describe('getMockScalar (@-prefixed property names)', () => {
   const baseArg = {
     imports: [],

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -151,12 +151,19 @@ export function getMockScalar({
         (item.format === 'int64' || item.format === 'uint64')
           ? 'bigInt'
           : 'int';
-      const numMin = (item.exclusiveMinimum ??
-        item.minimum ??
-        safeMockOptions.numberMin) as number | undefined;
-      const numMax = (item.exclusiveMaximum ??
-        item.maximum ??
-        safeMockOptions.numberMax) as number | undefined;
+      // Handle exclusiveMinimum/exclusiveMaximum for both OpenAPI 3.0 (boolean) and 3.1 (number).
+      // OpenAPI 3.0: booleans indicating whether minimum/maximum is exclusive — use minimum/maximum as the bound.
+      // OpenAPI 3.1: numbers representing the exclusive boundary value — use directly.
+      const numMin = (
+        typeof item.exclusiveMinimum === 'number'
+          ? item.exclusiveMinimum
+          : (item.minimum ?? safeMockOptions.numberMin)
+      ) as number | undefined;
+      const numMax = (
+        typeof item.exclusiveMaximum === 'number'
+          ? item.exclusiveMaximum
+          : (item.maximum ?? safeMockOptions.numberMax)
+      ) as number | undefined;
       const intParts: string[] = [];
       if (numMin !== undefined) intParts.push(`min: ${numMin}`);
       if (numMax !== undefined) intParts.push(`max: ${numMax}`);


### PR DESCRIPTION
## Summary

- Fixes invalid mock generation when a schema uses OpenAPI 3.0-style boolean `exclusiveMinimum: true` or `exclusiveMaximum: true`
- Previous code used nullish coalescing (`??`) which passed the boolean directly, producing `faker.number.float({ min: true })` — a type error at runtime
- Fix: distinguish OpenAPI 3.0 (boolean, use `minimum`/`maximum` as the bound) from OpenAPI 3.1 (number, use directly) via `typeof` check
- Matches the same pattern already used in `@orval/zod` for the same compatibility concern

## Changes

- `packages/mock/src/faker/getters/scalar.ts` — replace nullish coalescing with typeof-guarded ternary for `exclusiveMinimum`/`exclusiveMaximum`
- `packages/mock/src/faker/getters/scalar.test.ts` — add 7 unit tests covering OpenAPI 3.0 boolean and OpenAPI 3.1 numeric cases, including edge case with no `minimum`/`maximum` present

## Test plan

- [x] `bun vitest run packages/mock/src/faker/getters/scalar.test.ts` — 34 tests pass
- [x] `bun vitest run` — 2221 pass (3 pre-existing failures in resolve-version.test.ts unrelated to this PR)
- [x] `bun run test:snapshots` — 3550 pass, no snapshot changes
- [x] `bun run lint` — no errors
- [x] `bun run typecheck` — no errors
- [x] `bun run build` — success

Closes #3058


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of exclusive minimum and maximum constraints in numeric schemas, ensuring mock numbers are generated within correct bounds across OpenAPI specifications.

* **Tests**
  * Added comprehensive test coverage for exclusive bound behavior across different OpenAPI versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->