### PR TITLE
chore: TypeScript 6/7 support replace tsconfck with get-tsconfig

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,11 +182,11 @@
         "execa": "^9.6.1",
         "find-up": "8.0.0",
         "fs-extra": "^11.3.2",
+        "get-tsconfig": "^4.14.0",
         "jiti": "^2.6.1",
         "js-yaml": "4.1.1",
         "remeda": "^2.33.6",
         "string-argv": "^0.3.2",
-        "tsconfck": "^3.1.6",
         "typedoc": "^0.28.17",
         "typedoc-plugin-coverage": "^4.0.2",
         "typedoc-plugin-markdown": "^4.10.0",
@@ -3765,8 +3765,6 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
-
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1005,6 +1005,9 @@ export type TsConfigTarget =
   | 'es2020'
   | 'es2021'
   | 'es2022'
+  | 'es2023'
+  | 'es2024'
+  | 'es2025'
   | 'esnext'; // https://www.typescriptlang.org/tsconfig#target
 
 export interface PackageJson {

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -92,11 +92,11 @@
     "execa": "^9.6.1",
     "find-up": "8.0.0",
     "fs-extra": "^11.3.2",
+    "get-tsconfig": "^4.14.0",
     "jiti": "^2.6.1",
     "js-yaml": "4.1.1",
     "remeda": "^2.33.6",
     "string-argv": "^0.3.2",
-    "tsconfck": "^3.1.6",
     "typedoc": "^0.28.17",
     "typedoc-plugin-coverage": "^4.0.2",
     "typedoc-plugin-markdown": "^4.10.0"

--- a/packages/orval/src/utils/tsconfig.ts
+++ b/packages/orval/src/utils/tsconfig.ts
@@ -15,11 +15,15 @@ type LowercaseString<T extends string> = T extends `${infer First}${infer Rest}`
 
 const convertTarget = (config: TsConfigJsonResolved): Tsconfig => {
   if (!config.compilerOptions?.target) {
-    return config as Tsconfig;
+    return {
+      baseUrl: config.compilerOptions?.baseUrl,
+      ...config,
+    } as Tsconfig;
   }
   const lowercaseTarget =
     config.compilerOptions.target.toLowerCase() as LowercaseString<TsConfigJson.CompilerOptions.Target>;
   return {
+    baseUrl: config.compilerOptions?.baseUrl,
     ...config,
     compilerOptions: { ...config.compilerOptions, target: lowercaseTarget },
   };

--- a/packages/orval/src/utils/tsconfig.ts
+++ b/packages/orval/src/utils/tsconfig.ts
@@ -1,9 +1,29 @@
 import { isNullish, isObject, isString, type Tsconfig } from '@orval/core';
 import { findUp } from 'find-up';
 import fs from 'fs-extra';
-import { parse } from 'tsconfck';
+import {
+  parseTsconfig,
+  type TsConfigJson,
+  type TsConfigJsonResolved,
+} from 'get-tsconfig';
 
 import { normalizePath } from './options';
+
+type LowercaseString<T extends string> = T extends `${infer First}${infer Rest}`
+  ? `${Lowercase<First>}${LowercaseString<Rest>}`
+  : T;
+
+const convertTarget = (config: TsConfigJsonResolved): Tsconfig => {
+  if (!config.compilerOptions?.target) {
+    return config as Tsconfig;
+  }
+  const lowercaseTarget =
+    config.compilerOptions.target.toLowerCase() as LowercaseString<TsConfigJson.CompilerOptions.Target>;
+  return {
+    ...config,
+    compilerOptions: { ...config.compilerOptions, target: lowercaseTarget },
+  };
+};
 
 export const loadTsconfig = async (
   tsconfig?: Tsconfig | string,
@@ -14,8 +34,8 @@ export const loadTsconfig = async (
       cwd: workspace,
     });
     if (configPath) {
-      const config = await parse(configPath);
-      return config.tsconfig as Tsconfig;
+      const config = parseTsconfig(configPath);
+      return convertTarget(config);
     }
     return;
   }
@@ -23,13 +43,8 @@ export const loadTsconfig = async (
   if (isString(tsconfig)) {
     const normalizedPath = normalizePath(tsconfig, workspace);
     if (fs.existsSync(normalizedPath)) {
-      const config = await parse(normalizedPath);
-
-      const tsconfig = (config.referenced?.find(
-        ({ tsconfigFile }) => tsconfigFile === normalizedPath,
-      )?.tsconfig ?? config.tsconfig) as Tsconfig;
-
-      return tsconfig;
+      const config = parseTsconfig(normalizedPath);
+      return convertTarget(config);
     }
     return;
   }

--- a/packages/orval/src/utils/tsconfig.ts
+++ b/packages/orval/src/utils/tsconfig.ts
@@ -23,7 +23,7 @@ const convertTarget = (config: TsConfigJsonResolved): Tsconfig => {
   const lowercaseTarget =
     config.compilerOptions.target.toLowerCase() as LowercaseString<TsConfigJson.CompilerOptions.Target>;
   return {
-    baseUrl: config.compilerOptions?.baseUrl,
+    baseUrl: config.compilerOptions.baseUrl,
     ...config,
     compilerOptions: { ...config.compilerOptions, target: lowercaseTarget },
   };


### PR DESCRIPTION
Fix https://github.com/orval-labs/orval/issues/3316
Fix #3331 

Orval was using tsconfck to parse the ts config files, but the package is now discontinued and doesn't support typescript>=6. 

This PR replaces tsconfck with get-tsconfig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for TypeScript compiler targets: es2023, es2024, and es2025.

* **Chores**
  * Switched to a new tsconfig parser and simplified discovery logic.
  * Normalized compiler target values to lowercase for consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->