### PR TITLE
fix(core): add missing import for $ref types in additionalProperties (#3255)

### DIFF
--- a/packages/core/src/generators/interface.test.ts
+++ b/packages/core/src/generators/interface.test.ts
@@ -657,4 +657,45 @@ export type ConstEnum = typeof ConstEnumValue;
       expect(result[0].model).not.toContain('string | string');
     });
   });
+
+  it('should include imports from additionalProperties $ref when properties exist', () => {
+    const contextWithRef = withContext({
+      spec: {
+        components: {
+          schemas: {
+            ItemDetail: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+        },
+      },
+      additionalProperties: {
+        $ref: '#/components/schemas/ItemDetail',
+      },
+    };
+
+    const result = generateInterface({
+      name: 'ThingsResponse',
+      context: contextWithRef,
+      schema,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].model).toContain('ItemDetail');
+    expect(result[0].imports).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'ItemDetail' })]),
+    );
+  });
 });

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -360,6 +360,8 @@ export function getObject({
               const keyType = getIndexSignatureKey(schemaItem);
               acc.value += `\n  [key: ${keyType}]: ${resolvedValue.value};\n}`;
             }
+            acc.imports.push(...resolvedValue.imports);
+            acc.schemas.push(...resolvedValue.schemas);
             acc.dependencies.push(...resolvedValue.dependencies);
           }
         } else {


### PR DESCRIPTION
  ## Summary
  - Propagate `resolvedValue.imports` and `resolvedValue.schemas` when a schema has both `properties` and `additionalProperties` containing `$ref` types in
  `getObject()`.
  - Previously only `dependencies` were forwarded, causing the generated file to reference types without importing them when using split schema output (`schemas`
  option).
  - The standalone `additionalProperties` case (without `properties`) already correctly returned imports — only the combined case was missing them.

  ## Test plan
  - [x] `bun run build` — 12 successful
  - [x] `bun vitest run` — 2304 passed (3 pre-existing failures in `resolve-version.test.ts`, unrelated); 1 new test for the combined `properties` +
  `additionalProperties` case
  - [x] `bun run test:snapshots` — 3746 passed, no snapshot changes (bug only manifested in split schema mode which is not in the current snapshot fixtures)

  Closes #3255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where generated types didn't properly include necessary imports when using schema references in object properties.

* **Tests**
  * Added test coverage for schema reference handling in generated types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->