### PR TITLE
fix: file extension is not added to imported files when using NodeNext moduleResolution

### DIFF
--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -13,11 +13,13 @@ import { escapeRegExp } from '../utils/string';
 interface GenerateImportsOptions {
   imports: readonly GeneratorImport[];
   namingConvention?: NamingConvention;
+  importExtension?: string;
 }
 
 export function generateImports({
   imports,
   namingConvention = NamingConvention.CAMEL_CASE,
+  importExtension = '',
 }: GenerateImportsOptions) {
   if (imports.length === 0) {
     return '';
@@ -37,7 +39,8 @@ export function generateImports({
   ).map((imp) => ({
     ...imp,
     importPath:
-      imp.importPath ?? `./${conventionName(imp.name, namingConvention)}`,
+      imp.importPath ??
+      `./${conventionName(imp.name, namingConvention)}${importExtension}`,
   }));
 
   const grouped = groupBy(normalized, (imp) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -990,6 +990,9 @@ export interface Tsconfig {
     exactOptionalPropertyTypes?: boolean;
     paths?: Record<string, string[]>;
     target?: TsConfigTarget;
+    module?: string;
+    moduleResolution?: string;
+    allowImportingTsExtensions?: boolean;
   };
 }
 

--- a/packages/core/src/utils/tsconfig.test.ts
+++ b/packages/core/src/utils/tsconfig.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Tsconfig } from '../types';
+import { getImportExtension } from './tsconfig';
+
+describe('getImportExtension', () => {
+  it('strips a .ts file extension when no tsconfig is provided', () => {
+    expect(getImportExtension('.ts')).toBe('');
+    expect(getImportExtension('.gen.ts')).toBe('.gen');
+  });
+
+  it('preserves non-.ts file extensions when no tsconfig is provided', () => {
+    expect(getImportExtension('.mjs')).toBe('.mjs');
+  });
+
+  it('keeps the file extension as-is when allowImportingTsExtensions is true', () => {
+    const tsconfig: Tsconfig = {
+      compilerOptions: { allowImportingTsExtensions: true },
+    };
+    expect(getImportExtension('.gen.ts', tsconfig)).toBe('.gen.ts');
+    expect(getImportExtension('.ts', tsconfig)).toBe('.ts');
+  });
+
+  it('rewrites .ts to .js when module is NodeNext', () => {
+    const tsconfig: Tsconfig = {
+      compilerOptions: { module: 'NodeNext' },
+    };
+    expect(getImportExtension('.ts', tsconfig)).toBe('.js');
+    expect(getImportExtension('.gen.ts', tsconfig)).toBe('.gen.js');
+  });
+
+  it('rewrites .ts to .js when moduleResolution is Node16', () => {
+    const tsconfig: Tsconfig = {
+      compilerOptions: { moduleResolution: 'Node16' },
+    };
+    expect(getImportExtension('.ts', tsconfig)).toBe('.js');
+  });
+
+  it('matches NodeNext/Node16 case-insensitively', () => {
+    expect(
+      getImportExtension('.ts', { compilerOptions: { module: 'nodenext' } }),
+    ).toBe('.js');
+    expect(
+      getImportExtension('.ts', {
+        compilerOptions: { moduleResolution: 'node16' },
+      }),
+    ).toBe('.js');
+  });
+
+  it('prefers allowImportingTsExtensions over NodeNext rewrites', () => {
+    const tsconfig: Tsconfig = {
+      compilerOptions: {
+        module: 'NodeNext',
+        allowImportingTsExtensions: true,
+      },
+    };
+    expect(getImportExtension('.gen.ts', tsconfig)).toBe('.gen.ts');
+  });
+
+  it('falls back to stripping .ts for other module settings', () => {
+    const tsconfig: Tsconfig = {
+      compilerOptions: { module: 'ESNext' },
+    };
+    expect(getImportExtension('.ts', tsconfig)).toBe('');
+    expect(getImportExtension('.gen.ts', tsconfig)).toBe('.gen');
+  });
+});

--- a/packages/core/src/utils/tsconfig.ts
+++ b/packages/core/src/utils/tsconfig.ts
@@ -10,3 +10,29 @@ export function isSyntheticDefaultImportsAllow(config?: Tsconfig) {
     config.compilerOptions?.esModuleInterop
   );
 }
+
+const NODE_NEXT_MODULES = new Set(['nodenext', 'node16']);
+
+export function getImportExtension(
+  fileExtension: string,
+  tsconfig?: Tsconfig,
+): string {
+  const compilerOptions = tsconfig?.compilerOptions;
+
+  if (compilerOptions?.allowImportingTsExtensions) {
+    return fileExtension;
+  }
+
+  const module = compilerOptions?.module?.toLowerCase();
+  const moduleResolution = compilerOptions?.moduleResolution?.toLowerCase();
+  if (
+    (module && NODE_NEXT_MODULES.has(module)) ||
+    (moduleResolution && NODE_NEXT_MODULES.has(moduleResolution))
+  ) {
+    return fileExtension.endsWith('.ts')
+      ? `${fileExtension.slice(0, -3)}.js`
+      : fileExtension;
+  }
+
+  return fileExtension.replace(/\.ts$/, '') || '';
+}

--- a/packages/core/src/utils/tsconfig.ts
+++ b/packages/core/src/utils/tsconfig.ts
@@ -13,6 +13,13 @@ export function isSyntheticDefaultImportsAllow(config?: Tsconfig) {
 
 const NODE_NEXT_MODULES = new Set(['nodenext', 'node16']);
 
+const NODE_NEXT_EXTENSION_MAP: ReadonlyArray<readonly [string, string]> = [
+  ['.tsx', '.jsx'],
+  ['.mts', '.mjs'],
+  ['.cts', '.cjs'],
+  ['.ts', '.js'],
+];
+
 export function getImportExtension(
   fileExtension: string,
   tsconfig?: Tsconfig,
@@ -29,9 +36,12 @@ export function getImportExtension(
     (module && NODE_NEXT_MODULES.has(module)) ||
     (moduleResolution && NODE_NEXT_MODULES.has(moduleResolution))
   ) {
-    return fileExtension.endsWith('.ts')
-      ? `${fileExtension.slice(0, -3)}.js`
-      : fileExtension;
+    for (const [from, to] of NODE_NEXT_EXTENSION_MAP) {
+      if (fileExtension.endsWith(from)) {
+        return `${fileExtension.slice(0, -from.length)}${to}`;
+      }
+    }
+    return fileExtension;
   }
 
   return fileExtension.replace(/\.ts$/, '') || '';

--- a/packages/core/src/utils/tsconfig.ts
+++ b/packages/core/src/utils/tsconfig.ts
@@ -13,7 +13,7 @@ export function isSyntheticDefaultImportsAllow(config?: Tsconfig) {
 
 const NODE_NEXT_MODULES = new Set(['nodenext', 'node16']);
 
-const NODE_NEXT_EXTENSION_MAP: ReadonlyArray<readonly [string, string]> = [
+const NODE_NEXT_EXTENSION_MAP: readonly (readonly [string, string])[] = [
   ['.tsx', '.jsx'],
   ['.mts', '.mjs'],
   ['.cts', '.cjs'],

--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -5,7 +5,7 @@ import type {
   GeneratorImport,
   NormalizedOutputOptions,
 } from '../types';
-import { conventionName, isObject, upath } from '../utils';
+import { conventionName, getImportExtension, isObject, upath } from '../utils';
 
 export function generateImportsForBuilder(
   output: NormalizedOutputOptions,
@@ -39,7 +39,10 @@ export function generateImportsForBuilder(
         : (schemaImport.schemaName ?? schemaImport.name);
       const normalizedName = conventionName(baseName, output.namingConvention);
       const suffix = isZodSchemaOutput ? '.zod' : '';
-      const importExtension = output.fileExtension.replace(/\.ts$/, '') || '';
+      const importExtension = getImportExtension(
+        output.fileExtension,
+        output.tsconfig,
+      );
       const dependency = upath.joinSafe(
         relativeSchemasPath,
         `${normalizedName}${suffix}${importExtension}`,

--- a/packages/core/src/writers/schemas.test.ts
+++ b/packages/core/src/writers/schemas.test.ts
@@ -698,6 +698,90 @@ describe('writeSchemas indexFiles', () => {
     }
   });
 
+  it('emits .js import suffixes when tsconfig module is NodeNext', async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'orval-schema-nodenext-'),
+    );
+    const schemaPath = path.join(tempDir, 'schemas');
+
+    try {
+      await writeSchemas({
+        schemaPath,
+        schemas: [
+          createMockSchema('Pet'),
+          {
+            name: 'Owner',
+            model: 'export type Owner = { pet: Pet };',
+            imports: [{ name: 'Pet' }],
+            schema: {},
+          },
+        ],
+        target: 'src/api',
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.ts',
+        header: '// nodenext',
+        indexFiles: true,
+        tsconfig: { compilerOptions: { module: 'NodeNext' } },
+      });
+
+      const ownerContent = await fs.readFile(
+        path.join(schemaPath, 'owner.ts'),
+        'utf8',
+      );
+      expect(ownerContent).toContain("from './pet.js';");
+
+      const indexContent = await fs.readFile(
+        path.join(schemaPath, 'index.ts'),
+        'utf8',
+      );
+      expect(indexContent).toContain("export * from './pet.js';");
+      expect(indexContent).toContain("export * from './owner.js';");
+    } finally {
+      await fs.remove(tempDir);
+    }
+  });
+
+  it('keeps the .ts file extension on imports when allowImportingTsExtensions is true', async () => {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'orval-schema-allow-ts-'),
+    );
+    const schemaPath = path.join(tempDir, 'schemas');
+
+    try {
+      await writeSchemas({
+        schemaPath,
+        schemas: [
+          createMockSchema('Pet'),
+          {
+            name: 'Owner',
+            model: 'export type Owner = { pet: Pet };',
+            imports: [{ name: 'Pet' }],
+            schema: {},
+          },
+        ],
+        target: 'src/api',
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.gen.ts',
+        header: '// allowImportingTsExtensions',
+        indexFiles: true,
+        tsconfig: {
+          compilerOptions: {
+            module: 'NodeNext',
+            allowImportingTsExtensions: true,
+          },
+        },
+      });
+
+      const ownerContent = await fs.readFile(
+        path.join(schemaPath, 'owner.gen.ts'),
+        'utf8',
+      );
+      expect(ownerContent).toContain("from './pet.gen.ts';");
+    } finally {
+      await fs.remove(tempDir);
+    }
+  });
+
   it('normalizes imports to schema name canonical file when importPath is stale', async () => {
     const tempDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'orval-schema-import-normalize-'),

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -222,6 +222,10 @@ function normalizeCanonicalImportPaths(
         schemaPath,
         canonical.importPath.replaceAll('\\', '/'),
       );
+      // `relative` derives from canonical.importPath (built via getPath) so it
+      // normally ends with `fileExtension`; the `.ts$` branch is a defensive
+      // fallback for legacy/hardcoded `.ts` paths that don't match the
+      // configured fileExtension (e.g. `.gen.ts`).
       const withoutFileExtension = relative.endsWith(fileExtension)
         ? relative.slice(0, -fileExtension.length)
         : relative.replace(/\.ts$/, '');

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -8,8 +8,9 @@ import {
   type GeneratorImport,
   type GeneratorSchema,
   NamingConvention,
+  type Tsconfig,
 } from '../types';
-import { conventionName, upath } from '../utils';
+import { conventionName, getImportExtension, upath } from '../utils';
 import { writeGeneratedFile } from './file';
 
 type CanonicalInfo = Pick<GeneratorImport, 'importPath' | 'name'>;
@@ -60,14 +61,6 @@ export function splitSchemasByType(schemas: GeneratorSchema[]): {
 }
 
 /**
- * Get the import extension from a file extension.
- * Removes `.ts` suffix since TypeScript doesn't need it in imports.
- */
-function getImportExtension(fileExtension: string): string {
-  return fileExtension.replace(/\.ts$/, '') || '';
-}
-
-/**
  * Fix cross-directory imports when schemas reference other schemas in a different directory.
  * Updates import paths to use correct relative paths between directories.
  */
@@ -78,9 +71,10 @@ function fixSchemaImports(
   toPath: string,
   namingConvention: NamingConvention,
   fileExtension: string,
+  tsconfig?: Tsconfig,
 ): void {
   const relativePath = upath.relativeSafe(fromPath, toPath);
-  const importExtension = getImportExtension(fileExtension);
+  const importExtension = getImportExtension(fileExtension, tsconfig);
 
   for (const schema of schemas) {
     schema.imports = schema.imports.map((imp) => {
@@ -106,6 +100,7 @@ export function fixCrossDirectoryImports(
   operationSchemaPath: string,
   namingConvention: NamingConvention,
   fileExtension: string,
+  tsconfig?: Tsconfig,
 ): void {
   fixSchemaImports(
     operationSchemas,
@@ -114,6 +109,7 @@ export function fixCrossDirectoryImports(
     schemaPath,
     namingConvention,
     fileExtension,
+    tsconfig,
   );
 }
 
@@ -127,6 +123,7 @@ export function fixRegularSchemaImports(
   operationSchemaPath: string,
   namingConvention: NamingConvention,
   fileExtension: string,
+  tsconfig?: Tsconfig,
 ): void {
   fixSchemaImports(
     regularSchemas,
@@ -135,6 +132,7 @@ export function fixRegularSchemaImports(
     operationSchemaPath,
     namingConvention,
     fileExtension,
+    tsconfig,
   );
 }
 
@@ -204,7 +202,9 @@ function normalizeCanonicalImportPaths(
   schemaPath: string,
   namingConvention: NamingConvention,
   fileExtension: string,
+  tsconfig?: Tsconfig,
 ) {
+  const importExtension = getImportExtension(fileExtension, tsconfig);
   for (const schema of schemas) {
     schema.imports = schema.imports.map((imp) => {
       const canonicalByName = canonicalNameMap.get(imp.name);
@@ -218,12 +218,14 @@ function normalizeCanonicalImportPaths(
       const canonical = canonicalByName ?? canonicalByPath;
       if (!canonical?.importPath) return imp;
 
-      const importPath = removeTSExtension(
-        upath.relativeSafe(
-          schemaPath,
-          canonical.importPath.replaceAll('\\', '/'),
-        ),
+      const relative = upath.relativeSafe(
+        schemaPath,
+        canonical.importPath.replaceAll('\\', '/'),
       );
+      const withoutFileExtension = relative.endsWith(fileExtension)
+        ? relative.slice(0, -fileExtension.length)
+        : relative.replace(/\.ts$/, '');
+      const importPath = `${withoutFileExtension}${importExtension}`;
 
       return { ...imp, importPath };
     });
@@ -263,21 +265,19 @@ function resolveImportKey(
     .replaceAll('\\', '/');
 }
 
-function removeTSExtension(path: string) {
-  return path.endsWith('.ts') ? path.slice(0, -3) : path;
-}
-
 interface GetSchemaOptions {
   schema: GeneratorSchema;
   target: string;
   header: string;
   namingConvention?: NamingConvention;
+  importExtension?: string;
 }
 
 function getSchema({
   schema: { imports, model },
   header,
   namingConvention = NamingConvention.CAMEL_CASE,
+  importExtension,
 }: GetSchemaOptions): string {
   let file = header;
   file += generateImports({
@@ -287,6 +287,7 @@ function getSchema({
         !model.includes(`interface ${imp.alias ?? imp.name} {`),
     ),
     namingConvention,
+    importExtension,
   });
   file += imports.length > 0 ? '\n\n' : '\n';
   file += model;
@@ -316,6 +317,7 @@ interface WriteSchemaOptions {
   namingConvention: NamingConvention;
   fileExtension: string;
   header: string;
+  tsconfig?: Tsconfig;
 }
 
 export async function writeSchema({
@@ -325,6 +327,7 @@ export async function writeSchema({
   namingConvention,
   fileExtension,
   header,
+  tsconfig,
 }: WriteSchemaOptions) {
   const name = conventionName(schema.name, namingConvention);
 
@@ -336,6 +339,7 @@ export async function writeSchema({
         target,
         header,
         namingConvention,
+        importExtension: getImportExtension(fileExtension, tsconfig),
       }),
     );
   } catch (error) {
@@ -354,6 +358,7 @@ interface WriteSchemasOptions {
   fileExtension: string;
   header: string;
   indexFiles: boolean;
+  tsconfig?: Tsconfig;
 }
 
 export async function writeSchemas({
@@ -364,6 +369,7 @@ export async function writeSchemas({
   fileExtension,
   header,
   indexFiles,
+  tsconfig,
 }: WriteSchemasOptions) {
   const schemaGroups = getSchemaGroups(
     schemaPath,
@@ -386,6 +392,7 @@ export async function writeSchemas({
     schemaPath,
     namingConvention,
     fileExtension,
+    tsconfig,
   );
 
   for (const groupSchemas of Object.values(schemaGroups)) {
@@ -397,6 +404,7 @@ export async function writeSchemas({
         namingConvention,
         fileExtension,
         header,
+        tsconfig,
       });
       continue;
     }
@@ -410,6 +418,7 @@ export async function writeSchemas({
       namingConvention,
       fileExtension,
       header,
+      tsconfig,
     });
   }
 
@@ -419,9 +428,7 @@ export async function writeSchemas({
 
     // Ensure separate files are used for parallel schema writing.
     // Throw an exception if duplicates are detected (using convention names)
-    const ext = fileExtension.endsWith('.ts')
-      ? fileExtension.slice(0, -3)
-      : fileExtension;
+    const ext = getImportExtension(fileExtension, tsconfig);
     const conventionNamesSet = new Set(
       Object.values(schemaGroups).map((group) =>
         conventionName(group[0].name, namingConvention),

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -165,6 +165,7 @@ export async function writeSpecs(
           output.operationSchemas,
           output.namingConvention,
           fileExtension,
+          output.tsconfig,
         );
         fixRegularSchemaImports(
           regularSchemas,
@@ -173,6 +174,7 @@ export async function writeSpecs(
           output.operationSchemas,
           output.namingConvention,
           fileExtension,
+          output.tsconfig,
         );
 
         // Write regular schemas to schemas path
@@ -185,6 +187,7 @@ export async function writeSpecs(
             fileExtension,
             header,
             indexFiles: output.indexFiles,
+            tsconfig: output.tsconfig,
           });
         }
 
@@ -198,6 +201,7 @@ export async function writeSpecs(
             fileExtension,
             header,
             indexFiles: output.indexFiles,
+            tsconfig: output.tsconfig,
           });
 
           // Add re-export from operations in the main schemas index
@@ -218,6 +222,7 @@ export async function writeSpecs(
           fileExtension,
           header,
           indexFiles: output.indexFiles,
+          tsconfig: output.tsconfig,
         });
       }
     } else {
@@ -241,6 +246,7 @@ export async function writeSpecs(
             output.operationSchemas,
             output.namingConvention,
             fileExtension,
+            output.tsconfig,
           );
           fixRegularSchemaImports(
             regularSchemas,
@@ -249,6 +255,7 @@ export async function writeSpecs(
             output.operationSchemas,
             output.namingConvention,
             fileExtension,
+            output.tsconfig,
           );
 
           if (regularSchemas.length > 0) {
@@ -260,6 +267,7 @@ export async function writeSpecs(
               fileExtension,
               header,
               indexFiles: output.indexFiles,
+              tsconfig: output.tsconfig,
             });
           }
 
@@ -272,6 +280,7 @@ export async function writeSpecs(
               fileExtension,
               header,
               indexFiles: output.indexFiles,
+              tsconfig: output.tsconfig,
             });
 
             // Add re-export from operations in the main schemas index
@@ -292,6 +301,7 @@ export async function writeSpecs(
             fileExtension,
             header,
             indexFiles: output.indexFiles,
+            tsconfig: output.tsconfig,
           });
         }
       } else {


### PR DESCRIPTION
Fixes https://github.com/orval-labs/orval/issues/2284.

This basically takes the suggestion from that issue and runs with it:

> Is it possible for orval to respect more options from tsconfig.json, and use .js in case just moduleResolution (module) is set to ESNext, and .ts in case both moduleResolution set to ESNext and allowImportingTsExtensions set to true? 

- `interface Tsconfig` now includes the relevant options
- `getImportExtension` no longer just strips .ts - it takes the tsconfig as an argument and adds .js when those options are set
- the `tsconfig` has to be plumbed through to more places, but I think that's unavoidable

I've run this in my project, where the `orval`-generated files previously failed typechecking with `error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './datapoint.js'?`, and they now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated imports now respect additional TypeScript compiler options (module, moduleResolution, allowImportingTsExtensions) when resolving emitted extensions.
  * Import path extensions are computed consistently and can preserve .ts-style extensions when allowed.
  * Schema generation and index exports now emit imports using the configured extension logic.

* **Tests**
  * Added tests covering import/export suffix behavior across TypeScript configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3361)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->