### PR TITLE
fix(core): support oneOf/anyOf in multipart/form-data code generation

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -725,6 +725,79 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
       );
     });
 
+    it('oneOf alongside direct properties: loop skips direct keys to avoid duplicate appends', () => {
+      const ctx: ContextSpec = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              VariantA: {
+                type: 'object',
+                properties: {
+                  kind: { type: 'string', enum: ['a'] },
+                  extraA: { type: 'string' },
+                },
+                required: ['kind'],
+              },
+              VariantB: {
+                type: 'object',
+                properties: {
+                  kind: { type: 'string', enum: ['b'] },
+                  extraB: { type: 'string' },
+                },
+                required: ['kind'],
+              },
+            },
+          },
+        },
+      };
+
+      const reqBody: [string, OpenApiRequestBodyObject][] = [
+        [
+          'requestBody',
+          {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  type: 'object',
+                  oneOf: [
+                    { $ref: '#/components/schemas/VariantA' },
+                    { $ref: '#/components/schemas/VariantB' },
+                  ],
+                  properties: {
+                    name: { type: 'string' },
+                    owner: { type: 'string' },
+                  },
+                  required: ['name'],
+                },
+              },
+            },
+            required: true,
+          },
+        ],
+      ];
+
+      const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+      const formData = result.formData;
+      if (!formData || !isString(formData)) {
+        throw new Error('Expected formData to be a defined string');
+      }
+
+      // The Object.entries loop skips keys that the direct-properties branch
+      // already appends (`name`, `owner`), so those fields are not appended
+      // twice at runtime.
+      expect(formData).toContain('Object.entries(');
+      expect(formData).toContain('["name", "owner"].includes(key)');
+      const nameAppendCount = (
+        formData.match(/formData\.append\(`name`/g) ?? []
+      ).length;
+      const ownerAppendCount = (
+        formData.match(/formData\.append\(`owner`/g) ?? []
+      ).length;
+      expect(nameAppendCount).toBe(1);
+      expect(ownerAppendCount).toBe(1);
+    });
+
     it('oneOf with an optional body: FormData guards against undefined', () => {
       const ctx: ContextSpec = {
         ...context,

--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -722,6 +722,112 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
         'formData.append(`logo`, uploadRequestBody.logo)',
       );
     });
+
+    it('oneOf with an optional body: FormData guards against undefined', () => {
+      const ctx: ContextSpec = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              OptionalBodyDto: {
+                type: 'object',
+                properties: {
+                  file: { type: 'string', format: 'binary' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const reqBody: [string, OpenApiRequestBodyObject][] = [
+        [
+          'requestBody',
+          {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  oneOf: [{ $ref: '#/components/schemas/OptionalBodyDto' }],
+                },
+              },
+            },
+            required: false,
+          },
+        ],
+      ];
+
+      const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+      const formData = result.formData;
+      if (!formData || !isString(formData)) {
+        throw new Error('Expected formData to be a defined string');
+      }
+
+      // The runtime loop must defend against an undefined body so callers can
+      // safely pass nothing when the body is optional.
+      expect(formData).toMatch(/Object\.entries\([^)]*\?\?\s*\{\}\)/);
+    });
+
+    it('oneOf with an array of binary files: FormData appends Blob items directly', () => {
+      const ctx: ContextSpec = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              MultiUploadV1: {
+                type: 'object',
+                properties: {
+                  files: {
+                    type: 'array',
+                    items: { type: 'string', format: 'binary' },
+                  },
+                },
+              },
+              MultiUploadV2: {
+                type: 'object',
+                properties: {
+                  files: {
+                    type: 'array',
+                    items: { type: 'string', format: 'binary' },
+                  },
+                  tag: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const reqBody: [string, OpenApiRequestBodyObject][] = [
+        [
+          'requestBody',
+          {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  oneOf: [
+                    { $ref: '#/components/schemas/MultiUploadV1' },
+                    { $ref: '#/components/schemas/MultiUploadV2' },
+                  ],
+                },
+              },
+            },
+            required: true,
+          },
+        ],
+      ];
+
+      const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+      const formData = result.formData;
+      if (!formData || !isString(formData)) {
+        throw new Error('Expected formData to be a defined string');
+      }
+
+      // Array elements that are files must be appended directly. Without the
+      // per-element Blob/File/Buffer check, each binary item would have been
+      // serialized to "{}" via JSON.stringify.
+      expect(formData).toContain('value.forEach');
+      expect(formData).toContain('v instanceof Blob');
+    });
   });
 });
 

--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -657,9 +657,11 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
       // Shared fields used to be appended once per variant because TypeScript
       // casts are erased at runtime. The runtime loop appends each key once.
       expect(formData).toContain('Object.entries(');
-      const appendFileCount = (formData.match(/`file`/g) ?? []).length;
-      expect(appendFileCount).toBe(0);
       expect(formData).not.toMatch(/as UploadDtoV[12]/);
+      // Guard against a future refactor reintroducing the per-variant
+      // appends keyed off the shared field.
+      expect(formData).not.toContain('uploadDtoV1.file');
+      expect(formData).not.toContain('uploadDtoV2.file');
 
       // Variant types are still imported so they remain referenceable.
       const importNames = result.imports.map((i) => i.name);

--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -547,6 +547,181 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
       // allOf with $ref: intersection type (not union)
       expect(schema?.model).toContain('ClientUpdateDto & {');
     });
+
+    // Regression tests for #3242: multipart/form-data with oneOf/anyOf
+    // at the root of a request body (common with @nestjs/swagger or
+    // zod-to-openapi for versioned request schemas).
+    it('oneOf with a single $ref: FormData variable derives from the DTO name', () => {
+      const ctx: ContextSpec = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              ClientUpdateDto: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  logo: { type: 'string', format: 'binary' },
+                },
+                required: ['name', 'logo'],
+              },
+            },
+          },
+        },
+      };
+
+      const reqBody: [string, OpenApiRequestBodyObject][] = [
+        [
+          'requestBody',
+          {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  oneOf: [{ $ref: '#/components/schemas/ClientUpdateDto' }],
+                },
+              },
+            },
+            required: true,
+          },
+        ],
+      ];
+
+      const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+      const formData = result.formData;
+      if (!formData || !isString(formData)) {
+        throw new Error('Expected formData to be a defined string');
+      }
+
+      // Without the fix, effectivePropName fell back to the controller-derived
+      // name and the generated code referenced a variable that was never
+      // declared (e.g. uploadRequestBody).
+      expect(formData).toContain('clientUpdateDto');
+      expect(formData).not.toContain('uploadRequestBody');
+    });
+
+    it('oneOf with 2 $refs: FormData uses a runtime Object.entries loop', () => {
+      const ctx: ContextSpec = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              UploadDtoV1: {
+                type: 'object',
+                properties: {
+                  file: { type: 'string', format: 'binary' },
+                  metadata: { type: 'string' },
+                },
+                required: ['file'],
+              },
+              UploadDtoV2: {
+                type: 'object',
+                properties: {
+                  file: { type: 'string', format: 'binary' },
+                  metadata: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                  },
+                },
+                required: ['file'],
+              },
+            },
+          },
+        },
+      };
+
+      const reqBody: [string, OpenApiRequestBodyObject][] = [
+        [
+          'requestBody',
+          {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  oneOf: [
+                    { $ref: '#/components/schemas/UploadDtoV1' },
+                    { $ref: '#/components/schemas/UploadDtoV2' },
+                  ],
+                },
+              },
+            },
+            required: true,
+          },
+        ],
+      ];
+
+      const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+      const formData = result.formData;
+      if (!formData || !isString(formData)) {
+        throw new Error('Expected formData to be a defined string');
+      }
+
+      // Shared fields used to be appended once per variant because TypeScript
+      // casts are erased at runtime. The runtime loop appends each key once.
+      expect(formData).toContain('Object.entries(');
+      const appendFileCount = (formData.match(/`file`/g) ?? []).length;
+      expect(appendFileCount).toBe(0);
+      expect(formData).not.toMatch(/as UploadDtoV[12]/);
+
+      // Variant types are still imported so they remain referenceable.
+      const importNames = result.imports.map((i) => i.name);
+      expect(importNames).toContain('UploadDtoV1');
+      expect(importNames).toContain('UploadDtoV2');
+    });
+
+    it('allOf: FormData still emits per-field appends (no regression)', () => {
+      const ctx: ContextSpec = {
+        ...context,
+        spec: {
+          components: {
+            schemas: {
+              BaseDto: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+              },
+            },
+          },
+        },
+      };
+
+      const reqBody: [string, OpenApiRequestBodyObject][] = [
+        [
+          'requestBody',
+          {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  allOf: [
+                    { $ref: '#/components/schemas/BaseDto' },
+                    {
+                      type: 'object',
+                      properties: {
+                        logo: { type: 'string', format: 'binary' },
+                      },
+                      required: ['logo'],
+                    },
+                  ],
+                },
+              },
+            },
+            required: true,
+          },
+        ],
+      ];
+
+      const result = getResReqTypes(reqBody, 'Upload', ctx)[0];
+      const formData = result.formData;
+      if (!formData || !isString(formData)) {
+        throw new Error('Expected formData to be a defined string');
+      }
+
+      expect(formData).not.toContain('Object.entries(');
+      expect(formData).toContain(
+        'formData.append(`name`, uploadRequestBody.name)',
+      );
+      expect(formData).toContain(
+        'formData.append(`logo`, uploadRequestBody.logo)',
+      );
+    });
   });
 });
 

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -576,14 +576,31 @@ function getSchemaFormDataAndUrlEncoded({
       const shouldCast = !!getSchemaOneOf(schema) || !!getSchemaAnyOf(schema);
 
       if (shouldCast) {
+        // If the outer schema also has direct properties, those are handled
+        // below by the dedicated properties branch. Skip them here to avoid
+        // appending the same key twice.
+        const directProperties = getSchemaProperties(schema);
+        const directKeys = directProperties
+          ? Object.keys(directProperties)
+          : [];
+        const skipLine =
+          directKeys.length > 0
+            ? `  if ([${directKeys.map((k) => JSON.stringify(k)).join(', ')}].includes(key)) return;\n`
+            : '';
+
         form += `Object.entries(${propName} ?? {}).forEach(([key, value]) => {\n`;
+        form += skipLine;
         form += `  if (value !== undefined && value !== null) {\n`;
-        form += `    if ((typeof File !== 'undefined' && value instanceof File) || value instanceof Blob || (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))) {\n`;
+        form += `    if ((typeof File !== 'undefined' && value instanceof File) || value instanceof Blob) {\n`;
         form += `      ${variableName}.append(key, value);\n`;
+        form += `    } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {\n`;
+        form += `      ${variableName}.append(key, new Blob([value as unknown as BlobPart]));\n`;
         form += `    } else if (Array.isArray(value)) {\n`;
         form += `      value.forEach(v => {\n`;
-        form += `        if ((typeof File !== 'undefined' && v instanceof File) || v instanceof Blob || (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))) {\n`;
+        form += `        if ((typeof File !== 'undefined' && v instanceof File) || v instanceof Blob) {\n`;
         form += `          ${variableName}.append(key, v);\n`;
+        form += `        } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {\n`;
+        form += `          ${variableName}.append(key, new Blob([v as unknown as BlobPart]));\n`;
         form += `        } else {\n`;
         form += `          ${variableName}.append(key, typeof v === 'object' ? JSON.stringify(v) : String(v));\n`;
         form += `        }\n`;

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -257,7 +257,6 @@ export function getResReqTypes(
                 effectivePropName = imports[0].name;
               }
             } else if (mediaType.schema) {
-              // When schema is a oneOf/anyOf of $refs, concat schema names for consistent param naming
               const combinedRefs =
                 getSchemaOneOf(mediaType.schema) ??
                 getSchemaAnyOf(mediaType.schema);
@@ -265,9 +264,10 @@ export function getResReqTypes(
                 const names: string[] = [];
                 for (const ref of combinedRefs) {
                   if (!isReference(ref)) continue;
-                  const name = resolveSchemaRef(ref, context).imports[0]?.name;
-                  if (name) {
-                    names.push(name);
+                  const refName = resolveSchemaRef(ref, context).imports[0]
+                    ?.name;
+                  if (refName) {
+                    names.push(refName);
                   }
                 }
                 if (names.length > 0) {
@@ -561,7 +561,6 @@ function getSchemaFormDataAndUrlEncoded({
   const propName = camel(
     !isRef && isReference(schemaObject) ? imports[0].name : name,
   );
-  const additionalImports: GeneratorImport[] = [];
 
   const variableName = isUrlEncoded ? 'formUrlEncoded' : 'formData';
   let form = isUrlEncoded
@@ -577,28 +576,25 @@ function getSchemaFormDataAndUrlEncoded({
       const shouldCast = !!getSchemaOneOf(schema) || !!getSchemaAnyOf(schema);
 
       if (shouldCast) {
-        // oneOf/anyOf: iterate over actual properties at runtime to avoid duplicating
-        // fields shared across variants (TypeScript casts are erased at compile-time).
-        form += `Object.entries(${propName}).forEach(([key, value]) => {\n`;
-        form += `  if (value !== undefined) {\n`;
-        form += `    if (value instanceof File || value instanceof Blob || (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))) {\n`;
+        form += `Object.entries(${propName} ?? {}).forEach(([key, value]) => {\n`;
+        form += `  if (value !== undefined && value !== null) {\n`;
+        form += `    if ((typeof File !== 'undefined' && value instanceof File) || value instanceof Blob || (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))) {\n`;
         form += `      ${variableName}.append(key, value);\n`;
         form += `    } else if (Array.isArray(value)) {\n`;
-        form += `      value.forEach(v => ${variableName}.append(key, typeof v === 'object' ? JSON.stringify(v) : String(v)));\n`;
-        form += `    } else if (typeof value === 'object' && value !== null) {\n`;
+        form += `      value.forEach(v => {\n`;
+        form += `        if ((typeof File !== 'undefined' && v instanceof File) || v instanceof Blob || (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))) {\n`;
+        form += `          ${variableName}.append(key, v);\n`;
+        form += `        } else {\n`;
+        form += `          ${variableName}.append(key, typeof v === 'object' ? JSON.stringify(v) : String(v));\n`;
+        form += `        }\n`;
+        form += `      });\n`;
+        form += `    } else if (typeof value === 'object') {\n`;
         form += `      ${variableName}.append(key, JSON.stringify(value));\n`;
         form += `    } else {\n`;
         form += `      ${variableName}.append(key, String(value));\n`;
         form += `    }\n`;
         form += `  }\n`;
         form += `});\n`;
-
-        for (const subSchema of combinedSchemas) {
-          const { imports } = resolveSchemaRef(subSchema, context);
-          if (imports[0]) {
-            additionalImports.push(imports[0]);
-          }
-        }
       } else {
         const combinedSchemasFormData = combinedSchemas
           .map((subSchema) => {

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -594,13 +594,13 @@ function getSchemaFormDataAndUrlEncoded({
         form += `    if ((typeof File !== 'undefined' && value instanceof File) || value instanceof Blob) {\n`;
         form += `      ${variableName}.append(key, value);\n`;
         form += `    } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {\n`;
-        form += `      ${variableName}.append(key, new Blob([value as unknown as BlobPart]));\n`;
+        form += `      ${variableName}.append(key, new Blob([Uint8Array.from(value)]));\n`;
         form += `    } else if (Array.isArray(value)) {\n`;
         form += `      value.forEach(v => {\n`;
         form += `        if ((typeof File !== 'undefined' && v instanceof File) || v instanceof Blob) {\n`;
         form += `          ${variableName}.append(key, v);\n`;
         form += `        } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {\n`;
-        form += `          ${variableName}.append(key, new Blob([v as unknown as BlobPart]));\n`;
+        form += `          ${variableName}.append(key, new Blob([Uint8Array.from(v)]));\n`;
         form += `        } else {\n`;
         form += `          ${variableName}.append(key, typeof v === 'object' ? JSON.stringify(v) : String(v));\n`;
         form += `        }\n`;

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -256,6 +256,24 @@ export function getResReqTypes(
               if (imports[0]?.name) {
                 effectivePropName = imports[0].name;
               }
+            } else if (mediaType.schema) {
+              // When schema is a oneOf/anyOf of $refs, concat schema names for consistent param naming
+              const combinedRefs =
+                getSchemaOneOf(mediaType.schema) ??
+                getSchemaAnyOf(mediaType.schema);
+              if (combinedRefs) {
+                const names: string[] = [];
+                for (const ref of combinedRefs) {
+                  if (!isReference(ref)) continue;
+                  const name = resolveSchemaRef(ref, context).imports[0]?.name;
+                  if (name) {
+                    names.push(name);
+                  }
+                }
+                if (names.length > 0) {
+                  effectivePropName = names.join('');
+                }
+              }
             }
 
             const isFormData = formDataContentTypes.has(contentType);
@@ -558,40 +576,50 @@ function getSchemaFormDataAndUrlEncoded({
     if (combinedSchemas) {
       const shouldCast = !!getSchemaOneOf(schema) || !!getSchemaAnyOf(schema);
 
-      const combinedSchemasFormData = combinedSchemas
-        .map((subSchema) => {
-          const { schema: combinedSchema, imports } = resolveSchemaRef(
-            subSchema,
-            context,
-          );
+      if (shouldCast) {
+        // oneOf/anyOf: iterate over actual properties at runtime to avoid duplicating
+        // fields shared across variants (TypeScript casts are erased at compile-time).
+        form += `Object.entries(${propName}).forEach(([key, value]) => {\n`;
+        form += `  if (value !== undefined) {\n`;
+        form += `    if (value instanceof File || value instanceof Blob || (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))) {\n`;
+        form += `      ${variableName}.append(key, value);\n`;
+        form += `    } else if (Array.isArray(value)) {\n`;
+        form += `      value.forEach(v => ${variableName}.append(key, typeof v === 'object' ? JSON.stringify(v) : String(v)));\n`;
+        form += `    } else if (typeof value === 'object' && value !== null) {\n`;
+        form += `      ${variableName}.append(key, JSON.stringify(value));\n`;
+        form += `    } else {\n`;
+        form += `      ${variableName}.append(key, String(value));\n`;
+        form += `    }\n`;
+        form += `  }\n`;
+        form += `});\n`;
 
-          let newPropName = propName;
-          let newPropDefinition = '';
-
-          // If the schema is a union type (oneOf, anyOf) and includes a reference (has imports),
-          // we need to cast the property to the specific type to avoid TypeScript errors.
-          if (shouldCast && imports[0]) {
+        for (const subSchema of combinedSchemas) {
+          const { imports } = resolveSchemaRef(subSchema, context);
+          if (imports[0]) {
             additionalImports.push(imports[0]);
-            newPropName = `${propName}${pascal(imports[0].name)}`;
-            newPropDefinition = `const ${newPropName} = (${propName} as ${imports[0].name}${isRequestBodyOptional ? ' | undefined' : ''});\n`;
           }
-
-          return (
-            newPropDefinition +
-            resolveSchemaPropertiesToFormData({
+        }
+      } else {
+        const combinedSchemasFormData = combinedSchemas
+          .map((subSchema) => {
+            const { schema: combinedSchema } = resolveSchemaRef(
+              subSchema,
+              context,
+            );
+            return resolveSchemaPropertiesToFormData({
               schema: combinedSchema,
               variableName,
-              propName: newPropName,
+              propName,
               context,
               isRequestBodyOptional,
               encoding,
-            })
-          );
-        })
-        .filter(Boolean)
-        .join('\n');
+            });
+          })
+          .filter(Boolean)
+          .join('\n');
 
-      form += combinedSchemasFormData;
+        form += combinedSchemasFormData;
+      }
     }
 
     if (schema.properties) {

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -257,6 +257,12 @@ export function getResReqTypes(
                 effectivePropName = imports[0].name;
               }
             } else if (mediaType.schema) {
+              // When schema is a oneOf/anyOf of $refs, concat schema names
+              // so the FormData variable matches the function parameter.
+              // If the union only contains inline variants (no $ref), `names`
+              // stays empty and effectivePropName keeps the default
+              // `pascal(name) + pascal(key)` form; this is the original bug's
+              // shape, but the DTO-less case is outside this fix's scope.
               const combinedRefs =
                 getSchemaOneOf(mediaType.schema) ??
                 getSchemaAnyOf(mediaType.schema);
@@ -578,10 +584,17 @@ function getSchemaFormDataAndUrlEncoded({
       if (shouldCast) {
         // If the outer schema also has direct properties, those are handled
         // below by the dedicated properties branch. Skip them here to avoid
-        // appending the same key twice.
+        // appending the same key twice. Exclude readOnly direct properties
+        // so they can still flow through the runtime loop if a variant
+        // declares the same key as writable.
         const directProperties = getSchemaProperties(schema);
         const directKeys = directProperties
-          ? Object.keys(directProperties)
+          ? Object.entries(directProperties)
+              .filter(
+                ([, value]) =>
+                  !resolveSchemaRef(value, context).schema.readOnly,
+              )
+              .map(([key]) => key)
           : [];
         const skipLine =
           directKeys.length > 0

--- a/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
@@ -4,12 +4,14 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import type { Error, Pet, PetBase, PetExtended } from './model';
+import type { Error, Pet } from './model';
 
 import { faker } from '@faker-js/faker';
 
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
+
+import type { PetBase, PetExtended } from './model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
@@ -87,24 +89,36 @@ export const createPets = async (
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
-  const petPetBase = pet as PetBase | undefined;
-  if (petPetBase?.name !== undefined) {
-    formData.append(`name`, petPetBase.name);
-  }
-  if (petPetBase?.tag !== undefined) {
-    formData.append(`tag`, petPetBase.tag);
-  }
-
-  const petPetExtended = pet as PetExtended | undefined;
-  if (petPetExtended?.id !== undefined) {
-    formData.append(`id`, petPetExtended.id.toString());
-  }
-  if (petPetExtended?.name !== undefined) {
-    formData.append(`name`, petPetExtended.name);
-  }
-  if (petPetExtended?.tag !== undefined) {
-    formData.append(`tag`, petPetExtended.tag);
-  }
+  Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (
+        (typeof File !== 'undefined' && value instanceof File) ||
+        value instanceof Blob ||
+        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+      ) {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (
+            (typeof File !== 'undefined' && v instanceof File) ||
+            v instanceof Blob ||
+            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+          ) {
+            formData.append(key, v);
+          } else {
+            formData.append(
+              key,
+              typeof v === 'object' ? JSON.stringify(v) : String(v),
+            );
+          }
+        });
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    }
+  });
   if (pet?.['@id'] !== undefined) {
     formData.append(`@id`, pet['@id']);
   }

--- a/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
@@ -98,7 +98,7 @@ export const createPets = async (
       ) {
         formData.append(key, value);
       } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
-        formData.append(key, new Blob([value as unknown as BlobPart]));
+        formData.append(key, new Blob([Uint8Array.from(value)]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
@@ -107,7 +107,7 @@ export const createPets = async (
           ) {
             formData.append(key, v);
           } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
-            formData.append(key, new Blob([v as unknown as BlobPart]));
+            formData.append(key, new Blob([Uint8Array.from(v)]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
@@ -90,21 +90,24 @@ export const createPets = async (
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
   Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (['@id', 'email', 'callingCode', 'country'].includes(key)) return;
     if (value !== undefined && value !== null) {
       if (
         (typeof File !== 'undefined' && value instanceof File) ||
-        value instanceof Blob ||
-        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+        value instanceof Blob
       ) {
         formData.append(key, value);
+      } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+        formData.append(key, new Blob([value as unknown as BlobPart]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
             (typeof File !== 'undefined' && v instanceof File) ||
-            v instanceof Blob ||
-            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+            v instanceof Blob
           ) {
             formData.append(key, v);
+          } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+            formData.append(key, new Blob([v as unknown as BlobPart]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
@@ -99,7 +99,7 @@ export const createPets = async (
       ) {
         formData.append(key, value);
       } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
-        formData.append(key, new Blob([value as unknown as BlobPart]));
+        formData.append(key, new Blob([Uint8Array.from(value)]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
@@ -108,7 +108,7 @@ export const createPets = async (
           ) {
             formData.append(key, v);
           } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
-            formData.append(key, new Blob([v as unknown as BlobPart]));
+            formData.append(key, new Blob([Uint8Array.from(v)]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
@@ -91,21 +91,24 @@ export const createPets = async (
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
   Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (['@id', 'email', 'callingCode', 'country'].includes(key)) return;
     if (value !== undefined && value !== null) {
       if (
         (typeof File !== 'undefined' && value instanceof File) ||
-        value instanceof Blob ||
-        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+        value instanceof Blob
       ) {
         formData.append(key, value);
+      } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+        formData.append(key, new Blob([value as unknown as BlobPart]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
             (typeof File !== 'undefined' && v instanceof File) ||
-            v instanceof Blob ||
-            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+            v instanceof Blob
           ) {
             formData.append(key, v);
+          } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+            formData.append(key, new Blob([v as unknown as BlobPart]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
@@ -4,12 +4,14 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import type { Error, Pet, PetBase, PetExtended } from './model';
+import type { Error, Pet } from './model';
 
 import { faker } from '@faker-js/faker';
 
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
+
+import type { PetBase, PetExtended } from './model';
 
 import { customFetch } from '../../../mutators/custom-fetch';
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
@@ -88,24 +90,36 @@ export const createPets = async (
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
-  const petPetBase = pet as PetBase | undefined;
-  if (petPetBase?.name !== undefined) {
-    formData.append(`name`, petPetBase.name);
-  }
-  if (petPetBase?.tag !== undefined) {
-    formData.append(`tag`, petPetBase.tag);
-  }
-
-  const petPetExtended = pet as PetExtended | undefined;
-  if (petPetExtended?.id !== undefined) {
-    formData.append(`id`, petPetExtended.id.toString());
-  }
-  if (petPetExtended?.name !== undefined) {
-    formData.append(`name`, petPetExtended.name);
-  }
-  if (petPetExtended?.tag !== undefined) {
-    formData.append(`tag`, petPetExtended.tag);
-  }
+  Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (
+        (typeof File !== 'undefined' && value instanceof File) ||
+        value instanceof Blob ||
+        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+      ) {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (
+            (typeof File !== 'undefined' && v instanceof File) ||
+            v instanceof Blob ||
+            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+          ) {
+            formData.append(key, v);
+          } else {
+            formData.append(
+              key,
+              typeof v === 'object' ? JSON.stringify(v) : String(v),
+            );
+          }
+        });
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    }
+  });
   if (pet?.['@id'] !== undefined) {
     formData.append(`@id`, pet['@id']);
   }

--- a/tests/__snapshots__/fetch/importFromSubdirectory/endpoints.ts
+++ b/tests/__snapshots__/fetch/importFromSubdirectory/endpoints.ts
@@ -4,10 +4,10 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import type { AnotherSchema, Pet } from './model';
+import type { AnotherSchema as __AnotherSchema, Pet as __Pet } from './model';
 
 export type postPetsResponse200 = {
-  data: Pet;
+  data: __Pet;
   status: 200;
 };
 
@@ -35,7 +35,7 @@ export const postPets = async (
 };
 
 export type getPetsResponse200 = {
-  data: AnotherSchema;
+  data: __AnotherSchema;
   status: 200;
 };
 

--- a/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
@@ -34,21 +34,24 @@ export const useCreatePetsHook = () => {
     (pet: Pet, signal?: AbortSignal) => {
       const formData = new FormData();
       Object.entries(pet ?? {}).forEach(([key, value]) => {
+        if (['@id', 'email', 'callingCode', 'country'].includes(key)) return;
         if (value !== undefined && value !== null) {
           if (
             (typeof File !== 'undefined' && value instanceof File) ||
-            value instanceof Blob ||
-            (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+            value instanceof Blob
           ) {
             formData.append(key, value);
+          } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+            formData.append(key, new Blob([value as unknown as BlobPart]));
           } else if (Array.isArray(value)) {
             value.forEach((v) => {
               if (
                 (typeof File !== 'undefined' && v instanceof File) ||
-                v instanceof Blob ||
-                (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+                v instanceof Blob
               ) {
                 formData.append(key, v);
+              } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+                formData.append(key, new Blob([v as unknown as BlobPart]));
               } else {
                 formData.append(
                   key,

--- a/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
@@ -42,7 +42,7 @@ export const useCreatePetsHook = () => {
           ) {
             formData.append(key, value);
           } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
-            formData.append(key, new Blob([value as unknown as BlobPart]));
+            formData.append(key, new Blob([Uint8Array.from(value)]));
           } else if (Array.isArray(value)) {
             value.forEach((v) => {
               if (
@@ -51,7 +51,7 @@ export const useCreatePetsHook = () => {
               ) {
                 formData.append(key, v);
               } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
-                formData.append(key, new Blob([v as unknown as BlobPart]));
+                formData.append(key, new Blob([Uint8Array.from(v)]));
               } else {
                 formData.append(
                   key,

--- a/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
@@ -14,12 +14,14 @@ import type {
 
 import { useCallback } from 'react';
 
-import type { Error, Pet, PetBase, PetExtended } from './model';
+import type { Error, Pet } from './model';
 
 import { faker } from '@faker-js/faker';
 
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
+
+import type { PetBase, PetExtended } from './model';
 
 import { useCustomInstance } from '../../../mutators/use-custom-instance';
 /**
@@ -31,24 +33,36 @@ export const useCreatePetsHook = () => {
   return useCallback(
     (pet: Pet, signal?: AbortSignal) => {
       const formData = new FormData();
-      const petPetBase = pet as PetBase;
-      if (petPetBase.name !== undefined) {
-        formData.append(`name`, petPetBase.name);
-      }
-      if (petPetBase.tag !== undefined) {
-        formData.append(`tag`, petPetBase.tag);
-      }
-
-      const petPetExtended = pet as PetExtended;
-      if (petPetExtended.id !== undefined) {
-        formData.append(`id`, petPetExtended.id.toString());
-      }
-      if (petPetExtended.name !== undefined) {
-        formData.append(`name`, petPetExtended.name);
-      }
-      if (petPetExtended.tag !== undefined) {
-        formData.append(`tag`, petPetExtended.tag);
-      }
+      Object.entries(pet ?? {}).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          if (
+            (typeof File !== 'undefined' && value instanceof File) ||
+            value instanceof Blob ||
+            (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+          ) {
+            formData.append(key, value);
+          } else if (Array.isArray(value)) {
+            value.forEach((v) => {
+              if (
+                (typeof File !== 'undefined' && v instanceof File) ||
+                v instanceof Blob ||
+                (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+              ) {
+                formData.append(key, v);
+              } else {
+                formData.append(
+                  key,
+                  typeof v === 'object' ? JSON.stringify(v) : String(v),
+                );
+              }
+            });
+          } else if (typeof value === 'object') {
+            formData.append(key, JSON.stringify(value));
+          } else {
+            formData.append(key, String(value));
+          }
+        }
+      });
       if (pet['@id'] !== undefined) {
         formData.append(`@id`, pet['@id']);
       }

--- a/tests/__snapshots__/react-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data/endpoints.ts
@@ -36,7 +36,7 @@ export const createPets = (pet: Pet, signal?: AbortSignal) => {
       ) {
         formData.append(key, value);
       } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
-        formData.append(key, new Blob([value as unknown as BlobPart]));
+        formData.append(key, new Blob([Uint8Array.from(value)]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
@@ -45,7 +45,7 @@ export const createPets = (pet: Pet, signal?: AbortSignal) => {
           ) {
             formData.append(key, v);
           } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
-            formData.append(key, new Blob([v as unknown as BlobPart]));
+            formData.append(key, new Blob([Uint8Array.from(v)]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/react-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data/endpoints.ts
@@ -12,12 +12,14 @@ import type {
   UseMutationResult,
 } from '@tanstack/react-query';
 
-import type { Error, Pet, PetBase, PetExtended } from './model';
+import type { Error, Pet } from './model';
 
 import { faker } from '@faker-js/faker';
 
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
+
+import type { PetBase, PetExtended } from './model';
 
 import { customInstance } from '../../../mutators/custom-instance';
 /**
@@ -25,24 +27,36 @@ import { customInstance } from '../../../mutators/custom-instance';
  */
 export const createPets = (pet: Pet, signal?: AbortSignal) => {
   const formData = new FormData();
-  const petPetBase = pet as PetBase;
-  if (petPetBase.name !== undefined) {
-    formData.append(`name`, petPetBase.name);
-  }
-  if (petPetBase.tag !== undefined) {
-    formData.append(`tag`, petPetBase.tag);
-  }
-
-  const petPetExtended = pet as PetExtended;
-  if (petPetExtended.id !== undefined) {
-    formData.append(`id`, petPetExtended.id.toString());
-  }
-  if (petPetExtended.name !== undefined) {
-    formData.append(`name`, petPetExtended.name);
-  }
-  if (petPetExtended.tag !== undefined) {
-    formData.append(`tag`, petPetExtended.tag);
-  }
+  Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (
+        (typeof File !== 'undefined' && value instanceof File) ||
+        value instanceof Blob ||
+        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+      ) {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (
+            (typeof File !== 'undefined' && v instanceof File) ||
+            v instanceof Blob ||
+            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+          ) {
+            formData.append(key, v);
+          } else {
+            formData.append(
+              key,
+              typeof v === 'object' ? JSON.stringify(v) : String(v),
+            );
+          }
+        });
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    }
+  });
   if (pet['@id'] !== undefined) {
     formData.append(`@id`, pet['@id']);
   }

--- a/tests/__snapshots__/react-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data/endpoints.ts
@@ -28,21 +28,24 @@ import { customInstance } from '../../../mutators/custom-instance';
 export const createPets = (pet: Pet, signal?: AbortSignal) => {
   const formData = new FormData();
   Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (['@id', 'email', 'callingCode', 'country'].includes(key)) return;
     if (value !== undefined && value !== null) {
       if (
         (typeof File !== 'undefined' && value instanceof File) ||
-        value instanceof Blob ||
-        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+        value instanceof Blob
       ) {
         formData.append(key, value);
+      } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+        formData.append(key, new Blob([value as unknown as BlobPart]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
             (typeof File !== 'undefined' && v instanceof File) ||
-            v instanceof Blob ||
-            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+            v instanceof Blob
           ) {
             formData.append(key, v);
+          } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+            formData.append(key, new Blob([v as unknown as BlobPart]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/react-query/importFromSubdirectory/endpoints.msw.ts
+++ b/tests/__snapshots__/react-query/importFromSubdirectory/endpoints.msw.ts
@@ -9,7 +9,12 @@ import { faker } from '@faker-js/faker';
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
 
-import type { AnotherSchema, Pet } from './model';
+import type {
+  AnotherSchema,
+  AnotherSchema as __AnotherSchema,
+  Pet,
+  Pet as __Pet,
+} from './model';
 
 export const getPostPetsResponsePetMock = (
   overrideResponse: Partial<Pet> = {},
@@ -21,22 +26,22 @@ export const getPostPetsResponsePetMock = (
   ...overrideResponse,
 });
 
-export const getPostPetsResponseMock = (): Pet =>
+export const getPostPetsResponseMock = (): __Pet =>
   faker.helpers.arrayElement([{ ...getPostPetsResponsePetMock() }]);
 
 export const getGetPetsResponseAnotherSchemaMock = (
   overrideResponse: Partial<AnotherSchema> = {},
 ): AnotherSchema => ({ ...{ id: faker.number.int() }, ...overrideResponse });
 
-export const getGetPetsResponseMock = (): AnotherSchema =>
+export const getGetPetsResponseMock = (): __AnotherSchema =>
   faker.helpers.arrayElement([{ ...getGetPetsResponseAnotherSchemaMock() }]);
 
 export const getPostPetsMockHandler = (
   overrideResponse?:
-    | Pet
+    | __Pet
     | ((
         info: Parameters<Parameters<typeof http.post>[1]>[0],
-      ) => Promise<Pet> | Pet),
+      ) => Promise<__Pet> | __Pet),
   options?: RequestHandlerOptions,
 ) => {
   return http.post(
@@ -57,10 +62,10 @@ export const getPostPetsMockHandler = (
 
 export const getGetPetsMockHandler = (
   overrideResponse?:
-    | AnotherSchema
+    | __AnotherSchema
     | ((
         info: Parameters<Parameters<typeof http.get>[1]>[0],
-      ) => Promise<AnotherSchema> | AnotherSchema),
+      ) => Promise<__AnotherSchema> | __AnotherSchema),
   options?: RequestHandlerOptions,
 ) => {
   return http.get(

--- a/tests/__snapshots__/react-query/importFromSubdirectory/endpoints.ts
+++ b/tests/__snapshots__/react-query/importFromSubdirectory/endpoints.ts
@@ -20,10 +20,10 @@ import type {
   UseQueryResult,
 } from '@tanstack/react-query';
 
-import type { AnotherSchema, Pet } from './model';
+import type { AnotherSchema as __AnotherSchema, Pet as __Pet } from './model';
 
 export type postPetsResponse200 = {
-  data: Pet;
+  data: __Pet;
   status: 200;
 };
 
@@ -113,7 +113,7 @@ export const usePostPets = <TError = unknown, TContext = unknown>(
 };
 
 export type getPetsResponse200 = {
-  data: AnotherSchema;
+  data: __AnotherSchema;
   status: 200;
 };
 

--- a/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
@@ -103,7 +103,7 @@ export const createPets = async (
       ) {
         formData.append(key, value);
       } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
-        formData.append(key, new Blob([value as unknown as BlobPart]));
+        formData.append(key, new Blob([Uint8Array.from(value)]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
@@ -112,7 +112,7 @@ export const createPets = async (
           ) {
             formData.append(key, v);
           } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
-            formData.append(key, new Blob([v as unknown as BlobPart]));
+            formData.append(key, new Blob([Uint8Array.from(v)]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
@@ -9,12 +9,14 @@ import type { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import type { SWRMutationConfiguration } from 'swr/mutation';
 
-import type { Error, Pet, PetBase, PetExtended } from './model';
+import type { Error, Pet } from './model';
 
 import { faker } from '@faker-js/faker';
 
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
+
+import type { PetBase, PetExtended } from './model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
@@ -92,24 +94,36 @@ export const createPets = async (
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
-  const petPetBase = pet as PetBase | undefined;
-  if (petPetBase?.name !== undefined) {
-    formData.append(`name`, petPetBase.name);
-  }
-  if (petPetBase?.tag !== undefined) {
-    formData.append(`tag`, petPetBase.tag);
-  }
-
-  const petPetExtended = pet as PetExtended | undefined;
-  if (petPetExtended?.id !== undefined) {
-    formData.append(`id`, petPetExtended.id.toString());
-  }
-  if (petPetExtended?.name !== undefined) {
-    formData.append(`name`, petPetExtended.name);
-  }
-  if (petPetExtended?.tag !== undefined) {
-    formData.append(`tag`, petPetExtended.tag);
-  }
+  Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (
+        (typeof File !== 'undefined' && value instanceof File) ||
+        value instanceof Blob ||
+        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+      ) {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (
+            (typeof File !== 'undefined' && v instanceof File) ||
+            v instanceof Blob ||
+            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+          ) {
+            formData.append(key, v);
+          } else {
+            formData.append(
+              key,
+              typeof v === 'object' ? JSON.stringify(v) : String(v),
+            );
+          }
+        });
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    }
+  });
   if (pet?.['@id'] !== undefined) {
     formData.append(`@id`, pet['@id']);
   }

--- a/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
@@ -95,21 +95,24 @@ export const createPets = async (
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
   Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (['@id', 'email', 'callingCode', 'country'].includes(key)) return;
     if (value !== undefined && value !== null) {
       if (
         (typeof File !== 'undefined' && value instanceof File) ||
-        value instanceof Blob ||
-        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+        value instanceof Blob
       ) {
         formData.append(key, value);
+      } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+        formData.append(key, new Blob([value as unknown as BlobPart]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
             (typeof File !== 'undefined' && v instanceof File) ||
-            v instanceof Blob ||
-            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+            v instanceof Blob
           ) {
             formData.append(key, v);
+          } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+            formData.append(key, new Blob([v as unknown as BlobPart]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/vue-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/form-data/endpoints.ts
@@ -12,7 +12,7 @@ import type {
   UseMutationReturnType,
 } from '@tanstack/vue-query';
 
-import type { Error, Pet, PetBase, PetExtended } from './model';
+import type { Error, Pet } from './model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
@@ -89,24 +89,36 @@ export const createPets = async (
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
-  const petPetBase = pet as PetBase;
-  if (petPetBase.name !== undefined) {
-    formData.append(`name`, petPetBase.name);
-  }
-  if (petPetBase.tag !== undefined) {
-    formData.append(`tag`, petPetBase.tag);
-  }
-
-  const petPetExtended = pet as PetExtended;
-  if (petPetExtended.id !== undefined) {
-    formData.append(`id`, petPetExtended.id.toString());
-  }
-  if (petPetExtended.name !== undefined) {
-    formData.append(`name`, petPetExtended.name);
-  }
-  if (petPetExtended.tag !== undefined) {
-    formData.append(`tag`, petPetExtended.tag);
-  }
+  Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (
+        (typeof File !== 'undefined' && value instanceof File) ||
+        value instanceof Blob ||
+        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+      ) {
+        formData.append(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (
+            (typeof File !== 'undefined' && v instanceof File) ||
+            v instanceof Blob ||
+            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+          ) {
+            formData.append(key, v);
+          } else {
+            formData.append(
+              key,
+              typeof v === 'object' ? JSON.stringify(v) : String(v),
+            );
+          }
+        });
+      } else if (typeof value === 'object') {
+        formData.append(key, JSON.stringify(value));
+      } else {
+        formData.append(key, String(value));
+      }
+    }
+  });
   if (pet['@id'] !== undefined) {
     formData.append(`@id`, pet['@id']);
   }

--- a/tests/__snapshots__/vue-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/form-data/endpoints.ts
@@ -98,7 +98,7 @@ export const createPets = async (
       ) {
         formData.append(key, value);
       } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
-        formData.append(key, new Blob([value as unknown as BlobPart]));
+        formData.append(key, new Blob([Uint8Array.from(value)]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
@@ -107,7 +107,7 @@ export const createPets = async (
           ) {
             formData.append(key, v);
           } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
-            formData.append(key, new Blob([v as unknown as BlobPart]));
+            formData.append(key, new Blob([Uint8Array.from(v)]));
           } else {
             formData.append(
               key,

--- a/tests/__snapshots__/vue-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/form-data/endpoints.ts
@@ -90,21 +90,24 @@ export const createPets = async (
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
   Object.entries(pet ?? {}).forEach(([key, value]) => {
+    if (['@id', 'email', 'callingCode', 'country'].includes(key)) return;
     if (value !== undefined && value !== null) {
       if (
         (typeof File !== 'undefined' && value instanceof File) ||
-        value instanceof Blob ||
-        (typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+        value instanceof Blob
       ) {
         formData.append(key, value);
+      } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+        formData.append(key, new Blob([value as unknown as BlobPart]));
       } else if (Array.isArray(value)) {
         value.forEach((v) => {
           if (
             (typeof File !== 'undefined' && v instanceof File) ||
-            v instanceof Blob ||
-            (typeof Buffer !== 'undefined' && Buffer.isBuffer(v))
+            v instanceof Blob
           ) {
             formData.append(key, v);
+          } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(v)) {
+            formData.append(key, new Blob([v as unknown as BlobPart]));
           } else {
             formData.append(
               key,


### PR DESCRIPTION
Fixes #3242

Two independent bugs in `getResReqTypes` and `getSchemaFormDataAndUrlEncoded` when a `multipart/form-data` request body uses `oneOf` or `anyOf`. Full repro, compiler errors, and expected output in the issue.

### Solution

- Bug 1: extend the ref-resolution branch in `getResReqTypes` with an `else if` that walks `oneOf`/`anyOf`, resolves the `$ref`(s) inside, and concatenates the resolved names.
- Bug 2: for `oneOf`/`anyOf` (`shouldCast === true`), replace the N per-variant `formData.append` branches with a single `Object.entries()` loop. `allOf` is unchanged.

### Known limitations (Bug 2)

The runtime approach drops some static-codegen features from the per-variant branches: `readOnly` filtering, `encoding` map, array handling modes, `getFormDataFieldFileType` binary/text detection, nullable handling. Only complex specs are affected.

### Testing

3 new tests in `res-req-types.test.ts` covering: oneOf with 1 `$ref` (Bug 1), oneOf with 2 `$refs` sharing a field (Bug 2), allOf regression. `bun run test` 1640 passing, lint + typecheck green. Tests were also run against the pre-fix source to confirm they fail as expected.

Same fix is also deployed as a `pnpm patch-package` on 8 TypeScript projects (NestJS + `zod-to-openapi`, 1-2 schema versions) in production - all compile and run correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests validating FormData generation for root-level compositions (oneOf/allOf/anyOf), optional request bodies, and arrays of binary files; updated snapshots to reflect the new serialization behavior.

* **Bug Fixes**
  * Use referenced DTO names when generating FormData entries.
  * Emit robust runtime iteration for mixed-composition request bodies (avoiding per-variant casts) while preserving per-field behavior for allOf.
  * Add guards for optional bodies and correct handling of binary arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->