### PR TITLE
fix(orval): break cycles when inlining recursive external $refs (#1642)

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -903,6 +903,52 @@ describe('dereferenceExternalRefs', () => {
     expect(result).not.toHaveProperty('x-ext');
   });
 
+  it('should break cycles when an external ref recursively points back to itself (#1642)', () => {
+    // A self-referencing x-ext entry outside components.schemas would
+    // otherwise inline forever and OOM; the inner ref must collapse to `{}`.
+    const warnSpy = vi.spyOn(orvalCore, 'logWarning').mockImplementation(() => {
+      /* noop */
+    });
+
+    const input = {
+      openapi: '3.0.0',
+      components: {
+        schemas: {
+          Foo: { $ref: '#/x-ext/abc/Foo' },
+        },
+      },
+      'x-ext': {
+        abc: {
+          Foo: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              self: { $ref: '#/x-ext/abc/Foo' },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as {
+      components: { schemas: { Foo: Record<string, unknown> } };
+    };
+
+    expect(result.components.schemas.Foo).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        self: {},
+      },
+    });
+    expect(result).not.toHaveProperty('x-ext');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('circular external $ref'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
   it('should not inject components into Swagger 2.0 spec when no external refs exist', () => {
     const input = {
       swagger: '2.0',

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -301,18 +301,21 @@ function updateInternalRefs(
 }
 
 /**
- * Replace x-ext refs with either standard component refs or inlined content
+ * Replace x-ext refs with standard component refs, or inline the content.
+ * `inliningRefs` tracks the inline chain to break cycles in recursive
+ * external schemas that aren't under `components.schemas` (#1642).
  */
 function replaceXExtRefs(
   obj: unknown,
   extensions: Record<string, unknown>,
   schemaNameMappings: Record<string, Record<string, string>>,
+  inliningRefs = new Set<string>(),
 ): unknown {
   if (isNullish(obj)) return obj;
 
   if (Array.isArray(obj)) {
     return obj.map((element) =>
-      replaceXExtRefs(element, extensions, schemaNameMappings),
+      replaceXExtRefs(element, extensions, schemaNameMappings, inliningRefs),
     );
   }
 
@@ -342,7 +345,17 @@ function replaceXExtRefs(
             return { $ref: `#/components/schemas/${finalName}` };
           }
 
-          // Otherwise, inline the referenced content
+          // Otherwise inline the content; break cycles with `{}`.
+          if (inliningRefs.has(refValue)) {
+            logWarning(
+              `Detected a circular external $ref while inlining "${refValue}". ` +
+                `Replacing with an empty schema to avoid infinite recursion. ` +
+                `Move the schema under "components.schemas" in its source file ` +
+                `or pre-bundle the spec to keep the recursion intact.`,
+            );
+            return {};
+          }
+
           const extDoc = extensions[extKey];
           let refObj: unknown = extDoc;
           for (const p of parts) {
@@ -360,7 +373,14 @@ function replaceXExtRefs(
 
           if (refObj) {
             const cleaned = scrubUnwantedKeys(refObj);
-            return replaceXExtRefs(cleaned, extensions, schemaNameMappings);
+            const nextInlining = new Set(inliningRefs);
+            nextInlining.add(refValue);
+            return replaceXExtRefs(
+              cleaned,
+              extensions,
+              schemaNameMappings,
+              nextInlining,
+            );
           }
         }
       }
@@ -369,7 +389,12 @@ function replaceXExtRefs(
     // Recursively process all properties
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
-      result[key] = replaceXExtRefs(value, extensions, schemaNameMappings);
+      result[key] = replaceXExtRefs(
+        value,
+        extensions,
+        schemaNameMappings,
+        inliningRefs,
+      );
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- Adds cycle tracking to `replaceXExtRefs` in `@orval/orval` so a recursive external `$ref` (e.g. `common.yaml#/Foo` whose target lives at the document root and refers back to itself) no longer recurses forever during `dereferenceExternalRef`.
- When a cycle is detected during inlining, the inner ref collapses to `{}` and a `logWarning` advises hoisting the schema under `components.schemas` or pre-bundling the spec — mirroring the cycle-break already used by `dereference` in `@orval/zod`.

## Why
Closes #1642. Scalar's bundler embeds external files at `#/x-ext/<key>/...`. `dereferenceExternalRef` only converts refs that fall under `components.schemas` to standard component refs; anything else (root-level entries, or schemas under non-standard paths) is inlined in place. The inlining path had no cycle protection, so self- or cross-referencing external schemas blew the heap during code generation. The user-reported repro hit OOM with `client: 'zod'`, but any client running through this code path was at risk.

## Test plan
- [x] `bun vitest run packages/orval` — added a regression test in `dereferenceExternalRefs` that reproduces the #1642 shape (`#/x-ext/<key>/Foo` self-ref). All previously passing tests remain green.
- [x] `bun run test:snapshots` — 3951 snapshot tests pass; no generated output changes.
- [x] `bun run lint`, `bun run typecheck`, `bun prettier --write` — clean.
- [x] Manual repro with a multi-file spec (`api.yaml` + `common/common.yaml`, where `common.yaml#/Foo` self-references): pre-fix throws inside generation; post-fix generates valid output and emits the warning. Verified across `zod`, `axios`, `fetch`, `react-query`, `swr`, `hono`, `mcp` — every client now completes without OOM.
- [x] Verified that the proper hoisting path (`#/components/schemas/Foo` self-references) is unchanged: no warning, recursive type preserved end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite recursion issue when external schema references form circular dependencies; circular references are now gracefully collapsed and a diagnostic warning is emitted to alert users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3336)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->