### PR TITLE
feat: add throwOnError option to generate function

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -980,6 +980,7 @@ export interface GlobalOptions {
   input?: string | string[];
   output?: string;
   failOnWarnings?: boolean;
+  throwOnError?: boolean;
 }
 
 export interface Tsconfig {

--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -39,6 +39,9 @@ export async function generate(
         await generateSpec(workspace, normalizedOptions, projectName);
       } catch (error) {
         hasErrors = true;
+        if (options?.throwOnError) {
+          throw error;
+        }
         logError(error, projectName);
       }
 
@@ -88,6 +91,9 @@ export async function generate(
   try {
     await generateSpec(workspace, normalizedOptions);
   } catch (error) {
+    if (options?.throwOnError) {
+      throw error;
+    }
     logError(error);
   }
 
@@ -99,6 +105,9 @@ export async function generate(
         try {
           await generateSpec(workspace, normalizedOptions);
         } catch (error) {
+          if (options?.throwOnError) {
+            throw error;
+          }
           logError(error);
         }
         if (options.failOnWarnings && getWarningCount() > 0) {


### PR DESCRIPTION
## Summary
Added `throwOnError` option to the `generate` function that allows callers to opt into error-throwing behavior.

## Why
When using orval programmatically, errors are caught internally and only logged, making it difficult for callers to implement custom error handling.

## What changed
- Added `throwOnError?: boolean` to `GlobalOptions`
- Updated three `try/catch` blocks in `generate.ts` to re-throw when enabled

Closes #2290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `throwOnError` configuration setting to control error handling behavior during generation operations. When enabled, errors are re-thrown for improved error visibility and control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->