### PR TITLE
fix(core): resolve propertyNames const refs

### DIFF
--- a/packages/core/src/generators/interface.test.ts
+++ b/packages/core/src/generators/interface.test.ts
@@ -455,6 +455,46 @@ export type ConstEnum = typeof ConstEnumValue;
     expect(got).toEqual(want);
   });
 
+  it('should generate Record type with propertyNames referenced const (OpenAPI 3.1)', () => {
+    const testContext = withContext({
+      spec: {
+        components: {
+          schemas: {
+            Key: {
+              type: 'string',
+              const: 'key1',
+            },
+          },
+        },
+      },
+    });
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      propertyNames: {
+        $ref: '#/components/schemas/Key',
+      },
+      additionalProperties: {
+        type: 'string',
+      },
+    };
+
+    const got = generateInterface({
+      name: 'MyObject',
+      context: testContext,
+      schema,
+    });
+    const want: GeneratorSchema[] = [
+      {
+        name: 'MyObject',
+        model: `export type MyObject = Partial<Record<Key, string>>;\n`,
+        imports: [{ name: 'Key', schemaName: 'Key' }],
+        dependencies: ['Key'],
+        schema,
+      },
+    ];
+    expect(got).toEqual(want);
+  });
+
   it('should handle propertyNames const with additionalProperties as boolean', () => {
     const schema: OpenApiSchemaObject = {
       type: 'object',

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -84,7 +84,11 @@ function getPropertyNamesKeyType(
     context,
   });
 
-  if (!resolvedValue.isEnum || resolvedValue.type !== 'string') {
+  const resolvedConst = resolvedValue.originalSchema.const as unknown;
+  const isStringConst =
+    resolvedValue.type === 'string' && isString(resolvedConst);
+
+  if (!resolvedValue.isEnum && !isStringConst) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- allow `propertyNames.$ref` to narrow keys when the referenced schema is a string `const`
- add regression coverage for referenced `propertyNames` const schemas

Follow-up to #3329. Addresses the nitpick from https://github.com/orval-labs/orval/pull/3329#pullrequestreview-4237110463.

Fix #3328

## Test
- bun run --filter @orval/core test src/generators/interface.test.ts
- bun run --filter @orval/core typecheck
- bun run --filter @orval/core lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for propertyNames referencing a const via OpenAPI schema key.

* **Bug Fixes**
  * Extended propertyNames handling to support string constants in addition to string enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->