### PR TITLE
fix: add zip to the binary application types list

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -78,6 +78,7 @@ describe('isBinaryContentType', () => {
   it('should return true for binary content types', () => {
     expect(isBinaryContentType('application/octet-stream')).toBe(true);
     expect(isBinaryContentType('application/pdf')).toBe(true);
+    expect(isBinaryContentType('application/zip')).toBe(true);
     expect(isBinaryContentType('image/png')).toBe(true);
     expect(isBinaryContentType('image/jpeg')).toBe(true);
     expect(isBinaryContentType('audio/mp3')).toBe(true);

--- a/packages/core/src/getters/response.test.ts
+++ b/packages/core/src/getters/response.test.ts
@@ -130,12 +130,16 @@ describe('getResponse', () => {
   });
 
   describe('isBlob detection', () => {
-    it('should set isBlob to true for application/octet-stream response', () => {
+    it.each([
+      ['application/octet-stream'],
+      ['application/pdf'],
+      ['application/zip'],
+    ])('should set isBlob to true for %s response', (binaryApplicationType) => {
       const responses: OpenApiResponsesObject = {
         '200': {
           description: 'Binary file',
           content: {
-            'application/octet-stream': {
+            [binaryApplicationType]: {
               schema: { type: 'string', format: 'binary' },
             },
           },

--- a/packages/core/src/utils/content-type.ts
+++ b/packages/core/src/utils/content-type.ts
@@ -4,6 +4,7 @@ import type { OpenApiSchemaObject } from '../types';
 const binaryApplicationTypes = new Set([
   'application/octet-stream',
   'application/pdf',
+  'application/zip',
 ]);
 
 /**


### PR DESCRIPTION
Prior to the [v8.7.0 release](https://github.com/orval-labs/orval/releases/tag/v8.7.0), responses that had a `{"type": "string", "format": "binary"}` response would have a `responseType: 'blob'` in the generated client.

```
"responses": {
  "200": {
    "description": "Successful Response",
    "content": {
      "application/zip": {
        "schema": {
          "type": "string",
          "format": "binary"
        }
      }
    }
  },
}
```

From 8.7.0 onwards, there is a strict list of application types that will trigger the blob response type. This PR adds `application/zip` to the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary file type detection to properly classify ZIP files as binary content.

* **Tests**
  * Extended test coverage for binary content type detection across multiple MIME types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->