### PR TITLE
fix(core): baseUrl runtime imports missing in single mode without schemas

### DIFF
--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -250,9 +250,9 @@ describe('getBaseUrlRuntimeImports', () => {
 
   it('preserves explicit values: false on baseUrl imports', () => {
     const imports = [{ name: 'x', importPath: './x', values: false as const }];
-    expect(
-      getBaseUrlRuntimeImports({ runtime: 'x', imports }),
-    ).toEqual(imports);
+    expect(getBaseUrlRuntimeImports({ runtime: 'x', imports })).toEqual(
+      imports,
+    );
   });
 });
 

--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -235,7 +235,7 @@ describe('getBaseUrlRuntimeImports', () => {
         runtime: 'apiBase',
         imports,
       }),
-    ).toEqual(imports);
+    ).toEqual([{ ...imports[0], values: true }]);
   });
 
   it('returns imports for env object pattern (runtime uses property access)', () => {
@@ -245,6 +245,13 @@ describe('getBaseUrlRuntimeImports', () => {
         runtime: 'env.API_BASE_URL',
         imports,
       }),
+    ).toEqual([{ ...imports[0], values: true }]);
+  });
+
+  it('preserves explicit values: false on baseUrl imports', () => {
+    const imports = [{ name: 'x', importPath: './x', values: false as const }];
+    expect(
+      getBaseUrlRuntimeImports({ runtime: 'x', imports }),
     ).toEqual(imports);
   });
 });

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -129,6 +129,10 @@ export function getFullRoute(
 
 /**
  * Returns `GeneratorImport` entries for {@link BaseUrlRuntime.imports} when `baseUrl` is a runtime config.
+ *
+ * Defaults `values` to true so symbols in `runtime` emit as value imports in the
+ * generated client. Set `values: false` explicitly only for unusual cases (e.g.
+ * type-only symbols referenced from the expression).
  */
 export function getBaseUrlRuntimeImports(
   baseUrl?: NormalizedOutputOptions['baseUrl'],
@@ -137,7 +141,6 @@ export function getBaseUrlRuntimeImports(
   if (!isBaseUrlRuntime(baseUrl)) return [];
   return (baseUrl.imports ?? []).map((imp) => ({
     ...imp,
-    // Used inside generated URL template literals at runtime (not as types).
     values: imp.values ?? true,
   }));
 }

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -135,7 +135,11 @@ export function getBaseUrlRuntimeImports(
 ): GeneratorImport[] {
   if (!baseUrl) return [];
   if (!isBaseUrlRuntime(baseUrl)) return [];
-  return baseUrl.imports ?? [];
+  return (baseUrl.imports ?? []).map((imp) => ({
+    ...imp,
+    // Used inside generated URL template literals at runtime (not as types).
+    values: imp.values ?? true,
+  }));
 }
 
 // Creates a mixed use array with path variables and string from template string route

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -94,19 +94,18 @@ export async function writeSingleMode({
       }
     }
 
-    // When `schemas` is unset there is no schemasPath, but we must still emit
-    // imports that carry their own `importPath` (e.g. baseUrl.runtime imports).
-    // Use `.` only so `generateImportsForBuilder` receives a string; imports
-    // without `importPath` would be resolved relative to that path and can be
-    // wrong in no-`schemas` setups—typical single-file fetch + `baseUrl.imports`
-    // only uses entries with `importPath`. With `indexFiles`, schema buckets may
-    // list `dependency: '.'` and empty `exports`; `addDependency` then returns
-    // nothing and those entries are dropped from emitted import text.
-    const importsForBuilder = generateImportsForBuilder(
-      output,
-      normalizedImports,
-      schemasPath ?? '.',
-    );
+    // When `schemas` is unset there is no schemasPath. We must still emit imports
+    // that carry `importPath` (e.g. baseUrl.runtime imports), but we must not
+    // pass `'.'` for schema-relative imports: that becomes `from '.'` and breaks
+    // TS (see samples with a real `schemas` path). So only `importPath` entries
+    // use the `.` placeholder when `schemasPath` is missing.
+    const importsForBuilder = schemasPath
+      ? generateImportsForBuilder(output, normalizedImports, schemasPath)
+      : generateImportsForBuilder(
+          output,
+          normalizedImports.filter((imp) => !!imp.importPath),
+          '.',
+        );
 
     data += builder.imports({
       client: output.client,
@@ -125,18 +124,21 @@ export async function writeSingleMode({
     });
 
     if (output.mock) {
-      const importsMockForBuilder = generateImportsForBuilder(
-        output,
-        importsMock.filter(
-          (impMock) =>
-            !normalizedImports.some(
-              (imp) =>
-                imp.name === impMock.name &&
-                (imp.alias ?? '') === (impMock.alias ?? ''),
-            ),
-        ),
-        schemasPath ?? '.',
+      const filteredMockImports = importsMock.filter(
+        (impMock) =>
+          !normalizedImports.some(
+            (imp) =>
+              imp.name === impMock.name &&
+              (imp.alias ?? '') === (impMock.alias ?? ''),
+          ),
       );
+      const importsMockForBuilder = schemasPath
+        ? generateImportsForBuilder(output, filteredMockImports, schemasPath)
+        : generateImportsForBuilder(
+            output,
+            filteredMockImports.filter((imp) => !!imp.importPath),
+            '.',
+          );
       data += builder.importsMock({
         implementation: implementationMock,
         imports: importsMockForBuilder,

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -94,9 +94,13 @@ export async function writeSingleMode({
       }
     }
 
-    const importsForBuilder = schemasPath
-      ? generateImportsForBuilder(output, normalizedImports, schemasPath)
-      : [];
+    // When `schemas` is unset there is no schemasPath, but we must still emit
+    // imports that carry their own `importPath` (e.g. baseUrl.runtime imports).
+    const importsForBuilder = generateImportsForBuilder(
+      output,
+      normalizedImports,
+      schemasPath ?? '.',
+    );
 
     data += builder.imports({
       client: output.client,
@@ -115,20 +119,18 @@ export async function writeSingleMode({
     });
 
     if (output.mock) {
-      const importsMockForBuilder = schemasPath
-        ? generateImportsForBuilder(
-            output,
-            importsMock.filter(
-              (impMock) =>
-                !normalizedImports.some(
-                  (imp) =>
-                    imp.name === impMock.name &&
-                    (imp.alias ?? '') === (impMock.alias ?? ''),
-                ),
+      const importsMockForBuilder = generateImportsForBuilder(
+        output,
+        importsMock.filter(
+          (impMock) =>
+            !normalizedImports.some(
+              (imp) =>
+                imp.name === impMock.name &&
+                (imp.alias ?? '') === (impMock.alias ?? ''),
             ),
-            schemasPath,
-          )
-        : [];
+        ),
+        schemasPath ?? '.',
+      );
       data += builder.importsMock({
         implementation: implementationMock,
         imports: importsMockForBuilder,

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -96,6 +96,12 @@ export async function writeSingleMode({
 
     // When `schemas` is unset there is no schemasPath, but we must still emit
     // imports that carry their own `importPath` (e.g. baseUrl.runtime imports).
+    // Use `.` only so `generateImportsForBuilder` receives a string; imports
+    // without `importPath` would be resolved relative to that path and can be
+    // wrong in no-`schemas` setups—typical single-file fetch + `baseUrl.imports`
+    // only uses entries with `importPath`. With `indexFiles`, schema buckets may
+    // list `dependency: '.'` and empty `exports`; `addDependency` then returns
+    // nothing and those entries are dropped from emitted import text.
     const importsForBuilder = generateImportsForBuilder(
       output,
       normalizedImports,


### PR DESCRIPTION
Fixes runtime `baseUrl.imports` not appearing in generated clients when `output.schemas` is unset (single-file mode previously passed an empty import list to the builder).

Also default those import specs to `values: true` so symbols used inside generated URL template literals emit as value imports (not `import type`).

Closes the report in https://github.com/orval-labs/orval/issues/3071#issuecomment-4274524995


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve explicit import value flags and default unspecified import values to true.
  * Always generate builder imports so runtime/importPath-based entries appear even when schema configuration is missing.

* **Tests**
  * Added and updated unit tests to validate import value behavior and unconditional generation of builder imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->