### PR TITLE
fix(zod): order of stringFormat call

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -548,7 +548,24 @@ export const generateZodValidationSchemaDefinition = (
             if ('const' in schema) {
               functions.push(['literal', `"${schema.const}"`]);
             } else if (schema.pattern && schema.format) {
-              break;
+              const isStartWithSlash = schema.pattern.startsWith('/');
+              const isEndWithSlash = schema.pattern.endsWith('/');
+              const regexp = `new RegExp('${jsStringEscape(
+                schema.pattern.slice(
+                  isStartWithSlash ? 1 : 0,
+                  isEndWithSlash ? -1 : undefined,
+                ),
+              )}')`;
+              consts.push(
+                `export const ${name}RegExp${constsCounterValue} = ${regexp};\n`,
+              );
+              functions.push([
+                'stringFormat',
+                [
+                  `'${escape(schema.format)}'`,
+                  `${name}RegExp${constsCounterValue}`,
+                ],
+              ]);
             } else {
               functions.push([type as string, undefined]);
             }
@@ -753,7 +770,19 @@ export const generateZodValidationSchemaDefinition = (
     }
   }
 
-  if (matches && !hasNonArrayEnum) {
+  const stringFormatAlreadyEmitted =
+    isZodV4 &&
+    type === 'string' &&
+    !!matches &&
+    !!schema.format &&
+    !predefinedZodFormats.has(schema.format ?? '');
+
+  if (
+    matches &&
+    !hasNonArrayEnum &&
+    type === 'string' &&
+    !stringFormatAlreadyEmitted
+  ) {
     const isStartWithSlash = matches.startsWith('/');
     const isEndWithSlash = matches.endsWith('/');
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -3049,7 +3049,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
     const schemaFormatPattern: OpenApiSchemaObject = {
       type: 'string',
       format: 'my-id',
-      pattern: '^[A-Z]{3}-\\d+$',
+      pattern: String.raw`^[A-Z]{3}-\d+$`,
     };
 
     const result = generateZodValidationSchemaDefinition(
@@ -3089,7 +3089,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
   it('emits string().regex() for pattern-only in v3', () => {
     const schemaPatternOnly: OpenApiSchemaObject = {
       type: 'string',
-      pattern: '^\\d{4}$',
+      pattern: String.raw`^\d{4}$`,
     };
 
     const result = generateZodValidationSchemaDefinition(

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -935,6 +935,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       format: 'slug',
       pattern: '^[a-z0-9-]+$',
       minLength: 1,
+      maxLength: 64,
     };
 
     const result = generateZodValidationSchemaDefinition(
@@ -969,8 +970,10 @@ describe('generateZodValidationSchemaDefinition`', () => {
     // stringFormat must come before min so the chain is valid
     const sfIndex = parsed.zod.indexOf('.stringFormat(');
     const minIndex = parsed.zod.indexOf('.min(');
+    const maxIndex = parsed.zod.indexOf('.max(');
     expect(sfIndex).toBeGreaterThanOrEqual(0);
     expect(minIndex).toBeGreaterThan(sfIndex);
+    expect(maxIndex).toBeGreaterThan(minIndex);
     expect(parsed.zod).not.toContain('.regex(');
   });
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4316,12 +4316,12 @@ describe('generateZodWithMultiTypeArray', () => {
       true,
     );
 
-    // number branch must not have .stringFormat() or .regex() chained
-    expect(parsed.zod).not.toContain('number().stringFormat');
-    expect(parsed.zod).not.toContain('number().regex');
-    // string branch should still use stringFormat for the custom format
-    expect(parsed.zod).toContain('.stringFormat(');
     expect(parsed.zod).toContain('zod.union([');
+    expect(parsed.zod).toContain('zod.number()');
+    expect(parsed.zod).not.toMatch(
+      /zod\.number\(\)[^,\]]*\.(?:stringFormat|regex)\(/,
+    );
+    expect(parsed.zod.match(/\.stringFormat\(/g) ?? []).toHaveLength(1);
   });
 
   it('emits regex (not stringFormat) for predefined format with pattern in v4', () => {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2857,6 +2857,474 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
     });
   });
+
+  it('does not emit stringFormat when custom format has no pattern in v4', () => {
+    const schemaFormatOnly: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'slug',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaFormatOnly,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      true,
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      true,
+    );
+
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).not.toContain('.regex(');
+  });
+
+  it('does not emit stringFormat twice when format+pattern+minLength in v4', () => {
+    const schemaFormatPatternMin: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'slug',
+      pattern: '^[a-z0-9-]+$',
+      minLength: 1,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaFormatPatternMin,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      true,
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      true,
+    );
+
+    const count = (parsed.zod.match(/\.stringFormat\(/g) ?? []).length;
+    expect(count).toBe(1);
+    expect(parsed.zod).not.toContain('.regex(');
+  });
+
+  it('does not emit a duplicate RegExp const when format+pattern+minLength in v4', () => {
+    const schemaFormatPatternMin: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'slug',
+      pattern: '^[a-z0-9-]+$',
+      minLength: 1,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaFormatPatternMin,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      true,
+      { required: true },
+    );
+
+    const regexpConsts = result.consts.filter((c) => c.includes('RegExp'));
+    expect(regexpConsts).toHaveLength(1);
+  });
+
+  it('does not emit stringFormat for custom format+pattern in v3', () => {
+    const schemaFormatPattern: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'slug',
+      pattern: '^[a-z0-9-]+$',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaFormatPattern,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).toContain('.regex(');
+  });
+
+  it('does not emit stringFormat for pattern-only in v3', () => {
+    const schemaPatternOnly: OpenApiSchemaObject = {
+      type: 'string',
+      pattern: '^[a-z]+$',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaPatternOnly,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'word',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).toContain('.regex(');
+  });
+
+  it('emits string().regex() for custom format+pattern in v3', () => {
+    const schemaFormatPattern: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'my-id',
+      pattern: '^[A-Z]{3}-\\d+$',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaFormatPattern,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'myId',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('zod.string()');
+    expect(parsed.zod).toContain('.regex(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+  });
+
+  it('emits string().regex() for pattern-only in v3', () => {
+    const schemaPatternOnly: OpenApiSchemaObject = {
+      type: 'string',
+      pattern: '^\\d{4}$',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaPatternOnly,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'code',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('zod.string()');
+    expect(parsed.zod).toContain('.regex(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+  });
+
+  it('emits string().email() for email format in v3', () => {
+    const schemaEmail: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'email',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaEmail,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'email',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('.email(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+  });
+
+  it('emits string().uuid() for uuid format in v3', () => {
+    const schemaUuid: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'uuid',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaUuid,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'id',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('.uuid(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+  });
+
+  it('emits string().url() for uri format in v3', () => {
+    const schemaUri: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'uri',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaUri,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'url',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('.url(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+  });
+
+  it('emits string().min().max() for minLength+maxLength without pattern in v3', () => {
+    const schemaMinMax: OpenApiSchemaObject = {
+      type: 'string',
+      minLength: 2,
+      maxLength: 50,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaMinMax,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'name',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('.min(');
+    expect(parsed.zod).toContain('.max(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).not.toContain('.regex(');
+  });
+
+  it('emits string().regex().min() for pattern+minLength in v3', () => {
+    const schemaPatternMin: OpenApiSchemaObject = {
+      type: 'string',
+      pattern: '^[a-z]+$',
+      minLength: 1,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaPatternMin,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      false, // Zod v3
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).toContain('.regex(');
+    expect(parsed.zod).toContain('.min(');
+    expect(parsed.zod).not.toContain('.stringFormat(');
+  });
 });
 
 const basicApiSchema = {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -971,6 +971,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
     const minIndex = parsed.zod.indexOf('.min(');
     expect(sfIndex).toBeGreaterThanOrEqual(0);
     expect(minIndex).toBeGreaterThan(sfIndex);
+    expect(parsed.zod).not.toContain('.regex(');
   });
 
   it('does not use stringFormat for format+pattern+minLength in v3', () => {
@@ -3847,8 +3848,9 @@ describe('generateZodWithMultiTypeArray', () => {
       true,
     );
 
-    // number branch must not have .stringFormat() chained
+    // number branch must not have .stringFormat() or .regex() chained
     expect(parsed.zod).not.toContain('number().stringFormat');
+    expect(parsed.zod).not.toContain('number().regex');
     // string branch should still use stringFormat for the custom format
     expect(parsed.zod).toContain('.stringFormat(');
     expect(parsed.zod).toContain('zod.union([');

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -929,6 +929,73 @@ describe('generateZodValidationSchemaDefinition`', () => {
     expect(parsed.zod).not.toContain('.stringFormat([');
   });
 
+  it('places stringFormat before min/max when format and pattern and minLength are defined in v4', () => {
+    const schemaWithPatternFormatAndMin: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'slug',
+      pattern: '^[a-z0-9-]+$',
+      minLength: 1,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaWithPatternFormatAndMin,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      true,
+      { required: false },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      true,
+    );
+
+    // stringFormat must come before min so the chain is valid
+    const sfIndex = parsed.zod.indexOf('.stringFormat(');
+    const minIndex = parsed.zod.indexOf('.min(');
+    expect(sfIndex).toBeGreaterThanOrEqual(0);
+    expect(minIndex).toBeGreaterThan(sfIndex);
+  });
+
+  it('does not use stringFormat for format+pattern+minLength in v3', () => {
+    const result = generateZodValidationSchemaDefinition(
+      { type: 'string', format: 'slug', pattern: '^[a-z0-9-]+$', minLength: 1 },
+      { output: { override: { useDates: false } } } as ContextSpec,
+      'slug',
+      false,
+      false, // isZodV4 = false
+      { required: false },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      { output: { override: { useDates: false } } } as ContextSpec,
+      false,
+      false,
+      false,
+    );
+
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).toContain('.regex(');
+    expect(parsed.zod).toContain('.min(');
+  });
+
   it('generates string when format and pattern is defined in v3', () => {
     const stringWithPatternAndFormat: OpenApiSchemaObject = {
       type: 'string',
@@ -3745,6 +3812,104 @@ describe('generateZodWithMultiTypeArray', () => {
     expect(parsed.zod).toBe(
       'zod.union([zod.string(),zod.number()]).optional()',
     );
+  });
+
+  it('does not chain stringFormat/regex on number in multi-type with pattern and format (Zod v4)', () => {
+    const context = {
+      output: {
+        override: {
+          useDates: false,
+          zod: {},
+        },
+      },
+    } as unknown as ContextSpec;
+
+    const schemaWithMultiTypeAndPattern: OpenApiSchemaObject = {
+      type: ['integer', 'string'],
+      format: 'int64',
+      pattern: String.raw`^-?(?:0|[1-9]\d*)$`,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schemaWithMultiTypeAndPattern,
+      context,
+      'taskId',
+      false,
+      true,
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      context,
+      false,
+      false,
+      true,
+    );
+
+    // number branch must not have .stringFormat() chained
+    expect(parsed.zod).not.toContain('number().stringFormat');
+    // string branch should still use stringFormat for the custom format
+    expect(parsed.zod).toContain('.stringFormat(');
+    expect(parsed.zod).toContain('zod.union([');
+  });
+
+  it('emits regex (not stringFormat) for predefined format with pattern in v4', () => {
+    const context = {
+      output: {
+        override: {
+          useDates: false,
+          zod: { dateTimeOptions: {}, timeOptions: {} },
+        },
+      },
+    } as unknown as ContextSpec;
+
+    const result = generateZodValidationSchemaDefinition(
+      { type: 'string', format: 'uuid', pattern: '^[0-9a-f-]+$' },
+      context,
+      'myId',
+      false,
+      true,
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      context,
+      false,
+      false,
+      true,
+    );
+
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).toContain('.uuid(');
+    expect(parsed.zod).toContain('.regex(');
+  });
+
+  it('emits regex (not stringFormat) for pattern without format in v4', () => {
+    const context = {
+      output: { override: { useDates: false, zod: {} } },
+    } as unknown as ContextSpec;
+
+    const result = generateZodValidationSchemaDefinition(
+      { type: 'string', pattern: '^[a-z]+$' },
+      context,
+      'word',
+      false,
+      true,
+      { required: true },
+    );
+
+    const parsed = parseZodValidationSchemaDefinition(
+      result,
+      context,
+      false,
+      false,
+      true,
+    );
+
+    expect(parsed.zod).not.toContain('.stringFormat(');
+    expect(parsed.zod).toContain('.regex(');
   });
 });
 


### PR DESCRIPTION
closes https://github.com/orval-labs/orval/issues/3097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate or conflicting pattern+format constraints and ensure format-based validators are applied before length checks.

* **New Features**
  * Emit named regular-expression constants for applicable string schemas and reference them from format-based string validators.

* **Tests**
  * Expanded v3/v4 test coverage for string format+pattern ordering, deduplication, predefined formats, unions, multi-type branches, and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->