### PR TITLE
feat(orval): warn when optionsParamRequired is set with fetch httpClient

### DIFF
--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -529,6 +529,7 @@ describe('normalizeOptions', () => {
             output: {
               target: './generated.ts',
               httpClient: 'fetch',
+              optionsParamRequired: false,
             },
           },
           workspace,

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -2,8 +2,19 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getWarningCount, resetWarnings } from '@orval/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { logWarningSpy } = vi.hoisted(() => ({
+  logWarningSpy: vi.fn(),
+}));
+
+vi.mock('@orval/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@orval/core')>();
+  return {
+    ...actual,
+    logWarning: logWarningSpy,
+  };
+});
 
 import { normalizeOptions } from './options';
 
@@ -402,12 +413,15 @@ describe('normalizeOptions', () => {
   });
 
   describe('optionsParamRequired with fetch httpClient', () => {
+    const fetchOptionsRequiredWarningPattern =
+      /httpClient: 'fetch'.*optionsParamRequired.*cannot make.*options.*required/s;
+
     beforeEach(() => {
-      resetWarnings();
+      logWarningSpy.mockClear();
     });
 
     afterEach(() => {
-      resetWarnings();
+      logWarningSpy.mockClear();
     });
 
     it('warns when optionsParamRequired is true and httpClient is fetch', async () => {
@@ -432,7 +446,9 @@ describe('normalizeOptions', () => {
           workspace,
         );
 
-        expect(getWarningCount()).toBe(1);
+        expect(logWarningSpy).toHaveBeenCalledWith(
+          expect.stringMatching(fetchOptionsRequiredWarningPattern),
+        );
       } finally {
         await rm(workspace, { recursive: true, force: true });
       }
@@ -459,7 +475,9 @@ describe('normalizeOptions', () => {
           workspace,
         );
 
-        expect(getWarningCount()).toBe(1);
+        expect(logWarningSpy).toHaveBeenCalledWith(
+          expect.stringMatching(fetchOptionsRequiredWarningPattern),
+        );
       } finally {
         await rm(workspace, { recursive: true, force: true });
       }
@@ -487,7 +505,9 @@ describe('normalizeOptions', () => {
           workspace,
         );
 
-        expect(getWarningCount()).toBe(0);
+        expect(logWarningSpy).not.toHaveBeenCalledWith(
+          expect.stringMatching(fetchOptionsRequiredWarningPattern),
+        );
       } finally {
         await rm(workspace, { recursive: true, force: true });
       }
@@ -514,7 +534,42 @@ describe('normalizeOptions', () => {
           workspace,
         );
 
-        expect(getWarningCount()).toBe(0);
+        expect(logWarningSpy).not.toHaveBeenCalledWith(
+          expect.stringMatching(fetchOptionsRequiredWarningPattern),
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('does not warn when override.requestOptions is false with httpClient fetch', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        const validSpecPath = path.join(workspace, 'petstore.yaml');
+        await writeFile(
+          validSpecPath,
+          'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+        );
+
+        await normalizeOptions(
+          {
+            input: { target: validSpecPath },
+            output: {
+              target: './generated.ts',
+              httpClient: 'fetch',
+              optionsParamRequired: true,
+              override: {
+                requestOptions: false,
+              },
+            },
+          },
+          workspace,
+        );
+
+        expect(logWarningSpy).not.toHaveBeenCalledWith(
+          expect.stringMatching(fetchOptionsRequiredWarningPattern),
+        );
       } finally {
         await rm(workspace, { recursive: true, force: true });
       }

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -2,7 +2,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { getWarningCount, resetWarnings } from '@orval/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeOptions } from './options';
 
@@ -398,5 +399,125 @@ describe('normalizeOptions', () => {
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }
+  });
+
+  describe('optionsParamRequired with fetch httpClient', () => {
+    beforeEach(() => {
+      resetWarnings();
+    });
+
+    afterEach(() => {
+      resetWarnings();
+    });
+
+    it('warns when optionsParamRequired is true and httpClient is fetch', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        const validSpecPath = path.join(workspace, 'petstore.yaml');
+        await writeFile(
+          validSpecPath,
+          'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+        );
+
+        await normalizeOptions(
+          {
+            input: { target: validSpecPath },
+            output: {
+              target: './generated.ts',
+              httpClient: 'fetch',
+              optionsParamRequired: true,
+            },
+          },
+          workspace,
+        );
+
+        expect(getWarningCount()).toBe(1);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('warns when optionsParamRequired is true and httpClient defaults to fetch', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        const validSpecPath = path.join(workspace, 'petstore.yaml');
+        await writeFile(
+          validSpecPath,
+          'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+        );
+
+        await normalizeOptions(
+          {
+            input: { target: validSpecPath },
+            output: {
+              target: './generated.ts',
+              optionsParamRequired: true,
+            },
+          },
+          workspace,
+        );
+
+        expect(getWarningCount()).toBe(1);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('does not warn when httpClient is axios', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        const validSpecPath = path.join(workspace, 'petstore.yaml');
+        await writeFile(
+          validSpecPath,
+          'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+        );
+
+        await normalizeOptions(
+          {
+            input: { target: validSpecPath },
+            output: {
+              target: './generated.ts',
+              httpClient: 'axios',
+              optionsParamRequired: true,
+            },
+          },
+          workspace,
+        );
+
+        expect(getWarningCount()).toBe(0);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('does not warn when optionsParamRequired is false with httpClient fetch', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        const validSpecPath = path.join(workspace, 'petstore.yaml');
+        await writeFile(
+          validSpecPath,
+          'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+        );
+
+        await normalizeOptions(
+          {
+            input: { target: validSpecPath },
+            output: {
+              target: './generated.ts',
+              httpClient: 'fetch',
+            },
+          },
+          workspace,
+        );
+
+        expect(getWarningCount()).toBe(0);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -465,6 +465,15 @@ export async function normalizeOptions(
     );
   }
 
+  if (
+    normalizedOptions.output.httpClient === OutputHttpClient.FETCH &&
+    normalizedOptions.output.optionsParamRequired
+  ) {
+    logWarning(
+      `⚠️  \`optionsParamRequired: true\` has no effect when \`httpClient: 'fetch'\`. The generated \`options\` parameter will always be optional with type \`RequestInit\`. Set \`httpClient: 'axios'\` to make the options parameter required.`,
+    );
+  }
+
   return normalizedOptions;
 }
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -467,10 +467,11 @@ export async function normalizeOptions(
 
   if (
     normalizedOptions.output.httpClient === OutputHttpClient.FETCH &&
-    normalizedOptions.output.optionsParamRequired
+    normalizedOptions.output.optionsParamRequired &&
+    normalizedOptions.output.override.requestOptions !== false
   ) {
     logWarning(
-      `⚠️  \`optionsParamRequired: true\` has no effect when \`httpClient: 'fetch'\`. The generated \`options\` parameter will always be optional with type \`RequestInit\`. Set \`httpClient: 'axios'\` to make the options parameter required.`,
+      `⚠️  With \`httpClient: 'fetch'\`, \`optionsParamRequired: true\` cannot make the generated \`options\` parameter required. The fetch \`options\` parameter remains optional with type \`RequestInit\` (\`optionsParamRequired\` may still affect other generated parameters). Set \`httpClient: 'axios'\` to make the \`options\` parameter required.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Emit a warning during config normalization when `optionsParamRequired: true` is set with `httpClient: 'fetch'` (the default). The fetch generator hard-codes `options?: RequestInit` and silently ignores `optionsParamRequired`, so users hitting this combination get no feedback that their setting has no effect.

The warning suggests setting `httpClient: 'axios'` when required options are needed.

This is the follow-up agreed upon in #3243 (closed) and discussed with @soartec-lab and @melloware. The original issue (#2146) reporter likely hit this path — the fix here gives a clear signal pointing them toward the correct config.

## Test plan

- [x] Added 4 unit tests in `packages/orval/src/utils/options.test.ts`:
  - warns when `optionsParamRequired: true` + `httpClient: 'fetch'`
  - warns when `optionsParamRequired: true` + httpClient defaults to fetch
  - does not warn when `httpClient: 'axios'`
  - does not warn when `optionsParamRequired` is unset
- [x] `bun run test` (83 tests pass)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:snapshots` (3740 tests pass — no snapshot changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emit a validation warning for an incompatible configuration when using the fetch HTTP client with a required options parameter, unless request options are explicitly disabled.

* **Tests**
  * Added tests verifying the new warning and confirming it does not appear for compatible configurations (e.g., axios or when request options are disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->