### PR TITLE
fix(orval): pass skipErrorChecking to TypeDoc to scope it to generated entry points (#3338)

### DIFF
--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -463,6 +463,12 @@ export async function writeSpecs(
       const app = await Application.bootstrapWithPlugins({
         entryPoints: paths.map((x) => upath.toUnix(x)),
         theme: 'markdown',
+        // Skip TypeScript diagnostics on the consuming project: TypeDoc would
+        // otherwise pick up the user's tsconfig and surface errors from files
+        // unrelated to the generated entry points (e.g. a demo `App.tsx`
+        // with an unused `React` default import under the new JSX transform —
+        // see #3338). User-overridable via the `docs` option below.
+        skipErrorChecking: true,
         // Set the custom config location if it has been provided.
         ...config,
         plugin: ['typedoc-plugin-markdown', ...(config.plugin ?? [])],


### PR DESCRIPTION
## Summary

When `output.docs` is enabled, orval boots TypeDoc with the generated `.ts` files as entry points. TypeDoc still auto-discovers the consumer's `tsconfig.json` and builds a single `ts.Program` from it, which means it runs full TypeScript diagnostics over the whole consumer project — not just the files orval emitted.

Two consequences on master, reproduced locally on `samples/react-app`:

1. Diagnostics from files orval has nothing to do with leak into orval's stdout. This is exactly the `TS6133: 'React' is declared but its value is never read.` noise from `src/App.tsx` and `src/auth.context.tsx` that surfaces in CI logs for #3338.
2. Because `app.convert()` returns `undefined` whenever those diagnostics exist, the catch path in `write-specs.ts` logs `TypeDoc not initialized` and the docs are silently dropped. `output.docs` has effectively been broken for any project with a single unrelated TS error elsewhere in its source tree.

So the symptom @tothandras filed is the visible tip; the underlying issue is that orval's docs step is gated on a full type-check of the consumer's project.

## Why this path, and not the ones suggested in the issue thread

The issue discussion converged on two earlier directions before this investigation:

1. **@melloware:** "if it's unused should we just remove it and mark this a breaking change?"
2. **@melloware (follow-up):** "we have other code that parses the TSCONFIG — can we look for that? Then detect whether that is being used?" — pointing to #3320 which migrated tsconfig parsing to `get-tsconfig`.

I started down direction (2) and added a `Tsconfig.compilerOptions.jsx` field plus an `isReactJsxTransform()` helper, expecting to gate a `React` default import emit on it. While wiring it up I traced every emitter that could produce the offending line and found that **no generator in `packages/*` emits `import React` at all** (the only `'react'` literal in the source is the named-import `useCallback` in `packages/query/src/dependencies.ts`). Direction (1) — "just remove the default import" — has the same problem: there is nothing inside orval to remove.

The `import React, { useEffect, useState } from 'react'` shown in the issue body comes from the demo app files in `samples/react-app/src/*.tsx`. They are not orval-generated; they are consumer-style code authored by hand. So neither "remove the emit" nor "detect the JSX transform and conditionally emit" actually applies — there is no emit.

The reason the line still shows up in CI logs is the TypeDoc integration described above. The `samples/react-app:generate-api` task runs orval; orval, when `docs` is enabled, hands TypeDoc the entry points; TypeDoc loads `tsconfig.app.json` (which uses `jsx: "react-jsx"` and `noUnusedLocals: true`); TypeScript flags the unused `React` default import in `App.tsx` / `auth.context.tsx`; TypeDoc surfaces those diagnostics on stdout and aborts the conversion.

Given that, the responsibility line is clearer:

- **Consumer-owned:** whether their source has TS errors. Their `tsc` / bundler / lint pass owns that.
- **orval-owned:** not letting the consumer's unrelated diagnostics gate the docs step.

## Why `skipErrorChecking` — TypeDoc's officially-intended seam

`skipErrorChecking` is a first-class TypeDoc option. The [official documentation](https://typedoc.org/documents/Options.Other.html#skipErrorChecking) describes it verbatim as:

> Instructs TypeDoc to not run the type checker before converting a project. Enabling this option may improve generation time, but could also result in crashes if your code contains type errors.

Reading TypeDoc 0.28's own source (`Application.convert()` in `application.js`) confirms what that means in practice: when `skipErrorChecking === true`, TypeDoc skips the `ts.getPreEmitDiagnostics(program)` block and its abort-on-any-error branch. The `ts.Program` is still constructed, so type information for the entry points remains fully available to the converter. Only the pre-emit type-check gate is bypassed.

This matches the responsibility split above. orval is a documentation-generation step and is not the source of truth for the consumer's type-check — the consumer's own build is. TypeDoc itself frames the option around projects "where TypeDoc is not the source of truth for type checking," which is exactly this integration.

### Honest trade-off

The same upstream sentence is candid about the downside: "could also result in crashes if your code contains type errors." That risk applies to the *entry points* — i.e. the files orval just emitted. We accept the trade-off here because the type-correctness of generated code is already covered by a separate, more direct gate: the `bun run --filter orval-tests build` step compiles the generated output across all 15 client matrixes and fails CI if any of it is unsound. The pre-emit gate inside TypeDoc was therefore redundant on the happy path and actively harmful on the failure path (silently dropping docs for unrelated consumer errors).

A consumer who explicitly wants the stricter behaviour can opt back in via `docs: { skipErrorChecking: false }` — the option is placed *before* `...config` in the bootstrap precisely so user-provided values win.

This also intentionally does not need the `Tsconfig.jsx` plumbing I started — there is no emit to branch on, so adding the type/helper would be infrastructure with no caller. Happy to ship that separately if a future emitter ever needs it.

## Before / after on `samples/react-app`

Before (master):

```
[info] Loaded plugin typedoc-plugin-markdown
src/App.tsx:1:8 - error TS6133: 'React' is declared but its value is never read.
src/auth.context.tsx:2:8 - error TS6133: 'React' is declared but its value is never read.
TypeDoc not initialized
🎉 petstore-file-with-docs-markdown - ...
```

After:

```
[info] Loaded plugin typedoc-plugin-markdown
[info] html generated at ./docs-markdown
🎉 petstore-file-with-docs-markdown - ...
```

Note the second line in the "after" output: the docs are now actually written. On master that step has been a silent no-op for any consumer whose project contains a single unrelated TS error.

## Test plan

- [x] Reproduced the TS6133 noise and `TypeDoc not initialized` on master via `bun run --filter react-app generate-api`
- [x] Confirmed the fix removes the noise and actually writes the docs output
- [x] `bun run format:check`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run test:snapshots` (3951 passed, no diffs)
- [x] `bun run --filter orval-tests build` (all 15 clients)

Closes #3338.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation generation to suppress TypeScript diagnostics from the consuming project, reducing noise in generated documentation output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3345)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->