### PR TITLE
fix(zod): default dateTimeOptions to { offset: true } for RFC3339 date-time (#3124)

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -945,7 +945,9 @@ Add preprocess functions to schemas.
 
 **Type:** `Object`
 
-Configure Zod datetime/time validation options.
+**Default (dateTimeOptions):** `{ offset: true }`
+
+Configure Zod datetime/time validation options. `dateTimeOptions` defaults to `{ offset: true }` so generated schemas accept RFC3339 timestamps with timezone offsets (e.g. `2026-03-27T12:00:00+01:00`) — matching the OpenAPI `format: date-time` contract. Pass an explicit object to override (e.g. `{ offset: false }` or `{ offset: true, precision: 3 }`).
 
 ### useBrandedTypes
 

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -303,6 +303,70 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('defaults zod dateTimeOptions to { offset: true } so RFC3339 offset values are accepted', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './generated.ts',
+            client: 'zod',
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.zod.dateTimeOptions).toEqual({
+        offset: true,
+      });
+      expect(normalized.output.override.zod.timeOptions).toEqual({});
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves user-provided zod dateTimeOptions without merging defaults', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './generated.ts',
+            client: 'zod',
+            override: {
+              zod: {
+                dateTimeOptions: { precision: 3 },
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.zod.dateTimeOptions).toEqual({
+        precision: 3,
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('resolves hono compositeRoute relative to the workspace', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -392,7 +392,9 @@ export async function normalizeOptions(
             outputOptions.override?.zod?.generateEachHttpStatus ?? false,
           useBrandedTypes:
             outputOptions.override?.zod?.useBrandedTypes ?? false,
-          dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {},
+          dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {
+            offset: true,
+          },
           timeOptions: outputOptions.override?.zod?.timeOptions ?? {},
         },
         swr: {
@@ -717,7 +719,7 @@ function normalizeOperationsAndTags(
                     },
                     generateEachHttpStatus: zod.generateEachHttpStatus ?? false,
                     useBrandedTypes: zod.useBrandedTypes ?? false,
-                    dateTimeOptions: zod.dateTimeOptions ?? {},
+                    dateTimeOptions: zod.dateTimeOptions ?? { offset: true },
                     timeOptions: zod.timeOptions ?? {},
                   },
                 }

--- a/samples/mcp/custom-server/src/tool-schemas.zod.ts
+++ b/samples/mcp/custom-server/src/tool-schemas.zod.ts
@@ -160,7 +160,7 @@ export const GetOrderByIdResponse = zod.object({
   id: zod.number().optional(),
   petId: zod.number().optional(),
   quantity: zod.number().optional(),
-  shipDate: zod.string().datetime({}).optional(),
+  shipDate: zod.string().datetime({ offset: true }).optional(),
   status: zod
     .enum(['placed', 'approved', 'delivered'])
     .optional()

--- a/samples/mcp/petstore/src/tool-schemas.zod.ts
+++ b/samples/mcp/petstore/src/tool-schemas.zod.ts
@@ -160,7 +160,7 @@ export const GetOrderByIdResponse = zod.object({
   id: zod.number().optional(),
   petId: zod.number().optional(),
   quantity: zod.number().optional(),
-  shipDate: zod.string().datetime({}).optional(),
+  shipDate: zod.string().datetime({ offset: true }).optional(),
   status: zod
     .enum(['placed', 'approved', 'delivered'])
     .optional()

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
@@ -55,7 +55,7 @@ export const ListPetsByAgeQueryParams = zod.object({
     .describe('How many items to return at one time (max 100)'),
   latestBirthdate: zod
     .string()
-    .datetime({})
+    .datetime({ offset: true })
     .optional()
     .describe('Filter by latest birthdate.\nExample: 2020-01-01T00:00:00Z\n'),
 });

--- a/tests/__snapshots__/zod/time-options/time-options.ts
+++ b/tests/__snapshots__/zod/time-options/time-options.ts
@@ -16,7 +16,7 @@ export const ShowPetByIdParams = zod.object({
 export const ShowPetByIdResponse = zod.object({
   id: zod.number().optional(),
   birthDate: zod.string().date(),
-  createdAt: zod.string().datetime({}),
+  createdAt: zod.string().datetime({ offset: true }),
   age: zod.number().optional(),
   legCount: zod.number().optional(),
   weight: zod.number().optional(),


### PR DESCRIPTION
## Summary

Closes #3124.

OpenAPI `format: date-time` maps to RFC3339, which explicitly allows timezone offsets (e.g. `2026-03-27T12:00:00+01:00`). The current Zod client defaults `override.zod.dateTimeOptions` to `{}`, so it emits `z.iso.datetime({})` / `z.string().datetime({})`, which rejects every offset-based timestamp. This forces users to either write a post-generation replace script or override the option in every project — even though offset-aware timestamps are spec-valid and extremely common (.NET DateTimeOffset, Spring OffsetDateTime, etc.).

This PR changes the default of `override.zod.dateTimeOptions` from `{}` to `{ offset: true }` so generated schemas accept the full RFC3339 grammar out of the box. Users who want the previous UTC-only behavior can opt in explicitly:

```ts
override: {
  zod: {
    dateTimeOptions: { offset: false },
  },
},
```

Works for both Zod v3 (`.datetime({ offset: true })`) and Zod v4 (`.iso.datetime({ offset: true })`) — both versions support the `offset` flag.

## Changes

- `packages/orval/src/utils/options.ts`: set `dateTimeOptions` default to `{ offset: true }` in both the top-level and per-operation normalizers. `timeOptions` default is unchanged.
- `docs/content/docs/reference/configuration/output.mdx`: document the new default and the opt-out.
- `packages/orval/src/utils/options.test.ts`: add two tests — default emits `{ offset: true }`, and a user-provided object is preserved verbatim without merging the default.
- `tests/__snapshots__/zod/time-options/time-options.ts` and `tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts`: regenerated — these snapshots exercised the default path.
- `samples/mcp/custom-server/src/tool-schemas.zod.ts`, `samples/mcp/petstore/src/tool-schemas.zod.ts`: regenerated by `bun run build`.

## Breaking change note

`{ offset: true }` is a superset of `{}` — every timestamp the old default accepted is still accepted. The only observable difference is that offset-bearing RFC3339 values (e.g. `...+01:00`) now pass instead of failing. Users who intentionally want to reject offset-based values and did not already set `dateTimeOptions` explicitly can opt out with:

```ts
override: {
  zod: {
    dateTimeOptions: { offset: false },
  },
},
```

## Test plan

- [x] `bun vitest run` — all related suites green (3 pre-existing `resolve-version` failures on master, unrelated).
- [x] `bun run test:snapshots` — 3586 passed.
- [x] `bun run typecheck` — green.
- [x] `bun run lint` — green.
- [x] Verified `zod.string().datetime({ offset: true })` (v3) and `zod.iso.datetime({ offset: true })` (v4) accept both `2026-03-27T12:00:00Z` and `2026-03-27T12:00:00+01:00`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified Zod datetime validation documentation: `dateTimeOptions` now defaults to `{ offset: true }`, accepting RFC3339 date-time strings with timezone offsets. Users can override this with explicit configuration.

* **Tests**
  * Added test coverage for Zod datetime option normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->