### PR TITLE
fix(fetch,query,swr): attach JSDoc to main function instead of URL helper (#3266)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1141,6 +1141,8 @@ export interface GeneratorClient {
   implementation: string;
   imports: GeneratorImport[];
   mutators?: GeneratorMutator[];
+  /** When set, overrides the default verbOption.doc prepended to the implementation */
+  docComment?: string;
 }
 
 export interface GeneratorMutatorParsingInfo {

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -66,6 +66,7 @@ export const generateRequestFunction = (
     formData,
     formUrlEncoded,
     override,
+    doc,
   }: GeneratorVerbOptions,
   { route, context, pathRoute }: GeneratorOptions,
 ) => {
@@ -573,7 +574,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   return (
     responseTypeImplementation +
     `${getUrlFnImplementation}\n` +
-    `${fetchImplementation}\n`
+    `${doc}${fetchImplementation}\n`
   );
 };
 
@@ -626,6 +627,7 @@ export const generateClient: ClientBuilder = (verbOptions, options) => {
   return {
     implementation: `${functionImplementation}\n`,
     imports,
+    docComment: '',
   };
 };
 

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -295,7 +295,7 @@ export const generateOperations = (
 
       acc[operationKey] = {
         implementation: hasImplementation
-          ? verbOption.doc + client.implementation
+          ? (client.docComment ?? verbOption.doc) + client.implementation
           : client.implementation,
         imports: [...baseUrlImports, ...client.imports],
         implementationMock: generatedMock.implementation,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -5,6 +5,7 @@ import {
   generateVerbImports,
   mergeDeep,
   type NormalizedOutputOptions,
+  OutputHttpClient,
   type QueryOptions,
 } from '@orval/core';
 
@@ -100,10 +101,14 @@ export const generateQuery: ClientBuilder = async (
     adapter,
   );
 
+  const isFetchHttpClient =
+    options.context.output.httpClient !== OutputHttpClient.AXIOS;
+
   return {
     implementation: `${functionImplementation}\n\n${hookImplementation}`,
     imports: [...imports, ...hookImports],
     mutators,
+    ...(isFetchHttpClient && { docComment: '' }),
   };
 };
 

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -877,9 +877,13 @@ export const generateSwr: ClientBuilder = (verbOptions, options) => {
   );
   const hookImplementation = generateSwrHook(verbOptions, options);
 
+  const isFetchHttpClient =
+    options.context.output.httpClient !== OutputHttpClient.AXIOS;
+
   return {
     implementation: `${functionImplementation}\n\n${hookImplementation}`,
     imports,
+    ...(isFetchHttpClient && { docComment: '' }),
   };
 };
 

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -89,9 +89,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary search by query params
- */
 export const searchPets = (
   params: SearchPetsParams,
   options?: SecondParameter<typeof responseType>,
@@ -220,9 +217,6 @@ export function injectSearchPets<
   return query;
 }
 
-/**
- * @summary List all pets
- */
 export const listPets = (
   params?: ListPetsParams,
   options?: SecondParameter<typeof responseType>,
@@ -348,9 +342,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   createPetsBody: CreatePetsBody,
   options?: SecondParameter<typeof responseType>,
@@ -440,9 +431,6 @@ export const injectCreatePets = <
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   petId: string,
   options?: SecondParameter<typeof responseType>,
@@ -540,9 +528,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Delete a pet
- */
 export const deletePet = (
   petId: string,
   options?: SecondParameter<typeof responseType>,
@@ -626,9 +611,6 @@ export const injectDeletePet = <
 
   return injectMutation(() => deletePetMutationOptions);
 };
-/**
- * @summary Update a pet
- */
 export const updatePet = (
   petId: string,
   pet: Pet,
@@ -719,9 +701,6 @@ export const injectUpdatePet = <
 
   return injectMutation(() => updatePetMutationOptions);
 };
-/**
- * @summary Partially update a pet
- */
 export const patchPet = (
   petId: string,
   patchPetBody: PatchPetBody,
@@ -812,9 +791,6 @@ export const injectPatchPet = <
 
   return injectMutation(() => patchPetMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetText = (
   petId: string,
   options?: SecondParameter<typeof responseType>,
@@ -912,10 +888,6 @@ export function injectShowPetText<
   return query;
 }
 
-/**
- * Upload image of the pet.
- * @summary Uploads an image.
- */
 export const uploadFile = (
   petId: number,
   uploadFileBody?: Blob,
@@ -1006,10 +978,6 @@ export const injectUploadFile = <
 
   return injectMutation(() => uploadFileMutationOptions);
 };
-/**
- * Upload a file for a pet using multipart/form-data.
- * @summary Upload a file via multipart form data.
- */
 export const uploadFormData = (
   petId: number,
   uploadFormDataBody: UploadFormDataBody,
@@ -1110,10 +1078,6 @@ export const injectUploadFormData = <
 
   return injectMutation(() => uploadFormDataMutationOptions);
 };
-/**
- * Download image of the pet.
- * @summary Download an image.
- */
 export const downloadFile = (
   petId: number,
   options?: SecondParameter<typeof responseType>,
@@ -1220,9 +1184,6 @@ export function injectDownloadFile<
   return query;
 }
 
-/**
- * @summary Health check
- */
 export const healthCheck = (
   options?: SecondParameter<typeof responseType>,
   signal?: AbortSignal,

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -88,9 +88,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary search by query params
- */
 export const searchPets = (
   http: HttpClient,
   params: SearchPetsParams,
@@ -198,9 +195,6 @@ export function injectSearchPets<
   return query;
 }
 
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params?: ListPetsParams,
@@ -300,9 +294,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -387,9 +378,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -491,9 +479,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Delete a pet
- */
 export const deletePet = (
   http: HttpClient,
   petId: string,
@@ -575,9 +560,6 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => deletePetMutationOptions);
 };
-/**
- * @summary Update a pet
- */
 export const updatePet = (
   http: HttpClient,
   petId: string,
@@ -660,9 +642,6 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => updatePetMutationOptions);
 };
-/**
- * @summary Partially update a pet
- */
 export const patchPet = (
   http: HttpClient,
   petId: string,
@@ -745,9 +724,6 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => patchPetMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetText = (
   http: HttpClient,
   petId: string,
@@ -849,10 +825,6 @@ export function injectShowPetText<
   return query;
 }
 
-/**
- * Upload image of the pet.
- * @summary Uploads an image.
- */
 export const uploadFile = (
   http: HttpClient,
   petId: number,
@@ -941,10 +913,6 @@ export const injectUploadFile = <
 
   return injectMutation(() => uploadFileMutationOptions);
 };
-/**
- * Upload a file for a pet using multipart/form-data.
- * @summary Upload a file via multipart form data.
- */
 export const uploadFormData = (
   http: HttpClient,
   petId: number,
@@ -1044,10 +1012,6 @@ export const injectUploadFormData = <
 
   return injectMutation(() => uploadFormDataMutationOptions);
 };
-/**
- * Download image of the pet.
- * @summary Download an image.
- */
 export const downloadFile = (
   http: HttpClient,
   petId: number,
@@ -1153,9 +1117,6 @@ export function injectDownloadFile<
   return query;
 }
 
-/**
- * @summary Health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/health/health.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/health/health.ts
@@ -21,9 +21,6 @@ import { takeUntil } from 'rxjs/operators';
 
 import type { Error } from '../../model-zod';
 
-/**
- * @summary health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -85,9 +85,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
@@ -189,9 +186,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -282,9 +276,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -386,9 +377,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const deletePetById = (
   http: HttpClient,
   petId: string,
@@ -479,9 +467,6 @@ export const injectDeletePetById = <
 
   return injectMutation(() => deletePetByIdMutationOptions);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const showPetWithOwner = (
   http: HttpClient,
   petId: string,

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -91,9 +91,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary search by query params
- */
 export const searchPets = (
   http: HttpClient,
   params: SearchPetsParams,
@@ -231,9 +228,6 @@ export const invalidateSearchPets = async (
   return queryClient;
 };
 
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params?: ListPetsParams,
@@ -359,9 +353,6 @@ export const invalidateListPets = async (
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -467,9 +458,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -593,9 +581,6 @@ export const invalidateShowPetById = async (
   return queryClient;
 };
 
-/**
- * @summary Delete a pet
- */
 export const deletePet = (
   http: HttpClient,
   petId: string,
@@ -701,9 +686,6 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => deletePetMutationOptions);
 };
-/**
- * @summary Update a pet
- */
 export const updatePet = (
   http: HttpClient,
   petId: string,
@@ -810,9 +792,6 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => updatePetMutationOptions);
 };
-/**
- * @summary Partially update a pet
- */
 export const patchPet = (
   http: HttpClient,
   petId: string,
@@ -919,9 +898,6 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => patchPetMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetText = (
   http: HttpClient,
   petId: string,
@@ -1045,10 +1021,6 @@ export const invalidateShowPetText = async (
   return queryClient;
 };
 
-/**
- * Upload image of the pet.
- * @summary Uploads an image.
- */
 export const uploadFile = (
   http: HttpClient,
   petId: number,
@@ -1158,10 +1130,6 @@ export const injectUploadFile = <
 
   return injectMutation(() => uploadFileMutationOptions);
 };
-/**
- * Upload a file for a pet using multipart/form-data.
- * @summary Upload a file via multipart form data.
- */
 export const uploadFormData = (
   http: HttpClient,
   petId: number,
@@ -1262,10 +1230,6 @@ export const injectUploadFormData = <
 
   return injectMutation(() => uploadFormDataMutationOptions);
 };
-/**
- * Download image of the pet.
- * @summary Download an image.
- */
 export const downloadFile = (
   http: HttpClient,
   petId: number,
@@ -1393,9 +1357,6 @@ export const invalidateDownloadFile = async (
   return queryClient;
 };
 
-/**
- * @summary Health check
- */
 export const healthCheck = (
   http: HttpClient,
   version: number = 1,

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -89,9 +89,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary search by query params
- */
 export const searchPets = (
   params: SearchPetsParams,
   options?: SecondParameter<typeof responseType>,
@@ -220,9 +217,6 @@ export function injectSearchPets<
   return query;
 }
 
-/**
- * @summary List all pets
- */
 export const listPets = (
   params?: ListPetsParams,
   options?: SecondParameter<typeof responseType>,
@@ -348,9 +342,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   createPetsBody: CreatePetsBody,
   options?: SecondParameter<typeof responseType>,
@@ -440,9 +431,6 @@ export const injectCreatePets = <
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   petId: string,
   options?: SecondParameter<typeof responseType>,
@@ -540,9 +528,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Delete a pet
- */
 export const deletePet = (
   petId: string,
   options?: SecondParameter<typeof responseType>,
@@ -626,9 +611,6 @@ export const injectDeletePet = <
 
   return injectMutation(() => deletePetMutationOptions);
 };
-/**
- * @summary Update a pet
- */
 export const updatePet = (
   petId: string,
   pet: Pet,
@@ -719,9 +701,6 @@ export const injectUpdatePet = <
 
   return injectMutation(() => updatePetMutationOptions);
 };
-/**
- * @summary Partially update a pet
- */
 export const patchPet = (
   petId: string,
   patchPetBody: PatchPetBody,
@@ -812,9 +791,6 @@ export const injectPatchPet = <
 
   return injectMutation(() => patchPetMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetText = (
   petId: string,
   options?: SecondParameter<typeof responseType>,
@@ -912,10 +888,6 @@ export function injectShowPetText<
   return query;
 }
 
-/**
- * Upload image of the pet.
- * @summary Uploads an image.
- */
 export const uploadFile = (
   petId: number,
   uploadFileBody?: Blob,
@@ -1006,10 +978,6 @@ export const injectUploadFile = <
 
   return injectMutation(() => uploadFileMutationOptions);
 };
-/**
- * Upload a file for a pet using multipart/form-data.
- * @summary Upload a file via multipart form data.
- */
 export const uploadFormData = (
   petId: number,
   uploadFormDataBody: UploadFormDataBody,
@@ -1110,10 +1078,6 @@ export const injectUploadFormData = <
 
   return injectMutation(() => uploadFormDataMutationOptions);
 };
-/**
- * Download image of the pet.
- * @summary Download an image.
- */
 export const downloadFile = (
   petId: number,
   options?: SecondParameter<typeof responseType>,
@@ -1220,9 +1184,6 @@ export function injectDownloadFile<
   return query;
 }
 
-/**
- * @summary Health check
- */
 export const healthCheck = (
   options?: SecondParameter<typeof responseType>,
   signal?: AbortSignal,

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -88,9 +88,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary search by query params
- */
 export const searchPets = (
   http: HttpClient,
   params: SearchPetsParams,
@@ -198,9 +195,6 @@ export function injectSearchPets<
   return query;
 }
 
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params?: ListPetsParams,
@@ -300,9 +294,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -387,9 +378,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -491,9 +479,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Delete a pet
- */
 export const deletePet = (
   http: HttpClient,
   petId: string,
@@ -575,9 +560,6 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => deletePetMutationOptions);
 };
-/**
- * @summary Update a pet
- */
 export const updatePet = (
   http: HttpClient,
   petId: string,
@@ -660,9 +642,6 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => updatePetMutationOptions);
 };
-/**
- * @summary Partially update a pet
- */
 export const patchPet = (
   http: HttpClient,
   petId: string,
@@ -745,9 +724,6 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => patchPetMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetText = (
   http: HttpClient,
   petId: string,
@@ -849,10 +825,6 @@ export function injectShowPetText<
   return query;
 }
 
-/**
- * Upload image of the pet.
- * @summary Uploads an image.
- */
 export const uploadFile = (
   http: HttpClient,
   petId: number,
@@ -941,10 +913,6 @@ export const injectUploadFile = <
 
   return injectMutation(() => uploadFileMutationOptions);
 };
-/**
- * Upload a file for a pet using multipart/form-data.
- * @summary Upload a file via multipart form data.
- */
 export const uploadFormData = (
   http: HttpClient,
   petId: number,
@@ -1044,10 +1012,6 @@ export const injectUploadFormData = <
 
   return injectMutation(() => uploadFormDataMutationOptions);
 };
-/**
- * Download image of the pet.
- * @summary Download an image.
- */
 export const downloadFile = (
   http: HttpClient,
   petId: number,
@@ -1153,9 +1117,6 @@ export function injectDownloadFile<
   return query;
 }
 
-/**
- * @summary Health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },

--- a/samples/angular-query/src/api/endpoints-zod/health/health.ts
+++ b/samples/angular-query/src/api/endpoints-zod/health/health.ts
@@ -21,9 +21,6 @@ import { takeUntil } from 'rxjs/operators';
 
 import type { Error } from '../../model-zod';
 
-/**
- * @summary health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -85,9 +85,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
@@ -189,9 +186,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -282,9 +276,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -386,9 +377,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const deletePetById = (
   http: HttpClient,
   petId: string,
@@ -479,9 +467,6 @@ export const injectDeletePetById = <
 
   return injectMutation(() => deletePetByIdMutationOptions);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const showPetWithOwner = (
   http: HttpClient,
   petId: string,

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -91,9 +91,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary search by query params
- */
 export const searchPets = (
   http: HttpClient,
   params: SearchPetsParams,
@@ -231,9 +228,6 @@ export const invalidateSearchPets = async (
   return queryClient;
 };
 
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params?: ListPetsParams,
@@ -359,9 +353,6 @@ export const invalidateListPets = async (
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -467,9 +458,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -593,9 +581,6 @@ export const invalidateShowPetById = async (
   return queryClient;
 };
 
-/**
- * @summary Delete a pet
- */
 export const deletePet = (
   http: HttpClient,
   petId: string,
@@ -701,9 +686,6 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => deletePetMutationOptions);
 };
-/**
- * @summary Update a pet
- */
 export const updatePet = (
   http: HttpClient,
   petId: string,
@@ -810,9 +792,6 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => updatePetMutationOptions);
 };
-/**
- * @summary Partially update a pet
- */
 export const patchPet = (
   http: HttpClient,
   petId: string,
@@ -919,9 +898,6 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => patchPetMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetText = (
   http: HttpClient,
   petId: string,
@@ -1045,10 +1021,6 @@ export const invalidateShowPetText = async (
   return queryClient;
 };
 
-/**
- * Upload image of the pet.
- * @summary Uploads an image.
- */
 export const uploadFile = (
   http: HttpClient,
   petId: number,
@@ -1158,10 +1130,6 @@ export const injectUploadFile = <
 
   return injectMutation(() => uploadFileMutationOptions);
 };
-/**
- * Upload a file for a pet using multipart/form-data.
- * @summary Upload a file via multipart form data.
- */
 export const uploadFormData = (
   http: HttpClient,
   petId: number,
@@ -1262,10 +1230,6 @@ export const injectUploadFormData = <
 
   return injectMutation(() => uploadFormDataMutationOptions);
 };
-/**
- * Download image of the pet.
- * @summary Download an image.
- */
 export const downloadFile = (
   http: HttpClient,
   petId: number,
@@ -1393,9 +1357,6 @@ export const invalidateDownloadFile = async (
   return queryClient;
 };
 
-/**
- * @summary Health check
- */
 export const healthCheck = (
   http: HttpClient,
   version: number = 1,

--- a/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -83,6 +80,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8787/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -98,9 +98,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -126,6 +123,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8787/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -147,9 +147,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -175,6 +172,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8787/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: Pet,
   options?: RequestInit,
@@ -196,9 +196,6 @@ export const updatePets = async (
   } as updatePetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8787/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -83,6 +80,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8787/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -98,9 +98,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -126,6 +123,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8787/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -147,9 +147,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -175,6 +172,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8787/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: Pet,
   options?: RequestInit,
@@ -196,9 +196,6 @@ export const updatePets = async (
   } as updatePetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8787/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/mcp/custom-server/src/http-client.ts
+++ b/samples/mcp/custom-server/src/http-client.ts
@@ -119,6 +119,10 @@ export const getFindPetsByStatusUrl = (params?: FindPetsByStatusParams) => {
     : `https://petstore3.swagger.io/api/v3/pet/findByStatus`;
 };
 
+/**
+ * Multiple status values can be provided with comma separated strings.
+ * @summary Finds Pets by status.
+ */
 export const findPetsByStatus = async (
   params?: FindPetsByStatusParams,
   options?: RequestInit,
@@ -201,6 +205,10 @@ export const getFindPetsByTagsUrl = (params?: FindPetsByTagsParams) => {
     : `https://petstore3.swagger.io/api/v3/pet/findByTags`;
 };
 
+/**
+ * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+ * @summary Finds Pets by tags.
+ */
 export const findPetsByTags = async (
   params?: FindPetsByTagsParams,
   options?: RequestInit,
@@ -272,6 +280,10 @@ export const getGetPetByIdUrl = (petId: number) => {
   return `https://petstore3.swagger.io/api/v3/pet/${petId}`;
 };
 
+/**
+ * Returns a single pet.
+ * @summary Find pet by ID.
+ */
 export const getPetById = async (
   petId: number,
   options?: RequestInit,
@@ -352,6 +364,10 @@ export const getUpdatePetWithFormUrl = (
     : `https://petstore3.swagger.io/api/v3/pet/${petId}`;
 };
 
+/**
+ * Updates a pet resource based on the form data.
+ * @summary Updates a pet in the store with form data.
+ */
 export const updatePetWithForm = async (
   petId: number,
   params?: UpdatePetWithFormParams,
@@ -410,6 +426,10 @@ export const getDeletePetUrl = (petId: number) => {
   return `https://petstore3.swagger.io/api/v3/pet/${petId}`;
 };
 
+/**
+ * Delete a pet.
+ * @summary Deletes a pet.
+ */
 export const deletePet = async (
   petId: number,
   options?: RequestInit,
@@ -454,6 +474,10 @@ export const getGetInventoryUrl = () => {
   return `https://petstore3.swagger.io/api/v3/store/inventory`;
 };
 
+/**
+ * Returns a map of status codes to quantities.
+ * @summary Returns pet inventories by status.
+ */
 export const getInventory = async (
   options?: RequestInit,
 ): Promise<getInventoryResponse> => {
@@ -519,6 +543,10 @@ export const getGetOrderByIdUrl = (orderId: number) => {
   return `https://petstore3.swagger.io/api/v3/store/order/${orderId}`;
 };
 
+/**
+ * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
+ * @summary Find purchase order by ID.
+ */
 export const getOrderById = async (
   orderId: number,
   options?: RequestInit,
@@ -582,6 +610,10 @@ export const getDeleteOrderUrl = (orderId: number) => {
   return `https://petstore3.swagger.io/api/v3/store/order/${orderId}`;
 };
 
+/**
+ * For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.
+ * @summary Delete purchase order by identifier.
+ */
 export const deleteOrder = async (
   orderId: number,
   options?: RequestInit,
@@ -654,6 +686,10 @@ export const getLoginUserUrl = (params?: LoginUserParams) => {
     : `https://petstore3.swagger.io/api/v3/user/login`;
 };
 
+/**
+ * Log into the system.
+ * @summary Logs user into the system.
+ */
 export const loginUser = async (
   params?: LoginUserParams,
   options?: RequestInit,
@@ -703,6 +739,10 @@ export const getLogoutUserUrl = () => {
   return `https://petstore3.swagger.io/api/v3/user/logout`;
 };
 
+/**
+ * Log user out of the system.
+ * @summary Logs out current logged in user session.
+ */
 export const logoutUser = async (
   options?: RequestInit,
 ): Promise<logoutUserResponse> => {
@@ -768,6 +808,10 @@ export const getGetUserByNameUrl = (username: string) => {
   return `https://petstore3.swagger.io/api/v3/user/${username}`;
 };
 
+/**
+ * Get user detail based on username.
+ * @summary Get user by user name.
+ */
 export const getUserByName = async (
   username: string,
   options?: RequestInit,
@@ -831,6 +875,10 @@ export const getDeleteUserUrl = (username: string) => {
   return `https://petstore3.swagger.io/api/v3/user/${username}`;
 };
 
+/**
+ * This can only be done by the logged in user.
+ * @summary Delete user resource.
+ */
 export const deleteUser = async (
   username: string,
   options?: RequestInit,

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -119,6 +119,10 @@ export const getFindPetsByStatusUrl = (params?: FindPetsByStatusParams) => {
     : `https://petstore3.swagger.io/api/v3/pet/findByStatus`;
 };
 
+/**
+ * Multiple status values can be provided with comma separated strings.
+ * @summary Finds Pets by status.
+ */
 export const findPetsByStatus = async (
   params?: FindPetsByStatusParams,
   options?: RequestInit,
@@ -201,6 +205,10 @@ export const getFindPetsByTagsUrl = (params?: FindPetsByTagsParams) => {
     : `https://petstore3.swagger.io/api/v3/pet/findByTags`;
 };
 
+/**
+ * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+ * @summary Finds Pets by tags.
+ */
 export const findPetsByTags = async (
   params?: FindPetsByTagsParams,
   options?: RequestInit,
@@ -272,6 +280,10 @@ export const getGetPetByIdUrl = (petId: number) => {
   return `https://petstore3.swagger.io/api/v3/pet/${petId}`;
 };
 
+/**
+ * Returns a single pet.
+ * @summary Find pet by ID.
+ */
 export const getPetById = async (
   petId: number,
   options?: RequestInit,
@@ -352,6 +364,10 @@ export const getUpdatePetWithFormUrl = (
     : `https://petstore3.swagger.io/api/v3/pet/${petId}`;
 };
 
+/**
+ * Updates a pet resource based on the form data.
+ * @summary Updates a pet in the store with form data.
+ */
 export const updatePetWithForm = async (
   petId: number,
   params?: UpdatePetWithFormParams,
@@ -410,6 +426,10 @@ export const getDeletePetUrl = (petId: number) => {
   return `https://petstore3.swagger.io/api/v3/pet/${petId}`;
 };
 
+/**
+ * Delete a pet.
+ * @summary Deletes a pet.
+ */
 export const deletePet = async (
   petId: number,
   options?: RequestInit,
@@ -454,6 +474,10 @@ export const getGetInventoryUrl = () => {
   return `https://petstore3.swagger.io/api/v3/store/inventory`;
 };
 
+/**
+ * Returns a map of status codes to quantities.
+ * @summary Returns pet inventories by status.
+ */
 export const getInventory = async (
   options?: RequestInit,
 ): Promise<getInventoryResponse> => {
@@ -519,6 +543,10 @@ export const getGetOrderByIdUrl = (orderId: number) => {
   return `https://petstore3.swagger.io/api/v3/store/order/${orderId}`;
 };
 
+/**
+ * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
+ * @summary Find purchase order by ID.
+ */
 export const getOrderById = async (
   orderId: number,
   options?: RequestInit,
@@ -582,6 +610,10 @@ export const getDeleteOrderUrl = (orderId: number) => {
   return `https://petstore3.swagger.io/api/v3/store/order/${orderId}`;
 };
 
+/**
+ * For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.
+ * @summary Delete purchase order by identifier.
+ */
 export const deleteOrder = async (
   orderId: number,
   options?: RequestInit,
@@ -654,6 +686,10 @@ export const getLoginUserUrl = (params?: LoginUserParams) => {
     : `https://petstore3.swagger.io/api/v3/user/login`;
 };
 
+/**
+ * Log into the system.
+ * @summary Logs user into the system.
+ */
 export const loginUser = async (
   params?: LoginUserParams,
   options?: RequestInit,
@@ -703,6 +739,10 @@ export const getLogoutUserUrl = () => {
   return `https://petstore3.swagger.io/api/v3/user/logout`;
 };
 
+/**
+ * Log user out of the system.
+ * @summary Logs out current logged in user session.
+ */
 export const logoutUser = async (
   options?: RequestInit,
 ): Promise<logoutUserResponse> => {
@@ -768,6 +808,10 @@ export const getGetUserByNameUrl = (username: string) => {
   return `https://petstore3.swagger.io/api/v3/user/${username}`;
 };
 
+/**
+ * Get user detail based on username.
+ * @summary Get user by user name.
+ */
 export const getUserByName = async (
   username: string,
   options?: RequestInit,
@@ -831,6 +875,10 @@ export const getDeleteUserUrl = (username: string) => {
   return `https://petstore3.swagger.io/api/v3/user/${username}`;
 };
 
+/**
+ * This can only be done by the logged in user.
+ * @summary Delete user resource.
+ */
 export const deleteUser = async (
   username: string,
   options?: RequestInit,

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -84,9 +84,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -113,6 +110,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:3000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -123,9 +123,6 @@ export const listPets = async (
   });
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -151,6 +148,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:3000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -163,9 +163,6 @@ export const createPets = async (
   });
 };
 
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -191,6 +188,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:3000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -203,9 +203,6 @@ export const updatePets = async (
   });
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -231,6 +228,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:3000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -84,9 +84,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -113,6 +110,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:3000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -123,9 +123,6 @@ export const listPets = async (
   });
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -151,6 +148,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:3000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -163,9 +163,6 @@ export const createPets = async (
   });
 };
 
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -191,6 +188,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:3000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -203,9 +203,6 @@ export const updatePets = async (
   });
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -231,6 +228,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:3000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -64,9 +64,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -105,6 +102,9 @@ export const getListPetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   version: number = 1,
@@ -196,9 +196,6 @@ export const useListPetsSuspense = <TError = Error>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getCreatePetsUrl = (version: number = 1) => {
   return `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   version: number = 1,
@@ -281,9 +281,6 @@ export const useCreatePets = <TError = Error>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -309,6 +306,9 @@ export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   version: number = 1,

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -64,9 +64,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -105,6 +102,9 @@ export const getListPetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   version: number = 1,
@@ -196,9 +196,6 @@ export const useListPetsSuspense = <TError = Error>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getCreatePetsUrl = (version: number = 1) => {
   return `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   version: number = 1,
@@ -281,9 +281,6 @@ export const useCreatePets = <TError = Error>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -309,6 +306,9 @@ export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   version: number = 1,

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -18,9 +18,6 @@ import type {
   Pets,
 } from '../models';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -37,6 +34,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -91,13 +91,13 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -153,13 +153,13 @@ export const useCreatePets = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -18,9 +18,6 @@ import type {
   Pets,
 } from '../models';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -37,6 +34,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -91,13 +91,13 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -153,13 +153,13 @@ export const useCreatePets = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -102,9 +102,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -131,6 +128,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -267,9 +267,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -295,6 +292,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -373,9 +373,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -401,6 +398,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -479,9 +479,6 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -507,6 +504,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -102,9 +102,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -131,6 +128,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -267,9 +267,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -295,6 +292,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -373,9 +373,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -401,6 +398,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -479,9 +479,6 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -507,6 +504,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: PetsArray;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -181,9 +181,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse201 = {
   data: void;
   status: 201;
@@ -209,6 +206,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -283,9 +283,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   return useMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary List all pets as nested array
- */
 export type listPetsNestedArrayResponse200 = {
   data: PetsNestedArray;
   status: 200;
@@ -327,6 +324,9 @@ export const getListPetsNestedArrayUrl = (
     : `/pets-nested-array`;
 };
 
+/**
+ * @summary List all pets as nested array
+ */
 export const listPetsNestedArray = async (
   params?: ListPetsNestedArrayParams,
   options?: RequestInit,
@@ -406,9 +406,6 @@ export function useListPetsNestedArray<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -434,6 +431,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: PetsArray;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -181,9 +181,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse201 = {
   data: void;
   status: 201;
@@ -209,6 +206,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -283,9 +283,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   return useMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary List all pets as nested array
- */
 export type listPetsNestedArrayResponse200 = {
   data: PetsNestedArray;
   status: 200;
@@ -327,6 +324,9 @@ export const getListPetsNestedArrayUrl = (
     : `/pets-nested-array`;
 };
 
+/**
+ * @summary List all pets as nested array
+ */
 export const listPetsNestedArray = async (
   params?: ListPetsNestedArrayParams,
   options?: RequestInit,
@@ -406,9 +406,6 @@ export function useListPetsNestedArray<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -434,6 +431,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -74,9 +74,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: PetsArray;
   status: 200;
@@ -110,6 +107,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const useListPetsHook = (): ((
   params?: ListPetsParams,
   options?: RequestInit,
@@ -190,9 +190,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse201 = {
   data: void;
   status: 201;
@@ -218,6 +215,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const useCreatePetsHook = (): ((
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -299,9 +299,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   return useMutation(useCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary List all pets as nested array
- */
 export type listPetsNestedArrayResponse200 = {
   data: PetsNestedArray;
   status: 200;
@@ -343,6 +340,9 @@ export const getListPetsNestedArrayUrl = (
     : `/pets-nested-array`;
 };
 
+/**
+ * @summary List all pets as nested array
+ */
 export const useListPetsNestedArrayHook = (): ((
   params?: ListPetsNestedArrayParams,
   options?: RequestInit,
@@ -427,9 +427,6 @@ export function useListPetsNestedArray<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -455,6 +452,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const useShowPetByIdHook = (): ((
   petId: string,
   options?: RequestInit,

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -74,9 +74,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: PetsArray;
   status: 200;
@@ -110,6 +107,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const useListPetsHook = (): ((
   params?: ListPetsParams,
   options?: RequestInit,
@@ -190,9 +190,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse201 = {
   data: void;
   status: 201;
@@ -218,6 +215,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const useCreatePetsHook = (): ((
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -299,9 +299,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   return useMutation(useCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary List all pets as nested array
- */
 export type listPetsNestedArrayResponse200 = {
   data: PetsNestedArray;
   status: 200;
@@ -343,6 +340,9 @@ export const getListPetsNestedArrayUrl = (
     : `/pets-nested-array`;
 };
 
+/**
+ * @summary List all pets as nested array
+ */
 export const useListPetsNestedArrayHook = (): ((
   params?: ListPetsNestedArrayParams,
   options?: RequestInit,
@@ -427,9 +427,6 @@ export function useListPetsNestedArray<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -455,6 +452,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const useShowPetByIdHook = (): ((
   petId: string,
   options?: RequestInit,

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -102,9 +102,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -131,6 +128,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -209,9 +209,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -237,6 +234,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -334,9 +334,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     getCreatePetsMutationOptions(queryClient ?? backupQueryClient, options),
   );
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -362,6 +359,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -437,9 +437,6 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(options?: {
 > => {
   return createMutation(getUpdatePetsMutationOptions(options));
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -465,6 +462,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -102,9 +102,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -131,6 +128,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -209,9 +209,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -237,6 +234,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -334,9 +334,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     getCreatePetsMutationOptions(queryClient ?? backupQueryClient, options),
   );
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -362,6 +359,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -437,9 +437,6 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(options?: {
 > => {
   return createMutation(getUpdatePetsMutationOptions(options));
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -465,6 +462,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -104,9 +104,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -133,6 +130,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -231,9 +231,6 @@ export const prefetchListPetsQuery = async <
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -259,6 +256,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -358,9 +358,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     queryClient,
   );
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -386,6 +383,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -467,9 +467,6 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(
     queryClient,
   );
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -495,6 +492,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -104,9 +104,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -133,6 +130,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -231,9 +231,6 @@ export const prefetchListPetsQuery = async <
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -259,6 +256,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -358,9 +358,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     queryClient,
   );
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -386,6 +383,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -467,9 +467,6 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(
     queryClient,
   );
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -495,6 +492,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -88,9 +88,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -117,6 +114,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -170,9 +170,6 @@ export const useListPets = <TError = Promise<unknown>>(
     ...query,
   };
 };
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -198,6 +195,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -256,9 +256,6 @@ export const useCreatePets = <TError = Promise<Error>>(options?: {
     ...query,
   };
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -284,6 +281,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -342,9 +342,6 @@ export const useUpdatePets = <TError = Promise<Error>>(options?: {
     ...query,
   };
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -370,6 +367,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -88,9 +88,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -117,6 +114,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -170,9 +170,6 @@ export const useListPets = <TError = Promise<unknown>>(
     ...query,
   };
 };
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -198,6 +195,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -256,9 +256,6 @@ export const useCreatePets = <TError = Promise<Error>>(options?: {
     ...query,
   };
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -284,6 +281,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -342,9 +342,6 @@ export const useUpdatePets = <TError = Promise<Error>>(options?: {
     ...query,
   };
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -370,6 +367,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -102,9 +102,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -131,6 +128,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -217,9 +217,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -245,6 +242,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -323,9 +323,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -351,6 +348,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -429,9 +429,6 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -457,6 +454,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -102,9 +102,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -131,6 +128,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
     : `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -217,9 +217,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -245,6 +242,9 @@ export const getCreatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
@@ -323,9 +323,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Update a pet
- */
 export type updatePetsResponse200 = {
   data: Pet;
   status: 200;
@@ -351,6 +348,9 @@ export const getUpdatePetsUrl = () => {
   return `http://localhost:8000/pets`;
 };
 
+/**
+ * @summary Update a pet
+ */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
@@ -429,9 +429,6 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -457,6 +454,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `http://localhost:8000/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -87,9 +87,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
@@ -189,9 +186,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -281,9 +275,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   return injectMutation(() => createPetsMutationOptions);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -385,9 +376,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const deletePetById = (
   http: HttpClient,
   petId: string,
@@ -479,9 +467,6 @@ export const injectDeletePetById = <
   return injectMutation(() => deletePetByIdMutationOptions);
 };
 
-/**
- * @summary health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },
@@ -573,9 +558,6 @@ export function injectHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export const showPetWithOwner = (
   http: HttpClient,
   petId: string,

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -87,9 +87,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
@@ -189,9 +186,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -281,9 +275,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   return injectMutation(() => createPetsMutationOptions);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -385,9 +376,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const deletePetById = (
   http: HttpClient,
   petId: string,
@@ -479,9 +467,6 @@ export const injectDeletePetById = <
   return injectMutation(() => deletePetByIdMutationOptions);
 };
 
-/**
- * @summary health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },
@@ -573,9 +558,6 @@ export function injectHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export const showPetWithOwner = (
   http: HttpClient,
   petId: string,

--- a/tests/__snapshots__/angular-query/tags-split/health/health.ts
+++ b/tests/__snapshots__/angular-query/tags-split/health/health.ts
@@ -21,9 +21,6 @@ import { takeUntil } from 'rxjs/operators';
 
 import type { Error } from '../model';
 
-/**
- * @summary health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -87,9 +87,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
@@ -189,9 +186,6 @@ export function injectListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -280,9 +274,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 
   return injectMutation(() => createPetsMutationOptions);
 };
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -384,9 +375,6 @@ export function injectShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const deletePetById = (
   http: HttpClient,
   petId: string,
@@ -477,9 +465,6 @@ export const injectDeletePetById = <
 
   return injectMutation(() => deletePetByIdMutationOptions);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const showPetWithOwner = (
   http: HttpClient,
   petId: string,

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -88,9 +88,6 @@ function filterParams(
   }
   return filteredParams;
 }
-/**
- * @summary List all pets
- */
 export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
@@ -218,9 +215,6 @@ export const prefetchListPetsQuery = async <
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export const createPets = (
   http: HttpClient,
   createPetsBody: CreatePetsBody,
@@ -310,9 +304,6 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   return injectMutation(() => createPetsMutationOptions);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export const showPetById = (
   http: HttpClient,
   petId: string,
@@ -442,9 +433,6 @@ export const prefetchShowPetByIdQuery = async <
   return queryClient;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export const deletePetById = (
   http: HttpClient,
   petId: string,
@@ -536,9 +524,6 @@ export const injectDeletePetById = <
   return injectMutation(() => deletePetByIdMutationOptions);
 };
 
-/**
- * @summary health check
- */
 export const healthCheck = (
   http: HttpClient,
   options?: { signal?: AbortSignal | null },
@@ -657,9 +642,6 @@ export const prefetchHealthCheckQuery = async <
   return queryClient;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export const showPetWithOwner = (
   http: HttpClient,
   petId: string,

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -376,9 +376,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -404,6 +401,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -554,9 +554,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -582,6 +579,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -670,9 +670,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -698,6 +695,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -835,9 +835,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -863,6 +860,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/default/file-extension-tags-split/health/health.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/health/health.generated.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -89,6 +86,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -375,9 +375,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -403,6 +400,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -553,9 +553,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -581,6 +578,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -668,9 +668,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -696,6 +693,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/default/file-extension-tags/health.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/health.generated.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -89,6 +86,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -375,9 +375,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -403,6 +400,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -553,9 +553,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -581,6 +578,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -668,9 +668,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -696,6 +693,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/default/index-mock-file/health/health.ts
+++ b/tests/__snapshots__/default/index-mock-file/health/health.ts
@@ -48,9 +48,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -76,6 +73,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/default/index-mock-file/pets/pets.ts
+++ b/tests/__snapshots__/default/index-mock-file/pets/pets.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -92,6 +89,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -107,9 +107,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -145,6 +142,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -167,9 +167,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -195,6 +192,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -214,9 +214,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -242,6 +239,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -263,9 +263,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -291,6 +288,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/default/no-index-files/endpoints.ts
+++ b/tests/__snapshots__/default/no-index-files/endpoints.ts
@@ -60,9 +60,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -96,6 +93,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -111,9 +111,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -149,6 +146,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -171,9 +171,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -199,6 +196,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -218,9 +218,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -246,6 +243,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -267,9 +267,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -295,6 +292,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -313,9 +313,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -341,6 +338,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -92,6 +89,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -107,9 +107,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -145,6 +142,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -167,9 +167,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -195,6 +192,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -214,9 +214,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -242,6 +239,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -263,9 +263,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -291,6 +288,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -309,9 +309,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -337,6 +334,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/dateParams/pets/pets.ts
+++ b/tests/__snapshots__/fetch/dateParams/pets/pets.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets by country
- */
 export type listPetsByCountryResponse200 = {
   data: Pets;
   status: 200;
@@ -107,6 +104,9 @@ export const getListPetsByCountryUrl = (
     : `/pets-by-country/${country}`;
 };
 
+/**
+ * @summary List all pets by country
+ */
 export const listPetsByCountry = async (
   params?: ListPetsByCountryParams,
   country: CountryCode = 'UY',
@@ -127,9 +127,6 @@ export const listPetsByCountry = async (
   } as listPetsByCountryResponse;
 };
 
-/**
- * @summary List all pets by age
- */
 export type listPetsByAgeResponse200 = {
   data: Pets;
   status: 200;
@@ -177,6 +174,9 @@ export const getListPetsByAgeUrl = (
     : `/pets-by-age/${age}`;
 };
 
+/**
+ * @summary List all pets by age
+ */
 export const listPetsByAge = async (
   params?: ListPetsByAgeParams,
   age: number = 5,

--- a/tests/__snapshots__/fetch/default-only-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/default-only-response/endpoints.ts
@@ -8,9 +8,6 @@ export interface Dog {
   type?: string;
 }
 
-/**
- * @summary List all pets
- */
 export type listPetsResponseDefault = {
   data: Dog;
   status: number;
@@ -25,6 +22,9 @@ export const getListPetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   options?: RequestInit,
 ): Promise<listPetsResponse> => {

--- a/tests/__snapshots__/fetch/force-success-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -90,6 +87,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -118,9 +118,6 @@ export const listPets = async (
   } as listPetsResponseSuccess;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -152,6 +149,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -183,9 +183,6 @@ export const createPets = async (
   } as createPetsResponseSuccess;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -207,6 +204,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -235,9 +235,6 @@ export const showPetById = async (
   } as showPetByIdResponseSuccess;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -259,6 +256,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -291,9 +291,6 @@ export const deletePetById = async (
   } as deletePetByIdResponseSuccess;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -315,6 +312,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponseSuccess> => {
@@ -342,9 +342,6 @@ export const healthCheck = async (
   } as healthCheckResponseSuccess;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -366,6 +363,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-optional-request/endpoints.ts
@@ -55,9 +55,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -83,6 +80,9 @@ export const getCreatePetsUrl = (version: number = 1) => {
   return `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   pet?: Pet,
   version: number = 1,

--- a/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -84,6 +81,9 @@ export const getCreatePetsUrl = (version: number = 1) => {
   return `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   pet?: Pet,
   version: number = 1,

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -82,6 +79,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
@@ -53,9 +53,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -81,6 +78,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/headers/endpoints.ts
@@ -58,9 +58,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -94,6 +91,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   headers: ListPetsHeaders,
@@ -111,9 +111,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -149,6 +146,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -176,9 +176,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -204,6 +201,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -223,9 +223,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -251,6 +248,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -272,9 +272,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -300,6 +297,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -318,9 +318,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -346,6 +343,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
@@ -20,9 +20,6 @@ import type { RequestHandlerOptions } from 'msw';
 
 import type { Cat, Dachshund, Dog, Labradoodle } from './model';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -37,6 +34,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -52,9 +52,6 @@ export const listPets = async (
   return data;
 };
 
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = (params: CreatePetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -69,6 +66,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -87,13 +87,13 @@ export const createPets = async (
   return data;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -109,13 +109,13 @@ export const showPetById = async (
   return data;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -131,13 +131,13 @@ export const deletePetById = async (
   return data;
 };
 
-/**
- * @summary health check
- */
 export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (options?: RequestInit): Promise<string> => {
   const res = await fetch(getHealthCheckUrl(), {
     ...options,
@@ -150,13 +150,13 @@ export const healthCheck = async (options?: RequestInit): Promise<string> => {
   return data;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/mixed-content-responses-force-success/endpoints.ts
+++ b/tests/__snapshots__/fetch/mixed-content-responses-force-success/endpoints.ts
@@ -7,9 +7,6 @@
  */
 import type { GetData200, GetMixedSuccess200 } from './model';
 
-/**
- * @summary Returns JSON on success, plain text on rate limit
- */
 export type getDataResponse200 = {
   data: GetData200;
   status: 200;
@@ -31,6 +28,9 @@ export const getGetDataUrl = () => {
   return `/data`;
 };
 
+/**
+ * @summary Returns JSON on success, plain text on rate limit
+ */
 export const getData = async (
   options?: RequestInit,
 ): Promise<getDataResponseSuccess> => {
@@ -58,9 +58,6 @@ export const getData = async (
   } as getDataResponseSuccess;
 };
 
-/**
- * @summary Returns plain text
- */
 export type getTextResponse200 = {
   data: string;
   status: 200;
@@ -73,6 +70,9 @@ export const getGetTextUrl = () => {
   return `/text`;
 };
 
+/**
+ * @summary Returns plain text
+ */
 export const getText = async (
   options?: RequestInit,
 ): Promise<getTextResponseSuccess> => {
@@ -98,9 +98,6 @@ export const getText = async (
   } as getTextResponseSuccess;
 };
 
-/**
- * @summary Returns a binary image
- */
 export type getImageResponse200 = {
   data: Blob;
   status: 200;
@@ -113,6 +110,9 @@ export const getGetImageUrl = () => {
   return `/image`;
 };
 
+/**
+ * @summary Returns a binary image
+ */
 export const getImage = async (
   options?: RequestInit,
 ): Promise<getImageResponseSuccess> => {
@@ -143,9 +143,6 @@ export const getImage = async (
   } as getImageResponseSuccess;
 };
 
-/**
- * @summary Returns JSON on full success, plain text on partial success
- */
 export type getMixedSuccessResponse200 = {
   data: GetMixedSuccess200;
   status: 200;
@@ -166,6 +163,9 @@ export const getGetMixedSuccessUrl = () => {
   return `/mixed-success`;
 };
 
+/**
+ * @summary Returns JSON on full success, plain text on partial success
+ */
 export const getMixedSuccess = async (
   options?: RequestInit,
 ): Promise<getMixedSuccessResponseSuccess> => {

--- a/tests/__snapshots__/fetch/mixed-content-responses/endpoints.ts
+++ b/tests/__snapshots__/fetch/mixed-content-responses/endpoints.ts
@@ -7,9 +7,6 @@
  */
 import type { GetData200, GetMixedSuccess200 } from './model';
 
-/**
- * @summary Returns JSON on success, plain text on rate limit
- */
 export type getDataResponse200 = {
   data: GetData200;
   status: 200;
@@ -33,6 +30,9 @@ export const getGetDataUrl = () => {
   return `/data`;
 };
 
+/**
+ * @summary Returns JSON on success, plain text on rate limit
+ */
 export const getData = async (
   options?: RequestInit,
 ): Promise<getDataResponse> => {
@@ -47,9 +47,6 @@ export const getData = async (
   return { data, status: res.status, headers: res.headers } as getDataResponse;
 };
 
-/**
- * @summary Returns plain text
- */
 export type getTextResponse200 = {
   data: string;
   status: 200;
@@ -64,6 +61,9 @@ export const getGetTextUrl = () => {
   return `/text`;
 };
 
+/**
+ * @summary Returns plain text
+ */
 export const getText = async (
   options?: RequestInit,
 ): Promise<getTextResponse> => {
@@ -78,9 +78,6 @@ export const getText = async (
   return { data, status: res.status, headers: res.headers } as getTextResponse;
 };
 
-/**
- * @summary Returns a binary image
- */
 export type getImageResponse200 = {
   data: Blob;
   status: 200;
@@ -95,6 +92,9 @@ export const getGetImageUrl = () => {
   return `/image`;
 };
 
+/**
+ * @summary Returns a binary image
+ */
 export const getImage = async (
   options?: RequestInit,
 ): Promise<getImageResponse> => {
@@ -108,9 +108,6 @@ export const getImage = async (
   return { data, status: res.status, headers: res.headers } as getImageResponse;
 };
 
-/**
- * @summary Returns JSON on full success, plain text on partial success
- */
 export type getMixedSuccessResponse200 = {
   data: GetMixedSuccess200;
   status: 200;
@@ -133,6 +130,9 @@ export const getGetMixedSuccessUrl = () => {
   return `/mixed-success`;
 };
 
+/**
+ * @summary Returns JSON on full success, plain text on partial success
+ */
 export const getMixedSuccess = async (
   options?: RequestInit,
 ): Promise<getMixedSuccessResponse> => {

--- a/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
@@ -63,9 +63,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -99,6 +96,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -114,9 +114,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -152,6 +149,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -174,9 +174,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -202,6 +199,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -221,9 +221,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -249,6 +246,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -270,9 +270,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -298,6 +295,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -316,9 +316,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -344,6 +341,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -57,9 +57,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -93,6 +90,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -103,9 +103,6 @@ export const listPets = async (
   });
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -141,6 +138,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -154,9 +154,6 @@ export const createPets = async (
   });
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -182,6 +179,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -192,9 +192,6 @@ export const showPetById = async (
   });
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -220,6 +217,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -233,9 +233,6 @@ export const deletePetById = async (
   );
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -261,6 +258,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -270,9 +270,6 @@ export const healthCheck = async (
   });
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -298,6 +295,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -64,9 +64,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -98,6 +95,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -108,9 +108,6 @@ export const listPets = async (
   });
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -142,6 +139,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -155,9 +155,6 @@ export const createPets = async (
   });
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -179,6 +176,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -189,9 +189,6 @@ export const showPetById = async (
   });
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -213,6 +210,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -223,9 +223,6 @@ export const deletePetById = async (
   });
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -247,6 +244,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponseSuccess> => {
@@ -256,9 +256,6 @@ export const healthCheck = async (
   });
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -280,6 +277,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters/endpoints.ts
@@ -59,9 +59,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -95,6 +92,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -110,9 +110,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -148,6 +145,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -170,9 +170,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -198,6 +195,9 @@ export const getShowPetByIdUrl = ({ petId }: ShowPetByIdPathParameters) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   { petId }: ShowPetByIdPathParameters,
   options?: RequestInit,
@@ -217,9 +217,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -245,6 +242,9 @@ export const getDeletePetByIdUrl = ({ petId }: DeletePetByIdPathParameters) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   { petId }: DeletePetByIdPathParameters,
   options?: RequestInit,
@@ -266,9 +266,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -294,6 +291,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -312,9 +312,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -342,6 +339,9 @@ export const getShowPetWithOwnerUrl = ({
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   { petId }: ShowPetWithOwnerPathParameters,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/parameters/endpoints.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets by country
- */
 export type listPetsByCountryResponse200 = {
   data: Pets;
   status: 200;
@@ -107,6 +104,9 @@ export const getListPetsByCountryUrl = (
     : `/pets-by-country/${country}`;
 };
 
+/**
+ * @summary List all pets by country
+ */
 export const listPetsByCountry = async (
   params?: ListPetsByCountryParams,
   country: CountryCode = 'UY',
@@ -127,9 +127,6 @@ export const listPetsByCountry = async (
   } as listPetsByCountryResponse;
 };
 
-/**
- * @summary List all pets by age
- */
 export type listPetsByAgeResponse200 = {
   data: Pets;
   status: 200;
@@ -170,6 +167,9 @@ export const getListPetsByAgeUrl = (
     : `/pets-by-age/${age}`;
 };
 
+/**
+ * @summary List all pets by age
+ */
 export const listPetsByAge = async (
   params?: ListPetsByAgeParams,
   age: number = 5,

--- a/tests/__snapshots__/fetch/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/health/health.ts
@@ -48,9 +48,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -76,6 +73,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -92,6 +89,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -107,9 +107,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -145,6 +142,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -167,9 +167,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -195,6 +192,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -214,9 +214,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -242,6 +239,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -263,9 +263,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -291,6 +288,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/petstore/endpoints.ts
+++ b/tests/__snapshots__/fetch/petstore/endpoints.ts
@@ -63,9 +63,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -99,6 +96,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -114,9 +114,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -152,6 +149,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -174,9 +174,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -202,6 +199,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -221,9 +221,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -249,6 +246,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -270,9 +270,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -298,6 +295,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -316,9 +316,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -344,6 +341,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -92,6 +89,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -112,9 +112,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -150,6 +147,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -177,9 +177,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -205,6 +202,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -229,9 +229,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -257,6 +254,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -283,9 +283,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -311,6 +308,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -334,9 +334,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -362,6 +359,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/reviver/health/health.ts
+++ b/tests/__snapshots__/fetch/reviver/health/health.ts
@@ -50,9 +50,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -78,6 +75,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/fetch/reviver/pets/pets.ts
+++ b/tests/__snapshots__/fetch/reviver/pets/pets.ts
@@ -58,9 +58,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -94,6 +91,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -111,9 +111,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -149,6 +146,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -173,9 +173,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -201,6 +198,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -222,9 +222,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -250,6 +247,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -271,9 +271,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -299,6 +296,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/split/endpoints.ts
+++ b/tests/__snapshots__/fetch/split/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -92,6 +89,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -107,9 +107,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -145,6 +142,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -167,9 +167,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -195,6 +192,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -214,9 +214,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -242,6 +239,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -263,9 +263,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -291,6 +288,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -309,9 +309,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -337,6 +334,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/stream/endpoints.ts
@@ -10,9 +10,6 @@ interface TypedResponse<T> extends Response {
   json(): Promise<T>;
 }
 
-/**
- * Stream results
- */
 export type streamResponse200 = {
   stream: TypedResponse<StreamEntry>;
   status: 200;
@@ -27,6 +24,9 @@ export const getStreamUrl = () => {
   return `/stream`;
 };
 
+/**
+ * Stream results
+ */
 export const stream = async (
   options?: RequestInit,
 ): Promise<streamResponse> => {

--- a/tests/__snapshots__/fetch/tags/health.ts
+++ b/tests/__snapshots__/fetch/tags/health.ts
@@ -53,9 +53,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -81,6 +78,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/fetch/tags/pets.ts
+++ b/tests/__snapshots__/fetch/tags/pets.ts
@@ -63,9 +63,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -99,6 +96,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -114,9 +114,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -152,6 +149,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -174,9 +174,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -202,6 +199,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -221,9 +221,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -249,6 +246,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -270,9 +270,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -298,6 +295,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/wildcard-responses/endpoints.ts
+++ b/tests/__snapshots__/fetch/wildcard-responses/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Fetch the current logged in user
- */
 export type getLoggedInUserResponse2xx = {
   data: UserDto;
   status: HTTPStatusCode2xx;
@@ -92,6 +89,9 @@ export const getGetLoggedInUserUrl = () => {
   return `/api/users/me`;
 };
 
+/**
+ * @summary Fetch the current logged in user
+ */
 export const getLoggedInUser = async (
   options?: RequestInit,
 ): Promise<getLoggedInUserResponse> => {
@@ -110,9 +110,6 @@ export const getLoggedInUser = async (
   } as getLoggedInUserResponse;
 };
 
-/**
- * @summary List all items
- */
 export type listItemsResponse200 = {
   data: ItemDto[];
   status: 200;
@@ -146,6 +143,9 @@ export const getListItemsUrl = () => {
   return `/api/items`;
 };
 
+/**
+ * @summary List all items
+ */
 export const listItems = async (
   options?: RequestInit,
 ): Promise<listItemsResponse> => {
@@ -164,9 +164,6 @@ export const listItems = async (
   } as listItemsResponse;
 };
 
-/**
- * @summary Endpoint with both specific and wildcard codes
- */
 export type getMixedResponsesResponse200 = {
   data: SuccessDto;
   status: 200;
@@ -208,6 +205,9 @@ export const getGetMixedResponsesUrl = () => {
   return `/api/mixed`;
 };
 
+/**
+ * @summary Endpoint with both specific and wildcard codes
+ */
 export const getMixedResponses = async (
   options?: RequestInit,
 ): Promise<getMixedResponsesResponse> => {

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -90,6 +87,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -113,9 +113,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -151,6 +148,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -181,9 +181,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -209,6 +206,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -236,9 +236,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -264,6 +261,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -285,9 +285,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -313,6 +310,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -331,9 +331,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -359,6 +356,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -60,9 +60,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -96,6 +93,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -119,9 +119,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -157,6 +154,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -187,9 +187,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -215,6 +212,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -242,9 +242,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -270,6 +267,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -291,9 +291,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -319,6 +316,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -337,9 +337,6 @@ export const healthCheck = async (
   } as healthCheckResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -365,6 +362,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/health/health.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/health/health.ts
@@ -48,9 +48,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -76,6 +73,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -90,6 +87,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -113,9 +113,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -151,6 +148,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -181,9 +181,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -209,6 +206,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -236,9 +236,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -264,6 +261,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -285,9 +285,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -313,6 +310,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/health.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/health.ts
@@ -48,9 +48,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -76,6 +73,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -54,9 +54,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -90,6 +87,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -113,9 +113,6 @@ export const listPets = async (
   return { data, status: res.status, headers: res.headers } as listPetsResponse;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -151,6 +148,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -181,9 +181,6 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -209,6 +206,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -236,9 +236,6 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -264,6 +261,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -285,9 +285,6 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -313,6 +310,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -90,6 +90,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -140,6 +143,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -187,6 +193,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -231,6 +240,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -277,6 +289,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -320,6 +335,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -90,6 +90,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -140,6 +143,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -187,6 +193,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -231,6 +240,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -277,6 +289,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -320,6 +335,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -90,6 +90,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -140,6 +143,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -187,6 +193,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -231,6 +240,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -277,6 +289,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -320,6 +335,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -81,9 +81,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -117,6 +114,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   headers: ListPetsHeaders,
@@ -265,9 +265,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -303,6 +300,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -417,9 +417,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -445,6 +442,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -595,9 +595,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -623,6 +620,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -711,9 +711,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -739,6 +736,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -876,9 +876,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -904,6 +901,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -73,9 +73,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -109,6 +106,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -250,9 +250,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -288,6 +285,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -383,9 +383,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -411,6 +408,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -561,9 +561,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -589,6 +586,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -683,9 +683,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -711,6 +708,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -848,9 +848,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -876,6 +873,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/deprecated/endpoints.ts
+++ b/tests/__snapshots__/react-query/deprecated/endpoints.ts
@@ -68,9 +68,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -104,6 +101,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -245,9 +245,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -273,6 +270,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -82,9 +82,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -118,6 +115,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -254,9 +254,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -292,6 +289,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -372,9 +372,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -400,6 +397,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -541,9 +541,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -569,6 +566,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -646,9 +646,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -674,6 +671,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -802,9 +802,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -830,6 +827,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/health/health.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/health/health.ts
@@ -19,13 +19,13 @@ import type {
 
 import type { Error } from '../model';
 
-/**
- * @summary health check
- */
 export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (options?: RequestInit): Promise<string> => {
   const res = await fetch(getHealthCheckUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -30,9 +30,6 @@ import type {
   Pets,
 } from '../model';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -47,6 +44,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -188,9 +188,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = (params: CreatePetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -205,6 +202,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -289,13 +289,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -442,13 +442,13 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -530,13 +530,13 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/http-client-fetch/health/health.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/health/health.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -85,6 +82,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponseSuccess> => {

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -106,6 +103,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -260,9 +260,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -294,6 +291,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -391,9 +391,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -415,6 +412,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -574,9 +574,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -598,6 +595,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -696,9 +696,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -720,6 +717,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -396,9 +396,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   );
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -424,6 +421,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -574,9 +574,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -602,6 +599,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -690,9 +690,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -718,6 +715,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -855,9 +855,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -883,6 +880,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/invalidates-tags-split/health/health.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/health/health.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -89,6 +86,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -74,9 +74,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -110,6 +107,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -251,9 +251,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -289,6 +286,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -397,9 +397,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     queryClient,
   );
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -425,6 +422,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -575,9 +575,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -603,6 +600,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -690,9 +690,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -718,6 +715,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -81,9 +81,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -117,6 +114,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   headers: ListPetsHeaders,
@@ -265,9 +265,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -303,6 +300,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -449,9 +449,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   );
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -477,6 +474,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -627,9 +627,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -655,6 +652,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -766,9 +766,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   );
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -794,6 +791,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -931,9 +931,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -959,6 +956,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -256,9 +256,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -294,6 +291,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -383,9 +383,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -411,6 +408,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -561,9 +561,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -589,6 +586,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -677,9 +677,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -705,6 +702,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -842,9 +842,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -870,6 +867,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -256,9 +256,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -294,6 +291,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -383,9 +383,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -411,6 +408,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -561,9 +561,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -589,6 +586,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -677,9 +677,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -705,6 +702,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -842,9 +842,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -870,6 +867,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -78,9 +78,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -119,6 +116,9 @@ export const getListPetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   { version = 1 }: ListPetsPathParameters = {},
   params: ListPetsParams,
@@ -273,9 +273,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -316,6 +313,9 @@ export const getCreatePetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   { version = 1 }: CreatePetsPathParameters = {},
   createPetsBody: CreatePetsBody,
@@ -426,9 +426,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -457,6 +454,9 @@ export const getShowPetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   { version = 1, petId }: ShowPetByIdPathParameters,
   options?: RequestInit,
@@ -611,9 +611,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -642,6 +639,9 @@ export const getDeletePetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   { version = 1, petId }: DeletePetByIdPathParameters,
   options?: RequestInit,
@@ -730,9 +730,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -760,6 +757,9 @@ export const getHealthCheckUrl = ({
   return `/v${version}/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   { version = 1 }: HealthCheckPathParameters = {},
   options?: RequestInit,
@@ -913,9 +913,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -944,6 +941,9 @@ export const getShowPetWithOwnerUrl = ({
   return `/v${version}/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   { version = 1, petId }: ShowPetWithOwnerPathParameters,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/no-content-with-default/endpoints.ts
+++ b/tests/__snapshots__/react-query/no-content-with-default/endpoints.ts
@@ -19,9 +19,6 @@ import type {
 
 import type { ErrorResponse } from './model';
 
-/**
- * @summary Get an Error Item
- */
 export type createItemsResponseDefault = {
   data: ErrorResponse;
   status: number;
@@ -36,6 +33,9 @@ export const getCreateItemsUrl = () => {
   return `/error`;
 };
 
+/**
+ * @summary Get an Error Item
+ */
 export const createItems = async (
   options?: RequestInit,
 ): Promise<createItemsResponse> => {

--- a/tests/__snapshots__/react-query/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/health/health.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -89,6 +86,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -375,9 +375,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -403,6 +400,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -553,9 +553,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -581,6 +578,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -668,9 +668,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -696,6 +693,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -77,9 +77,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: _PetsArrAy;
   status: 200;
@@ -113,6 +110,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -254,9 +254,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse201 = {
   data: void;
   status: 201;
@@ -282,6 +279,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
@@ -370,9 +370,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary List all pets as nested array
- */
 export type listPetsNestedArrayResponse200 = {
   data: N42PetsNestedArray;
   status: 200;
@@ -414,6 +411,9 @@ export const getListPetsNestedArrayUrl = (
     : `/pets-nested-array`;
 };
 
+/**
+ * @summary List all pets as nested array
+ */
 export const listPetsNestedArray = async (
   params?: ListPetsNestedArrayParams,
   options?: RequestInit,
@@ -584,9 +584,6 @@ export function useListPetsNestedArray<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -612,6 +609,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -376,9 +376,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -404,6 +401,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -554,9 +554,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -582,6 +579,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -670,9 +670,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -698,6 +695,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -835,9 +835,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -863,6 +860,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -249,9 +249,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -287,6 +284,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -376,9 +376,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -404,6 +401,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -554,9 +554,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -582,6 +579,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -670,9 +670,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -698,6 +695,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -835,9 +835,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -863,6 +860,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/tags/health.ts
+++ b/tests/__snapshots__/react-query/tags/health.ts
@@ -66,9 +66,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -94,6 +91,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -256,9 +256,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -294,6 +291,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -382,9 +382,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -410,6 +407,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -560,9 +560,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -588,6 +585,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -675,9 +675,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -703,6 +700,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -260,9 +260,6 @@ export const useGetListPetsQueryData = () => {
     );
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -298,6 +295,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -387,9 +387,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -415,6 +412,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -576,9 +576,6 @@ export const useGetShowPetByIdQueryData = () => {
     );
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -604,6 +601,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -692,9 +692,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -720,6 +717,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -868,9 +868,6 @@ export const useGetHealthCheckQueryData = () => {
     );
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -896,6 +893,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -74,9 +74,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -110,6 +107,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -276,9 +276,6 @@ export const invalidateListPets = async (
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -314,6 +311,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -403,9 +403,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -431,6 +428,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -601,9 +601,6 @@ export const invalidateShowPetById = async (
   return queryClient;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -629,6 +626,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -717,9 +717,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -745,6 +742,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -906,9 +906,6 @@ export const invalidateHealthCheck = async (
   return queryClient;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -934,6 +931,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -73,9 +73,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -109,6 +106,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -266,9 +266,6 @@ export const invalidateListPets = async (
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -304,6 +301,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -393,9 +393,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -421,6 +418,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -587,9 +587,6 @@ export const invalidateShowPetById = async (
   return queryClient;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -615,6 +612,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -703,9 +703,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -731,6 +728,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -883,9 +883,6 @@ export const invalidateHealthCheck = async (
   return queryClient;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -911,6 +908,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -272,9 +272,6 @@ export const prefetchListPetsQuery = async <
   return queryClient;
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -310,6 +307,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -399,9 +399,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -427,6 +424,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -600,9 +600,6 @@ export const prefetchShowPetByIdQuery = async <
   return queryClient;
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -628,6 +625,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -716,9 +716,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -744,6 +741,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -903,9 +903,6 @@ export const prefetchHealthCheckQuery = async <
   return queryClient;
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -931,6 +928,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -81,9 +81,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -117,6 +114,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -497,9 +497,6 @@ export const useSetListPetsQueryData = () => {
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -535,6 +532,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -624,9 +624,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -652,6 +649,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -994,9 +994,6 @@ export const useSetShowPetByIdQueryData = () => {
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -1022,6 +1019,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -1110,9 +1110,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -1138,6 +1135,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -1452,9 +1452,6 @@ export const useSetHealthCheckQueryData = () => {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -1480,6 +1477,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
@@ -19,10 +19,6 @@ import type {
 
 import type { GetUsersUserIdOrdersParams } from './model';
 
-/**
- * Retrieves a list of orders for a specific user with optional filtering
- * @summary Get user orders
- */
 export type getUsersUserIdOrdersResponse200 = {
   data: string[];
   status: 200;
@@ -53,6 +49,10 @@ export const getGetUsersUserIdOrdersUrl = (
     : `/users/${userId}/orders`;
 };
 
+/**
+ * Retrieves a list of orders for a specific user with optional filtering
+ * @summary Get user orders
+ */
 export const getUsersUserIdOrders = async (
   userId: number,
   params?: GetUsersUserIdOrdersParams,

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -78,9 +78,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -119,6 +116,9 @@ export const getListPetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   { version = 1 }: ListPetsPathParameters = {},
   params: ListPetsParams,
@@ -292,9 +292,6 @@ export const useSetListPetsQueryData = () => {
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -335,6 +332,9 @@ export const getCreatePetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   { version = 1 }: CreatePetsPathParameters = {},
   createPetsBody: CreatePetsBody,
@@ -445,9 +445,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -476,6 +473,9 @@ export const getShowPetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   { version = 1, petId }: ShowPetByIdPathParameters,
   options?: RequestInit,
@@ -651,9 +651,6 @@ export const useSetShowPetByIdQueryData = () => {
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -682,6 +679,9 @@ export const getDeletePetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   { version = 1, petId }: DeletePetByIdPathParameters,
   options?: RequestInit,
@@ -770,9 +770,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -800,6 +797,9 @@ export const getHealthCheckUrl = ({
   return `/v${version}/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   { version = 1 }: HealthCheckPathParameters = {},
   options?: RequestInit,
@@ -971,9 +971,6 @@ export const useSetHealthCheckQueryData = () => {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -1002,6 +999,9 @@ export const getShowPetWithOwnerUrl = ({
   return `/v${version}/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   { version = 1, petId }: ShowPetWithOwnerPathParameters,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -267,9 +267,6 @@ export const useSetListPetsQueryData = () => {
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -305,6 +302,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -394,9 +394,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -422,6 +419,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -590,9 +590,6 @@ export const useSetShowPetByIdQueryData = () => {
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -618,6 +615,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -706,9 +706,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -734,6 +731,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -888,9 +888,6 @@ export const useSetHealthCheckQueryData = () => {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -916,6 +913,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -256,9 +256,6 @@ export function useListPets<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -294,6 +291,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -383,9 +383,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -411,6 +408,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -561,9 +561,6 @@ export function useShowPetById<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -589,6 +586,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -677,9 +677,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -705,6 +702,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -842,9 +842,6 @@ export function useHealthCheck<
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -870,6 +867,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -77,9 +77,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -113,6 +110,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -191,9 +191,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -229,6 +226,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -306,9 +306,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   return createMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -334,6 +331,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -417,9 +417,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -445,6 +442,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -522,9 +522,6 @@ export const createDeletePetById = <
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -550,6 +547,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -621,9 +621,6 @@ export function createHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -649,6 +646,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/health/health.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/health/health.ts
@@ -14,13 +14,13 @@ import type {
 
 import type { Error } from '../model';
 
-/**
- * @summary health check
- */
 export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (options?: RequestInit): Promise<string> => {
   const res = await fetch(getHealthCheckUrl(), {
     ...options,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -25,9 +25,6 @@ import type {
   Pets,
 } from '../model';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -42,6 +39,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -125,9 +125,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = (params: CreatePetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -142,6 +139,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -223,13 +223,13 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
 };
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -318,13 +318,13 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -406,13 +406,13 @@ export const createDeletePetById = <
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/http-client-fetch/health/health.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/health/health.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -84,6 +81,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -67,9 +67,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -103,6 +100,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -186,9 +186,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -309,9 +309,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -337,6 +334,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -429,9 +429,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -457,6 +454,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -544,9 +544,6 @@ export const createDeletePetById = <
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -572,6 +569,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/health.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/health.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -89,6 +86,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -83,9 +83,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -119,6 +116,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   headers: ListPetsHeaders,
@@ -206,9 +206,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -244,6 +241,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -381,9 +381,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     getCreatePetsMutationOptions(queryClient ?? backupQueryClient, options),
   );
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -409,6 +406,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -501,9 +501,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -529,6 +526,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -639,9 +639,6 @@ export const createDeletePetById = <TError = Error, TContext = unknown>(
     getDeletePetByIdMutationOptions(queryClient ?? backupQueryClient, options),
   );
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -667,6 +664,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -81,9 +81,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -117,6 +114,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   headers: ListPetsHeaders,
@@ -204,9 +204,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -242,6 +239,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -379,9 +379,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
   );
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -407,6 +404,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -499,9 +499,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -527,6 +524,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -637,9 +637,6 @@ export const createDeletePetById = <TError = Error, TContext = unknown>(
   );
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -665,6 +662,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -745,9 +745,6 @@ export function createHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -773,6 +770,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -120,6 +117,9 @@ export const getListPetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   { version = 1 }: ListPetsPathParameters = {},
   params: ListPetsParams,
@@ -308,9 +308,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -351,6 +348,9 @@ export const getCreatePetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   { version = 1 }: CreatePetsPathParameters = {},
   createPetsBody: CreatePetsBody,
@@ -458,9 +458,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   return createMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -489,6 +486,9 @@ export const getShowPetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   { version = 1, petId }: ShowPetByIdPathParameters,
   options?: RequestInit,
@@ -666,9 +666,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -697,6 +694,9 @@ export const getDeletePetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   { version = 1, petId }: DeletePetByIdPathParameters,
   options?: RequestInit,
@@ -785,9 +785,6 @@ export const createDeletePetById = <
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -815,6 +812,9 @@ export const getHealthCheckUrl = ({
   return `/v${version}/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   { version = 1 }: HealthCheckPathParameters = {},
   options?: RequestInit,
@@ -986,9 +986,6 @@ export function createHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -1017,6 +1014,9 @@ export const getShowPetWithOwnerUrl = ({
   return `/v${version}/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   { version = 1, petId }: ShowPetWithOwnerPathParameters,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/health/health.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -84,6 +81,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -67,9 +67,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -103,6 +100,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -186,9 +186,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -309,9 +309,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -337,6 +334,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -429,9 +429,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -457,6 +454,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -544,9 +544,6 @@ export const createDeletePetById = <
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -572,6 +569,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -80,9 +80,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -118,6 +115,9 @@ export const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   version: number = 1,
@@ -305,9 +305,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -348,6 +345,9 @@ export const getCreatePetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -435,9 +435,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   return createMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -463,6 +460,9 @@ export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   version: number = 1,
@@ -642,9 +642,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -670,6 +667,9 @@ export const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   version: number = 1,
@@ -759,9 +759,6 @@ export const createDeletePetById = <
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -787,6 +784,9 @@ export const getHealthCheckUrl = (version: number = 1) => {
   return `/v${version}/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   version: number = 1,
   options?: RequestInit,
@@ -953,9 +953,6 @@ export function createHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -981,6 +978,9 @@ export const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   version: number = 1,

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -67,9 +67,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -103,6 +100,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -186,9 +186,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -224,6 +221,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -310,9 +310,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   return createMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -338,6 +335,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -430,9 +430,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -458,6 +455,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -546,9 +546,6 @@ export const createDeletePetById = <
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -574,6 +571,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -654,9 +654,6 @@ export function createHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -682,6 +679,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/tags/health.ts
+++ b/tests/__snapshots__/svelte-query/tags/health.ts
@@ -61,9 +61,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -89,6 +86,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -74,9 +74,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -110,6 +107,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -193,9 +193,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -231,6 +228,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -316,9 +316,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -344,6 +341,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -436,9 +436,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -464,6 +461,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -551,9 +551,6 @@ export const createDeletePetById = <
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -579,6 +576,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -74,9 +74,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -110,6 +107,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -193,9 +193,6 @@ export function createListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -231,6 +228,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -317,9 +317,6 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   return createMutation(getCreatePetsMutationOptions(options));
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -345,6 +342,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -437,9 +437,6 @@ export function createShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -465,6 +462,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -553,9 +553,6 @@ export const createDeletePetById = <
   return createMutation(getDeletePetByIdMutationOptions(options));
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -581,6 +578,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -661,9 +661,6 @@ export function createHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -689,6 +686,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/blob-file/endpoints.ts
+++ b/tests/__snapshots__/swr/blob-file/endpoints.ts
@@ -13,9 +13,6 @@ import { faker } from '@faker-js/faker';
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
 
-/**
- * @summary Binary Blob response
- */
 export type getBinaryBlobResponse200 = {
   data: Blob;
   status: 200;
@@ -30,6 +27,9 @@ export const getGetBinaryBlobUrl = (version: number = 1) => {
   return `/v${version}/binary-blob`;
 };
 
+/**
+ * @summary Binary Blob response
+ */
 export const getBinaryBlob = async (
   version: number = 1,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/errors/endpoints.ts
+++ b/tests/__snapshots__/swr/errors/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Get an Error Item
- */
 export type createItemsResponse200 = {
   data: Item;
   status: 200;
@@ -92,6 +89,9 @@ export const getCreateItemsUrl = () => {
   return `/error`;
 };
 
+/**
+ * @summary Get an Error Item
+ */
 export const createItems = async (
   options?: RequestInit,
 ): Promise<createItemsResponse> => {

--- a/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
+++ b/tests/__snapshots__/swr/form-data-optional-request/endpoints.ts
@@ -60,9 +60,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -88,6 +85,9 @@ export const getCreatePetsUrl = (version: number = 1) => {
   return `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   pet?: Pet,
   version: number = 1,

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -157,9 +157,6 @@ export const useListPets = <TError = Error>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -195,6 +192,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -252,9 +252,6 @@ export const useCreatePets = <TError = Error>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -280,6 +277,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -328,9 +328,6 @@ export const useShowPetById = <TError = Error>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -356,6 +353,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -410,9 +410,6 @@ export const useDeletePetById = <TError = Error>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -438,6 +435,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -482,9 +482,6 @@ export const useHealthCheck = <TError = Error>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -510,6 +507,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/health/health.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/health/health.ts
@@ -9,13 +9,13 @@ import type { Key, SWRConfiguration } from 'swr';
 
 import type { Error } from '../model';
 
-/**
- * @summary health check
- */
 export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (options?: RequestInit): Promise<string> => {
   const res = await fetch(getHealthCheckUrl(), {
     ...options,

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -20,9 +20,6 @@ import type {
   Pets,
 } from '../model';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -37,6 +34,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -90,9 +90,6 @@ export const useListPets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = (params: CreatePetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -107,6 +104,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -168,13 +168,13 @@ export const useCreatePets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -227,13 +227,13 @@ export const useShowPetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Deletes a specific pet
- */
 export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -292,13 +292,13 @@ export const useDeletePetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/http-client-fetch/health/health.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/health/health.ts
@@ -51,9 +51,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -75,6 +72,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponseSuccess> => {

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -62,9 +62,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -96,6 +93,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -162,9 +162,6 @@ export const useListPets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -196,6 +193,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -270,9 +270,6 @@ export const useCreatePets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -294,6 +291,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -359,9 +359,6 @@ export const useShowPetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -383,6 +380,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -458,9 +458,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -482,6 +479,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -68,9 +68,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -109,6 +106,9 @@ export const getListPetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   { version = 1 }: ListPetsPathParameters = {},
   params: ListPetsParams,
@@ -168,9 +168,6 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -211,6 +208,9 @@ export const getCreatePetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   { version = 1 }: CreatePetsPathParameters = {},
   createPetsBody: CreatePetsBody,
@@ -283,9 +283,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -314,6 +311,9 @@ export const getShowPetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   { version = 1, petId }: ShowPetByIdPathParameters,
   options?: RequestInit,
@@ -375,9 +375,6 @@ export const useShowPetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -406,6 +403,9 @@ export const getDeletePetByIdUrl = ({
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   { version = 1, petId }: DeletePetByIdPathParameters,
   options?: RequestInit,
@@ -477,9 +477,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -507,6 +504,9 @@ export const getHealthCheckUrl = ({
   return `/v${version}/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   { version = 1 }: HealthCheckPathParameters = {},
   options?: RequestInit,
@@ -567,9 +567,6 @@ export const useHealthCheck = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -598,6 +595,9 @@ export const getShowPetWithOwnerUrl = ({
   return `/v${version}/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   { version = 1, petId }: ShowPetWithOwnerPathParameters,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/nested-arrays/endpoints.ts
+++ b/tests/__snapshots__/swr/nested-arrays/endpoints.ts
@@ -16,9 +16,6 @@ import { faker } from '@faker-js/faker';
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
 
-/**
- * @summary sample
- */
 export type postApiSampleResponse200 = {
   data: ResSampleModel;
   status: 200;
@@ -33,6 +30,9 @@ export const getPostApiSampleUrl = () => {
   return `/api/sample`;
 };
 
+/**
+ * @summary sample
+ */
 export const postApiSample = async (
   options?: RequestInit,
 ): Promise<postApiSampleResponse> => {

--- a/tests/__snapshots__/swr/pattern/endpoints.ts
+++ b/tests/__snapshots__/swr/pattern/endpoints.ts
@@ -14,9 +14,6 @@ import { faker } from '@faker-js/faker';
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
 
-/**
- * @summary Example
- */
 export type getVversionExampleResponse200 = {
   data: Node;
   status: 200;
@@ -32,6 +29,9 @@ export const getGetVversionExampleUrl = (version: number = 1) => {
   return `/v${version}/example`;
 };
 
+/**
+ * @summary Example
+ */
 export const getVversionExample = async (
   version: number = 1,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -68,9 +68,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -104,6 +101,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -278,9 +278,6 @@ export const useListPetsMutation = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -316,6 +313,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -385,9 +385,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -413,6 +410,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -587,9 +587,6 @@ export const useShowPetByIdMutation = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -615,6 +612,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -683,9 +683,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -711,6 +708,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -872,9 +872,6 @@ export const useHealthCheckMutation = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -900,6 +897,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/health/health.ts
@@ -51,9 +51,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -79,6 +76,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -62,9 +62,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -98,6 +95,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -151,9 +151,6 @@ export const useListPets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -189,6 +186,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -254,9 +254,6 @@ export const useCreatePets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -282,6 +279,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -338,9 +338,6 @@ export const useShowPetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -366,6 +363,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -430,9 +430,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -458,6 +455,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -70,9 +70,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -106,6 +103,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   headers: ListPetsHeaders,
@@ -233,9 +233,6 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -271,6 +268,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -344,9 +344,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -372,6 +369,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -495,9 +495,6 @@ export const useShowPetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -523,6 +520,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -588,9 +588,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -616,6 +613,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -732,9 +732,6 @@ export const useHealthCheck = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -760,6 +757,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -69,9 +69,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -107,6 +104,9 @@ export const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   version: number = 1,
@@ -164,9 +164,6 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -207,6 +204,9 @@ export const getCreatePetsUrl = (
     : `/v${version}/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -279,9 +279,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -307,6 +304,9 @@ export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   version: number = 1,
@@ -368,9 +368,6 @@ export const useShowPetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -396,6 +393,9 @@ export const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   version: number = 1,
@@ -467,9 +467,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -495,6 +492,9 @@ export const getHealthCheckUrl = (version: number = 1) => {
   return `/v${version}/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   version: number = 1,
   options?: RequestInit,
@@ -554,9 +554,6 @@ export const useHealthCheck = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -582,6 +579,9 @@ export const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
   return `/v${version}/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   version: number = 1,

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -62,9 +62,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -98,6 +95,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -152,9 +152,6 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -190,6 +187,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -256,9 +256,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -284,6 +281,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -341,9 +341,6 @@ export const useShowPetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -369,6 +366,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -434,9 +434,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -462,6 +459,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -515,9 +515,6 @@ export const useHealthCheck = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -543,6 +540,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/swr-infinite-pagination/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-infinite-pagination/endpoints.ts
@@ -21,9 +21,6 @@ import type {
   PetsWrappedResponse,
 } from './model';
 
-/**
- * @summary List all pets as direct array
- */
 export type listPetsArrayResponse200 = {
   data: Pet[];
   status: 200;
@@ -50,6 +47,9 @@ export const getListPetsArrayUrl = (params?: ListPetsArrayParams) => {
     : `/pets-array`;
 };
 
+/**
+ * @summary List all pets as direct array
+ */
 export const listPetsArray = async (
   params?: ListPetsArrayParams,
   options?: RequestInit,
@@ -183,9 +183,6 @@ export const useListPetsArray = <TError = Promise<unknown>>(
   };
 };
 
-/**
- * @summary List all pets wrapped in data property
- */
 export type listPetsWrappedResponse200 = {
   data: PetsWrappedResponse;
   status: 200;
@@ -212,6 +209,9 @@ export const getListPetsWrappedUrl = (params?: ListPetsWrappedParams) => {
     : `/pets-wrapped`;
 };
 
+/**
+ * @summary List all pets wrapped in data property
+ */
 export const listPetsWrapped = async (
   params?: ListPetsWrappedParams,
   options?: RequestInit,
@@ -345,9 +345,6 @@ export const useListPetsWrapped = <TError = Promise<unknown>>(
   };
 };
 
-/**
- * @summary Get a single pet object
- */
 export type getPetSingleResponse200 = {
   data: Pet;
   status: 200;
@@ -362,6 +359,9 @@ export const getGetPetSingleUrl = () => {
   return `/pet-single`;
 };
 
+/**
+ * @summary Get a single pet object
+ */
 export const getPetSingle = async (
   options?: RequestInit,
 ): Promise<getPetSingleResponse> => {

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -62,9 +62,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -98,6 +95,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -189,9 +189,6 @@ export const useListPetsSuspense = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -227,6 +224,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -293,9 +293,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -321,6 +318,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -415,9 +415,6 @@ export const useShowPetByIdSuspense = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -443,6 +440,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -508,9 +508,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -536,6 +533,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -623,9 +623,6 @@ export const useHealthCheckSuspense = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -651,6 +648,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -62,9 +62,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -98,6 +95,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -153,9 +153,6 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -191,6 +188,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -258,9 +258,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -286,6 +283,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -344,9 +344,6 @@ export const useShowPetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -372,6 +369,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -438,9 +438,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -466,6 +463,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -520,9 +520,6 @@ export const useHealthCheck = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -548,6 +545,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/tags/health.ts
+++ b/tests/__snapshots__/swr/tags/health.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -84,6 +81,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -69,9 +69,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -105,6 +102,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -158,9 +158,6 @@ export const useListPets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -196,6 +193,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -261,9 +261,6 @@ export const useCreatePets = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -289,6 +286,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -345,9 +345,6 @@ export const useShowPetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -373,6 +370,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -437,9 +437,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
     ...query,
   };
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -465,6 +462,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -69,9 +69,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -105,6 +102,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -159,9 +159,6 @@ export const useListPets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -197,6 +194,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -263,9 +263,6 @@ export const useCreatePets = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -291,6 +288,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -348,9 +348,6 @@ export const useShowPetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -376,6 +373,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -441,9 +441,6 @@ export const useDeletePetById = <TError = Promise<Error>>(
   };
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -469,6 +466,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -522,9 +522,6 @@ export const useHealthCheck = <TError = Promise<Error>>(options?: {
   };
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -550,6 +547,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -201,9 +201,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -239,6 +236,9 @@ export const getCreatePetsUrl = (params?: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params?: CreatePetsParams,
@@ -328,9 +328,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -356,6 +353,9 @@ export const getShowPetByIdUrl = (petId: string | undefined | null) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string | undefined | null,
   options?: RequestInit,
@@ -449,9 +449,6 @@ export function useShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -477,6 +474,9 @@ export const getDeletePetByIdUrl = (petId: string | undefined | null) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string | undefined | null,
   options?: RequestInit,
@@ -565,9 +565,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -593,6 +590,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -678,9 +678,6 @@ export function useHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -706,6 +703,9 @@ export const getShowPetWithOwnerUrl = (petId: string | undefined | null) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string | undefined | null,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params?: ListPetsParams,
   options?: RequestInit,
@@ -201,9 +201,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -239,6 +236,9 @@ export const getCreatePetsUrl = (params?: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params?: CreatePetsParams,
@@ -328,9 +328,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -356,6 +353,9 @@ export const getShowPetByIdUrl = (petId: string | undefined | null) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string | undefined | null,
   options?: RequestInit,
@@ -449,9 +449,6 @@ export function useShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -477,6 +474,9 @@ export const getDeletePetByIdUrl = (petId: string | undefined | null) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string | undefined | null,
   options?: RequestInit,
@@ -565,9 +565,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -593,6 +590,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -678,9 +678,6 @@ export function useHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -706,6 +703,9 @@ export const getShowPetWithOwnerUrl = (petId: string | undefined | null) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string | undefined | null,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/form-data/endpoints.ts
@@ -56,9 +56,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -84,6 +81,9 @@ export const getCreatePetsUrl = () => {
   return `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   pet: Pet,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -82,9 +82,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -118,6 +115,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -199,9 +199,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -237,6 +234,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -317,9 +317,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -345,6 +342,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -427,9 +427,6 @@ export function useShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -455,6 +452,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -532,9 +532,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -560,6 +557,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -636,9 +636,6 @@ export function useHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -664,6 +661,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/health/health.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/health/health.ts
@@ -18,13 +18,13 @@ import { unref } from 'vue';
 
 import type { Error } from '../model';
 
-/**
- * @summary health check
- */
 export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (options?: RequestInit): Promise<string> => {
   const res = await fetch(getHealthCheckUrl(), {
     ...options,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -30,9 +30,6 @@ import type {
   Pets,
 } from '../model';
 
-/**
- * @summary List all pets
- */
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -47,6 +44,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -133,9 +133,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export const getCreatePetsUrl = (params: CreatePetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -150,6 +147,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -234,13 +234,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -328,13 +328,13 @@ export function useShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -416,13 +416,13 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-multi-query-params/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-multi-query-params/endpoints.ts
@@ -19,10 +19,6 @@ import type { MaybeRef } from 'vue';
 
 import type { GetUsersUserIdOrdersParams } from './model';
 
-/**
- * Retrieves a list of orders for a specific user with optional filtering
- * @summary Get user orders
- */
 export type getUsersUserIdOrdersResponse200 = {
   data: string[];
   status: 200;
@@ -53,6 +49,10 @@ export const getGetUsersUserIdOrdersUrl = (
     : `/users/${userId}/orders`;
 };
 
+/**
+ * Retrieves a list of orders for a specific user with optional filtering
+ * @summary Get user orders
+ */
 export const getUsersUserIdOrders = async (
   userId: number,
   params?: GetUsersUserIdOrdersParams,

--- a/tests/__snapshots__/vue-query/http-client-fetch/health/health.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/health/health.ts
@@ -60,9 +60,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -88,6 +85,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -194,9 +194,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -232,6 +229,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -320,9 +320,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -348,6 +345,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -439,9 +439,6 @@ export function useShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -467,6 +464,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -554,9 +554,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -582,6 +579,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -79,9 +79,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -115,6 +112,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -201,9 +201,6 @@ export function useListPets<
   return query;
 }
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -239,6 +236,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -328,9 +328,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -356,6 +353,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -447,9 +447,6 @@ export function useShowPetById<
   return query;
 }
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -475,6 +472,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -563,9 +563,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -591,6 +588,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -676,9 +676,6 @@ export function useHealthCheck<
   return query;
 }
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -704,6 +701,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -72,9 +72,6 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
-/**
- * @summary List all pets
- */
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -108,6 +105,9 @@ export const getListPetsUrl = (params: ListPetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary List all pets
+ */
 export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
@@ -210,9 +210,6 @@ export const setListPetsQueryData = (
   queryClient.setQueryData(getListPetsQueryKey(params), updater);
 };
 
-/**
- * @summary Create a pet
- */
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -248,6 +245,9 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
   return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
 };
 
+/**
+ * @summary Create a pet
+ */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
@@ -337,9 +337,6 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
 };
 
-/**
- * @summary Info for a specific pet
- */
 export type showPetByIdResponse200 = {
   data: Pet;
   status: 200;
@@ -365,6 +362,9 @@ export const getShowPetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Info for a specific pet
+ */
 export const showPetById = async (
   petId: string,
   options?: RequestInit,
@@ -472,9 +472,6 @@ export const setShowPetByIdQueryData = (
   queryClient.setQueryData(getShowPetByIdQueryKey(petId), updater);
 };
 
-/**
- * @summary Deletes a specific pet
- */
 export type deletePetByIdResponse204 = {
   data: void;
   status: 204;
@@ -500,6 +497,9 @@ export const getDeletePetByIdUrl = (petId: string) => {
   return `/pets/${petId}`;
 };
 
+/**
+ * @summary Deletes a specific pet
+ */
 export const deletePetById = async (
   petId: string,
   options?: RequestInit,
@@ -588,9 +588,6 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);
 };
 
-/**
- * @summary health check
- */
 export type healthCheckResponse200 = {
   data: string;
   status: 200;
@@ -616,6 +613,9 @@ export const getHealthCheckUrl = () => {
   return `/health`;
 };
 
+/**
+ * @summary health check
+ */
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
@@ -716,9 +716,6 @@ export const setHealthCheckQueryData = (
   queryClient.setQueryData(getHealthCheckQueryKey(), updater);
 };
 
-/**
- * @summary combinate nullable and $ref
- */
 export type showPetWithOwnerResponse200 = {
   data: PetWithTag;
   status: 200;
@@ -744,6 +741,9 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
   return `/pets/${petId}/owner`;
 };
 
+/**
+ * @summary combinate nullable and $ref
+ */
 export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,


### PR DESCRIPTION
  ## Summary
  - Move doc comment placement in fetch `generateRequestFunction` to appear before the main async function instead of the URL helper (`getXxxUrl`).
  - Add optional `docComment` field to `GeneratorClient` interface so clients can control whether the external `verbOption.doc` prepend is applied.
  - Apply `docComment: ''` to fetch, query (react/vue/svelte/solid), and swr clients that share `generateRequestFunction` from `@orval/fetch`, preventing duplicate
   JSDoc on response types.
  - JSDoc (`@summary`, `@deprecated`, description) now correctly annotates the callable function across all affected clients.

  ## Test plan
  - [x] `bun run build` — 12 successful
  - [x] `bun vitest run` — 2303 passed (3 pre-existing failures in `resolve-version.test.ts`, unrelated)
  - [x] `bun run test:snapshots` — 3746 passed; 166 snapshot/sample files updated (JSDoc moved from response type / URL helper to main function)
  - [x] Verified non-fetch axios-based outputs are byte-identical to before (no `docComment` set, fallback to `verbOption.doc`)
  - [x] Manual inspection of react-query, svelte-query, swr, vue-query, mcp, and default client snapshots to confirm no duplicate JSDoc

  Closes #3266