### PR TITLE
Angluar: Fix PUT request bodies for multi-content responses#1

### DIFF
--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -867,62 +867,64 @@ describe('angular HttpClient generator', () => {
     });
 
     it('places body in options (not positional arg) for DELETE with multiple response types', () => {
-  const verbOption = createVerbOption({
-    operationId: 'deletePet',
-    operationName: 'deletePet',
-    verb: 'delete',
-    route: '/pets/${petId}',
-    pathRoute: '/pets/{petId}',
-    body: {
-      implementation: 'deletePetBody',
-      definition: 'DeletePetBody',
-      imports: [],
-      schemas: [],
-      originalSchema: {} as never,
-      contentType: 'application/json',
-      formData: '',
-      formUrlEncoded: '',
-      isOptional: false,
-    },
-    props: [
-      {
-        name: 'petId',
-        definition: 'petId: string',
-        implementation: 'petId: string',
-        default: false,
-        required: true,
-        type: GetterPropType.PARAM,
-      },
-      {
-        name: 'deletePetBody',
-        definition: 'deletePetBody: DeletePetBody',
-        implementation: 'deletePetBody: DeletePetBody',
-        default: false,
-        required: true,
-        type: GetterPropType.BODY,
-      },
-    ],
-    response: baseResponse({
-      definition: { success: 'Pet | string', errors: 'Error' },
-      types: {
-        success: [
-          createSuccessType('Pet', 'application/json'),
-          createSuccessType('string', 'text/plain'),
+      const verbOption = createVerbOption({
+        operationId: 'deletePet',
+        operationName: 'deletePet',
+        verb: 'delete',
+        route: '/pets/${petId}',
+        pathRoute: '/pets/{petId}',
+        body: {
+          implementation: 'deletePetBody',
+          definition: 'DeletePetBody',
+          imports: [],
+          schemas: [],
+          originalSchema: {} as never,
+          contentType: 'application/json',
+          formData: '',
+          formUrlEncoded: '',
+          isOptional: false,
+        },
+        props: [
+          {
+            name: 'petId',
+            definition: 'petId: string',
+            implementation: 'petId: string',
+            default: false,
+            required: true,
+            type: GetterPropType.PARAM,
+          },
+          {
+            name: 'deletePetBody',
+            definition: 'deletePetBody: DeletePetBody',
+            implementation: 'deletePetBody: DeletePetBody',
+            default: false,
+            required: true,
+            type: GetterPropType.BODY,
+          },
         ],
-        errors: [],
-      },
-      contentTypes: ['application/json', 'text/plain'],
-    }),
-  });
-  const options = createGeneratorOptions({ route: '/api/pets/${petId}' });
+        response: baseResponse({
+          definition: { success: 'Pet | string', errors: 'Error' },
+          types: {
+            success: [
+              createSuccessType('Pet', 'application/json'),
+              createSuccessType('string', 'text/plain'),
+            ],
+            errors: [],
+          },
+          contentTypes: ['application/json', 'text/plain'],
+        }),
+      });
+      const options = createGeneratorOptions({ route: '/api/pets/${petId}' });
 
-  const impl = generateHttpClientImplementation(verbOption, options);
+      const impl = generateHttpClientImplementation(verbOption, options);
 
-  // Body must be in options, not a positional argument
-  expect(impl).toContain('body: deletePetBody');
-  // DELETE must NOT get a positional body argument
-  expect(impl).not.toContain('this.http.delete(`/api/pets/${petId}`, deletePetBody,');
-});
+      // Body must be in options, not a positional argument
+      expect(impl).toContain('body: deletePetBody');
+      // DELETE must NOT get a positional body argument
+      expect(impl).not.toContain(
+        'this.http.delete(`/api/pets/${petId}`, deletePetBody,',
+      );
+    });
 
     it('preserves query params for multi-content responses when requestOptions is false', () => {
       const verbOption = createVerbOption({

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -757,6 +757,66 @@ describe('angular HttpClient generator', () => {
       expect(impl).toContain("accept: GetPetFileAccept = 'application/json'");
     });
 
+    it('passes request bodies for PUT operations with multiple response types', () => {
+      const verbOption = createVerbOption({
+        operationId: 'updatePet',
+        operationName: 'updatePet',
+        verb: 'put',
+        route: '/pets/${petId}',
+        pathRoute: '/pets/{petId}',
+        body: {
+          implementation: 'updatePetBody',
+          definition: 'UpdatePetBody',
+          imports: [],
+          schemas: [],
+          originalSchema: {} as never,
+          contentType: 'application/json',
+          formData: '',
+          formUrlEncoded: '',
+          isOptional: false,
+        },
+        props: [
+          {
+            name: 'petId',
+            definition: 'petId: string',
+            implementation: 'petId: string',
+            default: false,
+            required: true,
+            type: GetterPropType.PARAM,
+          },
+          {
+            name: 'updatePetBody',
+            definition: 'updatePetBody: UpdatePetBody',
+            implementation: 'updatePetBody: UpdatePetBody',
+            default: false,
+            required: true,
+            type: GetterPropType.BODY,
+          },
+        ],
+        response: baseResponse({
+          definition: { success: 'Pet | string', errors: 'Error' },
+          types: {
+            success: [
+              createSuccessType('Pet', 'application/json'),
+              createSuccessType('string', 'text/plain'),
+            ],
+            errors: [],
+          },
+          contentTypes: ['application/json', 'text/plain'],
+        }),
+      });
+      const options = createGeneratorOptions({ route: '/api/pets/${petId}' });
+
+      const impl = generateHttpClientImplementation(verbOption, options);
+
+      expect(impl).toContain(
+        'this.http.put<Pet>(`/api/pets/${petId}`, updatePetBody, {',
+      );
+      expect(impl).toContain(
+        'this.http.put(`/api/pets/${petId}`, updatePetBody, {',
+      );
+    });
+
     it('preserves query params for multi-content responses', () => {
       const verbOption = createVerbOption({
         operationId: 'listPets',

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -866,6 +866,64 @@ describe('angular HttpClient generator', () => {
       expect(impl).toContain('params: filteredParams');
     });
 
+    it('places body in options (not positional arg) for DELETE with multiple response types', () => {
+  const verbOption = createVerbOption({
+    operationId: 'deletePet',
+    operationName: 'deletePet',
+    verb: 'delete',
+    route: '/pets/${petId}',
+    pathRoute: '/pets/{petId}',
+    body: {
+      implementation: 'deletePetBody',
+      definition: 'DeletePetBody',
+      imports: [],
+      schemas: [],
+      originalSchema: {} as never,
+      contentType: 'application/json',
+      formData: '',
+      formUrlEncoded: '',
+      isOptional: false,
+    },
+    props: [
+      {
+        name: 'petId',
+        definition: 'petId: string',
+        implementation: 'petId: string',
+        default: false,
+        required: true,
+        type: GetterPropType.PARAM,
+      },
+      {
+        name: 'deletePetBody',
+        definition: 'deletePetBody: DeletePetBody',
+        implementation: 'deletePetBody: DeletePetBody',
+        default: false,
+        required: true,
+        type: GetterPropType.BODY,
+      },
+    ],
+    response: baseResponse({
+      definition: { success: 'Pet | string', errors: 'Error' },
+      types: {
+        success: [
+          createSuccessType('Pet', 'application/json'),
+          createSuccessType('string', 'text/plain'),
+        ],
+        errors: [],
+      },
+      contentTypes: ['application/json', 'text/plain'],
+    }),
+  });
+  const options = createGeneratorOptions({ route: '/api/pets/${petId}' });
+
+  const impl = generateHttpClientImplementation(verbOption, options);
+
+  // Body must be in options, not a positional argument
+  expect(impl).toContain('body: deletePetBody');
+  // DELETE must NOT get a positional body argument
+  expect(impl).not.toContain('this.http.delete(`/api/pets/${petId}`, deletePetBody,');
+});
+
     it('preserves query params for multi-content responses when requestOptions is false', () => {
       const verbOption = createVerbOption({
         operationId: 'listPets',

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -614,13 +614,13 @@ export const generateHttpClientImplementation = (
     const bodyArgument =
       generateBodyOptions(body, isFormData, isFormUrlEncoded) ?? '';
     const deleteBodyOption =
-      verb === 'delete' && bodyArgument ? `body: ${bodyArgument},` : '';
+      verb === 'delete' && bodyArgument ? `body: ${bodyArgument}` : '';
     const buildOptionsObject = (responseType: string) => `{
         ...options,
         responseType: '${responseType}',
         headers,
         ${angularParamsRef ? `params: ${angularParamsRef},` : ''}
-        ${deleteBodyOption}
+        ${deleteBodyOption ? `${deleteBodyOption},` : ''}
       }`;
     const buildHttpClientCall = (typeArg: string, optionsObject: string) =>
       getIsBodyVerb(verb) && verb !== 'delete'

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -611,10 +611,13 @@ export const generateHttpClientImplementation = (
     : `Observable<${observableDataType}>`;
 
   if (hasMultipleContentTypes) {
-    const bodyArgument =
-      generateBodyOptions(body, isFormData, isFormUrlEncoded) ?? '';
+    const bodyIdentifier = generateBodyOptions(
+      body,
+      isFormData,
+      isFormUrlEncoded,
+    );
     const deleteBodyOption =
-      verb === 'delete' && bodyArgument ? `body: ${bodyArgument}` : '';
+      verb === 'delete' && bodyIdentifier ? `body: ${bodyIdentifier}` : '';
     const buildOptionsObject = (responseType: string) => `{
         ...options,
         responseType: '${responseType}',
@@ -624,7 +627,7 @@ export const generateHttpClientImplementation = (
       }`;
     const buildHttpClientCall = (typeArg: string, optionsObject: string) =>
       getIsBodyVerb(verb) && verb !== 'delete'
-        ? `this.http.${verb}${typeArg}(\`${route}\`, ${bodyArgument || 'undefined'}, ${optionsObject})`
+        ? `this.http.${verb}${typeArg}(\`${route}\`, ${bodyIdentifier ?? 'undefined'}, ${optionsObject})`
         : `this.http.${verb}${typeArg}(\`${route}\`, ${optionsObject})`;
 
     const requiredPart = props

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -5,6 +5,7 @@ import {
   type ClientFooterBuilder,
   type ClientHeaderBuilder,
   type ContextSpec,
+  generateBodyOptions,
   generateFormDataAndUrlEncodedFunction,
   generateMutatorConfig,
   generateMutatorRequestOptions,
@@ -16,6 +17,7 @@ import {
   getAngularFilteredParamsHelperBody,
   getDefaultContentType,
   getEnumImplementation,
+  getIsBodyVerb,
   isBoolean,
   pascal,
   toObjectString,
@@ -609,6 +611,23 @@ export const generateHttpClientImplementation = (
     : `Observable<${observableDataType}>`;
 
   if (hasMultipleContentTypes) {
+    const bodyArgument = generateBodyOptions(body, isFormData, isFormUrlEncoded)
+      .trim()
+      .replace(/,$/, '');
+    const deleteBodyOption =
+      verb === 'delete' && bodyArgument ? `body: ${bodyArgument},` : '';
+    const buildOptionsObject = (responseType: string) => `{
+        ...options,
+        responseType: '${responseType}',
+        headers,
+        ${angularParamsRef ? `params: ${angularParamsRef},` : ''}
+        ${deleteBodyOption}
+      }`;
+    const buildHttpClientCall = (typeArg: string, optionsObject: string) =>
+      getIsBodyVerb(verb) && verb !== 'delete'
+        ? `this.http.${verb}${typeArg}(\`${route}\`, ${bodyArgument || 'undefined'}, ${optionsObject})`
+        : `this.http.${verb}${typeArg}(\`${route}\`, ${optionsObject})`;
+
     const requiredPart = props
       .filter((p) => p.required && !p.default)
       .map((p) => p.implementation)
@@ -635,37 +654,17 @@ export const generateHttpClientImplementation = (
       : { ...(options?.headers ?? {}), Accept: accept };
 
     if (accept.includes('json') || accept.includes('+json')) {
-      return this.http.${verb}<${parsedJsonReturnType}>(\`${route}\`, {
-        ...options,
-        responseType: 'json',
-        headers,
-        ${angularParamsRef ? `params: ${angularParamsRef},` : ''}
-      })${jsonValidationPipe};
+      return ${buildHttpClientCall(`<${parsedJsonReturnType}>`, buildOptionsObject('json'))}${jsonValidationPipe};
     } else if (accept.startsWith('text/') || accept.includes('xml')) {
-      return this.http.${verb}(\`${route}\`, {
-        ...options,
-        responseType: 'text',
-        headers,
-        ${angularParamsRef ? `params: ${angularParamsRef},` : ''}
-      }) as Observable<string>;
+      return ${buildHttpClientCall('', buildOptionsObject('text'))} as Observable<string>;
     }${
       blobSuccessTypes.length > 0
         ? ` else {
-      return this.http.${verb}(\`${route}\`, {
-        ...options,
-        responseType: 'blob',
-        headers,
-        ${angularParamsRef ? `params: ${angularParamsRef},` : ''}
-      }) as Observable<Blob>;
+      return ${buildHttpClientCall('', buildOptionsObject('blob'))} as Observable<Blob>;
     }`
         : `
 
-    return this.http.${verb}<${parsedJsonReturnType}>(\`${route}\`, {
-      ...options,
-      responseType: 'json',
-      headers,
-      ${angularParamsRef ? `params: ${angularParamsRef},` : ''}
-    })${jsonValidationPipe};`
+    return ${buildHttpClientCall(`<${parsedJsonReturnType}>`, buildOptionsObject('json'))}${jsonValidationPipe};`
     }
   }
 `;

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -611,9 +611,8 @@ export const generateHttpClientImplementation = (
     : `Observable<${observableDataType}>`;
 
   if (hasMultipleContentTypes) {
-    const bodyArgument = generateBodyOptions(body, isFormData, isFormUrlEncoded)
-      .trim()
-      .replace(/,$/, '');
+    const bodyArgument =
+      generateBodyOptions(body, isFormData, isFormUrlEncoded) ?? '';
     const deleteBodyOption =
       verb === 'delete' && bodyArgument ? `body: ${bodyArgument},` : '';
     const buildOptionsObject = (responseType: string) => `{

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../types';
 import {
   generateAxiosOptions,
+  generateBodyOptions,
   generateMutatorConfig,
   generateOptions,
 } from './options';
@@ -402,6 +403,27 @@ describe('generateAxiosOptions', () => {
       );
       expect(result).not.toContain('false &&');
     });
+  });
+});
+
+describe('generateBodyOptions', () => {
+  it('should return a plain body identifier without formatting', () => {
+    expect(generateBodyOptions(minimalBody, false, false)).toBe('data');
+  });
+
+  it('should return undefined when no request body is available', () => {
+    expect(
+      generateBodyOptions(
+        {
+          ...minimalBody,
+          implementation: '',
+          formData: '',
+          formUrlEncoded: '',
+        },
+        false,
+        false,
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -408,7 +408,13 @@ describe('generateAxiosOptions', () => {
 
 describe('generateBodyOptions', () => {
   it('should return a plain body identifier without formatting', () => {
-    expect(generateBodyOptions(minimalBody, false, false)).toBe('data');
+    expect(
+      generateBodyOptions(
+        { ...minimalBody, implementation: 'data' },
+        false,
+        false,
+      ),
+    ).toBe('data');
   });
 
   it('should return undefined when no request body is available', () => {

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -407,6 +407,26 @@ describe('generateAxiosOptions', () => {
 });
 
 describe('generateBodyOptions', () => {
+  it('should return formData when form data handling is enabled', () => {
+    expect(
+      generateBodyOptions(
+        { ...minimalBody, formData: 'something' },
+        true,
+        false,
+      ),
+    ).toBe('formData');
+  });
+
+  it('should return formUrlEncoded when url encoded handling is enabled', () => {
+    expect(
+      generateBodyOptions(
+        { ...minimalBody, formUrlEncoded: 'something' },
+        false,
+        true,
+      ),
+    ).toBe('formUrlEncoded');
+  });
+
   it('should return a plain body identifier without formatting', () => {
     expect(
       generateBodyOptions(

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -141,20 +141,20 @@ export function generateBodyOptions(
   body: GetterBody,
   isFormData: boolean,
   isFormUrlEncoded: boolean,
-) {
+): string | undefined {
   if (isFormData && body.formData) {
-    return '\n      formData,';
+    return 'formData';
   }
 
   if (isFormUrlEncoded && body.formUrlEncoded) {
-    return '\n      formUrlEncoded,';
+    return 'formUrlEncoded';
   }
 
   if (body.implementation) {
-    return `\n      ${body.implementation},`;
+    return body.implementation;
   }
 
-  return '';
+  return undefined;
 }
 
 interface GenerateAxiosOptions {
@@ -352,9 +352,9 @@ export function generateOptions({
   paramsSerializer,
   paramsSerializerOptions,
 }: GenerateOptionsOptions) {
-  const bodyOptions = getIsBodyVerb(verb)
+  const bodyIdentifier = getIsBodyVerb(verb)
     ? generateBodyOptions(body, isFormData, isFormUrlEncoded)
-    : '';
+    : undefined;
 
   const axiosOptions = generateAxiosOptions({
     response,
@@ -387,7 +387,7 @@ export function generateOptions({
     : '';
 
   if (verb === Verbs.DELETE) {
-    if (!bodyOptions) {
+    if (!bodyIdentifier) {
       return `\n      \`${route}\`${optionsArgument ? `,${optionsArgument}` : ''}\n    `;
     }
 
@@ -397,10 +397,12 @@ export function generateOptions({
 
     return `\n      \`${route}\`,{${
       isAngular ? 'body' : 'data'
-    }:${bodyOptions} ${axiosOptions ? deleteBodyOptions : ''}}\n    `;
+    }: ${bodyIdentifier}${axiosOptions ? `,${deleteBodyOptions}` : ''}}\n    `;
   }
 
-  const bodyOrOptions = getIsBodyVerb(verb) ? bodyOptions || 'undefined,' : '';
+  const bodyOrOptions = getIsBodyVerb(verb)
+    ? `\n      ${bodyIdentifier ?? 'undefined'},`
+    : '';
   const separator = bodyOrOptions || optionsArgument ? ',' : '';
 
   return `\n      \`${route}\`${separator}${bodyOrOptions}${optionsArgument}\n    `;

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -394,10 +394,9 @@ export function generateOptions({
     const deleteBodyOptions = isRawOptionsArgument
       ? `...${optionsArgument}`
       : axiosOptions;
+    const deleteBodyField = `${isAngular ? 'body' : 'data'}: ${bodyIdentifier}`;
 
-    return `\n      \`${route}\`,{${
-      isAngular ? 'body' : 'data'
-    }: ${bodyIdentifier}${axiosOptions ? `,${deleteBodyOptions}` : ''}}\n    `;
+    return `\n      \`${route}\`,{${deleteBodyField}${axiosOptions ? `,${deleteBodyOptions}` : ''}}\n    `;
   }
 
   const bodyOrOptions = getIsBodyVerb(verb)


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/Gogolian/orval/sessions/3a13532a-5083-4e77-b8fd-07855d210aa2

## Summary
- Fixed Angular HttpClient generation for multi-content-type operations so body verbs (including PUT) pass the generated request body argument.
- Preserved DELETE body handling via options and GET-style calls without body arguments.
- Added regression coverage for PUT operations with request bodies and multiple response content types.

## Validation
- `bun run --filter @orval/angular test --run`
- `bun run --filter @orval/angular typecheck`
- `bun run --filter @orval/angular lint`
- Code review and CodeQL validation passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests ensuring PUT/DELETE request bodies are placed correctly across multiple response content types.

* **Refactor**
  * Simplified Angular HTTP client logic for multi-content-type responses by centralizing request/options construction and standardizing JSON/text/blob handling.

* **Chores**
  * Adjusted internal option handling to use an explicit "no body" sentinel and updated related test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->