### PR TITLE
fix: order exports with 'en' locale to prevent different ordering in different environments

### DIFF
--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -435,7 +435,7 @@ export async function writeSchemas({
       // Create export statements
       const currentExports = uniqueSchemaNames
         .map((schemaName) => `export * from './${schemaName}${ext}';`)
-        .toSorted((a, b) => a.localeCompare(b));
+        .toSorted((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
 
       const exports = currentExports.join('\n');
 

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -435,7 +435,7 @@ export async function writeSchemas({
       // Create export statements
       const currentExports = uniqueSchemaNames
         .map((schemaName) => `export * from './${schemaName}${ext}';`)
-        .toSorted((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }));
+        .toSorted((a, b) => a.localeCompare(b, 'en'));
 
       const exports = currentExports.join('\n');
 


### PR DESCRIPTION
Fix #3317

localeCompare produces different orders in different environments in certain cases. For example, 'aa' is ordered as 'å' in Norwegian environments, but not in e.g. English. Using an explicit locale produces consistent ordering in different environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Export ordering for schema names is now locale-aware and case-insensitive, producing a more consistent, deterministic order when names differ only by case or diacritics. This reduces ordering surprises in generated index lists and improves predictability for downstream tooling and consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->