### PR TITLE
fix(core): treat OpenAPI validation failures as warnings instead of errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -942,7 +942,7 @@
       "@angular/forms": "21.2.2",
       "@angular/platform-browser": "21.2.2",
       "@angular/router": "21.2.2",
-      "@tanstack/angular-query-experimental": "5.90.16",
+      "@tanstack/angular-query-experimental": "5.90.25",
       "rxjs": "7.8.2",
     },
     "axios": {
@@ -1760,15 +1760,15 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@tanstack/angular-query-experimental": ["@tanstack/angular-query-experimental@5.90.16", "", { "dependencies": { "@tanstack/query-core": "5.90.12" }, "optionalDependencies": { "@tanstack/query-devtools": "5.91.1" }, "peerDependencies": { "@angular/common": ">=16.0.0", "@angular/core": ">=16.0.0" } }, "sha512-ezXyxuaSA6kpwUxwrxo5Tf3B7KL7mb7cxhLnun/RMlw6h3ZQJzl1cJgrvN97+C0AeHoucmK7RwhEoIY12gY7WA=="],
+    "@tanstack/angular-query-experimental": ["@tanstack/angular-query-experimental@5.90.25", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "optionalDependencies": { "@tanstack/query-devtools": "5.93.0" }, "peerDependencies": { "@angular/common": ">=16.0.0", "@angular/core": ">=16.0.0" } }, "sha512-8MmtvEq83kRbwtt6NNbDAWPMOFHLxSmvhScFtdmBP/Xo5gSSzAf4JHcblQDHV/CgWIGKOp7eOa6aXDiVIK+kbw=="],
 
     "@tanstack/directive-functions-plugin": ["@tanstack/directive-functions-plugin@1.121.21", "", { "dependencies": { "@babel/code-frame": "7.26.2", "@babel/core": "^7.26.8", "@babel/traverse": "^7.26.8", "@babel/types": "^7.26.8", "@tanstack/router-utils": "^1.121.21", "babel-dead-code-elimination": "^1.0.10", "tiny-invariant": "^1.3.3" }, "peerDependencies": { "vite": ">=6.0.0" } }, "sha512-B9z/HbF7gJBaRHieyX7f2uQ4LpLLAVAEutBZipH6w+CYD6RHRJvSVPzECGHF7icFhNWTiJQL2QR6K07s59yzEw=="],
 
     "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@8.19.4", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.90.12", "", {}, "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
-    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.91.1", "", {}, "sha512-l8bxjk6BMsCaVQH6NzQEE/bEgFy1hAs5qbgXl0xhzezlaQbPk6Mgz9BqEg2vTLPOHD8N4k+w/gdgCbEzecGyNg=="],
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.93.0", "", {}, "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.62.16", "", { "dependencies": { "@tanstack/query-core": "5.62.16" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-XJIZNj65d2IdvU8VBESmrPakfIm6FSdHDzrS1dPrAwmq3ZX+9riMh/ZfbNQHAWnhrgmq7KoXpgZSRyXnqMYT9A=="],
 
@@ -4148,8 +4148,6 @@
 
     "@tanstack/server-functions-plugin/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@tanstack/solid-query/@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
-
     "@tanstack/svelte-query/@tanstack/query-core": ["@tanstack/query-core@4.41.0", "", {}, "sha512-193R4Jp9hjvlij6LryxrB5Mpbffd2L9PeWh3KlIy/hJV4SkBOfiQZ+jc5qAZLDCrdbkA5FjGj+UoDYw6TcNnyA=="],
 
     "@tanstack/vue-query/@tanstack/query-core": ["@tanstack/query-core@5.90.18", "", {}, "sha512-rbGx6bHgPNVzutP7BEr+53UPKohpckqlMAad+To9UxTbeaQ+kC/1SDRj+QzkwbQ7qhLT/1IKp34yS6thda6fzA=="],
@@ -5111,8 +5109,6 @@
     "svelte-check/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "svelte-check/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
-    "svelte-query-v6-custom-fetch/@tanstack/svelte-query/@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -310,7 +310,7 @@
         "@angular/forms": "catalog:angular",
         "@angular/platform-browser": "catalog:angular",
         "@angular/router": "catalog:angular",
-        "@tanstack/angular-query-experimental": "^5.90.16",
+        "@tanstack/angular-query-experimental": "catalog:angular",
         "rxjs": "catalog:angular",
         "tslib": "catalog:",
         "zod": "^4.3.6",
@@ -1760,15 +1760,15 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@tanstack/angular-query-experimental": ["@tanstack/angular-query-experimental@5.90.25", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "optionalDependencies": { "@tanstack/query-devtools": "5.93.0" }, "peerDependencies": { "@angular/common": ">=16.0.0", "@angular/core": ">=16.0.0" } }, "sha512-8MmtvEq83kRbwtt6NNbDAWPMOFHLxSmvhScFtdmBP/Xo5gSSzAf4JHcblQDHV/CgWIGKOp7eOa6aXDiVIK+kbw=="],
+    "@tanstack/angular-query-experimental": ["@tanstack/angular-query-experimental@5.90.16", "", { "dependencies": { "@tanstack/query-core": "5.90.12" }, "optionalDependencies": { "@tanstack/query-devtools": "5.91.1" }, "peerDependencies": { "@angular/common": ">=16.0.0", "@angular/core": ">=16.0.0" } }, "sha512-ezXyxuaSA6kpwUxwrxo5Tf3B7KL7mb7cxhLnun/RMlw6h3ZQJzl1cJgrvN97+C0AeHoucmK7RwhEoIY12gY7WA=="],
 
     "@tanstack/directive-functions-plugin": ["@tanstack/directive-functions-plugin@1.121.21", "", { "dependencies": { "@babel/code-frame": "7.26.2", "@babel/core": "^7.26.8", "@babel/traverse": "^7.26.8", "@babel/types": "^7.26.8", "@tanstack/router-utils": "^1.121.21", "babel-dead-code-elimination": "^1.0.10", "tiny-invariant": "^1.3.3" }, "peerDependencies": { "vite": ">=6.0.0" } }, "sha512-B9z/HbF7gJBaRHieyX7f2uQ4LpLLAVAEutBZipH6w+CYD6RHRJvSVPzECGHF7icFhNWTiJQL2QR6K07s59yzEw=="],
 
     "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@8.19.4", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.12", "", {}, "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg=="],
 
-    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.93.0", "", {}, "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg=="],
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.91.1", "", {}, "sha512-l8bxjk6BMsCaVQH6NzQEE/bEgFy1hAs5qbgXl0xhzezlaQbPk6Mgz9BqEg2vTLPOHD8N4k+w/gdgCbEzecGyNg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.62.16", "", { "dependencies": { "@tanstack/query-core": "5.62.16" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-XJIZNj65d2IdvU8VBESmrPakfIm6FSdHDzrS1dPrAwmq3ZX+9riMh/ZfbNQHAWnhrgmq7KoXpgZSRyXnqMYT9A=="],
 
@@ -4148,6 +4148,8 @@
 
     "@tanstack/server-functions-plugin/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
+    "@tanstack/solid-query/@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
+
     "@tanstack/svelte-query/@tanstack/query-core": ["@tanstack/query-core@4.41.0", "", {}, "sha512-193R4Jp9hjvlij6LryxrB5Mpbffd2L9PeWh3KlIy/hJV4SkBOfiQZ+jc5qAZLDCrdbkA5FjGj+UoDYw6TcNnyA=="],
 
     "@tanstack/vue-query/@tanstack/query-core": ["@tanstack/query-core@5.90.18", "", {}, "sha512-rbGx6bHgPNVzutP7BEr+53UPKohpckqlMAad+To9UxTbeaQ+kC/1SDRj+QzkwbQ7qhLT/1IKp34yS6thda6fzA=="],
@@ -5109,6 +5111,8 @@
     "svelte-check/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "svelte-check/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "svelte-query-v6-custom-fetch/@tanstack/svelte-query/@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -220,3 +220,36 @@ export default defineConfig({
   },
 });
 ```
+
+## unsafeDisableValidation
+
+Disable OpenAPI spec validation during code generation.
+
+**Type:** `boolean`
+**Default:** `false`
+
+<Callout type="warn">
+  **Use at your own risk.** Code generation from an invalid OpenAPI spec is not
+  guaranteed to work and may break in minor updates. Bug reports with validation
+  disabled will not be accepted.
+</Callout>
+
+When `true`, orval skips both spec-level validation (`@scalar/openapi-parser`)
+and the component-key check — including the post-transformer validation when
+`override.transformer` is used — and proceeds with code generation regardless
+of spec errors. Intended as an escape hatch for specs that use non-standard
+extensions (e.g. FastAPI's `itemSchema` on `text/event-stream` responses) which
+a compliant validator would otherwise reject.
+
+```ts title="orval.config.ts"
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './petstore.yaml',
+      unsafeDisableValidation: true,
+    },
+  },
+});
+```

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "rxjs": "7.8.2",
       "@angular/build": "21.2.2",
       "@angular/cli": "21.2.2",
-      "@tanstack/angular-query-experimental": "5.90.16"
+      "@tanstack/angular-query-experimental": "5.90.25"
     },
     "axios": {
       "axios": "1.13.6"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -206,6 +206,7 @@ export interface NormalizedOperationOptions {
 export interface NormalizedInputOptions {
   target: string | OpenApiDocument;
   override: OverrideInput;
+  validation?: boolean;
   filters?: InputFiltersOptions;
   parserOptions?: {
     headers?: {
@@ -326,6 +327,8 @@ export interface InputFiltersOptions {
 export interface InputOptions {
   target: string | string[] | Record<string, unknown> | OpenApiDocument;
   override?: OverrideInput;
+  /** Enable or disable OpenAPI spec validation. Default: true */
+  validation?: boolean;
   filters?: InputFiltersOptions;
   parserOptions?: {
     headers?: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -206,7 +206,7 @@ export interface NormalizedOperationOptions {
 export interface NormalizedInputOptions {
   target: string | OpenApiDocument;
   override: OverrideInput;
-  validation?: boolean;
+  validation: boolean;
   filters?: InputFiltersOptions;
   parserOptions?: {
     headers?: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -206,7 +206,7 @@ export interface NormalizedOperationOptions {
 export interface NormalizedInputOptions {
   target: string | OpenApiDocument;
   override: OverrideInput;
-  validation: boolean;
+  unsafeDisableValidation: boolean;
   filters?: InputFiltersOptions;
   parserOptions?: {
     headers?: {
@@ -327,8 +327,16 @@ export interface InputFiltersOptions {
 export interface InputOptions {
   target: string | string[] | Record<string, unknown> | OpenApiDocument;
   override?: OverrideInput;
-  /** Enable or disable OpenAPI spec validation. Default: true */
-  validation?: boolean;
+  /**
+   * Disable OpenAPI spec validation.
+   *
+   * **Use at your own risk** — code generation with invalid specs is not guaranteed
+   * to work and may break in minor updates. Bug reports with validation disabled are
+   * not accepted.
+   *
+   * @default false
+   */
+  unsafeDisableValidation?: boolean;
   filters?: InputFiltersOptions;
   parserOptions?: {
     headers?: {

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -6,7 +6,6 @@ import {
   generateSchemasDefinition,
   type ImportOpenApi,
   type InputOptions,
-  logWarning,
   type NormalizedOutputOptions,
   type OpenApiComponentsObject,
   type OpenApiDocument,
@@ -82,9 +81,11 @@ async function applyTransformer(
   if (validation) {
     const { valid, errors } = await validate(transformedOpenApi);
     if (!valid) {
-      logWarning(
-        `⚠️  Transformed OpenAPI spec validation warning:\n${JSON.stringify(errors, undefined, 2)}\n` +
-          `  To disable validation, set input.validation to false in your orval config.`,
+      throw new Error(
+        `Transformed OpenAPI spec validation failed:\n${JSON.stringify(errors, undefined, 2)}\n\n` +
+          `If your spec uses non-standard extensions and you want to skip validation,\n` +
+          `set input.validation to false in your orval config.\n` +
+          `Note: no bug reports are accepted with validation disabled.`,
       );
     }
   }

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -29,7 +29,7 @@ export async function importOpenApi({
     spec,
     input.override.transformer,
     workspace,
-    input.validation ?? true,
+    input.validation,
   );
 
   const schemas = getApiSchemas({

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -6,6 +6,7 @@ import {
   generateSchemasDefinition,
   type ImportOpenApi,
   type InputOptions,
+  logWarning,
   type NormalizedOutputOptions,
   type OpenApiComponentsObject,
   type OpenApiDocument,
@@ -28,6 +29,7 @@ export async function importOpenApi({
     spec,
     input.override.transformer,
     workspace,
+    input.validation ?? true,
   );
 
   const schemas = getApiSchemas({
@@ -65,6 +67,7 @@ async function applyTransformer(
   openApi: OpenApiDocument,
   transformer: OverrideInput['transformer'],
   workspace: string,
+  validation = true,
 ): Promise<OpenApiDocument> {
   const transformerFn = transformer
     ? await dynamicImport(transformer, workspace)
@@ -76,9 +79,14 @@ async function applyTransformer(
 
   const transformedOpenApi = transformerFn(openApi);
 
-  const { valid, errors } = await validate(transformedOpenApi);
-  if (!valid) {
-    throw new Error(`Validation failed`, { cause: errors });
+  if (validation) {
+    const { valid, errors } = await validate(transformedOpenApi);
+    if (!valid) {
+      logWarning(
+        `⚠️  Transformed OpenAPI spec validation warning:\n${JSON.stringify(errors, undefined, 2)}\n` +
+          `  To disable validation, set input.validation to false in your orval config.`,
+      );
+    }
   }
 
   return transformedOpenApi;

--- a/packages/orval/src/import-open-api.ts
+++ b/packages/orval/src/import-open-api.ts
@@ -28,7 +28,7 @@ export async function importOpenApi({
     spec,
     input.override.transformer,
     workspace,
-    input.validation,
+    input.unsafeDisableValidation,
   );
 
   const schemas = getApiSchemas({
@@ -66,7 +66,7 @@ async function applyTransformer(
   openApi: OpenApiDocument,
   transformer: OverrideInput['transformer'],
   workspace: string,
-  validation = true,
+  unsafeDisableValidation = false,
 ): Promise<OpenApiDocument> {
   const transformerFn = transformer
     ? await dynamicImport(transformer, workspace)
@@ -78,15 +78,10 @@ async function applyTransformer(
 
   const transformedOpenApi = transformerFn(openApi);
 
-  if (validation) {
+  if (!unsafeDisableValidation) {
     const { valid, errors } = await validate(transformedOpenApi);
     if (!valid) {
-      throw new Error(
-        `Transformed OpenAPI spec validation failed:\n${JSON.stringify(errors, undefined, 2)}\n\n` +
-          `If your spec uses non-standard extensions and you want to skip validation,\n` +
-          `set input.validation to false in your orval config.\n` +
-          `Note: no bug reports are accepted with validation disabled.`,
-      );
+      throw new Error(`Validation failed`, { cause: errors });
     }
   }
 

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -1,5 +1,6 @@
 import type { OpenApiDocument } from '@orval/core';
-import { describe, expect, it } from 'vitest';
+import * as orvalCore from '@orval/core';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   dereferenceExternalRef,
@@ -142,7 +143,7 @@ const SSE_ITEM_SCHEMA_SPEC: OpenApiDocument = {
 };
 
 describe('validation', () => {
-  it('should not throw on non-standard fields like itemSchema (warns instead)', async () => {
+  it('should throw on non-standard fields like itemSchema by default', async () => {
     const workspace = 'test';
     const normalizedOptions = await normalizeOptions(
       {
@@ -153,10 +154,9 @@ describe('validation', () => {
       {},
     );
 
-    const spec = await importSpecs(workspace, normalizedOptions);
-
-    expect(spec.verbOptions).toHaveProperty('sse_endpoint');
-    expect(spec.verbOptions).toHaveProperty('list_pets');
+    await expect(importSpecs(workspace, normalizedOptions)).rejects.toThrow(
+      'OpenAPI spec validation failed',
+    );
   });
 
   it('should skip validation when input.validation is false', async () => {
@@ -172,10 +172,21 @@ describe('validation', () => {
 
     expect(normalizedOptions.input.validation).toBe(false);
 
-    const spec = await importSpecs(workspace, normalizedOptions);
+    const warnSpy = vi.spyOn(orvalCore, 'logWarning').mockImplementation(() => {
+      /* noop */
+    });
 
-    expect(spec.verbOptions).toHaveProperty('sse_endpoint');
-    expect(spec.verbOptions).toHaveProperty('list_pets');
+    try {
+      const spec = await importSpecs(workspace, normalizedOptions);
+
+      expect(spec.verbOptions).toHaveProperty('sse_endpoint');
+      expect(spec.verbOptions).toHaveProperty('list_pets');
+
+      const warnings = warnSpy.mock.calls.map(([msg]) => msg).join('\n');
+      expect(warnings).toContain('OpenAPI spec validation is disabled');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -159,18 +159,18 @@ describe('validation', () => {
     );
   });
 
-  it('should skip validation when input.validation is false', async () => {
+  it('should skip validation when input.unsafeDisableValidation is true', async () => {
     const workspace = 'test';
     const normalizedOptions = await normalizeOptions(
       {
         output: { target: '' },
-        input: { target: SSE_ITEM_SCHEMA_SPEC, validation: false },
+        input: { target: SSE_ITEM_SCHEMA_SPEC, unsafeDisableValidation: true },
       },
       workspace,
       {},
     );
 
-    expect(normalizedOptions.input.validation).toBe(false);
+    expect(normalizedOptions.input.unsafeDisableValidation).toBe(true);
 
     const warnSpy = vi.spyOn(orvalCore, 'logWarning').mockImplementation(() => {
       /* noop */

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -82,6 +82,103 @@ const TEST_SPEC: OpenApiDocument = {
   },
 };
 
+const SSE_ITEM_SCHEMA_SPEC: OpenApiDocument = {
+  openapi: '3.1.0',
+  info: {
+    title: 'FastAPI',
+    version: '0.1.0',
+  },
+  paths: {
+    '/api/events/': {
+      post: {
+        tags: ['stream'],
+        summary: 'Sse Endpoint',
+        operationId: 'sse_endpoint',
+        responses: {
+          '200': {
+            description: 'Successful Response',
+            content: {
+              'text/event-stream': {
+                itemSchema: {
+                  type: 'object',
+                  properties: {
+                    data: { type: 'string' },
+                    event: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/pets': {
+      get: {
+        tags: ['pets'],
+        summary: 'List Pets',
+        operationId: 'list_pets',
+        responses: {
+          '200': {
+            description: 'Successful Response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'integer' },
+                      name: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('validation', () => {
+  it('should not throw on non-standard fields like itemSchema (warns instead)', async () => {
+    const workspace = 'test';
+    const normalizedOptions = await normalizeOptions(
+      {
+        output: { target: '' },
+        input: { target: SSE_ITEM_SCHEMA_SPEC },
+      },
+      workspace,
+      {},
+    );
+
+    const spec = await importSpecs(workspace, normalizedOptions);
+
+    expect(spec.verbOptions).toHaveProperty('sse_endpoint');
+    expect(spec.verbOptions).toHaveProperty('list_pets');
+  });
+
+  it('should skip validation when input.validation is false', async () => {
+    const workspace = 'test';
+    const normalizedOptions = await normalizeOptions(
+      {
+        output: { target: '' },
+        input: { target: SSE_ITEM_SCHEMA_SPEC, validation: false },
+      },
+      workspace,
+      {},
+    );
+
+    expect(normalizedOptions.input.validation).toBe(false);
+
+    const spec = await importSpecs(workspace, normalizedOptions);
+
+    expect(spec.verbOptions).toHaveProperty('sse_endpoint');
+    expect(spec.verbOptions).toHaveProperty('list_pets');
+  });
+});
+
 describe('optionsParamRequired', () => {
   it('should not require all params when optionsParamRequired is false', async () => {
     const workspace = 'test';

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -48,11 +48,19 @@ async function resolveSpec(
 
     const { valid, errors } = await validateSpec(dereferencedData);
     if (!valid) {
-      logWarning(
-        `⚠️  OpenAPI spec validation warning:\n${JSON.stringify(errors, undefined, 2)}\n` +
-          `  To disable validation, set input.validation to false in your orval config.`,
+      throw new Error(
+        `OpenAPI spec validation failed:\n${JSON.stringify(errors, undefined, 2)}\n\n` +
+          `If your spec uses non-standard extensions and you want to skip validation,\n` +
+          `set input.validation to false in your orval config.\n` +
+          `Note: no bug reports are accepted with validation disabled.`,
       );
     }
+  } else {
+    logWarning(
+      `🚨 OpenAPI spec validation is disabled (input.validation: false).\n` +
+        `  Code generation with invalid specs is not guaranteed to work and may break in minor updates.\n` +
+        `  Bug reports with validation disabled will not be accepted.`,
+    );
   }
 
   const { specification } = upgrade(dereferencedData);

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -43,9 +43,9 @@ async function resolveSpec(
     data as Record<string, unknown>,
   );
 
-  validateComponentKeys(dereferencedData);
-
   if (validation) {
+    validateComponentKeys(dereferencedData);
+
     const { valid, errors } = await validateSpec(dereferencedData);
     if (!valid) {
       logWarning(
@@ -70,7 +70,7 @@ export async function importSpecs(
   const spec = await resolveSpec(
     input.target,
     input.parserOptions,
-    input.validation ?? true,
+    input.validation,
   );
 
   return importOpenApi({

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -1,6 +1,7 @@
 import {
   isObject,
   isString,
+  logWarning,
   type NormalizedOptions,
   type OpenApiDocument,
   type WriteSpecBuilder,
@@ -25,6 +26,7 @@ async function resolveSpec(
       headers: Record<string, string>;
     }[];
   },
+  validation = true,
 ): Promise<OpenApiDocument> {
   const data = await bundle(input, {
     plugins: [
@@ -43,9 +45,14 @@ async function resolveSpec(
 
   validateComponentKeys(dereferencedData);
 
-  const { valid, errors } = await validateSpec(dereferencedData);
-  if (!valid) {
-    throw new Error('Validation failed', { cause: errors });
+  if (validation) {
+    const { valid, errors } = await validateSpec(dereferencedData);
+    if (!valid) {
+      logWarning(
+        `⚠️  OpenAPI spec validation warning:\n${JSON.stringify(errors, undefined, 2)}\n` +
+          `  To disable validation, set input.validation to false in your orval config.`,
+      );
+    }
   }
 
   const { specification } = upgrade(dereferencedData);
@@ -60,7 +67,11 @@ export async function importSpecs(
 ): Promise<WriteSpecBuilder> {
   const { input, output } = options;
 
-  const spec = await resolveSpec(input.target, input.parserOptions);
+  const spec = await resolveSpec(
+    input.target,
+    input.parserOptions,
+    input.validation ?? true,
+  );
 
   return importOpenApi({
     spec,

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -26,7 +26,7 @@ async function resolveSpec(
       headers: Record<string, string>;
     }[];
   },
-  validation = true,
+  unsafeDisableValidation = false,
 ): Promise<OpenApiDocument> {
   const data = await bundle(input, {
     plugins: [
@@ -43,24 +43,21 @@ async function resolveSpec(
     data as Record<string, unknown>,
   );
 
-  if (validation) {
+  if (unsafeDisableValidation) {
+    logWarning(
+      `🚨 OpenAPI spec validation is disabled.\n` +
+        `  Code generation with invalid specs is not guaranteed to work and may break in minor updates.\n` +
+        `  Bug reports with validation disabled will not be accepted.`,
+    );
+  } else {
     validateComponentKeys(dereferencedData);
 
     const { valid, errors } = await validateSpec(dereferencedData);
     if (!valid) {
       throw new Error(
-        `OpenAPI spec validation failed:\n${JSON.stringify(errors, undefined, 2)}\n\n` +
-          `If your spec uses non-standard extensions and you want to skip validation,\n` +
-          `set input.validation to false in your orval config.\n` +
-          `Note: no bug reports are accepted with validation disabled.`,
+        `OpenAPI spec validation failed:\n${JSON.stringify(errors, undefined, 2)}`,
       );
     }
-  } else {
-    logWarning(
-      `🚨 OpenAPI spec validation is disabled (input.validation: false).\n` +
-        `  Code generation with invalid specs is not guaranteed to work and may break in minor updates.\n` +
-        `  Bug reports with validation disabled will not be accepted.`,
-    );
   }
 
   const { specification } = upgrade(dereferencedData);
@@ -78,7 +75,7 @@ export async function importSpecs(
   const spec = await resolveSpec(
     input.target,
     input.parserOptions,
-    input.validation,
+    input.unsafeDisableValidation,
   );
 
   return importOpenApi({

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -214,7 +214,7 @@ export async function normalizeOptions(
           workspace,
         ),
       },
-      validation: inputOptions.validation ?? true,
+      unsafeDisableValidation: inputOptions.unsafeDisableValidation ?? false,
       filters: inputOptions.filters,
       parserOptions: inputOptions.parserOptions,
     },

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -214,6 +214,7 @@ export async function normalizeOptions(
           workspace,
         ),
       },
+      validation: inputOptions.validation ?? true,
       filters: inputOptions.filters,
       parserOptions: inputOptions.parserOptions,
     },

--- a/samples/angular-query/package.json
+++ b/samples/angular-query/package.json
@@ -21,7 +21,7 @@
     "@angular/forms": "catalog:angular",
     "@angular/platform-browser": "catalog:angular",
     "@angular/router": "catalog:angular",
-    "@tanstack/angular-query-experimental": "^5.90.16",
+    "@tanstack/angular-query-experimental": "catalog:angular",
     "rxjs": "catalog:angular",
     "tslib": "catalog:",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary
- Change OpenAPI spec validation from hard error to warning, allowing code generation to proceed with non-standard fields (#3072)
- Add `input.validation` option (`boolean`, default `true`) to let users disable validation entirely
- Apply to both main spec validation (`import-specs.ts`) and transformer validation (`import-open-api.ts`)

## Problem
FastAPI SSE endpoints add a non-standard `itemSchema` field to response content. The `@scalar/openapi-parser` validator rejects this field, causing orval to throw and exit immediately. This blocks generation of all endpoints, even when the SSE endpoints are excluded via `input.filters`.

## Solution
Replace `throw new Error('Validation failed')` with `logWarning()` in both vlidation sites. When validation fails, orval now:
1. Prints a yellow warning with the validation errors
2. Suggests `input.validation: false` as an escape hatch
3. Continues with code generation

Users who want to completely skip validation can set:
```ts
input: {
  target: './openapi.json',
  validation: false,
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional input setting to enable/disable OpenAPI validation (enabled by default).
  * Import flow now emits warnings with validation details for invalid specs instead of aborting the import.

* **Tests**
  * Added tests covering import behavior with validation enabled and disabled.

* **Chores**
  * Added an Angular Query generate script and introduced the Angular Query experimental dependency in samples/tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->