### PR TITLE
docs(query): Document suspense override options

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -637,8 +637,10 @@ export default defineConfig({
       override: {
         query: {
           useQuery: true,
+          useSuspenseQuery: true,
           useMutation: true,
           useInfinite: true,
+          useSuspenseInfiniteQuery: true,
           useInfiniteQueryParam: 'nextId',
           usePrefetch: true,
           useInvalidate: true,
@@ -662,6 +664,12 @@ export default defineConfig({
 
 Generate `useQuery` hooks.
 
+### useSuspenseQuery
+
+**Type:** `Boolean`
+
+Generate `useSuspenseQuery` hooks.
+
 ### useMutation
 
 **Type:** `Boolean`
@@ -673,6 +681,12 @@ Generate `useMutation` hooks for non-GET operations.
 **Type:** `Boolean`
 
 Generate `useInfiniteQuery` hooks.
+
+### useSuspenseInfiniteQuery
+
+**Type:** `Boolean`
+
+Generate `useSuspenseInfiniteQuery` hooks.
 
 ### useInfiniteQueryParam
 


### PR DESCRIPTION
PR documents the `useSuspenseQuery` and `useSuspenseInfiniteQuery` options that can be passed to `override.query`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended configuration reference with two new Suspense-compatible query options: `useSuspenseQuery` and `useSuspenseInfiniteQuery`.
  * Added detailed descriptions and configuration examples for both options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->