### PR TITLE
fix(mock): skip MSW resolvedBody prelude when no *ResponseMock is generated

### DIFF
--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -384,6 +384,31 @@ describe('generateMSW', () => {
       expect(result.implementation.handler).not.toContain('HttpResponse.text(');
     });
 
+    // Regression test for https://github.com/orval-labs/orval/issues/3270.
+    // When the response definition resolves to `unknown` (as with a 302
+    // redirect returning text/html that is not treated as a success body),
+    // no `*ResponseMock` helper is generated. The handler must not emit a
+    // `resolvedBody`/`textBody` prelude that references the missing helper.
+    it('should not reference a missing *ResponseMock for unknown text responses', () => {
+      const unknownHtmlVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          ...mockVerbOptions.response,
+          definition: { success: 'unknown' },
+          types: { success: [{ key: '302', value: 'unknown' }] },
+          contentTypes: ['text/html'],
+        },
+      } as GeneratorVerbOptions;
+
+      const result = generateMSW(unknownHtmlVerbOptions, baseOptions);
+
+      expect(result.implementation.function).toBe('');
+      expect(result.implementation.handler).not.toContain('ResponseMock()');
+      expect(result.implementation.handler).not.toContain('resolvedBody');
+      expect(result.implementation.handler).not.toContain('textBody');
+      expect(result.implementation.handler).toContain('new HttpResponse(null,');
+    });
+
     it('should use HttpResponse.xml for vendor +xml responses', () => {
       const vendorXmlVerbOptions = {
         ...mockVerbOptions,

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -250,15 +250,19 @@ function generateDefinition(
 
   let responseBody: string;
   // Use a prelude to evaluate the override expression once into a temp variable
-  // (the expression contains `await` so must not be duplicated)
+  // (the expression contains `await` so must not be duplicated). Only emit it
+  // when we actually generate a `*ResponseMock()` helper — otherwise the
+  // prelude would reference a function that doesn't exist (issue #3270).
   let responsePrelude = '';
-  if (isBinaryResponse) {
-    responsePrelude = `const binaryBody = ${resolvedResponseExpr};`;
-  } else if (isVoidUnionType || needsRuntimeContentTypeSwitch) {
-    responsePrelude = `const resolvedBody = ${resolvedResponseExpr};`;
-  } else if (isTextResponse && !shouldPreferJsonResponse) {
-    responsePrelude = `const resolvedBody = ${resolvedResponseExpr};
+  if (isReturnHttpResponse) {
+    if (isBinaryResponse) {
+      responsePrelude = `const binaryBody = ${resolvedResponseExpr};`;
+    } else if (isVoidUnionType || needsRuntimeContentTypeSwitch) {
+      responsePrelude = `const resolvedBody = ${resolvedResponseExpr};`;
+    } else if (isTextResponse && !shouldPreferJsonResponse) {
+      responsePrelude = `const resolvedBody = ${resolvedResponseExpr};
     const textBody = typeof resolvedBody === 'string' ? resolvedBody : JSON.stringify(resolvedBody ?? null);`;
+    }
   }
   if (!isReturnHttpResponse) {
     responseBody = `new HttpResponse(null,


### PR DESCRIPTION
<!-- Fixes https://github.com/orval-labs/orval/issues/3270 -->

## Summary

The MSW mock handler was emitting `const resolvedBody = ... : getXxxResponseMock()` for any endpoint with a text-like content type (and a few other branches), without checking whether the `*ResponseMock` helper was actually generated. When the success `definition` resolves to `unknown` — which happens with e.g. a 302 redirect returning `text/html` under the axios client — `getMockScalarJsTypes` falls through to its `default` arm and returns the literal string `"undefined"`, so `isReturnHttpResponse` is false and the helper is intentionally skipped. The prelude then referenced a function that did not exist, producing `Cannot find name 'getXxxResponseMock'` under `tsc`.

This regressed around 8.4: the prelude shape and the `isVoidUnionType` branch were introduced by #2960 and later #3205, neither of which guarded emission on `isReturnHttpResponse`. 8.2.0 did not emit the prelude at all in this case.

## The fix

Wrap the entire prelude block in `if (isReturnHttpResponse)` in `packages/mock/src/msw/index.ts`. The `!isReturnHttpResponse` arm of `responseBody` (further down the same function) already returns `new HttpResponse(null, { status })` and never consumes `resolvedBody` / `textBody` / `binaryBody`, so suppressing the prelude in that case is strictly correct and matches the pre-8.4 output for this family of responses.

A single outer `if` is preferred over per-branch guards because any future arm added to the prelude list automatically inherits the invariant.

## Regression test

`packages/mock/src/msw/index.test.ts` gains `should not reference a missing *ResponseMock for unknown text responses`. It drives `response.definition.success: 'unknown'` + `contentTypes: ['text/html']` (the exact shape from #3270) and asserts that the handler contains `new HttpResponse(null,` and does *not* reference `ResponseMock()`, `resolvedBody`, or `textBody`. It also asserts that `result.implementation.function` is empty, confirming the helper isn't generated. Without the fix it fails; with the fix it passes.

## Verification

Run locally from the repo root:

- `bun run --filter @orval/mock test` — 114 tests pass (previously 113, the new regression test is the +1).
- `bun run test` — all 12 package test suites pass.
- `bun run typecheck` — clean.
- `bun run lint` — clean.
- `bun run test:cli` — all 15 client integration generators pass, `verify-mock-generated.mjs` passes.
- `bun run --filter orval-tests test:snapshots` — all 3714 snapshot tests pass with no drift (`git status` clean after).

End-to-end sanity check with the minimal spec from the issue:

```yaml
openapi: 3.0.3
info: { title: Demo, version: 0.0.0 }
paths:
  "/api/v1/users/{user_hash}/confirm_new_email":
    get:
      operationId: confirmNewEmail
      parameters:
        - { name: user_hash, in: path, required: true, schema: { type: string } }
      responses:
        '302':
          description: does not sign out the user
          content: { text/html: { schema: { type: string } } }
```

Before: generated handler includes a call to the undefined `getConfirmNewEmailResponseMock()` and fails `tsc --noEmit`.
After: handler reduces to `new HttpResponse(null, { status: 200 })`, matching the 8.2.0 output; `tsc --noEmit` succeeds.

## Scope / risk

- Strictly subtractive: removes emission in a case that was already broken (unused declarations referencing a non-existent function). No handler that compiled before should compile differently after.
- No snapshot diff across the full test suite, so existing fixtures aren't affected — this is a previously-unexercised state-space.
- No change to `mocks.ts`. Whether empty-schema responses should themselves mock *something* is a separate question and intentionally out of scope for this regression fix.

## Issue

#3270 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mock code generation to prevent emitting unnecessary function references in generated handlers, ensuring proper code output.

* **Tests**
  * Added regression test to validate correct handler generation in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->