### PR TITLE
fix(core): revert multipart JSON object parts to plain string append

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -405,7 +405,7 @@ formData.append(\`cmtText\`, bodyRequestBody.cmtText instanceof Blob ? bodyReque
 formData.append(\`encOverride\`, bodyRequestBody.encOverride instanceof Blob ? bodyRequestBody.encOverride : new Blob([bodyRequestBody.encOverride], { type: 'text/csv' }));
 formData.append(\`formatBinary\`, bodyRequestBody.formatBinary);
 formData.append(\`base64Field\`, bodyRequestBody.base64Field);
-formData.append(\`metadata\`, new Blob([JSON.stringify(bodyRequestBody.metadata)], { type: 'application/json' }));
+formData.append(\`metadata\`, JSON.stringify(bodyRequestBody.metadata));
 formData.append(\`wildcardFile\`, bodyRequestBody.wildcardFile instanceof Blob ? bodyRequestBody.wildcardFile : new Blob([bodyRequestBody.wildcardFile], { type: '*/*' }));
 bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
 `);

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -763,9 +763,7 @@ function resolveSchemaPropertiesToFormData({
               depth: depth + 1,
               encoding,
             })
-          : partContentType
-            ? `${variableName}.append(\`${keyPrefix}${key}\`, new Blob([JSON.stringify(${nonOptionalValueKey})], { type: '${partContentType}' }));\n`
-            : `${variableName}.append(\`${keyPrefix}${key}\`, JSON.stringify(${nonOptionalValueKey}));\n`;
+          : `${variableName}.append(\`${keyPrefix}${key}\`, JSON.stringify(${nonOptionalValueKey}));\n`;
     } else if (property.type === 'array') {
       let valueStr = 'value';
       let hasNonPrimitiveChild = false;


### PR DESCRIPTION
## Summary
Reverts a behavior change from #2643 where object-typed multipart fields with `encoding.contentType: application/json` started being wrapped as `new Blob([JSON.stringify(value)], { type: 'application/json' })` instead of the prior `JSON.stringify(value)` plain string append.

Fixes #3273.

## Why revert
The Blob form is technically OAS-correct — it sets the part's `Content-Type: application/json` header — but it has an unavoidable side effect mandated by the [WHATWG HTML Standard's "create an entry" algorithm](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#create-an-entry):

> If `value` is not a `File` object, then set `value` to a new `File` object, representing the same bytes, whose `name` attribute value is **`"blob"`**.

When `FormData.append(name, blob)` is called without a third filename argument, the spec requires the Blob to be promoted to a `File` named `"blob"`. That `File.name` then appears as the `filename` parameter in the multipart `Content-Disposition` header — `Content-Disposition: form-data; name="params"; filename="blob"`. This is not a browser quirk; it is the spec, and there is no way for Orval to suppress it without injecting an explicit filename string that would be just as misleading.

Several common backend frameworks then split multipart parsing by whether a part has a `filename`:

- **multer (Express)** — parts with `filename` go to `req.files`, parts without go to `req.body`. A JSON Blob lands in `req.files` and never reaches the route's expected `req.body.params`. ([multer docs](https://github.com/expressjs/multer))
- **ASP.NET Core `[FromForm]` / `IFormFile`** — `[FromForm]` binds form parts, `IFormFile` binds file parts; the model binder routes by `filename` presence. A community NuGet package ([Swashbuckle.AspNetCore.JsonMultipartFormDataSupport](https://github.com/Morasiu/Swashbuckle.AspNetCore.JsonMultipartFormDataSupport)) exists specifically to bridge this gap. See write-ups by [Andrew Lock](https://andrewlock.net/reading-json-and-binary-data-from-multipart-form-data-sections-in-aspnetcore/) and [Thomas Levesque](https://thomaslevesque.com/2018/09/04/handling-multipart-requests-with-json-and-file-uploads-in-asp-net-core/).
- **FastAPI / Starlette** — python-multipart classifies parts with `filename` as files, so a `params: SomeModel = Form(...)` parameter won't bind a Blob-shaped part. Discussed in [fastapi/fastapi#8971](https://github.com/fastapi/fastapi/discussions/8971).

The pre-#2643 plain-string append produces a part with `Content-Type: text/plain` and **no** filename, which works with all of the above (the application code typically `JSON.parse`s the string field). The Blob form silently breaks them.

## Scope
Surgical revert of the `else if (property.type === 'object')` branch in `resolveSchemaPropertiesToFormData` (`packages/core/src/getters/res-req-types.ts`). Binary, text, and XML handling from #2643 are untouched.

```diff
-          : partContentType
-            ? `${variableName}.append(\`${keyPrefix}${key}\`, new Blob([JSON.stringify(${nonOptionalValueKey})], { type: '${partContentType}' }));\n`
-            : `${variableName}.append(\`${keyPrefix}${key}\`, JSON.stringify(${nonOptionalValueKey}));\n`;
+          : `${variableName}.append(\`${keyPrefix}${key}\`, JSON.stringify(${nonOptionalValueKey}));\n`;
```

## Trade-off
Users whose backend strictly requires `Content-Type: application/json` on the part itself (rather than tolerating `text/plain` JSON, which most do) will lose that header after this revert. If such a user shows up, the right follow-up is an opt-in `override.formData.jsonEncodingStrategy: 'string' | 'blob'` (default `'string'`) — not a re-revert, since that would re-break the larger framework population above.

## Test plan
- [x] `bun run test` — all 12 package suites pass (1649 core, 75 query, 79 orval, etc.)
- [x] `bun run test:snapshots` — 3823 sample-snapshot tests pass; no sample pinned the Blob form
- [x] Updated `metadata` assertion in `res-req-types.test.ts` to expect plain `JSON.stringify`