### PR TITLE
fix(angular,query): skip Content-Type for multipart/form-data ONLY for Angular httpClient

### DIFF
--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -516,7 +516,7 @@ describe('generateMutatorConfig', () => {
       expect(result).toContain("'Content-Type': 'application/json'");
     });
 
-    it('should not set Content-Type header for multipart/form-data', () => {
+    it('should not set Content-Type header for multipart/form-data in Angular', () => {
       const result = generateMutatorConfig({
         route: '/api/test',
         body: { ...minimalBody, contentType: 'multipart/form-data' },
@@ -528,12 +528,30 @@ describe('generateMutatorConfig', () => {
         isFormUrlEncoded: false,
         hasSignal: false,
         isExactOptionalPropertyTypes: false,
+        isAngular: true,
       });
       expect(result).not.toContain('Content-Type');
       expect(result).not.toContain('multipart/form-data');
     });
 
-    it('should skip Content-Type but include headers for multipart/form-data with headers', () => {
+    it('should set Content-Type header for multipart/form-data when not Angular', () => {
+      const result = generateMutatorConfig({
+        route: '/api/test',
+        body: { ...minimalBody, contentType: 'multipart/form-data' },
+        headers: undefined,
+        queryParams: undefined,
+        response: minimalResponse,
+        verb: Verbs.POST,
+        isFormData: true,
+        isFormUrlEncoded: false,
+        hasSignal: false,
+        isExactOptionalPropertyTypes: false,
+        isAngular: false,
+      });
+      expect(result).toContain("'Content-Type': 'multipart/form-data'");
+    });
+
+    it('should skip Content-Type but include headers for multipart/form-data with headers in Angular', () => {
       const result = generateMutatorConfig({
         route: '/api/test',
         body: { ...minimalBody, contentType: 'multipart/form-data' },
@@ -545,6 +563,7 @@ describe('generateMutatorConfig', () => {
         isFormUrlEncoded: false,
         hasSignal: false,
         isExactOptionalPropertyTypes: false,
+        isAngular: true,
       });
       expect(result).not.toContain('Content-Type');
       expect(result).toContain('headers');

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -499,7 +499,7 @@ export function generateMutatorConfig({
     queryParams,
   );
 
-  const ignoreContentTypes = ['multipart/form-data'];
+  const ignoreContentTypes = isAngular ? ['multipart/form-data'] : [];
   const shouldSetContentType =
     body.contentType && !ignoreContentTypes.includes(body.contentType);
 

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -143,6 +143,7 @@ export const generateAngularHttpRequestFunction = (
       hasSignalParam,
       isExactOptionalPropertyTypes,
       isVue: false,
+      isAngular: context.output.httpClient === OutputHttpClient.ANGULAR,
     });
 
     const requestOptions = isRequestOptions

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -98,7 +98,43 @@ export const searchPets = (
   signal?: AbortSignal,
 ) => {
   return responseType<Pets>(
-    { url: `/search`, method: 'GET', params, signal },
+    {
+      url: `/search`,
+      method: 'GET',
+      params: (() => {
+        const requiredNullableParamKeys = new Set<string>([
+          'requirednullableString',
+          'requirednullableStringTwo',
+        ]);
+        const filteredParams: Record<
+          string,
+          string | number | boolean | Array<string | number | boolean>
+        > = {};
+        for (const [key, value] of Object.entries(params ?? {})) {
+          if (Array.isArray(value)) {
+            const filtered = value.filter(
+              (item) =>
+                item != null &&
+                (typeof item === 'string' ||
+                  typeof item === 'number' ||
+                  typeof item === 'boolean'),
+            ) as Array<string | number | boolean>;
+            if (filtered.length) {
+              filteredParams[key] = filtered;
+            }
+          } else if (
+            value != null &&
+            (typeof value === 'string' ||
+              typeof value === 'number' ||
+              typeof value === 'boolean')
+          ) {
+            filteredParams[key] = value;
+          }
+        }
+        return filteredParams;
+      })(),
+      signal,
+    },
     options,
   );
 };
@@ -193,7 +229,40 @@ export const listPets = (
   signal?: AbortSignal,
 ) => {
   return responseType<Pets>(
-    { url: `/pets`, method: 'GET', params, signal },
+    {
+      url: `/pets`,
+      method: 'GET',
+      params: (() => {
+        const requiredNullableParamKeys = new Set<string>([]);
+        const filteredParams: Record<
+          string,
+          string | number | boolean | Array<string | number | boolean>
+        > = {};
+        for (const [key, value] of Object.entries(params ?? {})) {
+          if (Array.isArray(value)) {
+            const filtered = value.filter(
+              (item) =>
+                item != null &&
+                (typeof item === 'string' ||
+                  typeof item === 'number' ||
+                  typeof item === 'boolean'),
+            ) as Array<string | number | boolean>;
+            if (filtered.length) {
+              filteredParams[key] = filtered;
+            }
+          } else if (
+            value != null &&
+            (typeof value === 'string' ||
+              typeof value === 'number' ||
+              typeof value === 'boolean')
+          ) {
+            filteredParams[key] = value;
+          }
+        }
+        return filteredParams;
+      })(),
+      signal,
+    },
     options,
   );
 };

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -98,7 +98,43 @@ export const searchPets = (
   signal?: AbortSignal,
 ) => {
   return responseType<Pets>(
-    { url: `/search`, method: 'GET', params, signal },
+    {
+      url: `/search`,
+      method: 'GET',
+      params: (() => {
+        const requiredNullableParamKeys = new Set<string>([
+          'requirednullableString',
+          'requirednullableStringTwo',
+        ]);
+        const filteredParams: Record<
+          string,
+          string | number | boolean | Array<string | number | boolean>
+        > = {};
+        for (const [key, value] of Object.entries(params ?? {})) {
+          if (Array.isArray(value)) {
+            const filtered = value.filter(
+              (item) =>
+                item != null &&
+                (typeof item === 'string' ||
+                  typeof item === 'number' ||
+                  typeof item === 'boolean'),
+            ) as Array<string | number | boolean>;
+            if (filtered.length) {
+              filteredParams[key] = filtered;
+            }
+          } else if (
+            value != null &&
+            (typeof value === 'string' ||
+              typeof value === 'number' ||
+              typeof value === 'boolean')
+          ) {
+            filteredParams[key] = value;
+          }
+        }
+        return filteredParams;
+      })(),
+      signal,
+    },
     options,
   );
 };
@@ -193,7 +229,40 @@ export const listPets = (
   signal?: AbortSignal,
 ) => {
   return responseType<Pets>(
-    { url: `/pets`, method: 'GET', params, signal },
+    {
+      url: `/pets`,
+      method: 'GET',
+      params: (() => {
+        const requiredNullableParamKeys = new Set<string>([]);
+        const filteredParams: Record<
+          string,
+          string | number | boolean | Array<string | number | boolean>
+        > = {};
+        for (const [key, value] of Object.entries(params ?? {})) {
+          if (Array.isArray(value)) {
+            const filtered = value.filter(
+              (item) =>
+                item != null &&
+                (typeof item === 'string' ||
+                  typeof item === 'number' ||
+                  typeof item === 'boolean'),
+            ) as Array<string | number | boolean>;
+            if (filtered.length) {
+              filteredParams[key] = filtered;
+            }
+          } else if (
+            value != null &&
+            (typeof value === 'string' ||
+              typeof value === 'number' ||
+              typeof value === 'boolean')
+          ) {
+            filteredParams[key] = value;
+          }
+        }
+        return filteredParams;
+      })(),
+      signal,
+    },
     options,
   );
 };

--- a/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
@@ -82,6 +82,7 @@ export const useCreatePetsHook = () => {
       return createPets({
         url: `/pets`,
         method: 'POST',
+        headers: { 'Content-Type': 'multipart/form-data' },
         data: formData,
         signal,
       });

--- a/tests/__snapshots__/react-query/form-data-with-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-mutator/endpoints.ts
@@ -31,6 +31,7 @@ export const createPets = (pet: Pet, signal?: AbortSignal) => {
   return customInstance<Pet>({
     url: `/pets`,
     method: 'POST',
+    headers: { 'Content-Type': 'multipart/form-data' },
     data: formData,
     signal,
   });

--- a/tests/__snapshots__/react-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data/endpoints.ts
@@ -76,6 +76,7 @@ export const createPets = (pet: Pet, signal?: AbortSignal) => {
   return customInstance<Pet>({
     url: `/pets`,
     method: 'POST',
+    headers: { 'Content-Type': 'multipart/form-data' },
     data: formData,
     signal,
   });


### PR DESCRIPTION
cc @ScriptType @superxiao 

Fix #3268
Fix #2845 

this reverts the change for https://github.com/orval-labs/orval/issues/2845 and limits it ONLY to the Angular client to make the fix more specific as this broke my Axios React Query use case in #3268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * multipart/form-data Content-Type handling corrected: non-Angular clients now include the header; Angular clients continue to omit it.
* **Improvements**
  * Outgoing query parameters are sanitized to remove null/unsupported values and empty arrays before requests.
  * Generated client calls for multipart form-data now explicitly set Content-Type where applicable.
* **Tests**
  * Tests split and expanded to validate multipart/form-data behavior separately for Angular and non-Angular cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->