### PR TITLE
fix(mcp): broken path params name convention

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,6 +11,7 @@ import {
   type GeneratorVerbOptions,
   getFileInfo,
   getFullRoute,
+  getParamsInPath,
   isObject,
   isString,
   jsDoc,
@@ -110,9 +111,10 @@ export const getMcpHeader: ClientHeaderBuilder = ({ verbOptions, output }) => {
 
 export const generateMcp: ClientBuilder = (verbOptions) => {
   const handlerArgsTypes = [];
+  const originalParamNames = getParamsInPath(verbOptions.pathRoute);
   const pathParamsType = verbOptions.params
-    .map((param) => {
-      const paramName = param.name.split(': ')[0];
+    .map((param, index) => {
+      const paramName = originalParamNames[index];
       const paramType = param.implementation.split(': ')[1];
       return `    ${paramName}: ${paramType}`;
     })
@@ -141,12 +143,8 @@ ${handlerArgsTypes.join('\n')}
 
   const fetchParams = [];
   if (verbOptions.params.length > 0) {
-    const pathParamsArgs = verbOptions.params
-      .map((param) => {
-        const paramName = param.name.split(': ')[0];
-
-        return `args.pathParams.${paramName}`;
-      })
+    const pathParamsArgs = originalParamNames
+      .map((paramName) => `args.pathParams.${paramName}`)
       .join(', ');
 
     fetchParams.push(pathParamsArgs);


### PR DESCRIPTION
# Summary

When an OpenAPI spec contains snake_case path parameters (e.g. {pet_id}), the MCP handler generator was incorrectly converting them to camelCase (petId). This caused a name mismatch with the generated Zod schema, which kept the original name — resulting in undefined at runtime and 404 errors.

```yaml
/pets/{pet_id}:
  get:
    parameters:
      - name: pet_id
        in: path
```

## Before

```ts
// tool-schemas.zod.ts — ✅ correct
export const ShowPetByIdParams = zod.object({
  pet_id: zod.string(),
});

// handlers.ts — ❌ camelCase mismatch
export type showPetByIdArgs = {
  pathParams: { petId: string };       // key is petId
};
export const showPetByIdHandler = async (args: showPetByIdArgs) => {
  const res = await showPetById(args.pathParams.petId); // → undefined → 404
};
```

### After

// handlers.ts — ✅ original name preserved
export type showPetByIdArgs = {
  pathParams: { pet_id: string };
};
export const showPetByIdHandler = async (args: showPetByIdArgs) => {
  const res = await showPetById(args.pathParams.pet_id); // ✅ works correctly
};


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path parameter handling in the MCP generator for more consistent and reliable parameter extraction and construction during API request building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->