### PR TITLE
fix(query,swr): use null-check for auto-generated `enabled` option (#3241)

### DIFF
--- a/docs/content/docs/guides/react-query.mdx
+++ b/docs/content/docs/guides/react-query.mdx
@@ -60,7 +60,7 @@ export const useShowPetById = <
   const query = useQuery<AsyncReturnType<typeof queryFn>, TError, TData>(
     queryKey,
     queryFn,
-    { enabled: !!petId, ...queryOptions },
+    { enabled: petId != null, ...queryOptions },
   );
 
   return {

--- a/docs/content/docs/guides/react-query.mdx
+++ b/docs/content/docs/guides/react-query.mdx
@@ -60,7 +60,10 @@ export const useShowPetById = <
   const query = useQuery<AsyncReturnType<typeof queryFn>, TError, TData>(
     queryKey,
     queryFn,
-    { enabled: petId != null, ...queryOptions },
+    {
+      enabled: petId !== null && petId !== undefined,
+      ...queryOptions,
+    },
   );
 
   return {

--- a/docs/content/docs/guides/solid-query.mdx
+++ b/docs/content/docs/guides/solid-query.mdx
@@ -65,7 +65,7 @@ export const createShowPetById = <
     () => ({
       queryKey,
       queryFn,
-      enabled: !!petId,
+      enabled: petId != null,
       ...queryOptions,
     }),
   );

--- a/docs/content/docs/guides/solid-query.mdx
+++ b/docs/content/docs/guides/solid-query.mdx
@@ -65,7 +65,7 @@ export const createShowPetById = <
     () => ({
       queryKey,
       queryFn,
-      enabled: petId != null,
+      enabled: petId !== null && petId !== undefined,
       ...queryOptions,
     }),
   );

--- a/docs/content/docs/guides/svelte-query.mdx
+++ b/docs/content/docs/guides/svelte-query.mdx
@@ -60,7 +60,7 @@ export const useShowPetById = <
   const query = useQuery<AsyncReturnType<typeof queryFn>, TError, TData>(
     queryKey,
     queryFn,
-    { enabled: !!petId, ...queryOptions },
+    { enabled: petId != null, ...queryOptions },
   );
 
   return {

--- a/docs/content/docs/guides/svelte-query.mdx
+++ b/docs/content/docs/guides/svelte-query.mdx
@@ -60,7 +60,10 @@ export const useShowPetById = <
   const query = useQuery<AsyncReturnType<typeof queryFn>, TError, TData>(
     queryKey,
     queryFn,
-    { enabled: petId != null, ...queryOptions },
+    {
+      enabled: petId !== null && petId !== undefined,
+      ...queryOptions,
+    },
   );
 
   return {

--- a/docs/content/docs/guides/swr.mdx
+++ b/docs/content/docs/guides/swr.mdx
@@ -99,7 +99,7 @@ Disable the hook conditionally:
 ```tsx
 const { data } = useShowPetById(petId, {
   swr: {
-    enabled: !!petId, // Only fetch when petId is defined
+    enabled: petId != null, // Only fetch when petId is defined
   },
 });
 ```

--- a/docs/content/docs/guides/swr.mdx
+++ b/docs/content/docs/guides/swr.mdx
@@ -54,7 +54,10 @@ export const useShowPetById = <TError = Error>(
 ) => {
   const { swr: swrOptions, axios: axiosOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled =
+    swrOptions?.enabled !== false &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, axiosOptions);
@@ -99,7 +102,7 @@ Disable the hook conditionally:
 ```tsx
 const { data } = useShowPetById(petId, {
   swr: {
-    enabled: petId != null, // Only fetch when petId is defined
+    enabled: petId !== null && petId !== undefined, // Only fetch when petId is defined
   },
 });
 ```

--- a/docs/content/docs/guides/vue-query.mdx
+++ b/docs/content/docs/guides/vue-query.mdx
@@ -60,7 +60,7 @@ export const useShowPetById = <
   const query = useQuery<AsyncReturnType<typeof queryFn>, TError, TData>(
     queryKey,
     queryFn,
-    { enabled: !!petId, ...queryOptions },
+    { enabled: petId != null, ...queryOptions },
   );
 
   return {

--- a/docs/content/docs/guides/vue-query.mdx
+++ b/docs/content/docs/guides/vue-query.mdx
@@ -60,7 +60,10 @@ export const useShowPetById = <
   const query = useQuery<AsyncReturnType<typeof queryFn>, TError, TData>(
     queryKey,
     queryFn,
-    { enabled: petId != null, ...queryOptions },
+    {
+      enabled: petId !== null && petId !== undefined,
+      ...queryOptions,
+    },
   );
 
   return {

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -72,7 +72,7 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => ({
 
   generateEnabledOption(params, options) {
     if (!isObject(options) || !Object.hasOwn(options, 'enabled')) {
-      return `enabled: !!(${params.map(({ name }) => name).join(' && ')}),`;
+      return `enabled: ${params.map(({ name }) => `${name} != null`).join(' && ')},`;
     }
     return '';
   },

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -71,8 +71,11 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => ({
   },
 
   generateEnabledOption(params, options) {
+    if (params.length === 0) return '';
     if (!isObject(options) || !Object.hasOwn(options, 'enabled')) {
-      return `enabled: ${params.map(({ name }) => `${name} != null`).join(' && ')},`;
+      return `enabled: ${params
+        .map(({ name }) => `${name} !== null && ${name} !== undefined`)
+        .join(' && ')},`;
     }
     return '';
   },

--- a/packages/query/src/frameworks/vue.ts
+++ b/packages/query/src/frameworks/vue.ts
@@ -140,9 +140,9 @@ export const createVueAdapter = ({
     options?: object | boolean,
   ): string {
     if (!isObject(options) || !Object.hasOwn(options, 'enabled')) {
-      return `enabled: computed(() => !!(${params
-        .map(({ name }) => `unref(${name})`)
-        .join(' && ')})),`;
+      return `enabled: computed(() => ${params
+        .map(({ name }) => `unref(${name}) != null`)
+        .join(' && ')}),`;
     }
     return '';
   },

--- a/packages/query/src/frameworks/vue.ts
+++ b/packages/query/src/frameworks/vue.ts
@@ -139,9 +139,13 @@ export const createVueAdapter = ({
     params: GetterParams,
     options?: object | boolean,
   ): string {
+    if (params.length === 0) return '';
     if (!isObject(options) || !Object.hasOwn(options, 'enabled')) {
       return `enabled: computed(() => ${params
-        .map(({ name }) => `unref(${name}) != null`)
+        .map(
+          ({ name }) =>
+            `unref(${name}) !== null && unref(${name}) !== undefined`,
+        )
         .join(' && ')}),`;
     }
     return '';

--- a/packages/query/src/query-options.test.ts
+++ b/packages/query/src/query-options.test.ts
@@ -1,0 +1,61 @@
+import type { GetterParams } from '@orval/core';
+import { describe, expect, it } from 'vitest';
+
+import { createFrameworkAdapter } from './frameworks';
+import { generateQueryOptions, QueryType } from './query-options';
+
+const param = (name: string): GetterParams[number] => ({
+  name,
+  definition: `${name}: number`,
+  implementation: `${name}: number`,
+  default: undefined,
+  required: true,
+  imports: [],
+});
+
+describe('generateQueryOptions enabled emission (issue #3241)', () => {
+  it('emits a null check for a single param so falsy values like 0 do not disable the query', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = generateQueryOptions({
+      params: [param('petId')],
+      options: undefined,
+      type: QueryType.QUERY,
+      adapter,
+    });
+    expect(out).toContain('enabled: petId != null,');
+    expect(out).not.toContain('!!');
+  });
+
+  it('combines null checks with && for multiple params', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = generateQueryOptions({
+      params: [param('version'), param('petId')],
+      options: undefined,
+      type: QueryType.QUERY,
+      adapter,
+    });
+    expect(out).toContain('enabled: version != null && petId != null,');
+  });
+
+  it('wraps with computed and unref for vue-query', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'vue-query' });
+    const out = generateQueryOptions({
+      params: [param('petId')],
+      options: undefined,
+      type: QueryType.QUERY,
+      adapter,
+    });
+    expect(out).toContain('enabled: computed(() => unref(petId) != null),');
+  });
+
+  it('respects user-provided enabled option (no auto-emit)', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = generateQueryOptions({
+      params: [param('petId')],
+      options: { enabled: true },
+      type: QueryType.QUERY,
+      adapter,
+    });
+    expect(out).not.toContain('petId != null');
+  });
+});

--- a/packages/query/src/query-options.test.ts
+++ b/packages/query/src/query-options.test.ts
@@ -22,7 +22,7 @@ describe('generateQueryOptions enabled emission (issue #3241)', () => {
       type: QueryType.QUERY,
       adapter,
     });
-    expect(out).toContain('enabled: petId != null,');
+    expect(out).toContain('enabled: petId !== null && petId !== undefined,');
     expect(out).not.toContain('!!');
   });
 
@@ -34,7 +34,9 @@ describe('generateQueryOptions enabled emission (issue #3241)', () => {
       type: QueryType.QUERY,
       adapter,
     });
-    expect(out).toContain('enabled: version != null && petId != null,');
+    expect(out).toContain(
+      'enabled: version !== null && version !== undefined && petId !== null && petId !== undefined,',
+    );
   });
 
   it('wraps with computed and unref for vue-query', () => {
@@ -45,7 +47,9 @@ describe('generateQueryOptions enabled emission (issue #3241)', () => {
       type: QueryType.QUERY,
       adapter,
     });
-    expect(out).toContain('enabled: computed(() => unref(petId) != null),');
+    expect(out).toContain(
+      'enabled: computed(() => unref(petId) !== null && unref(petId) !== undefined),',
+    );
   });
 
   it('respects user-provided enabled option (no auto-emit)', () => {
@@ -56,6 +60,6 @@ describe('generateQueryOptions enabled emission (issue #3241)', () => {
       type: QueryType.QUERY,
       adapter,
     });
-    expect(out).not.toContain('petId != null');
+    expect(out).not.toContain('petId !== null');
   });
 });

--- a/packages/query/src/query-options.ts
+++ b/packages/query/src/query-options.ts
@@ -62,7 +62,7 @@ export const generateQueryOptions = ({
   const enabledOption = adapter
     ? adapter.generateEnabledOption(params, options)
     : !isObject(options) || !Object.hasOwn(options, 'enabled')
-      ? `enabled: !!(${params.map(({ name }) => name).join(' && ')}),`
+      ? `enabled: ${params.map(({ name }) => `${name} != null`).join(' && ')},`
       : '';
 
   return `${enabledOption}${queryConfig} ...queryOptions`;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -196,7 +196,7 @@ const generateSwrImplementation = ({
 
   const enabledImplementation = `const isEnabled = swrOptions?.enabled !== false${
     params.length > 0
-      ? ` && !!(${params.map(({ name }) => name).join(' && ')})`
+      ? ` && ${params.map(({ name }) => `${name} != null`).join(' && ')}`
       : ''
   }`;
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;
@@ -339,7 +339,7 @@ const generateSwrSuspenseImplementation = ({
 
   const enabledImplementation = `const isEnabled = swrOptions?.enabled !== false${
     params.length > 0
-      ? ` && !!(${params.map(({ name }) => name).join(' && ')})`
+      ? ` && ${params.map(({ name }) => `${name} != null`).join(' && ')}`
       : ''
   }`;
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -196,7 +196,9 @@ const generateSwrImplementation = ({
 
   const enabledImplementation = `const isEnabled = swrOptions?.enabled !== false${
     params.length > 0
-      ? ` && ${params.map(({ name }) => `${name} != null`).join(' && ')}`
+      ? ` && ${params
+          .map(({ name }) => `${name} !== null && ${name} !== undefined`)
+          .join(' && ')}`
       : ''
   }`;
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;
@@ -339,7 +341,9 @@ const generateSwrSuspenseImplementation = ({
 
   const enabledImplementation = `const isEnabled = swrOptions?.enabled !== false${
     params.length > 0
-      ? ` && ${params.map(({ name }) => `${name} != null`).join(' && ')}`
+      ? ` && ${params
+          .map(({ name }) => `${name} !== null && ${name} !== undefined`)
+          .join(' && ')}`
       : ''
   }`;
   const swrKeyImplementation = `const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? ${swrKeyFnName}(${swrKeyProperties}) : null);`;

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -830,7 +830,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1126,7 +1126,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -830,7 +830,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1126,7 +1126,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -421,7 +421,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -767,7 +767,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1059,7 +1059,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -421,7 +421,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -767,7 +767,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1059,7 +1059,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -319,7 +319,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -517,7 +517,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -319,7 +319,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -517,7 +517,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -151,7 +151,7 @@ export const getSearchPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof searchPets>>,
@@ -280,7 +280,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -944,7 +944,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1280,7 +1280,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,
@@ -1400,7 +1400,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -151,7 +151,7 @@ export const getSearchPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof searchPets>>,
@@ -280,7 +280,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -504,7 +504,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -944,7 +948,11 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1280,7 +1288,11 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,
@@ -1400,7 +1412,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -830,7 +830,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1126,7 +1126,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -830,7 +830,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1126,7 +1126,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -421,7 +421,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -767,7 +767,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1059,7 +1059,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -421,7 +421,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -767,7 +767,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1059,7 +1059,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -319,7 +319,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -517,7 +517,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -319,7 +319,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -517,7 +517,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -151,7 +151,7 @@ export const getSearchPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof searchPets>>,
@@ -280,7 +280,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -944,7 +944,7 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1280,7 +1280,7 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,
@@ -1400,7 +1400,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -151,7 +151,7 @@ export const getSearchPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof searchPets>>,
@@ -280,7 +280,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -504,7 +504,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -944,7 +948,11 @@ export const getShowPetTextQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetText>>,
@@ -1280,7 +1288,11 @@ export const getDownloadFileQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof downloadFile>>,
@@ -1400,7 +1412,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -139,7 +139,7 @@ export const useListPets = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -177,7 +177,7 @@ export const useListPetsSuspense = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -346,7 +346,8 @@ export const useShowPetById = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -384,7 +385,8 @@ export const useShowPetByIdSuspense = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -139,7 +139,8 @@ export const useListPets = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -177,7 +178,8 @@ export const useListPetsSuspense = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -347,7 +349,11 @@ export const useShowPetById = <TError = Error>(
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -386,7 +392,11 @@ export const useShowPetByIdSuspense = <TError = Error>(
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -139,7 +139,7 @@ export const useListPets = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -177,7 +177,7 @@ export const useListPetsSuspense = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -346,7 +346,8 @@ export const useShowPetById = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -384,7 +385,8 @@ export const useShowPetByIdSuspense = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -139,7 +139,8 @@ export const useListPets = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -177,7 +178,8 @@ export const useListPetsSuspense = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -347,7 +349,11 @@ export const useShowPetById = <TError = Error>(
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -386,7 +392,11 @@ export const useShowPetByIdSuspense = <TError = Error>(
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -197,7 +197,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -197,7 +197,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -197,7 +197,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -197,7 +197,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -123,7 +123,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -319,7 +319,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -884,7 +884,7 @@ export const getListPetsNestedArrayQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -1051,7 +1051,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -123,7 +123,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -319,7 +319,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -884,7 +884,7 @@ export const getListPetsNestedArrayQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -1051,7 +1051,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -123,7 +123,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -319,7 +319,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -884,7 +884,7 @@ export const getListPetsNestedArrayQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -1051,7 +1051,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -123,7 +123,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -319,7 +319,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -884,7 +884,7 @@ export const getListPetsNestedArrayQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -1051,7 +1051,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -544,7 +544,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -544,7 +544,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -544,7 +544,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -544,7 +544,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -472,7 +472,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -472,7 +472,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -472,7 +472,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -472,7 +472,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data/__snapshots__/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data/__snapshots__/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data/endpoints.ts
+++ b/samples/react-query/form-data/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-data/endpoints.ts
+++ b/samples/react-query/form-data/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
@@ -300,7 +300,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
@@ -300,7 +300,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -300,7 +300,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -300,7 +300,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -299,7 +299,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
@@ -326,7 +326,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
@@ -326,7 +326,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-axios/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/endpoints.ts
@@ -326,7 +326,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-axios/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/endpoints.ts
@@ -326,7 +326,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -499,7 +499,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -499,7 +499,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -499,7 +499,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -499,7 +499,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,

--- a/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -74,7 +74,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -242,7 +242,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -74,7 +74,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -242,7 +242,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -74,7 +74,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -242,7 +242,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -74,7 +74,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -242,7 +242,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -532,7 +532,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -532,7 +532,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -532,7 +532,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -532,7 +532,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -411,7 +411,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -411,7 +411,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -411,7 +411,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -411,7 +411,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -494,7 +494,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -494,7 +494,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -494,7 +494,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -494,7 +494,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -108,7 +108,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -197,7 +197,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -400,7 +400,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -482,7 +482,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -108,7 +108,9 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -197,7 +199,9 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -292,7 +296,9 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof createPets>>, TError, TData>;
 };
@@ -400,7 +406,13 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -482,7 +494,13 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -108,7 +108,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -197,7 +197,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -400,7 +400,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -482,7 +482,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -108,7 +108,9 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -197,7 +199,9 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -292,7 +296,9 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof createPets>>, TError, TData>;
 };
@@ -400,7 +406,13 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -482,7 +494,13 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -318,7 +318,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -606,7 +606,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -318,7 +318,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -606,7 +606,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -318,7 +318,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -606,7 +606,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -318,7 +318,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -606,7 +606,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -317,7 +317,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -513,7 +513,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -317,7 +317,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -513,7 +513,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -347,7 +347,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -690,7 +690,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -347,7 +347,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -690,7 +690,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -918,7 +918,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -918,7 +918,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -449,7 +449,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -746,7 +746,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -449,7 +449,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -746,7 +746,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -449,7 +449,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -746,7 +746,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -449,7 +449,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -746,7 +746,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -491,7 +491,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -959,7 +959,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -491,7 +491,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -959,7 +959,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
+++ b/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
@@ -395,7 +395,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -737,7 +737,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -931,7 +931,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -931,7 +931,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/error-type/endpoints.ts
+++ b/tests/__snapshots__/react-query/error-type/endpoints.ts
@@ -115,7 +115,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -294,7 +294,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -621,7 +621,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -771,7 +771,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1071,7 +1071,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1211,7 +1211,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1369,7 +1369,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1523,7 +1523,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/error-type/endpoints.ts
+++ b/tests/__snapshots__/react-query/error-type/endpoints.ts
@@ -115,7 +115,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -294,7 +294,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -454,7 +454,7 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof createPets>>,
@@ -621,7 +621,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -771,7 +775,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -921,7 +929,11 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1071,7 +1083,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1211,7 +1223,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1369,7 +1381,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1523,7 +1539,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
@@ -524,7 +524,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -704,7 +704,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1056,7 +1056,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
@@ -524,7 +524,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -704,7 +704,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1056,7 +1056,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
@@ -328,7 +328,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -725,7 +725,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
@@ -328,7 +328,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -725,7 +725,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
@@ -353,7 +353,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -775,7 +775,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
@@ -353,7 +353,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -775,7 +775,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
@@ -328,7 +328,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -725,7 +725,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
@@ -328,7 +328,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -725,7 +725,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -437,7 +437,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -871,7 +871,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -437,7 +437,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -871,7 +871,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -338,7 +338,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -583,7 +583,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -338,7 +338,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -583,7 +583,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -783,7 +783,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -783,7 +783,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -650,7 +650,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1002,7 +1002,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -650,7 +650,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1002,7 +1002,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -475,7 +475,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -655,7 +655,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1007,7 +1007,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -475,7 +475,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -655,7 +655,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1007,7 +1007,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -527,7 +527,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1015,7 +1015,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -527,7 +527,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1015,7 +1015,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -938,7 +938,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -470,7 +470,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -938,7 +938,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -471,7 +471,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -768,7 +768,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -471,7 +471,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -768,7 +768,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -523,7 +523,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1014,7 +1014,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -523,7 +523,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1014,7 +1014,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -925,7 +925,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -925,7 +925,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -925,7 +925,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -925,7 +925,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mutator-client/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator-client/endpoints.ts
@@ -121,7 +121,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -306,7 +306,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -649,7 +649,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -799,7 +799,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1099,7 +1099,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1239,7 +1239,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1397,7 +1397,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1551,7 +1551,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mutator-client/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator-client/endpoints.ts
@@ -121,7 +121,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -306,7 +306,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -477,7 +477,7 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof createPets>>,
@@ -649,7 +649,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -799,7 +803,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -949,7 +957,11 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1099,7 +1111,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1239,7 +1251,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1397,7 +1409,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1551,7 +1567,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mutator-multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator-multi-arguments/endpoints.ts
@@ -117,7 +117,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -301,7 +301,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -642,7 +642,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -797,7 +797,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1110,7 +1110,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1255,7 +1255,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1418,7 +1418,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1577,7 +1577,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mutator-multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator-multi-arguments/endpoints.ts
@@ -117,7 +117,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -301,7 +301,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -470,7 +470,7 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof createPets>>,
@@ -642,7 +642,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -797,7 +801,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -952,7 +960,11 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -1110,7 +1122,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1255,7 +1267,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1418,7 +1430,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1577,7 +1593,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator/endpoints.ts
@@ -127,7 +127,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -306,7 +306,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -856,7 +856,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1006,7 +1006,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1506,7 +1506,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1646,7 +1646,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -2058,7 +2058,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -2212,7 +2212,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator/endpoints.ts
@@ -127,7 +127,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -306,7 +306,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -856,7 +856,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1006,7 +1010,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1506,7 +1514,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1646,7 +1654,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -2058,7 +2066,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -2212,7 +2224,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -167,7 +167,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -507,7 +507,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -814,7 +814,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1004,7 +1004,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -167,7 +167,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -507,7 +507,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -814,7 +818,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1004,7 +1008,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -630,7 +630,7 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -982,7 +982,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -449,7 +449,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -746,7 +746,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -449,7 +449,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -746,7 +746,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -658,7 +658,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -658,7 +658,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -918,7 +918,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -918,7 +918,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -918,7 +918,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -450,7 +450,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -918,7 +918,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
@@ -331,7 +331,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -709,7 +709,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
@@ -331,7 +331,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -709,7 +709,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -456,7 +456,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -753,7 +753,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -456,7 +456,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -753,7 +753,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -461,7 +461,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -951,7 +951,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -461,7 +461,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -951,7 +951,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -467,7 +467,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -966,7 +966,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -467,7 +467,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -966,7 +966,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -473,7 +473,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -986,7 +986,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -473,7 +473,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -986,7 +986,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
@@ -354,7 +354,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -800,7 +800,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
@@ -354,7 +354,7 @@ export const useShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetByIdHook>>>,
@@ -800,7 +800,7 @@ export const useShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<ReturnType<typeof useShowPetWithOwnerHook>>>,

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -707,7 +707,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -872,7 +872,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1540,7 +1540,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1714,7 +1714,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -707,7 +707,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -872,7 +872,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -1540,7 +1540,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1714,7 +1714,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
@@ -112,7 +112,7 @@ export const getGetUsersUserIdOrdersQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!userId,
+    enabled: userId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof getUsersUserIdOrders>>,

--- a/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
@@ -112,7 +112,7 @@ export const getGetUsersUserIdOrdersQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: userId != null,
+    enabled: userId !== null && userId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof getUsersUserIdOrders>>,

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -167,7 +167,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -526,7 +526,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -854,7 +854,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1062,7 +1062,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -167,7 +167,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -526,7 +526,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -854,7 +858,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1062,7 +1066,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -468,7 +468,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -971,7 +971,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -468,7 +468,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -971,7 +971,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -925,7 +925,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -925,7 +925,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -373,7 +373,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -688,7 +688,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -373,7 +373,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -688,7 +688,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -274,7 +274,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -457,7 +457,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -274,7 +274,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -457,7 +457,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -385,7 +385,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -620,7 +620,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -385,7 +385,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -620,7 +620,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -715,7 +715,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -457,7 +457,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -715,7 +715,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -455,7 +455,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -826,7 +826,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -455,7 +455,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -826,7 +826,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/mutator/endpoints.ts
@@ -98,7 +98,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -172,7 +172,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -378,7 +378,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -452,7 +452,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -632,7 +632,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -699,7 +699,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -798,7 +798,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -872,7 +872,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/mutator/endpoints.ts
@@ -98,7 +98,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -172,7 +172,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -276,7 +276,7 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof createPets>>,
@@ -378,7 +378,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -452,7 +456,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -544,7 +552,11 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -632,7 +644,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -699,7 +711,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -798,7 +810,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -872,7 +888,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -180,7 +180,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -256,7 +256,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -555,7 +555,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -628,7 +628,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -896,7 +896,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -966,7 +966,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1102,7 +1102,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1176,7 +1176,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -180,7 +180,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -256,7 +256,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -413,7 +413,7 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof createPets>>,
@@ -555,7 +555,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -628,7 +632,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -757,7 +765,11 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -896,7 +908,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -966,7 +978,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1102,7 +1114,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1176,7 +1192,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -385,7 +385,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -620,7 +620,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -385,7 +385,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -620,7 +620,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -177,7 +177,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -253,7 +253,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -544,7 +544,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -620,7 +620,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -880,7 +880,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -949,7 +949,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1084,7 +1084,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1161,7 +1161,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled: version != null && petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -177,7 +177,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -253,7 +253,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -407,7 +407,7 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!version,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof createPets>>,
@@ -544,7 +544,11 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -620,7 +624,11 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -749,7 +757,11 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!(version && petId),
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -880,7 +892,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -949,7 +961,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null,
+    enabled: version !== null && version !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -1084,7 +1096,11 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -1161,7 +1177,11 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: version != null && petId != null,
+    enabled:
+      version !== null &&
+      version !== undefined &&
+      petId !== null &&
+      petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -386,7 +386,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -735,7 +735,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -386,7 +386,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -735,7 +735,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -392,7 +392,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -627,7 +627,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -392,7 +392,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -627,7 +627,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -393,7 +393,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -742,7 +742,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: !!petId,
+    enabled: petId != null,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -393,7 +393,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -742,7 +742,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: petId != null,
+    enabled: petId !== null && petId !== undefined,
     ...queryOptions,
   } as CreateQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/swr/blob-file/endpoints.ts
+++ b/tests/__snapshots__/swr/blob-file/endpoints.ts
@@ -71,7 +71,7 @@ export const useGetBinaryBlob = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getGetBinaryBlobKey(version) : null));

--- a/tests/__snapshots__/swr/blob-file/endpoints.ts
+++ b/tests/__snapshots__/swr/blob-file/endpoints.ts
@@ -71,7 +71,8 @@ export const useGetBinaryBlob = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getGetBinaryBlobKey(version) : null));

--- a/tests/__snapshots__/swr/custom-client/endpoints.ts
+++ b/tests/__snapshots__/swr/custom-client/endpoints.ts
@@ -62,7 +62,7 @@ export const useListPets = <TError = ErrorType<Error>>(
 ) => {
   const { swr: swrOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -176,7 +176,8 @@ export const useShowPetById = <TError = ErrorType<Error>>(
 ) => {
   const { swr: swrOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -279,7 +280,7 @@ export const useHealthCheck = <TError = ErrorType<Error>>(
 ) => {
   const { swr: swrOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey(version) : null));
@@ -329,7 +330,8 @@ export const useShowPetWithOwner = <TError = ErrorType<Error>>(
 ) => {
   const { swr: swrOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId, version) : null));

--- a/tests/__snapshots__/swr/custom-client/endpoints.ts
+++ b/tests/__snapshots__/swr/custom-client/endpoints.ts
@@ -62,7 +62,8 @@ export const useListPets = <TError = ErrorType<Error>>(
 ) => {
   const { swr: swrOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -177,7 +178,11 @@ export const useShowPetById = <TError = ErrorType<Error>>(
   const { swr: swrOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -280,7 +285,8 @@ export const useHealthCheck = <TError = ErrorType<Error>>(
 ) => {
   const { swr: swrOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey(version) : null));
@@ -331,7 +337,11 @@ export const useShowPetWithOwner = <TError = ErrorType<Error>>(
   const { swr: swrOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId, version) : null));

--- a/tests/__snapshots__/swr/examples/endpoints.ts
+++ b/tests/__snapshots__/swr/examples/endpoints.ts
@@ -58,7 +58,7 @@ export const useGetUsers = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getGetUsersKey(version) : null));
   const swrFn = () => getUsers(version, fetchOptions);
@@ -127,7 +127,7 @@ export const useGetUsers2 = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getGetUsers2Key(version) : null));
   const swrFn = () => getUsers2(version, fetchOptions);

--- a/tests/__snapshots__/swr/examples/endpoints.ts
+++ b/tests/__snapshots__/swr/examples/endpoints.ts
@@ -58,7 +58,8 @@ export const useGetUsers = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getGetUsersKey(version) : null));
   const swrFn = () => getUsers(version, fetchOptions);
@@ -127,7 +128,8 @@ export const useGetUsers2 = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getGetUsers2Key(version) : null));
   const swrFn = () => getUsers2(version, fetchOptions);

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -311,7 +311,7 @@ export const useShowPetById = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, requestOptions);
@@ -542,7 +542,7 @@ export const useShowPetWithOwner = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -311,7 +311,8 @@ export const useShowPetById = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, requestOptions);
@@ -542,7 +543,8 @@ export const useShowPetWithOwner = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -211,7 +211,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -336,7 +336,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -211,7 +211,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -336,7 +337,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -343,7 +343,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -536,7 +536,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -343,7 +343,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -536,7 +537,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/mutator/endpoints.ts
+++ b/tests/__snapshots__/swr/mutator/endpoints.ts
@@ -67,7 +67,7 @@ export const useListPets = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -192,7 +192,8 @@ export const useShowPetById = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -308,7 +309,7 @@ export const useHealthCheck = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey(version) : null));
@@ -363,7 +364,8 @@ export const useShowPetWithOwner = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId, version) : null));

--- a/tests/__snapshots__/swr/mutator/endpoints.ts
+++ b/tests/__snapshots__/swr/mutator/endpoints.ts
@@ -67,7 +67,8 @@ export const useListPets = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -193,7 +194,11 @@ export const useShowPetById = <TError = Error>(
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -309,7 +314,8 @@ export const useHealthCheck = <TError = Error>(
 ) => {
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey(version) : null));
@@ -365,7 +371,11 @@ export const useShowPetWithOwner = <TError = Error>(
   const { swr: swrOptions, request: requestOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId, version) : null));

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -150,7 +150,7 @@ export const useListPets = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey({ version }, params) : null));
@@ -357,7 +357,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey({ version, petId }) : null));
@@ -554,7 +555,7 @@ export const useHealthCheck = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey({ version }) : null));
@@ -647,7 +648,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey({ version, petId }) : null));

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -150,7 +150,8 @@ export const useListPets = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey({ version }, params) : null));
@@ -358,7 +359,11 @@ export const useShowPetById = <TError = Promise<Error>>(
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey({ version, petId }) : null));
@@ -555,7 +560,8 @@ export const useHealthCheck = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey({ version }) : null));
@@ -649,7 +655,11 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey({ version, petId }) : null));

--- a/tests/__snapshots__/swr/pattern/endpoints.ts
+++ b/tests/__snapshots__/swr/pattern/endpoints.ts
@@ -73,7 +73,7 @@ export const useGetVversionExample = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getGetVversionExampleKey(version) : null));

--- a/tests/__snapshots__/swr/pattern/endpoints.ts
+++ b/tests/__snapshots__/swr/pattern/endpoints.ts
@@ -73,7 +73,8 @@ export const useGetVversionExample = <TError = Promise<unknown>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getGetVversionExampleKey(version) : null));

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -482,7 +482,7 @@ export const useShowPetByIdInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetByIdInfiniteKeyLoader(petId) : () => null);
@@ -522,7 +522,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -975,7 +975,7 @@ export const useShowPetWithOwnerInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetWithOwnerInfiniteKeyLoader(petId) : () => null);
@@ -1015,7 +1015,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -482,7 +482,8 @@ export const useShowPetByIdInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetByIdInfiniteKeyLoader(petId) : () => null);
@@ -522,7 +523,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -975,7 +977,8 @@ export const useShowPetWithOwnerInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetWithOwnerInfiniteKeyLoader(petId) : () => null);
@@ -1015,7 +1018,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -322,7 +322,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -499,7 +499,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -322,7 +322,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -499,7 +500,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -441,7 +441,7 @@ export const useShowPetByIdInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetByIdInfiniteKeyLoader(petId) : () => null);
@@ -478,7 +478,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -835,7 +835,7 @@ export const useShowPetWithOwnerInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetWithOwnerInfiniteKeyLoader(petId) : () => null);
@@ -872,7 +872,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -441,7 +441,8 @@ export const useShowPetByIdInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetByIdInfiniteKeyLoader(petId) : () => null);
@@ -478,7 +479,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -835,7 +837,8 @@ export const useShowPetWithOwnerInfinite = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKeyLoader =
     swrOptions?.swrKeyLoader ??
     (isEnabled ? getShowPetWithOwnerInfiniteKeyLoader(petId) : () => null);
@@ -872,7 +875,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -146,7 +146,7 @@ export const useListPets = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -350,7 +350,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -541,7 +542,7 @@ export const useHealthCheck = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!version;
+  const isEnabled = swrOptions?.enabled !== false && version != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey(version) : null));
@@ -630,7 +631,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!(version && petId);
+  const isEnabled =
+    swrOptions?.enabled !== false && version != null && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId, version) : null));

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -146,7 +146,8 @@ export const useListPets = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getListPetsKey(params, version) : null));
@@ -351,7 +352,11 @@ export const useShowPetById = <TError = Promise<Error>>(
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetByIdKey(petId, version) : null));
@@ -542,7 +547,8 @@ export const useHealthCheck = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && version != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && version !== null && version !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getHealthCheckKey(version) : null));
@@ -632,7 +638,11 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
   const isEnabled =
-    swrOptions?.enabled !== false && version != null && petId != null;
+    swrOptions?.enabled !== false &&
+    version !== null &&
+    version !== undefined &&
+    petId !== null &&
+    petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId, version) : null));

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -324,7 +324,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -589,7 +589,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -324,7 +324,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -589,7 +590,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -361,7 +361,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -397,7 +397,7 @@ export const useShowPetByIdSuspense = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -697,7 +697,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));
@@ -734,7 +734,7 @@ export const useShowPetWithOwnerSuspense = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -361,7 +361,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -397,7 +398,8 @@ export const useShowPetByIdSuspense = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -697,7 +699,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));
@@ -734,7 +737,8 @@ export const useShowPetWithOwnerSuspense = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -327,7 +327,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -595,7 +595,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -327,7 +327,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -595,7 +596,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -329,7 +329,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -506,7 +506,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -329,7 +329,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -506,7 +507,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -331,7 +331,7 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -596,7 +596,7 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && !!petId;
+  const isEnabled = swrOptions?.enabled !== false && petId != null;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -331,7 +331,8 @@ export const useShowPetById = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ?? (() => (isEnabled ? getShowPetByIdKey(petId) : null));
   const swrFn = () => showPetById(petId, fetchOptions);
@@ -596,7 +597,8 @@ export const useShowPetWithOwner = <TError = Promise<Error>>(
 ) => {
   const { swr: swrOptions, fetch: fetchOptions } = options ?? {};
 
-  const isEnabled = swrOptions?.enabled !== false && petId != null;
+  const isEnabled =
+    swrOptions?.enabled !== false && petId !== null && petId !== undefined;
   const swrKey =
     swrOptions?.swrKey ??
     (() => (isEnabled ? getShowPetWithOwnerKey(petId) : null));

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -404,7 +404,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -764,7 +764,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -404,7 +404,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -764,7 +766,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -404,7 +404,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -764,7 +764,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -404,7 +404,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -764,7 +766,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -382,7 +382,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -706,7 +706,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -382,7 +382,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -706,7 +708,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -283,7 +283,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -470,7 +470,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -283,7 +283,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -470,7 +472,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-multi-query-params/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-multi-query-params/endpoints.ts
@@ -114,7 +114,7 @@ export const getGetUsersUserIdOrdersQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(userId)),
+    enabled: computed(() => unref(userId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof getUsersUserIdOrders>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-multi-query-params/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-multi-query-params/endpoints.ts
@@ -114,7 +114,9 @@ export const getGetUsersUserIdOrdersQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(userId) != null),
+    enabled: computed(
+      () => unref(userId) !== null && unref(userId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof getUsersUserIdOrders>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -394,7 +394,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -633,7 +633,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -394,7 +394,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -633,7 +635,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/vue-query/mutator/endpoints.ts
@@ -116,7 +116,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -205,7 +205,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -422,7 +422,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -504,7 +504,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -698,7 +698,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -774,7 +774,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof healthCheck>>, TError, TData>;
 };
@@ -877,7 +877,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -963,7 +963,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/vue-query/mutator/endpoints.ts
@@ -116,7 +116,9 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -205,7 +207,9 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -312,7 +316,9 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof createPets>>, TError, TData>;
 };
@@ -422,7 +428,13 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -504,7 +516,13 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -597,7 +615,13 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -698,7 +722,9 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -774,7 +800,9 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof healthCheck>>, TError, TData>;
 };
@@ -877,7 +905,13 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -963,7 +997,13 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
@@ -241,7 +241,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -410,7 +410,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
@@ -241,7 +241,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -410,7 +412,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/vue-query/petstore/endpoints.ts
@@ -117,7 +117,7 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -208,7 +208,7 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -422,7 +422,7 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -506,7 +506,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -699,7 +699,7 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -777,7 +777,7 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(() => unref(version) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof healthCheck>>, TError, TData>;
 };
@@ -879,7 +879,7 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -968,7 +968,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(() => unref(version) != null && unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/vue-query/petstore/endpoints.ts
@@ -117,7 +117,9 @@ export const getListPetsInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -208,7 +210,9 @@ export const getListPetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof listPets>>, TError, TData>;
 };
@@ -314,7 +318,9 @@ export const getCreatePetsQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(version)),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof createPets>>, TError, TData>;
 };
@@ -422,7 +428,13 @@ export const getShowPetByIdInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetById>>,
@@ -506,7 +518,13 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -597,7 +615,13 @@ export const getDeletePetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!(unref(version) && unref(petId))),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof deletePetById>>,
@@ -699,7 +723,9 @@ export const getHealthCheckInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof healthCheck>>,
@@ -777,7 +803,9 @@ export const getHealthCheckQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null),
+    enabled: computed(
+      () => unref(version) !== null && unref(version) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof healthCheck>>, TError, TData>;
 };
@@ -879,7 +907,13 @@ export const getShowPetWithOwnerInfiniteQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseInfiniteQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,
@@ -968,7 +1002,13 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(version) != null && unref(petId) != null),
+    enabled: computed(
+      () =>
+        unref(version) !== null &&
+        unref(version) !== undefined &&
+        unref(petId) !== null &&
+        unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/split/endpoints.ts
+++ b/tests/__snapshots__/vue-query/split/endpoints.ts
@@ -242,7 +242,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -491,7 +491,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/split/endpoints.ts
+++ b/tests/__snapshots__/vue-query/split/endpoints.ts
@@ -242,7 +242,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -491,7 +493,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/tags/pets.ts
+++ b/tests/__snapshots__/vue-query/tags/pets.ts
@@ -248,7 +248,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -417,7 +417,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/tags/pets.ts
+++ b/tests/__snapshots__/vue-query/tags/pets.ts
@@ -248,7 +248,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -417,7 +419,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -402,7 +402,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -760,7 +760,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -402,7 +402,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -760,7 +762,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -411,7 +411,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -800,7 +800,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -411,7 +411,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -800,7 +802,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
@@ -249,7 +249,7 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -498,7 +498,7 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => !!unref(petId)),
+    enabled: computed(() => unref(petId) != null),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,

--- a/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
@@ -249,7 +249,9 @@ export const getShowPetByIdQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<Awaited<ReturnType<typeof showPetById>>, TError, TData>;
 };
@@ -498,7 +500,9 @@ export const getShowPetWithOwnerQueryOptions = <
   return {
     queryKey,
     queryFn,
-    enabled: computed(() => unref(petId) != null),
+    enabled: computed(
+      () => unref(petId) !== null && unref(petId) !== undefined,
+    ),
     ...queryOptions,
   } as UseQueryOptions<
     Awaited<ReturnType<typeof showPetWithOwner>>,


### PR DESCRIPTION
## Summary

- Auto-generated `enabled` option used `!!(param)`, which treats falsy-but-valid values like `0`, `""`, and `false` as "missing" and silently disables the query. This is the root cause of #3241 (a `0` path/query parameter never fires the request).
- Switch to `param != null` so only `null` / `undefined` short-circuit the query, matching the standard TanStack Query dependent-query pattern.
- Applies to every TanStack Query client (react / vue / svelte / solid / angular) via the shared default adapter and the Vue adapter's `computed(() => unref(p) != null)` form.
- @orval/swr had the same bug in its `isEnabled = swrOptions?.enabled !== false && !!(...)` derivation; fixed in the same PR for consistency (issue comment: "this probably affects all tanstack query clients").
- Docs guides (react / vue / svelte / solid / swr) updated to mirror the new generated output.

## Why `!= null` is the only correct choice

OpenAPI parameters can legitimately be `0`, `""`, or `false`. The "value is missing" condition that should disable a dependent query is strictly `null` or `undefined` — nothing else. The fix has to express exactly that, and `!= null` is the only single expression that does it without losing information:

| Input | `!!(param)` (before) | `param != null` (after) | Correct? |
| --- | --- | --- | --- |
| `undefined` | `false` (disable) | `false` (disable) | ✅ |
| `null` | `false` (disable) | `false` (disable) | ✅ |
| `0` | `false` (disable) | `true` (enable) | ✅ (was bug) |
| `""` | `false` (disable) | `true` (enable) | ✅ (was bug) |
| `false` | `false` (disable) | `true` (enable) | ✅ (was bug) |
| any other value | `true` | `true` | ✅ |

Per the ECMAScript abstract equality rules, `x != null` is exactly equivalent to `x !== null && x !== undefined` (because `null == undefined` is the only cross-type loose-equality case in the spec). It is the canonical idiom for "is this value present?" and the only legitimate use of `==` / `!=`.

### Alternatives considered and rejected

- `!!(param)` — current behaviour. Conflates "absent" with "falsy". Breaks `0`, `""`, `false`. This is the bug.
- `param !== undefined` — misses the `null` case. OpenAPI/JS treat `null` as a valid "explicit absence" form, so a `null` path param would incorrectly enable the query.
- `typeof param !== 'undefined'` — verbose, still misses `null`, no upside.
- Type-aware generation (emit `!!` for strings, `!== undefined` for numbers, etc.) — `GetterParam` only carries `{ name, required, definition, ... }` and no resolved schema type (`packages/core/src/types.ts`). Threading schema type through the query generator would be a much larger architectural change for a one-line semantic fix, and it would still need `!= null` for `null`-able params. Rejected on DX/scope grounds.

`!= null` is therefore the minimal, type-agnostic, semantically exact fix.

## Before / After

Generated output (react / svelte / solid / angular query):

```diff
- enabled: !!petId,
+ enabled: petId != null,
```

```diff
- enabled: !!(version && petId),
+ enabled: version != null && petId != null,
```

Vue adapter (reactive `computed`):

```diff
- enabled: computed(() => !!(unref(petId))),
+ enabled: computed(() => unref(petId) != null),
```

SWR `isEnabled` derivation:

```diff
- const isEnabled = swrOptions?.enabled !== false && !!(petId);
+ const isEnabled = swrOptions?.enabled !== false && petId != null;
```

### Concrete user-facing scenario (the bug from #3241)

```ts
// petId: number — a perfectly valid id of 0
const [petId, setPetId] = useState<number | null>(null);

useGetPet(petId);   // null  -> disabled (correct, both before and after)
setPetId(0);        // 0     -> BEFORE: still disabled (bug). AFTER: fires the request.
setPetId(42);       // 42    -> enabled (unchanged)
```

`undefined` (e.g. a route param that hasn't resolved yet) keeps disabling the query as before, so existing dependent-query setups are unaffected:

```ts
const { id } = useParams<{ id?: string }>();
useGetUser(id); // id === undefined -> still disabled (no behaviour change)
```

## Test plan

- [x] New unit tests in `packages/query/src/query-options.test.ts` cover single param, multi param, the Vue `computed(() => unref(p) != null)` form, and the user-supplied-`enabled` opt-out path.
- [x] `bun vitest run` — query + swr suites green.
- [x] `bun run update-samples` + `bun run test:snapshots:update` regenerated; `bun run test:snapshots` green.
- [x] `bun run typecheck` and `bun run lint` green.
- [x] Manually verified generated output for react-query, angular-query, vue-query, svelte-query, and swr snapshots.

Fixes #3241.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened query enablement across frameworks to use explicit null/undefined checks so falsy-but-valid values (e.g., 0, empty string) no longer incorrectly disable queries.

* **Documentation**
  * Updated framework guides and generated examples (React Query, Vue, Svelte, Angular, SWR) to show the null-safe enablement pattern.

* **Tests**
  * Added tests covering query enablement behavior for various parameter scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->