### PR TITLE
fix(mock): apply useExamples to property-level example after OAS 3.0 upgrade

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -632,3 +632,32 @@ describe('getMockScalar (pattern-backed string escaping)', () => {
     );
   });
 });
+
+describe('getMockScalar (post-upgrader OAS 3.0 example handling)', () => {
+  // OAS 3.0 inputs go through @scalar/openapi-parser's upgrade(), which
+  // rewrites property-level `example: <value>` into `examples: [<value>]`
+  // and deletes the singular field. The scalar getter must read the array
+  // form so that useExamples keeps working for OAS 3.0 specs.
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+    mockOptions: { useExamples: true },
+    context: { output: { override: {} } } as ContextSpec,
+  };
+
+  it('uses examples[0] for a string property when useExamples is true', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as const,
+        name: 'slug',
+        examples: ['relaxation'],
+      } as Parameters<typeof getMockScalar>[0]['item'],
+    });
+
+    expect(result.value).toBe('"relaxation"');
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -99,16 +99,27 @@ export function getMockScalar({
   }
 
   if (
-    (context.output.override.mock?.useExamples ||
-      safeMockOptions.useExamples) &&
-    item.example !== undefined
+    context.output.override.mock?.useExamples ||
+    safeMockOptions.useExamples
   ) {
-    return {
-      value: JSON.stringify(item.example),
-      imports: [],
-      name: item.name,
-      overrided: true,
-    };
+    // OAS 3.0 inputs go through @scalar/openapi-parser's upgrade(), which
+    // rewrites property-level `example: <value>` into `examples: [<value>]`
+    // and deletes the singular field. Fall back to the array form so this
+    // option keeps working post-upgrade.
+    const propertyExample =
+      item.example === undefined
+        ? Array.isArray(item.examples) && item.examples.length > 0
+          ? item.examples[0]
+          : undefined
+        : item.example;
+    if (propertyExample !== undefined) {
+      return {
+        value: JSON.stringify(propertyExample),
+        imports: [],
+        name: item.name,
+        overrided: true,
+      };
+    }
   }
 
   const formatOverrides = safeMockOptions.format ?? {};


### PR DESCRIPTION
Fixes #3305.

## Summary

When `output.mock.useExamples: true` is set, property-level `example` values from OpenAPI 3.0 specs were silently dropped from generated MSW mocks (faker fallback was used instead). This is a regression caused by the `@scalar/openapi-parser` integration.

## Root cause

orval calls `upgrade()` from `@scalar/openapi-parser` for every spec (`packages/orval/src/import-specs.ts:63`). For OAS 3.0 inputs, that helper rewrites property-level `example: <value>` into `examples: [<value>]` and **deletes** the singular field. The scalar mock getter (`packages/mock/src/faker/getters/scalar.ts`) only checked `item.example`, so the post-upgrade shape was missed.

The response-level handler (`packages/mock/src/msw/mocks.ts`) already reads both `example` and `examples` forms via `getExampleEntries`. Only the scalar (property-level) handler was asymmetric.

## Fix

In the scalar getter's `useExamples` branch, fall back to `item.examples[0]` when `item.example` is absent. `null` and other falsy values continue to flow through (preserving the behavior added in #2110).

## Tests

- New regression test in `packages/mock/src/faker/getters/scalar.test.ts` covering the post-upgrader shape (`examples: ['relaxation']`).
- Verified failing on master before the fix and passing after.
- Full repo gates: `bun run typecheck`, `bun run lint`, `bun run format:check`, `bun run test`, `bun run test:snapshots` all green on the latest `master` (v8.9.1).

## Prior art

Same shape of bug previously fixed for other keywords transformed by the upgrader:

- `exclusiveMinimum` / `exclusiveMaximum` (boolean → numeric) — #3142, #3221
- `format: binary` → `contentMediaType: application/octet-stream` — #3248

## Out of scope

OAS 3.1 specs that use `examples: [...]` (array) at the property level are also currently not picked up by the scalar getter. That is a pre-existing scope gap (the array form was never wired in at scalar level), separate from this regression. Filing as a follow-up enhancement issue if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock data generation to properly utilize OpenAPI 3.0 schema examples format, ensuring examples are correctly applied when available.

* **Tests**
  * Added test coverage for mock data generation with OpenAPI 3.0 examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->