### PR TITLE
fix(zod): preserve literal types in object defaults with `as const` (#3244)

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -366,7 +366,10 @@ export const generateZodValidationSchemaDefinition = (
             return `${key}: ${value}`;
         })
         .join(', ');
-      defaultValue = `{ ${entries} }`;
+      // `as const` preserves literal types so `zod.enum([...])` properties
+      // accept the emitted default (#3244).
+      defaultValue =
+        entries.length === 0 ? `{} as const` : `{ ${entries} } as const`;
     } else {
       // OpenApiSchemaObject defines default as 'any'
       const rawStringified = stringify(schema.default);

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1574,7 +1574,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['default', 'testObjectDefaultDefault'],
         ],
         consts: [
-          'export const testObjectDefaultDefault = { name: "Fluffy", age: 3 };',
+          'export const testObjectDefaultDefault = { name: "Fluffy", age: 3 } as const;',
         ],
       });
 
@@ -1589,7 +1589,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'zod.object({\n  "name": zod.string().optional(),\n  "age": zod.number().optional()\n}).default(testObjectDefaultDefault)',
       );
       expect(parsed.consts).toBe(
-        'export const testObjectDefaultDefault = { name: "Fluffy", age: 3 };',
+        'export const testObjectDefaultDefault = { name: "Fluffy", age: 3 } as const;',
       );
     });
 
@@ -2327,6 +2327,35 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(parsed.zod).toBe(
         "zod.array(zod.enum(['A', 'B', 'C'])).default([`A`])",
       );
+    });
+
+    it('appends "as const" to object defaults so enum properties keep literal types (#3244)', () => {
+      const schemaWithObjectEnumDefault: OpenApiSchemaObject = {
+        type: 'object',
+        required: ['enabled', 'value'],
+        properties: {
+          enabled: { type: 'boolean' },
+          value: { type: 'string', enum: ['a', 'b', 'c'] },
+        },
+        default: { enabled: true, value: 'a' },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithObjectEnumDefault,
+        context,
+        'enumPropertiesObject',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toEqual([
+        'export const enumPropertiesObjectDefault = { enabled: true, value: "a" } as const;',
+      ]);
+      expect(result.functions).toContainEqual([
+        'default',
+        'enumPropertiesObjectDefault',
+      ]);
     });
 
     it('does not append trailing enum chain for arrays with enum items and constraints (#2765)', () => {


### PR DESCRIPTION
## Summary
- Object defaults emitted by the zod client (e.g. `{ enabled: true, value: 'a' }`) are now suffixed with `as const`, so TypeScript keeps the narrow literal types required by `zod.enum([...])` properties.
- Fixes the `.default(...)` overload error reported in #3244 (follow-up to #2427 / #2498, which already handled the same problem for enum arrays).
- Adds a regression test that mirrors the minimal repro from the issue and updates the existing object-default test to assert the new `as const` suffix.

## Test plan
- [x] bun vitest run packages/zod
- [x] bun run test:snapshots
- [x] bun run lint
- [x] bun run build
- [x] No new/untracked files under tests/__snapshots__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Generated Zod validation schemas now emit object default values with TypeScript `as const` assertions to preserve literal type information, including for enum-backed properties and empty-object defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->