### PR TITLE
fix(hono): emit routes as method chain for type inference

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -120,11 +120,11 @@ export const getHonoHeader: ClientHeaderBuilder = ({
     handlers = `import {\n${importHandlerNames}\n} from './${tag ?? targetInfo.filename}.handlers';`;
   }
 
-  return `${handlers}\n\n
-const app = new Hono()\n\n`;
+  return `${handlers}\n\nconst app = new Hono()\n`;
 };
 
-export const getHonoFooter: ClientFooterBuilder = () => 'export default app';
+export const getHonoFooter: ClientFooterBuilder = () =>
+  ';\n\nexport default app;\n';
 
 const generateHonoRoute = (
   { operationName, verb }: GeneratorVerbOptions,
@@ -132,8 +132,7 @@ const generateHonoRoute = (
 ) => {
   const path = getRoute(pathRoute);
 
-  return `
-app.${verb.toLowerCase()}('${path}',...${operationName}Handlers)`;
+  return `\n  .${verb.toLowerCase()}('${path}', ...${operationName}Handlers)`;
 };
 
 export const generateHono: ClientBuilder = (verbOptions, options) => {
@@ -147,7 +146,7 @@ export const generateHono: ClientBuilder = (verbOptions, options) => {
   const routeImplementation = generateHonoRoute(verbOptions, options.pathRoute);
 
   return {
-    implementation: routeImplementation ? `${routeImplementation}\n\n` : '',
+    implementation: routeImplementation,
     imports: [
       ...verbOptions.params.flatMap((param) => param.imports),
       ...verbOptions.body.imports,
@@ -767,7 +766,7 @@ const generateCompositeRoutes = (
     .map((verbOption) => {
       return generateHonoRoute(verbOption, verbOption.pathRoute);
     })
-    .join(';');
+    .join('');
 
   const importHandlers = Object.values(verbOptions);
 
@@ -815,12 +814,11 @@ const generateCompositeRoutes = (
 
   const honoImport = `import { Hono } from 'hono';`;
   const honoInitialization = `\nconst app = new Hono()`;
-  const honoAppExport = `\nexport default app`;
+  const honoAppExport = `\nexport default app;`;
 
   const content = `${header}${honoImport}
 ${ImportHandlersImplementation}
-${honoInitialization}
-${routes}
+${honoInitialization}${routes};
 ${honoAppExport}
 `;
 

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -146,7 +146,7 @@ export const generateHono: ClientBuilder = (verbOptions, options) => {
   const routeImplementation = generateHonoRoute(verbOptions, options.pathRoute);
 
   return {
-    implementation: routeImplementation,
+    implementation: `${routeImplementation}\n`,
     imports: [
       ...verbOptions.params.flatMap((param) => param.imports),
       ...verbOptions.body.imports,

--- a/samples/hono/composite-routes-with-tags-split/__snapshots__/routes.ts
+++ b/samples/hono/composite-routes-with-tags-split/__snapshots__/routes.ts
@@ -12,11 +12,10 @@ import {
   showPetByIdHandlers,
 } from './endpoints/pets/pets.handlers';
 
-const app = new Hono();
-
-app.get('/pets', ...listPetsHandlers);
-app.post('/pets', ...createPetsHandlers);
-app.put('/pets', ...updatePetsHandlers);
-app.get('/pets/:petId', ...showPetByIdHandlers);
+const app = new Hono()
+  .get('/pets', ...listPetsHandlers)
+  .post('/pets', ...createPetsHandlers)
+  .put('/pets', ...updatePetsHandlers)
+  .get('/pets/:petId', ...showPetByIdHandlers);
 
 export default app;

--- a/samples/hono/composite-routes-with-tags-split/src/routes.ts
+++ b/samples/hono/composite-routes-with-tags-split/src/routes.ts
@@ -12,11 +12,10 @@ import {
   showPetByIdHandlers,
 } from './endpoints/pets/pets.handlers';
 
-const app = new Hono();
-
-app.get('/pets', ...listPetsHandlers);
-app.post('/pets', ...createPetsHandlers);
-app.put('/pets', ...updatePetsHandlers);
-app.get('/pets/:petId', ...showPetByIdHandlers);
+const app = new Hono()
+  .get('/pets', ...listPetsHandlers)
+  .post('/pets', ...createPetsHandlers)
+  .put('/pets', ...updatePetsHandlers)
+  .get('/pets/:petId', ...showPetByIdHandlers);
 
 export default app;

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.ts
@@ -11,30 +11,25 @@ import { createPetsHandlers } from './handlers/createPets';
 import { updatePetsHandlers } from './handlers/updatePets';
 import { showPetByIdHandlers } from './handlers/showPetById';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Update a pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .put('/pets', ...updatePetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
-
-/**
- * @summary Update a pet
- */
-
-app.put('/pets', ...updatePetsHandlers);
-
-/**
- * @summary Info for a specific pet
- */
-
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
+  .get('/pets/:petId', ...showPetByIdHandlers);
 export default app;

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.ts
@@ -17,19 +17,23 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Update a pet
    */
 
   .put('/pets', ...updatePetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers);
+
 export default app;

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.ts
@@ -11,30 +11,25 @@ import { createPetsHandlers } from './handlers/createPets';
 import { updatePetsHandlers } from './handlers/updatePets';
 import { showPetByIdHandlers } from './handlers/showPetById';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Update a pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .put('/pets', ...updatePetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
-
-/**
- * @summary Update a pet
- */
-
-app.put('/pets', ...updatePetsHandlers);
-
-/**
- * @summary Info for a specific pet
- */
-
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
+  .get('/pets/:petId', ...showPetByIdHandlers);
 export default app;

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.ts
@@ -17,19 +17,23 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Update a pet
    */
 
   .put('/pets', ...updatePetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers);
+
 export default app;

--- a/samples/hono/hono-with-zod/__snapshots__/petstore.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/petstore.ts
@@ -11,30 +11,25 @@ import { createPetsHandlers } from './handlers/createPets';
 import { updatePetsHandlers } from './handlers/updatePets';
 import { showPetByIdHandlers } from './handlers/showPetById';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Update a pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .put('/pets', ...updatePetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
-
-/**
- * @summary Update a pet
- */
-
-app.put('/pets', ...updatePetsHandlers);
-
-/**
- * @summary Info for a specific pet
- */
-
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
+  .get('/pets/:petId', ...showPetByIdHandlers);
 export default app;

--- a/samples/hono/hono-with-zod/__snapshots__/petstore.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/petstore.ts
@@ -17,19 +17,23 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Update a pet
    */
 
   .put('/pets', ...updatePetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers);
+
 export default app;

--- a/samples/hono/hono-with-zod/src/petstore.ts
+++ b/samples/hono/hono-with-zod/src/petstore.ts
@@ -11,30 +11,25 @@ import { createPetsHandlers } from './handlers/createPets';
 import { updatePetsHandlers } from './handlers/updatePets';
 import { showPetByIdHandlers } from './handlers/showPetById';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Update a pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .put('/pets', ...updatePetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
-
-/**
- * @summary Update a pet
- */
-
-app.put('/pets', ...updatePetsHandlers);
-
-/**
- * @summary Info for a specific pet
- */
-
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
+  .get('/pets/:petId', ...showPetByIdHandlers);
 export default app;

--- a/samples/hono/hono-with-zod/src/petstore.ts
+++ b/samples/hono/hono-with-zod/src/petstore.ts
@@ -17,19 +17,23 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Update a pet
    */
 
   .put('/pets', ...updatePetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers);
+
 export default app;

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.ts
@@ -11,18 +11,15 @@ import {
   listPetsByAgeHandlers,
 } from './endpoints.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets by country
+   */
 
-/**
- * @summary List all pets by country
- */
+  .get('/pets-by-country/:country', ...listPetsByCountryHandlers)
+  /**
+   * @summary List all pets by age
+   */
 
-app.get('/pets-by-country/:country', ...listPetsByCountryHandlers);
-
-/**
- * @summary List all pets by age
- */
-
-app.get('/pets-by-age/:age', ...listPetsByAgeHandlers);
-
+  .get('/pets-by-age/:age', ...listPetsByAgeHandlers);
 export default app;

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.ts
@@ -17,9 +17,11 @@ const app = new Hono()
    */
 
   .get('/pets-by-country/:country', ...listPetsByCountryHandlers)
+
   /**
    * @summary List all pets by age
    */
 
   .get('/pets-by-age/:age', ...listPetsByAgeHandlers);
+
 export default app;

--- a/tests/__snapshots__/hono/petstore-single/endpoints.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.ts
@@ -169,29 +169,35 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers)
+
   /**
    * @summary Deletes a specific pet
    */
 
   .delete('/pets/:petId', ...deletePetByIdHandlers)
+
   /**
    * @summary health check
    */
 
   .get('/health', ...healthCheckHandlers)
+
   /**
    * @summary combinate nullable and $ref
    */
 
   .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
+
 export default app;

--- a/tests/__snapshots__/hono/petstore-single/endpoints.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.ts
@@ -163,42 +163,35 @@ import {
   showPetWithOwnerHandlers,
 } from './endpoints.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .get('/pets/:petId', ...showPetByIdHandlers)
+  /**
+   * @summary Deletes a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
+  .delete('/pets/:petId', ...deletePetByIdHandlers)
+  /**
+   * @summary health check
+   */
 
-/**
- * @summary Info for a specific pet
- */
+  .get('/health', ...healthCheckHandlers)
+  /**
+   * @summary combinate nullable and $ref
+   */
 
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
-/**
- * @summary Deletes a specific pet
- */
-
-app.delete('/pets/:petId', ...deletePetByIdHandlers);
-
-/**
- * @summary health check
- */
-
-app.get('/health', ...healthCheckHandlers);
-
-/**
- * @summary combinate nullable and $ref
- */
-
-app.get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
-
+  .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
 export default app;

--- a/tests/__snapshots__/hono/petstore-split/endpoints.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.ts
@@ -15,42 +15,35 @@ import {
   showPetWithOwnerHandlers,
 } from './endpoints.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .get('/pets/:petId', ...showPetByIdHandlers)
+  /**
+   * @summary Deletes a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
+  .delete('/pets/:petId', ...deletePetByIdHandlers)
+  /**
+   * @summary health check
+   */
 
-/**
- * @summary Info for a specific pet
- */
+  .get('/health', ...healthCheckHandlers)
+  /**
+   * @summary combinate nullable and $ref
+   */
 
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
-/**
- * @summary Deletes a specific pet
- */
-
-app.delete('/pets/:petId', ...deletePetByIdHandlers);
-
-/**
- * @summary health check
- */
-
-app.get('/health', ...healthCheckHandlers);
-
-/**
- * @summary combinate nullable and $ref
- */
-
-app.get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
-
+  .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
 export default app;

--- a/tests/__snapshots__/hono/petstore-split/endpoints.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.ts
@@ -21,29 +21,35 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers)
+
   /**
    * @summary Deletes a specific pet
    */
 
   .delete('/pets/:petId', ...deletePetByIdHandlers)
+
   /**
    * @summary health check
    */
 
   .get('/health', ...healthCheckHandlers)
+
   /**
    * @summary combinate nullable and $ref
    */
 
   .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
+
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/health/health.ts
@@ -14,5 +14,4 @@ const app = new Hono()
    */
 
   .get('/health', ...healthCheckHandlers);
-
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/health/health.ts
@@ -8,12 +8,11 @@ import { Hono } from 'hono';
 
 import { healthCheckHandlers } from './health.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary health check
+   */
 
-/**
- * @summary health check
- */
-
-app.get('/health', ...healthCheckHandlers);
+  .get('/health', ...healthCheckHandlers);
 
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.ts
@@ -19,22 +19,25 @@ const app = new Hono()
    * @summary List all pets
    */
 
-  .get('/pets', ...listPetsHandlers) /**
+  .get('/pets', ...listPetsHandlers)
+  /**
    * @summary Create a pet
    */
 
-  .post('/pets', ...createPetsHandlers) /**
+  .post('/pets', ...createPetsHandlers)
+  /**
    * @summary Info for a specific pet
    */
 
-  .get('/pets/:petId', ...showPetByIdHandlers) /**
+  .get('/pets/:petId', ...showPetByIdHandlers)
+  /**
    * @summary Deletes a specific pet
    */
 
-  .delete('/pets/:petId', ...deletePetByIdHandlers) /**
+  .delete('/pets/:petId', ...deletePetByIdHandlers)
+  /**
    * @summary combinate nullable and $ref
    */
 
   .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
-
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.ts
@@ -14,36 +14,27 @@ import {
   showPetWithOwnerHandlers,
 } from './pets.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers) /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers) /**
+   * @summary Info for a specific pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .get('/pets/:petId', ...showPetByIdHandlers) /**
+   * @summary Deletes a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
+  .delete('/pets/:petId', ...deletePetByIdHandlers) /**
+   * @summary combinate nullable and $ref
+   */
 
-/**
- * @summary Info for a specific pet
- */
-
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
-/**
- * @summary Deletes a specific pet
- */
-
-app.delete('/pets/:petId', ...deletePetByIdHandlers);
-
-/**
- * @summary combinate nullable and $ref
- */
-
-app.get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
+  .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
 
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags/health.ts
+++ b/tests/__snapshots__/hono/petstore-tags/health.ts
@@ -14,5 +14,4 @@ const app = new Hono()
    */
 
   .get('/health', ...healthCheckHandlers);
-
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags/health.ts
+++ b/tests/__snapshots__/hono/petstore-tags/health.ts
@@ -8,12 +8,11 @@ import { Hono } from 'hono';
 
 import { healthCheckHandlers } from './health.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary health check
+   */
 
-/**
- * @summary health check
- */
-
-app.get('/health', ...healthCheckHandlers);
+  .get('/health', ...healthCheckHandlers);
 
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags/pets.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.ts
@@ -19,22 +19,25 @@ const app = new Hono()
    * @summary List all pets
    */
 
-  .get('/pets', ...listPetsHandlers) /**
+  .get('/pets', ...listPetsHandlers)
+  /**
    * @summary Create a pet
    */
 
-  .post('/pets', ...createPetsHandlers) /**
+  .post('/pets', ...createPetsHandlers)
+  /**
    * @summary Info for a specific pet
    */
 
-  .get('/pets/:petId', ...showPetByIdHandlers) /**
+  .get('/pets/:petId', ...showPetByIdHandlers)
+  /**
    * @summary Deletes a specific pet
    */
 
-  .delete('/pets/:petId', ...deletePetByIdHandlers) /**
+  .delete('/pets/:petId', ...deletePetByIdHandlers)
+  /**
    * @summary combinate nullable and $ref
    */
 
   .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
-
 export default app;

--- a/tests/__snapshots__/hono/petstore-tags/pets.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.ts
@@ -14,36 +14,27 @@ import {
   showPetWithOwnerHandlers,
 } from './pets.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers) /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers) /**
+   * @summary Info for a specific pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .get('/pets/:petId', ...showPetByIdHandlers) /**
+   * @summary Deletes a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
+  .delete('/pets/:petId', ...deletePetByIdHandlers) /**
+   * @summary combinate nullable and $ref
+   */
 
-/**
- * @summary Info for a specific pet
- */
-
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
-/**
- * @summary Deletes a specific pet
- */
-
-app.delete('/pets/:petId', ...deletePetByIdHandlers);
-
-/**
- * @summary combinate nullable and $ref
- */
-
-app.get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
+  .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
 
 export default app;

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.ts
@@ -15,42 +15,35 @@ import {
   showPetWithOwnerHandlers,
 } from './endpoints.handlers';
 
-const app = new Hono();
+const app = new Hono()
+  /**
+   * @summary List all pets
+   */
 
-/**
- * @summary List all pets
- */
+  .get('/pets', ...listPetsHandlers)
+  /**
+   * @summary Create a pet
+   */
 
-app.get('/pets', ...listPetsHandlers);
+  .post('/pets', ...createPetsHandlers)
+  /**
+   * @summary Info for a specific pet
+   */
 
-/**
- * @summary Create a pet
- */
+  .get('/pets/:petId', ...showPetByIdHandlers)
+  /**
+   * @summary Deletes a specific pet
+   */
 
-app.post('/pets', ...createPetsHandlers);
+  .delete('/pets/:petId', ...deletePetByIdHandlers)
+  /**
+   * @summary health check
+   */
 
-/**
- * @summary Info for a specific pet
- */
+  .get('/health', ...healthCheckHandlers)
+  /**
+   * @summary combinate nullable and $ref
+   */
 
-app.get('/pets/:petId', ...showPetByIdHandlers);
-
-/**
- * @summary Deletes a specific pet
- */
-
-app.delete('/pets/:petId', ...deletePetByIdHandlers);
-
-/**
- * @summary health check
- */
-
-app.get('/health', ...healthCheckHandlers);
-
-/**
- * @summary combinate nullable and $ref
- */
-
-app.get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
-
+  .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
 export default app;

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.ts
@@ -21,29 +21,35 @@ const app = new Hono()
    */
 
   .get('/pets', ...listPetsHandlers)
+
   /**
    * @summary Create a pet
    */
 
   .post('/pets', ...createPetsHandlers)
+
   /**
    * @summary Info for a specific pet
    */
 
   .get('/pets/:petId', ...showPetByIdHandlers)
+
   /**
    * @summary Deletes a specific pet
    */
 
   .delete('/pets/:petId', ...deletePetByIdHandlers)
+
   /**
    * @summary health check
    */
 
   .get('/health', ...healthCheckHandlers)
+
   /**
    * @summary combinate nullable and $ref
    */
 
   .get('/pets/:petId/owner', ...showPetWithOwnerHandlers);
+
 export default app;


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- Fixes https://github.com/orval-labs/orval/issues/3274 -->

## Summary

`@orval/hono` emits routes as standalone `app.<verb>(...)` statements, so the chained return values are discarded and `typeof app` stays at `Hono<BlankEnv, BlankSchema, "/">`.

This breaks `hc<typeof app>()` and `testClient(app)`, which [require the methods to be chained on the `new Hono()` expression](https://hono.dev/docs/guides/rpc). Runtime behavior is identical between the two forms; only the declared type of `app` differs.

This PR switches the generator output in `packages/hono/src/index.ts` to a single chained expression.

## Before / After

`samples/hono/composite-routes-with-tags-split/__snapshots__/routes.ts`:

```diff
-const app = new Hono();
-
-app.get('/pets', ...listPetsHandlers);
-app.post('/pets', ...createPetsHandlers);
-app.put('/pets', ...updatePetsHandlers);
-app.get('/pets/:petId', ...showPetByIdHandlers);
+const app = new Hono()
+  .get('/pets', ...listPetsHandlers)
+  .post('/pets', ...createPetsHandlers)
+  .put('/pets', ...updatePetsHandlers)
+  .get('/pets/:petId', ...showPetByIdHandlers);

 export default app;
```

Closes #3274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Generated Hono route output now uses fluent method chaining for route registration, producing more concise chained expressions.
  * JSDoc summaries and statement formatting adjusted to align with the chained style (semicolons/spacing updated).
  * Snapshots and generated samples updated to reflect the new chaining format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->