### PR TITLE
fix(core): deterministic comparators in sorting

### DIFF
--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -55,7 +55,13 @@ export function generateImports({
   );
 
   return Object.entries(grouped)
-    .toSorted(([a], [b]) => a.localeCompare(b))
+    .toSorted(([a], [b]) =>
+      a.localeCompare(b, undefined, {
+        usage: 'sort',
+        sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+        numeric: true,
+      }),
+    )
     .map(([, group]) => {
       const sample = group[0];
       const canAggregate =

--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -55,13 +55,7 @@ export function generateImports({
   );
 
   return Object.entries(grouped)
-    .toSorted(([a], [b]) =>
-      a.localeCompare(b, undefined, {
-        usage: 'sort',
-        sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
-        numeric: true,
-      }),
-    )
+    .toSorted(([a], [b]) => a.localeCompare(b, 'en', { numeric: true }))
     .map(([, group]) => {
       const sample = group[0];
       const canAggregate =

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -325,7 +325,11 @@ export function getObject({
       if (entries.length - 1 === index) {
         // Bridge assertion: additionalProperties is boolean | ReferenceObject | SchemaObject
         // but AnyOtherAttribute infects property access
-        const additionalProps = schemaItem.additionalProperties;
+        const additionalProps = schemaItem.additionalProperties as
+          | boolean
+          | OpenApiSchemaObject
+          | OpenApiReferenceObject
+          | undefined;
         if (additionalProps) {
           if (additionalProps === true) {
             const recordType = getPropertyNamesRecordType(
@@ -342,7 +346,9 @@ export function getObject({
             }
           } else {
             const resolvedValue = resolveValue({
-              schema: additionalProps,
+              schema: additionalProps as
+                | OpenApiSchemaObject
+                | OpenApiReferenceObject,
               name,
               context,
             });
@@ -373,7 +379,11 @@ export function getObject({
   }
 
   // Bridge assertion: additionalProperties is boolean | ReferenceObject | SchemaObject
-  const outerAdditionalProps = schemaItem.additionalProperties;
+  const outerAdditionalProps = schemaItem.additionalProperties as
+    | boolean
+    | OpenApiSchemaObject
+    | OpenApiReferenceObject
+    | undefined;
   const readOnlyFlag = schemaItem.readOnly as boolean | undefined;
   if (outerAdditionalProps) {
     if (outerAdditionalProps === true) {
@@ -405,7 +415,9 @@ export function getObject({
       };
     }
     const resolvedValue = resolveValue({
-      schema: outerAdditionalProps,
+      schema: outerAdditionalProps as
+        | OpenApiSchemaObject
+        | OpenApiReferenceObject,
       name,
       context,
     });

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -183,7 +183,11 @@ export function getObject({
     const entries = Object.entries(itemProperties);
     if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
-        return a[0].localeCompare(b[0]);
+        return a[0].localeCompare(b[0], undefined, {
+          usage: 'sort',
+          sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+          numeric: true,
+        });
       });
     }
     const acc: ScalarValue = {
@@ -321,11 +325,7 @@ export function getObject({
       if (entries.length - 1 === index) {
         // Bridge assertion: additionalProperties is boolean | ReferenceObject | SchemaObject
         // but AnyOtherAttribute infects property access
-        const additionalProps = schemaItem.additionalProperties as
-          | boolean
-          | OpenApiSchemaObject
-          | OpenApiReferenceObject
-          | undefined;
+        const additionalProps = schemaItem.additionalProperties;
         if (additionalProps) {
           if (additionalProps === true) {
             const recordType = getPropertyNamesRecordType(
@@ -342,9 +342,7 @@ export function getObject({
             }
           } else {
             const resolvedValue = resolveValue({
-              schema: additionalProps as
-                | OpenApiSchemaObject
-                | OpenApiReferenceObject,
+              schema: additionalProps,
               name,
               context,
             });
@@ -375,11 +373,7 @@ export function getObject({
   }
 
   // Bridge assertion: additionalProperties is boolean | ReferenceObject | SchemaObject
-  const outerAdditionalProps = schemaItem.additionalProperties as
-    | boolean
-    | OpenApiSchemaObject
-    | OpenApiReferenceObject
-    | undefined;
+  const outerAdditionalProps = schemaItem.additionalProperties;
   const readOnlyFlag = schemaItem.readOnly as boolean | undefined;
   if (outerAdditionalProps) {
     if (outerAdditionalProps === true) {
@@ -411,9 +405,7 @@ export function getObject({
       };
     }
     const resolvedValue = resolveValue({
-      schema: outerAdditionalProps as
-        | OpenApiSchemaObject
-        | OpenApiReferenceObject,
+      schema: outerAdditionalProps,
       name,
       context,
     });

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -183,9 +183,7 @@ export function getObject({
     const entries = Object.entries(itemProperties);
     if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
-        return a[0].localeCompare(b[0], undefined, {
-          usage: 'sort',
-          sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+        return a[0].localeCompare(b[0], 'en', {
           numeric: true,
         });
       });

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -435,7 +435,13 @@ export async function writeSchemas({
       // Create export statements
       const currentExports = uniqueSchemaNames
         .map((schemaName) => `export * from './${schemaName}${ext}';`)
-        .toSorted((a, b) => a.localeCompare(b));
+        .toSorted((a, b) =>
+          a.localeCompare(b, undefined, {
+            usage: 'sort',
+            sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+            numeric: true,
+          }),
+        );
 
       const exports = currentExports.join('\n');
 

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -435,13 +435,7 @@ export async function writeSchemas({
       // Create export statements
       const currentExports = uniqueSchemaNames
         .map((schemaName) => `export * from './${schemaName}${ext}';`)
-        .toSorted((a, b) =>
-          a.localeCompare(b, undefined, {
-            usage: 'sort',
-            sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
-            numeric: true,
-          }),
-        );
+        .toSorted((a, b) => a.localeCompare(b, 'en', { numeric: true }));
 
       const exports = currentExports.join('\n');
 

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -80,11 +80,7 @@ export function getMockObject({
     | Record<string, OpenApiReferenceObject | OpenApiSchemaObject>
     | undefined;
   const itemRequired = schemaItem.required as string[] | undefined;
-  const itemAdditionalProperties = schemaItem.additionalProperties as
-    | boolean
-    | OpenApiReferenceObject
-    | OpenApiSchemaObject
-    | undefined;
+  const itemAdditionalProperties = schemaItem.additionalProperties;
 
   if (itemAllOf || itemOneOf || itemAnyOf) {
     const separator = itemAllOf ? 'allOf' : itemOneOf ? 'oneOf' : 'anyOf';
@@ -140,7 +136,11 @@ export function getMockObject({
     const entries = Object.entries(itemProperties);
     if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
-        return a[0].localeCompare(b[0]);
+        return a[0].localeCompare(b[0], undefined, {
+          usage: 'sort',
+          sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+          numeric: true,
+        });
       });
     }
     const propertyScalars = entries

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -80,7 +80,11 @@ export function getMockObject({
     | Record<string, OpenApiReferenceObject | OpenApiSchemaObject>
     | undefined;
   const itemRequired = schemaItem.required as string[] | undefined;
-  const itemAdditionalProperties = schemaItem.additionalProperties;
+  const itemAdditionalProperties = schemaItem.additionalProperties as
+    | boolean
+    | OpenApiReferenceObject
+    | OpenApiSchemaObject
+    | undefined;
 
   if (itemAllOf || itemOneOf || itemAnyOf) {
     const separator = itemAllOf ? 'allOf' : itemOneOf ? 'oneOf' : 'anyOf';

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -140,11 +140,7 @@ export function getMockObject({
     const entries = Object.entries(itemProperties);
     if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
-        return a[0].localeCompare(b[0], undefined, {
-          usage: 'sort',
-          sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
-          numeric: true,
-        });
+        return a[0].localeCompare(b[0], 'en', { numeric: true });
       });
     }
     const propertyScalars = entries

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -77,12 +77,7 @@ export function getMockScalar({
     properties: {},
   };
   const sortedTags = Object.entries(safeMockOptions.tags ?? {}).toSorted(
-    (a, b) =>
-      a[0].localeCompare(b[0], undefined, {
-        usage: 'sort',
-        sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
-        numeric: true,
-      }),
+    (a, b) => a[0].localeCompare(b[0], 'en', { numeric: true }),
   );
   for (const [tag, options] of sortedTags) {
     if (!tags.includes(tag)) {

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -77,7 +77,12 @@ export function getMockScalar({
     properties: {},
   };
   const sortedTags = Object.entries(safeMockOptions.tags ?? {}).toSorted(
-    (a, b) => a[0].localeCompare(b[0]),
+    (a, b) =>
+      a[0].localeCompare(b[0], undefined, {
+        usage: 'sort',
+        sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+        numeric: true,
+      }),
   );
   for (const [tag, options] of sortedTags) {
     if (!tags.includes(tag)) {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -398,7 +398,7 @@ export async function writeZodSchemasFromVerbs(
               formUrlEncodedBodyMedia,
             ] as const)
           : [undefined, undefined];
-    const bodySchema = bodyMedia?.schema;
+    const bodySchema = bodyMedia?.schema as OpenApiSchemaObject | undefined;
 
     const bodySchemas = bodySchema
       ? [

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -152,20 +152,12 @@ const groupSchemasByFilePath = <T extends { filePath: string }>(
 
   const sortedGroups = [...grouped.values()].map((group) =>
     [...group].toSorted((a, b) =>
-      a.filePath.localeCompare(b.filePath, undefined, {
-        usage: 'sort',
-        sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
-        numeric: true,
-      }),
+      a.filePath.localeCompare(b.filePath, 'en', { numeric: true }),
     ),
   );
 
   return sortedGroups.toSorted((a, b) =>
-    a[0].filePath.localeCompare(b[0].filePath, undefined, {
-      usage: 'sort',
-      sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
-      numeric: true,
-    }),
+    a[0].filePath.localeCompare(b[0].filePath, 'en', { numeric: true }),
   );
 };
 

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -151,11 +151,21 @@ const groupSchemasByFilePath = <T extends { filePath: string }>(
   }
 
   const sortedGroups = [...grouped.values()].map((group) =>
-    [...group].toSorted((a, b) => a.filePath.localeCompare(b.filePath)),
+    [...group].toSorted((a, b) =>
+      a.filePath.localeCompare(b.filePath, undefined, {
+        usage: 'sort',
+        sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+        numeric: true,
+      }),
+    ),
   );
 
   return sortedGroups.toSorted((a, b) =>
-    a[0].filePath.localeCompare(b[0].filePath),
+    a[0].filePath.localeCompare(b[0].filePath, undefined, {
+      usage: 'sort',
+      sensitivity: 'variant', // distinguishes æ/ø/å from a/o, etc.
+      numeric: true,
+    }),
   );
 };
 
@@ -388,7 +398,7 @@ export async function writeZodSchemasFromVerbs(
               formUrlEncodedBodyMedia,
             ] as const)
           : [undefined, undefined];
-    const bodySchema = bodyMedia?.schema as OpenApiSchemaObject | undefined;
+    const bodySchema = bodyMedia?.schema;
 
     const bodySchemas = bodySchema
       ? [

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -790,9 +790,14 @@ export const healthCheck = async (
     method: 'GET',
   });
 
+  const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: healthCheckResponse['data'] = body !== null ? body : '';
+  const data: healthCheckResponse['data'] = body
+    ? contentType.includes('json')
+      ? JSON.parse(body)
+      : body
+    : {};
   return {
     data,
     status: res.status,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -795,9 +795,14 @@ export const healthCheck = async (
     method: 'GET',
   });
 
+  const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: healthCheckResponse['data'] = body !== null ? body : '';
+  const data: healthCheckResponse['data'] = body
+    ? contentType.includes('json')
+      ? JSON.parse(body)
+      : body
+    : {};
   return {
     data,
     status: res.status,

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -803,9 +803,14 @@ export const healthCheck = async (
     method: 'GET',
   });
 
+  const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
 
-  const data: healthCheckResponse['data'] = body !== null ? body : '';
+  const data: healthCheckResponse['data'] = body
+    ? contentType.includes('json')
+      ? JSON.parse(body)
+      : body
+    : {};
   return {
     data,
     status: res.status,


### PR DESCRIPTION
fix(core): deterministic comparators in sorting

Fix #3317 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting across generated imports, object properties, schema export lists, and mock data to use consistent English, numeric-aware ordering for more predictable, human-friendly results.
  * Make health-check response parsing content-type aware: JSON responses are parsed, others returned as text, and absent bodies map to an empty object instead of an empty string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->