### PR TITLE
fix(core): prevent empty import type statement with enumGenerationType: 'enum' (#3246)

### DIFF
--- a/packages/core/src/generators/imports.test.ts
+++ b/packages/core/src/generators/imports.test.ts
@@ -83,6 +83,39 @@ export type MyError = Error;
       );
     });
 
+    it('does not emit an empty type-only import when all types are already covered by value imports', () => {
+      const implementation = 'const status = MyEnum.Active;';
+
+      const dep = addDependency({
+        implementation,
+        dependency: './types',
+        projectName: undefined,
+        hasSchemaDir: true,
+        isAllowSyntheticDefaultImports: true,
+        exports: [{ name: 'MyEnum', values: true }],
+      });
+
+      expect(dep).toBe("import {\n  MyEnum\n} from './types';\n");
+      expect(dep).not.toContain('import type');
+    });
+
+    it('does not emit an empty type-only import when enum $ref types are filtered out by value imports', () => {
+      const implementation = 'const val = MyEnum.Foo;';
+
+      const dep = addDependency({
+        implementation,
+        dependency: './types',
+        projectName: undefined,
+        hasSchemaDir: true,
+        isAllowSyntheticDefaultImports: true,
+        exports: [{ name: 'MyEnum', values: true }, { name: 'MyEnum' }],
+      });
+
+      // Should only have the value import, not an empty "import type  from './types';"
+      expect(dep).toBe("import {\n  MyEnum\n} from './types';\n");
+      expect(dep).not.toMatch(/import type\s+from/);
+    });
+
     it('escapes regex metacharacters when matching referenced imports', () => {
       const dep = addDependency({
         implementation: 'const value = schema$Value.parse(data);',

--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -294,16 +294,20 @@ export function addDependency({
                     v.name === t.name && (v.alias ?? '') === (t.alias ?? ''),
                 ),
             );
-            dep += '\n';
           }
-          dep += generateDependency({
-            deps: uniqueTypes,
-            isAllowSyntheticDefaultImports,
-            dependency,
-            projectName,
-            key,
-            onlyTypes: true,
-          });
+          if (uniqueTypes.length > 0) {
+            if (values.length > 0) {
+              dep += '\n';
+            }
+            dep += generateDependency({
+              deps: uniqueTypes,
+              isAllowSyntheticDefaultImports,
+              dependency,
+              projectName,
+              key,
+              onlyTypes: true,
+            });
+          }
         }
 
         return dep;


### PR DESCRIPTION
  ## Summary
  - Add `uniqueTypes.length > 0` guard before calling `generateDependency` with `onlyTypes: true` in `addDependency`.
  - Prevents invalid `import type  from './types'` when enum `$ref` types are already covered by value imports (e.g. `enumGenerationType: 'enum'` + `mock: { type:
  'msw' }`).
  - Move the newline separator inside the guard so it is only emitted when there is actually a type import to generate.

  ## Test plan
  - [x] `bun run build` — 12 successful
  - [x] `bun vitest run` — 2305 passed (3 pre-existing failures in `resolve-version.test.ts`, unrelated); 2 new tests for the guard
  - [x] `bun run test:snapshots` — 3746 passed, no snapshot changes (bug only manifested in MSW mock output which is not snapshot-tested for this case)

  Closes #3246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where empty type-only import statements were being generated when all referenced types were already covered by value imports or enum types were filtered out.

* **Tests**
  * Added test cases to verify the generator properly avoids emitting empty type-only import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->