### PR TITLE
test(orval): cover internal $ref in external parameter (#394)

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -795,8 +795,12 @@ describe('dereferenceExternalRefs', () => {
 
     const result = dereferenceExternalRef(input) as OpenApiDocument;
 
-    // The Switch schema from the external doc should be merged into main components
-    expect(result.components?.schemas).toHaveProperty('Switch');
+    // The Switch schema from the external doc should be merged into main
+    // components with its content intact
+    expect(result.components?.schemas?.Switch).toEqual({
+      type: 'string',
+      enum: ['on', 'off'],
+    });
 
     // The parameter should be inlined where the x-ext ref was, and its
     // internal $ref must still point to Switch (now in the main spec)

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -752,6 +752,66 @@ describe('dereferenceExternalRefs', () => {
     expect(result).not.toHaveProperty('x-ext');
   });
 
+  // Regression test for https://github.com/orval-labs/orval/issues/394
+  it('should resolve internal $ref inside an external parameter against the external doc', () => {
+    const input = {
+      openapi: '3.0.2',
+      info: { title: 'Demo', version: '0.0.0' },
+      paths: {
+        '/path': {
+          get: {
+            parameters: [{ $ref: '#/x-ext/refs/components/parameters/switch' }],
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+      'x-ext': {
+        refs: {
+          components: {
+            schemas: {
+              Switch: {
+                type: 'string',
+                enum: ['on', 'off'],
+              },
+            },
+            parameters: {
+              switch: {
+                name: 'switch',
+                in: 'query',
+                schema: { $ref: '#/components/schemas/Switch' },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as OpenApiDocument;
+
+    // The Switch schema from the external doc should be merged into main components
+    expect(result.components?.schemas).toHaveProperty('Switch');
+
+    // The parameter should be inlined where the x-ext ref was, and its
+    // internal $ref must still point to Switch (now in the main spec)
+    const params = result.paths?.['/path']?.get?.parameters;
+    expect(params).toEqual([
+      expect.objectContaining({
+        name: 'switch',
+        in: 'query',
+        schema: { $ref: '#/components/schemas/Switch' },
+      }),
+    ]);
+
+    expect(result).not.toHaveProperty('x-ext');
+  });
+
   it('should handle schema name collisions - add suffix to external schema', () => {
     const input = {
       openapi: '3.0.3',


### PR DESCRIPTION
## Summary

Fix [issue #394](https://github.com/orval-labs/orval/issues/394).

The scenario — a parameter referenced from an external file (`refs.yaml#/components/parameters/switch`) whose schema is itself a `$ref` to another component in the same external file (`#/components/schemas/Switch`) — is correctly resolved by current `master`, thanks to the bundler / dereference pipeline introduced in #2944. However there was no dedicated test pinning down this specific shape, so this PR adds one to `dereferenceExternalRefs` covering:

- The external `Switch` schema is merged into the main spec's `components.schemas`
- The parameter is inlined where the x-ext ref was
- The parameter's internal `$ref` is preserved and now points to the merged `Switch` in the main spec

No production code changes — test only.

## Test plan
- [x] `bun run test` (orval package: 85 passed)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test to ensure internal references inside external parameters are resolved correctly against external documents, external schemas are merged into the shared schema registry, inlined parameter references point to the primary schema, and extraneous external sections are removed.

*No user-facing changes.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->