### PR TITLE
feat(bun): config to add min age on install package

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Only install package versions published at least 3 days ago
+minimumReleaseAge = 259200


### PR DESCRIPTION
Add a bun config to have a minimum version age to be able to install it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced a minimum release age for package installations to improve stability.
  * Switched the npm registry to a new registry endpoint.
  * Upgraded the Vite development dependency across the root project and sample packages to a newer patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3351)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->