### PR TITLE
fix(mock): preserve object properties for nullable type arrays (OpenAPI 3.1) (#3081)

### DIFF
--- a/packages/mock/src/faker/getters/object.test.ts
+++ b/packages/mock/src/faker/getters/object.test.ts
@@ -7,7 +7,7 @@ import { getMockObject } from './object';
 describe('getMockObject', () => {
   const context: ContextSpec = createTestContextSpec();
 
-  it('keeps nullable object type arrays', () => {
+  it('generates object properties for nullable object type arrays (OpenAPI 3.1)', () => {
     const result = getMockObject({
       item: {
         name: 'nullableObject',
@@ -17,6 +17,53 @@ describe('getMockObject', () => {
             type: 'string',
           },
         },
+      },
+      operationId: 'getNullableObject',
+      tags: [],
+      context,
+      imports: [],
+      existingReferencedProperties: [],
+      splitMockImplementations: [],
+    });
+
+    expect(result.value).toBe(
+      'faker.helpers.arrayElement([{id: faker.helpers.arrayElement([faker.string.alpha(), undefined])},null,])',
+    );
+  });
+
+  it('generates object properties for nullable object with required fields (OpenAPI 3.1)', () => {
+    const result = getMockObject({
+      item: {
+        name: 'nullableObject',
+        type: ['object', 'null'],
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+        },
+        required: ['id'],
+      },
+      operationId: 'getNullableObject',
+      tags: [],
+      context,
+      imports: [],
+      existingReferencedProperties: [],
+      splitMockImplementations: [],
+    });
+
+    expect(result.value).toBe(
+      'faker.helpers.arrayElement([{id: faker.string.alpha(), name: faker.helpers.arrayElement([faker.string.alpha(), undefined])},null,])',
+    );
+  });
+
+  it('returns empty object variant when nullable object has no properties (OpenAPI 3.1)', () => {
+    const result = getMockObject({
+      item: {
+        name: 'nullableObject',
+        type: ['object', 'null'],
       },
       operationId: 'getNullableObject',
       tags: [],

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -103,9 +103,18 @@ export function getMockObject({
   }
 
   if (Array.isArray(itemType)) {
+    // Spread the base schema into each type entry so that object properties
+    // (e.g. `properties`, `required`, `additionalProperties`) are preserved.
+    // Without this, `{ type: "object", properties: {...} }` collapses to
+    // `{ type: "object" }` and the mock generator returns `{}` instead of
+    // building the actual object shape. Mirrors the fix in core getters/object.ts.
+    const baseItem = schemaItem as Record<string, unknown>;
     return combineSchemasMock({
       item: {
-        anyOf: itemType.map((type) => ({ type })) as unknown as MockSchema[],
+        anyOf: itemType.map((type) => ({
+          ...baseItem,
+          type,
+        })) as unknown as MockSchema[],
         name: schemaItem.name,
       },
       separator: 'anyOf',

--- a/tests/__snapshots__/default/null-type-v3-0/endpoints.ts
+++ b/tests/__snapshots__/default/null-type-v3-0/endpoints.ts
@@ -68,7 +68,18 @@ export const getFetchNullableResponseMock = (): string | null =>
   ]);
 
 export const getFetchNullableObjectResponseMock = (): NullableObject | null =>
-  faker.helpers.arrayElement([null]);
+  faker.helpers.arrayElement([
+    {
+      name: faker.helpers.arrayElement([
+        faker.helpers.arrayElement([
+          faker.string.alpha({ length: { min: 10, max: 20 } }),
+          null,
+        ]),
+        undefined,
+      ]),
+    },
+    null,
+  ]);
 
 export const getFetchNullableAnyObjectResponseMock =
   (): NullableAnyObject | null => faker.helpers.arrayElement([null]);

--- a/tests/__snapshots__/default/one-of/endpoints.ts
+++ b/tests/__snapshots__/default/one-of/endpoints.ts
@@ -39,7 +39,13 @@ export const getGetOneOfWithNullableObjectResponseCatMock = (
 
 export const getGetOneOfWithNullableObjectResponseMock = (): Pet =>
   faker.helpers.arrayElement([
-    faker.helpers.arrayElement([null]),
+    faker.helpers.arrayElement([
+      {
+        id: faker.number.int(),
+        name: faker.string.alpha({ length: { min: 10, max: 20 } }),
+      },
+      null,
+    ]),
     { ...getGetOneOfWithNullableObjectResponseCatMock() },
   ]);
 


### PR DESCRIPTION
## Summary

- Fixes getMockObject dropping all object properties when the schema uses OpenAPI 3.1 nullable type array syntax (`type: ["object", "null"]`)
- Spreads base schema item into each type entry so `properties`, `required`, and `additionalProperties` are preserved, matching the existing approach in core/getters/object.ts
- Updates two integration snapshots that previously generated `faker.helpers.arrayElement([null])` to now include the full object shape

## Root Cause

In getMockObject, the Array.isArray(itemType) branch mapped each type to `{ type }` only, stripping all schema properties. When combineSchemasMock then processed `{ type: "object" }` with no properties, getMockObject returned `{}`, which was silently skipped (the `resolvedValue.value === '{}'` guard in combineSchemasMock), leaving only `null` in the final anyOf output.

## Test Plan

- [ ] bun vitest run — 3 new/updated unit tests in getMockObject pass; all 1700+ tests pass
- [ ] bun run test:snapshots — 2 snapshots updated (null-type-v3-0, one-of); all 3556 tests pass
- [ ] bun run typecheck — no type errors
- [ ] bun run lint — no lint errors

Closes #3081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved nullable object mock generation to produce realistic objects with properties instead of only returning null values
  * Enhanced field preservation in mock schemas to maintain object structure when combining type variations
  * Updated mock response generation to properly handle nullable objects with required and optional properties

* **Tests**
  * Added test coverage for OpenAPI 3.1 nullable object behavior including edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->