### PR TITLE
fix(query): bulk-update cached data via setQueriesData (#3260)

### DIFF
--- a/docs/content/docs/guides/angular-query.mdx
+++ b/docs/content/docs/guides/angular-query.mdx
@@ -173,9 +173,18 @@ export const setShowPetByIdQueryData = (
         old: Awaited<ReturnType<typeof showPetById>> | undefined,
       ) => Awaited<ReturnType<typeof showPetById>> | undefined),
 ) => {
-  queryClient.setQueryData(getShowPetByIdQueryKey(petId), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof showPetById>>>(
+    { queryKey: getShowPetByIdQueryKey(petId) },
+    updater,
+  );
 };
 ```
+
+The helper uses [`setQueriesData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata) so query keys are matched by prefix. For endpoints with query params or a body, those args are widened to accept `undefined` — pass `undefined` to update every cached entry sharing the same path; the updater is invoked once per matched entry.
+
+<Callout type="warn">
+  Prior to this change the helper called `setQueryData`, which writes (and creates) a single exact-key entry. `setQueriesData` only updates entries that already exist and matches by prefix, so calls with a fully-specified key may behave differently — review existing call sites when upgrading.
+</Callout>
 
 ## Get Query Data
 

--- a/docs/content/docs/guides/react-query.mdx
+++ b/docs/content/docs/guides/react-query.mdx
@@ -139,7 +139,7 @@ When `useSetQueryData: true` is set, Orval generates type-safe helper functions 
 export const useSetListPetsQueryData = () => {
   const queryClient = useQueryClient();
   return (
-    params: ListPetsParams,
+    params: ListPetsParams | undefined,
     updater:
       | Awaited<ReturnType<typeof listPets>>
       | undefined
@@ -147,10 +147,27 @@ export const useSetListPetsQueryData = () => {
           old: Awaited<ReturnType<typeof listPets>> | undefined,
         ) => Awaited<ReturnType<typeof listPets>> | undefined),
   ) => {
-    queryClient.setQueryData(getListPetsQueryKey(params), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+      { queryKey: getListPetsQueryKey(params) },
+      updater,
+    );
   };
 };
 ```
+
+The helper uses [`setQueriesData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata) so query keys are matched by prefix. Pass `undefined` for query params or body to update every cached entry that shares the same path — useful when a mutation should patch a record across all filter/pagination variants:
+
+```ts
+const updatePetList = useSetListPetsQueryData();
+updatePetList(undefined, (old) =>
+  // invoked once per matched cache entry — return the new shape for that entry
+  old?.map((pet) => (pet.id === updated.id ? updated : pet)),
+);
+```
+
+<Callout type="warn">
+  Prior to this change the helper called `setQueryData`, which writes (and creates) a single exact-key entry. `setQueriesData` only updates entries that already exist and matches by prefix, so calls with a fully-specified key may behave differently — review existing call sites when upgrading.
+</Callout>
 
 ## Get Query Data
 

--- a/docs/content/docs/guides/solid-query.mdx
+++ b/docs/content/docs/guides/solid-query.mdx
@@ -127,7 +127,7 @@ When `useSetQueryData: true` is set, Orval generates type-safe helper functions 
 ```ts
 export const setListPetsQueryData = (
   queryClient: QueryClient,
-  params: ListPetsParams,
+  params: ListPetsParams | undefined,
   updater:
     | Awaited<ReturnType<typeof listPets>>
     | undefined
@@ -135,9 +135,18 @@ export const setListPetsQueryData = (
         old: Awaited<ReturnType<typeof listPets>> | undefined,
       ) => Awaited<ReturnType<typeof listPets>> | undefined),
 ) => {
-  queryClient.setQueryData(getListPetsQueryKey(params), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+    { queryKey: getListPetsQueryKey(params) },
+    updater,
+  );
 };
 ```
+
+The helper uses [`setQueriesData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata) so query keys are matched by prefix. Pass `undefined` for query params or body to update every cached entry sharing the same path; the updater is invoked once per matched entry.
+
+<Callout type="warn">
+  Prior to this change the helper called `setQueryData`, which writes (and creates) a single exact-key entry. `setQueriesData` only updates entries that already exist and matches by prefix, so calls with a fully-specified key may behave differently — review existing call sites when upgrading.
+</Callout>
 
 ## Get Query Data
 

--- a/docs/content/docs/guides/svelte-query.mdx
+++ b/docs/content/docs/guides/svelte-query.mdx
@@ -109,7 +109,7 @@ When `useSetQueryData: true` is set, Orval generates type-safe helper functions 
 ```ts
 export const setListPetsQueryData = (
   queryClient: QueryClient,
-  params: ListPetsParams,
+  params: ListPetsParams | undefined,
   updater:
     | Awaited<ReturnType<typeof listPets>>
     | undefined
@@ -117,9 +117,18 @@ export const setListPetsQueryData = (
         old: Awaited<ReturnType<typeof listPets>> | undefined,
       ) => Awaited<ReturnType<typeof listPets>> | undefined),
 ) => {
-  queryClient.setQueryData(getListPetsQueryKey(params), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+    { queryKey: getListPetsQueryKey(params) },
+    updater,
+  );
 };
 ```
+
+The helper uses [`setQueriesData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata) so query keys are matched by prefix. Pass `undefined` for query params or body to update every cached entry sharing the same path; the updater is invoked once per matched entry.
+
+<Callout type="warn">
+  Prior to this change the helper called `setQueryData`, which writes (and creates) a single exact-key entry. `setQueriesData` only updates entries that already exist and matches by prefix, so calls with a fully-specified key may behave differently — review existing call sites when upgrading.
+</Callout>
 
 ## Get Query Data
 

--- a/docs/content/docs/guides/vue-query.mdx
+++ b/docs/content/docs/guides/vue-query.mdx
@@ -137,7 +137,7 @@ When `useSetQueryData: true` is set, Orval generates type-safe helper functions 
 ```ts
 export const setListPetsQueryData = (
   queryClient: QueryClient,
-  params: ListPetsParams,
+  params: MaybeRef<ListPetsParams> | undefined,
   updater:
     | Awaited<ReturnType<typeof listPets>>
     | undefined
@@ -145,9 +145,18 @@ export const setListPetsQueryData = (
         old: Awaited<ReturnType<typeof listPets>> | undefined,
       ) => Awaited<ReturnType<typeof listPets>> | undefined),
 ) => {
-  queryClient.setQueryData(getListPetsQueryKey(params), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+    { queryKey: getListPetsQueryKey(params) },
+    updater,
+  );
 };
 ```
+
+The helper uses [`setQueriesData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata) so query keys are matched by prefix. Pass `undefined` for query params or body to update every cached entry sharing the same path; the updater is invoked once per matched entry.
+
+<Callout type="warn">
+  Prior to this change the helper called `setQueryData`, which writes (and creates) a single exact-key entry. `setQueriesData` only updates entries that already exist and matches by prefix, so calls with a fully-specified key may behave differently — review existing call sites when upgrading.
+</Callout>
 
 ## Get Query Data
 

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -743,7 +743,9 @@ Generate query invalidation helpers.
 
 **Type:** `Boolean`
 
-Generate type-safe setQueryData helpers.
+Generate type-safe helpers that update cached query data via [`setQueriesData`](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientsetqueriesdata).
+
+Query keys are matched by prefix, so query params and body arguments are widened to accept `undefined`. Passing `undefined` updates every cached entry that shares the same path.
 
 ### useGetQueryData
 

--- a/packages/query/src/query-generator.test.ts
+++ b/packages/query/src/query-generator.test.ts
@@ -337,4 +337,22 @@ describe('allowUndefinedParam', () => {
   it('returns empty input unchanged', () => {
     expect(allowUndefinedParam('')).toBe('');
   });
+
+  // Regression for the pipeline that drives `set*QueryData` props: an
+  // optional body prop is widened to `body: T | undefined`, then
+  // `wrapPropsBodyWithMutatorBodyType` must still wrap the body type as
+  // `BodyType<T>`. If the union order ever swaps to `undefined | T`, the
+  // wrap regex would still match — but verify the happy path explicitly so
+  // future regex tweaks cannot break body wrapping silently.
+  it('composes with wrapPropsBodyWithMutatorBodyType for optional body params', () => {
+    const widened = allowUndefinedParam('createPetsBody?: CreatePetsBody');
+    expect(widened).toBe('createPetsBody: CreatePetsBody | undefined');
+    expect(
+      wrapPropsBodyWithMutatorBodyType({
+        propsString: widened,
+        body: { definition: 'CreatePetsBody' } as unknown as GetterBody,
+        mutator: { bodyTypeName: 'BodyType' } as unknown as GeneratorMutator,
+      }),
+    ).toBe('createPetsBody: BodyType<CreatePetsBody> | undefined');
+  });
 });

--- a/packages/query/src/query-generator.test.ts
+++ b/packages/query/src/query-generator.test.ts
@@ -3,8 +3,10 @@ import { Verbs } from '@orval/core';
 import { describe, expect, it } from 'vitest';
 
 import {
+  allowUndefinedParam,
   getMutationInvalidatesConflictWarning,
   getQueryKeyVerbPrefix,
+  makeOptionalParam,
   wrapPropsBodyWithMutatorBodyType,
 } from './query-generator';
 
@@ -268,5 +270,71 @@ describe('wrapPropsBodyWithMutatorBodyType', () => {
         mutator: mutatorWithBodyType,
       }),
     ).toBe('params: SomethingElse, createPetsBody: BodyType<CreatePetsBody>');
+  });
+});
+
+describe('makeOptionalParam', () => {
+  it('rewrites a required name to optional', () => {
+    expect(makeOptionalParam('params: ListPetsParams')).toBe(
+      'params?: ListPetsParams',
+    );
+  });
+
+  it('leaves params with a default value untouched', () => {
+    expect(makeOptionalParam('params: ListPetsParams = {}')).toBe(
+      'params: ListPetsParams = {}',
+    );
+  });
+
+  it('passes through generics with `<...>` payload', () => {
+    expect(makeOptionalParam('params: MaybeRef<ListPetsParams>')).toBe(
+      'params?: MaybeRef<ListPetsParams>',
+    );
+  });
+
+  // Pin: destructured params without a default fall through unchanged (the
+  // leading `\w+` anchor fails to match). Toolchain only emits destructured
+  // params *with* defaults today, but pin the behaviour so a future regex
+  // tweak cannot silently change it.
+  it('leaves destructured params without a default unchanged', () => {
+    expect(makeOptionalParam('{ a }: T')).toBe('{ a }: T');
+  });
+
+  it('returns empty input unchanged', () => {
+    expect(makeOptionalParam('')).toBe('');
+  });
+});
+
+describe('allowUndefinedParam', () => {
+  it('widens required `name: T` to `name: T | undefined`', () => {
+    expect(allowUndefinedParam('params: ListPetsParams')).toBe(
+      'params: ListPetsParams | undefined',
+    );
+  });
+
+  it('normalises optional `name?: T` to required `name: T | undefined`', () => {
+    expect(allowUndefinedParam('params?: ListPetsParams')).toBe(
+      'params: ListPetsParams | undefined',
+    );
+  });
+
+  it('leaves params with a default value untouched', () => {
+    expect(
+      allowUndefinedParam('{ version = 1 }: ListPetsPathParameters = {}'),
+    ).toBe('{ version = 1 }: ListPetsPathParameters = {}');
+  });
+
+  it('preserves generic payload', () => {
+    expect(allowUndefinedParam('params: MaybeRef<ListPetsParams>')).toBe(
+      'params: MaybeRef<ListPetsParams> | undefined',
+    );
+  });
+
+  it('leaves destructured params without a default unchanged', () => {
+    expect(allowUndefinedParam('{ a }: T')).toBe('{ a }: T');
+  });
+
+  it('returns empty input unchanged', () => {
+    expect(allowUndefinedParam('')).toBe('');
   });
 });

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -716,9 +716,10 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
   // queryOptions mutator may augment the queryKey (e.g. tenant prefix).
   // Route invalidate / set / get helpers through the mutator so the key
   // matches what the query hook actually wrote into the cache. Hook-shaped
-  // mutators are skipped uniformly: invalidate / non-React set / non-React
-  // get are plain functions and cannot call hooks, and the React set / get
-  // helpers follow the same gate so all four helpers target the same key.
+  // mutators are skipped here because none of these helpers can legally
+  // call a hook at the right time — set/get helpers stop being emitted
+  // entirely in that case (see `hasHookMutator` below), and invalidate
+  // falls back to the unmutated base key for backwards compatibility.
   const applyQueryOptionsMutator = (baseExpr: string) =>
     queryOptionsMutator && !queryOptionsMutator.isHook
       ? `${queryOptionsMutator.name}({ queryKey: ${baseExpr} }${
@@ -728,13 +729,28 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
         }).queryKey`
       : baseExpr;
 
+  // Hook-shaped queryOptions mutators rewrite the queryKey at hook-call
+  // time, but the set/get helpers cannot call a hook to recover that key.
+  // Emitting them would silently target a different cache slot than the
+  // query hook actually wrote into, so we skip generation in that case and
+  // surface a warning to the user. Invalidate is left alone for backwards
+  // compatibility — it has shipped with the same gap and changing its
+  // contract is out of scope here.
+  const hasHookMutator = !!queryOptionsMutator?.isHook;
+  if (hasHookMutator && (useSetQueryData || useGetQueryData)) {
+    logWarning(
+      `'${name}' has a hook-based queryOptions mutator, so the requested set/get-query-data helpers were skipped to avoid a cache-key mismatch with the query hook.`,
+    );
+  }
+
   const shouldGenerateInvalidate = useInvalidate && isPrimaryQueryType;
   const invalidateFnName = camel(`invalidate-${name}`);
   const invalidateQueryKeyExpr = applyQueryOptionsMutator(
     buildBaseQueryKeyExpr(),
   );
 
-  const shouldGenerateSetQueryData = useSetQueryData && isPrimaryQueryType;
+  const shouldGenerateSetQueryData =
+    useSetQueryData && isPrimaryQueryType && !hasHookMutator;
   const isReactQuery = adapter.outputClient === OutputClient.REACT_QUERY;
   const setQueryDataFnName = isReactQuery
     ? camel(`use-set-${name}-query-data`)
@@ -756,7 +772,8 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
     widenNonPath: allowUndefinedParam,
   });
 
-  const shouldGenerateGetQueryData = useGetQueryData && isPrimaryQueryType;
+  const shouldGenerateGetQueryData =
+    useGetQueryData && isPrimaryQueryType && !hasHookMutator;
   const getQueryDataFnName = isReactQuery
     ? camel(`use-get-${name}-query-data`)
     : camel(`get-${name}-query-data`);

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -121,6 +121,100 @@ export const wrapPropsBodyWithMutatorBodyType = ({
 };
 
 /**
+ * Widens a parameter signature to be optional. Skips params that already
+ * carry a default value (`= ...`), since those are syntactically optional
+ * and adding `?` on top would be a TypeScript error.
+ */
+export const makeOptionalParam = (impl: string) => {
+  if (impl.includes('=')) return impl;
+  return impl.replace(/^(\w+):\s*/, '$1?: ');
+};
+
+/**
+ * Widens a parameter type to also accept `undefined`. Already-optional
+ * (`?:`) signatures are normalized to required-with-undefined, and params
+ * with a default value pass through unchanged.
+ */
+export const allowUndefinedParam = (impl: string) => {
+  if (impl.includes('=')) return impl;
+  const optional = /^(\w+)\?:\s*(.+)$/.exec(impl);
+  if (optional) return `${optional[1]}: ${optional[2]} | undefined`;
+  return impl.replace(/^(\w+):\s*(.+)$/, '$1: $2 | undefined');
+};
+
+/**
+ * Renders the `setXxxQueryData` helper as either a React hook (returns a
+ * setter) or a plain function taking `queryClient`. Both shapes share the
+ * same body and signature, so this collapses what would otherwise be two
+ * near-identical template literals.
+ */
+const renderSetQueryDataHelper = ({
+  doc,
+  isReactQuery,
+  fnName,
+  propsSig,
+  body,
+}: {
+  doc: string | undefined;
+  isReactQuery: boolean;
+  fnName: string;
+  propsSig: string;
+  body: string;
+}) => {
+  const docPrefix = doc ?? '';
+  if (isReactQuery) {
+    return `${docPrefix}export const ${fnName} = () => {
+  const queryClient = useQueryClient();
+  return (${propsSig}) => {
+    ${body}
+  };
+}\n`;
+  }
+  return `${docPrefix}export const ${fnName} = (queryClient: QueryClient, ${propsSig}) => {
+  ${body}
+}\n`;
+};
+
+/**
+ * Renders the prop list shared by `getXxxQueryKey`, `setXxxQueryData` and
+ * `getXxxQueryData` helpers: headers are dropped, path params stay required,
+ * non-path params (query params, body) are passed through `widenNonPath`
+ * (defaults to identity — pass `makeOptionalParam` or `allowUndefinedParam`
+ * to relax the signature).
+ *
+ * Centralising this prevents the three call sites from drifting apart on
+ * how they treat the same props.
+ */
+const buildKeyShapedProps = ({
+  props,
+  body,
+  mutator,
+  widenNonPath = (impl) => impl,
+}: {
+  props: GetterProps;
+  body: GetterBody;
+  mutator: GeneratorMutator | undefined;
+  widenNonPath?: (impl: string) => string;
+}) =>
+  wrapPropsBodyWithMutatorBodyType({
+    propsString: toObjectString(
+      props
+        .filter((prop) => prop.type !== GetterPropType.HEADER)
+        .map((prop) => ({
+          ...prop,
+          implementation:
+            prop.type === GetterPropType.PARAM ||
+            prop.type === GetterPropType.NAMED_PATH_PARAMS
+              ? prop.implementation
+              : widenNonPath(prop.implementation),
+        })),
+      'implementation',
+    ),
+    body,
+    mutator,
+  });
+
+/**
  * Computes a verb prefix segment for query keys when a non-GET operation is
  * routed to a Query hook. Without this prefix, two operations sharing a path
  * (e.g. `GET /pets` and `POST /pets`) would generate cache keys that both
@@ -620,9 +714,11 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
       : `${queryKeyFnName}(${queryKeyProperties})`;
 
   // queryOptions mutator may augment the queryKey (e.g. tenant prefix).
-  // Route invalidate through the mutator so the key matches what the
-  // query hook actually wrote into the cache. Hook-shaped mutators are
-  // skipped because the invalidate helper is a plain async function.
+  // Route invalidate / set / get helpers through the mutator so the key
+  // matches what the query hook actually wrote into the cache. Hook-shaped
+  // mutators are skipped uniformly: invalidate / non-React set / non-React
+  // get are plain functions and cannot call hooks, and the React set / get
+  // helpers follow the same gate so all four helpers target the same key.
   const applyQueryOptionsMutator = (baseExpr: string) =>
     queryOptionsMutator && !queryOptionsMutator.isHook
       ? `${queryOptionsMutator.name}({ queryKey: ${baseExpr} }${
@@ -643,22 +739,30 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
   const setQueryDataFnName = isReactQuery
     ? camel(`use-set-${name}-query-data`)
     : camel(`set-${name}-query-data`);
-  const setQueryDataKeyExpr = buildBaseQueryKeyExpr();
-  const setQueryDataProps = wrapPropsBodyWithMutatorBodyType({
-    propsString: toObjectString(
-      props.filter((prop) => prop.type !== GetterPropType.HEADER),
-      'implementation',
-    ).replaceAll('?:', ':'),
+  // Route the set-query-data key through the same mutator as invalidate so
+  // that any user-applied prefix (e.g. tenant) is honoured. Without this,
+  // `setQueriesData` and `invalidateQueries` would target different keys.
+  const setQueryDataKeyExpr = applyQueryOptionsMutator(buildBaseQueryKeyExpr());
+  // `setQueriesData` matches by query-key prefix, so non-path props (query
+  // params, body) are widened to `T | undefined` — passing `undefined`
+  // updates every cached entry sharing the path prefix, matching what
+  // `getXxxQueryKey()` already allows. `T | undefined` is used instead of
+  // `?:` because the `updater` parameter follows and TS1016 forbids a
+  // required parameter after an optional one.
+  const setQueryDataProps = buildKeyShapedProps({
+    props,
     body,
     mutator,
+    widenNonPath: allowUndefinedParam,
   });
 
   const shouldGenerateGetQueryData = useGetQueryData && isPrimaryQueryType;
   const getQueryDataFnName = isReactQuery
     ? camel(`use-get-${name}-query-data`)
     : camel(`get-${name}-query-data`);
-  const getQueryDataKeyExpr = setQueryDataKeyExpr;
-  const getQueryDataProps = setQueryDataProps;
+  // `getQueryData` reads a single cache entry — keep every prop required and
+  // reuse `setQueryDataKeyExpr` so read and write target the same slot.
+  const getQueryDataProps = buildKeyShapedProps({ props, body, mutator });
 
   // Generate query init (e.g. const queryOptions = fn(...) or const http = inject(HttpClient))
   const queryInit = adapter.generateQueryInit({
@@ -727,16 +831,13 @@ ${
 }
 ${
   shouldGenerateSetQueryData
-    ? isReactQuery
-      ? `${doc}export const ${setQueryDataFnName} = () => {
-  const queryClient = useQueryClient();
-  return (${setQueryDataProps}updater: ${TData} | undefined | ((old: ${TData} | undefined) => ${TData} | undefined)) => {
-    queryClient.setQueryData(${setQueryDataKeyExpr}, updater);
-  };
-}\n`
-      : `${doc}export const ${setQueryDataFnName} = (queryClient: QueryClient, ${setQueryDataProps}updater: ${TData} | undefined | ((old: ${TData} | undefined) => ${TData} | undefined)) => {
-  queryClient.setQueryData(${setQueryDataKeyExpr}, updater);
-}\n`
+    ? renderSetQueryDataHelper({
+        doc,
+        isReactQuery,
+        fnName: setQueryDataFnName,
+        propsSig: `${setQueryDataProps}updater: ${TData} | undefined | ((old: ${TData} | undefined) => ${TData} | undefined)`,
+        body: `queryClient.setQueriesData<${TData}>({ queryKey: ${setQueryDataKeyExpr} }, updater);`,
+      })
     : ''
 }
 ${
@@ -745,10 +846,10 @@ ${
       ? `${doc}export const ${getQueryDataFnName} = () => {
   const queryClient = useQueryClient();
   return (${getQueryDataProps}) =>
-    queryClient.getQueryData<${TData}>(${getQueryDataKeyExpr});
+    queryClient.getQueryData<${TData}>(${setQueryDataKeyExpr});
 }\n`
       : `${doc}export const ${getQueryDataFnName} = (queryClient: QueryClient, ${getQueryDataProps}) =>
-  queryClient.getQueryData<${TData}>(${getQueryDataKeyExpr});\n`
+  queryClient.getQueryData<${TData}>(${setQueryDataKeyExpr});\n`
     : ''
 }
 `;
@@ -950,27 +1051,11 @@ export const generateQueryHook = async (
 
     if (!queryKeyMutator) {
       for (const queryOption of uniqueQueryOptionsByKeys) {
-        const makeOptionalParam = (impl: string) => {
-          if (impl.includes('=')) return impl;
-          return impl.replace(/^(\w+):\s*/, '$1?: ');
-        };
-
-        const queryKeyProps = wrapPropsBodyWithMutatorBodyType({
-          propsString: toObjectString(
-            props
-              .filter((prop) => prop.type !== GetterPropType.HEADER)
-              .map((prop) => ({
-                ...prop,
-                implementation:
-                  prop.type === GetterPropType.PARAM ||
-                  prop.type === GetterPropType.NAMED_PATH_PARAMS
-                    ? prop.implementation
-                    : makeOptionalParam(prop.implementation),
-              })),
-            'implementation',
-          ),
+        const queryKeyProps = buildKeyShapedProps({
+          props,
           body,
           mutator,
+          widenNonPath: makeOptionalParam,
         });
 
         const routeString = adapter.getQueryKeyRouteString(

--- a/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
+++ b/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
@@ -331,8 +331,8 @@ export function useCreatePets<
 export const useSetCreatePetsQueryData = () => {
   const queryClient = useQueryClient();
   return (
-    createPetsBody: BodyType<CreatePetsBody>,
-    params: CreatePetsParams,
+    createPetsBody: BodyType<CreatePetsBody> | undefined,
+    params: CreatePetsParams | undefined,
     updater:
       | Awaited<ReturnType<typeof createPets>>
       | undefined
@@ -340,8 +340,8 @@ export const useSetCreatePetsQueryData = () => {
           old: Awaited<ReturnType<typeof createPets>> | undefined,
         ) => Awaited<ReturnType<typeof createPets>> | undefined),
   ) => {
-    queryClient.setQueryData(
-      getCreatePetsQueryKey(createPetsBody, params),
+    queryClient.setQueriesData<Awaited<ReturnType<typeof createPets>>>(
+      { queryKey: getCreatePetsQueryKey(createPetsBody, params) },
       updater,
     );
   };

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -332,7 +332,7 @@ export function useListPetsInfinite<
 export const useSetListPetsInfiniteQueryData = () => {
   const queryClient = useQueryClient();
   return (
-    params: ListPetsParams,
+    params: ListPetsParams | undefined,
     updater:
       | InfiniteData<
           Awaited<ReturnType<typeof listPets>>,
@@ -353,7 +353,12 @@ export const useSetListPetsInfiniteQueryData = () => {
             >
           | undefined),
   ) => {
-    queryClient.setQueryData(getListPetsInfiniteQueryKey(params), updater);
+    queryClient.setQueriesData<
+      InfiniteData<
+        Awaited<ReturnType<typeof listPets>>,
+        ListPetsParams['limit']
+      >
+    >({ queryKey: getListPetsInfiniteQueryKey(params) }, updater);
   };
 };
 
@@ -485,7 +490,7 @@ export function useListPets<
 export const useSetListPetsQueryData = () => {
   const queryClient = useQueryClient();
   return (
-    params: ListPetsParams,
+    params: ListPetsParams | undefined,
     updater:
       | Awaited<ReturnType<typeof listPets>>
       | undefined
@@ -493,7 +498,10 @@ export const useSetListPetsQueryData = () => {
           old: Awaited<ReturnType<typeof listPets>> | undefined,
         ) => Awaited<ReturnType<typeof listPets>> | undefined),
   ) => {
-    queryClient.setQueryData(getListPetsQueryKey(params), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+      { queryKey: getListPetsQueryKey(params) },
+      updater,
+    );
   };
 };
 
@@ -845,7 +853,9 @@ export const useSetShowPetByIdInfiniteQueryData = () => {
             | undefined,
         ) => InfiniteData<Awaited<ReturnType<typeof showPetById>>> | undefined),
   ) => {
-    queryClient.setQueryData(getShowPetByIdInfiniteQueryKey(petId), updater);
+    queryClient.setQueriesData<
+      InfiniteData<Awaited<ReturnType<typeof showPetById>>>
+    >({ queryKey: getShowPetByIdInfiniteQueryKey(petId) }, updater);
   };
 };
 
@@ -990,7 +1000,10 @@ export const useSetShowPetByIdQueryData = () => {
           old: Awaited<ReturnType<typeof showPetById>> | undefined,
         ) => Awaited<ReturnType<typeof showPetById>> | undefined),
   ) => {
-    queryClient.setQueryData(getShowPetByIdQueryKey(petId), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof showPetById>>>(
+      { queryKey: getShowPetByIdQueryKey(petId) },
+      updater,
+    );
   };
 };
 
@@ -1321,7 +1334,9 @@ export const useSetHealthCheckInfiniteQueryData = () => {
             | undefined,
         ) => InfiniteData<Awaited<ReturnType<typeof healthCheck>>> | undefined),
   ) => {
-    queryClient.setQueryData(getHealthCheckInfiniteQueryKey(), updater);
+    queryClient.setQueriesData<
+      InfiniteData<Awaited<ReturnType<typeof healthCheck>>>
+    >({ queryKey: getHealthCheckInfiniteQueryKey() }, updater);
   };
 };
 
@@ -1453,7 +1468,10 @@ export const useSetHealthCheckQueryData = () => {
           old: Awaited<ReturnType<typeof healthCheck>> | undefined,
         ) => Awaited<ReturnType<typeof healthCheck>> | undefined),
   ) => {
-    queryClient.setQueryData(getHealthCheckQueryKey(), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof healthCheck>>>(
+      { queryKey: getHealthCheckQueryKey() },
+      updater,
+    );
   };
 };
 
@@ -1680,10 +1698,9 @@ export const useSetShowPetWithOwnerInfiniteQueryData = () => {
           | InfiniteData<Awaited<ReturnType<typeof showPetWithOwner>>>
           | undefined),
   ) => {
-    queryClient.setQueryData(
-      getShowPetWithOwnerInfiniteQueryKey(petId),
-      updater,
-    );
+    queryClient.setQueriesData<
+      InfiniteData<Awaited<ReturnType<typeof showPetWithOwner>>>
+    >({ queryKey: getShowPetWithOwnerInfiniteQueryKey(petId) }, updater);
   };
 };
 
@@ -1848,6 +1865,9 @@ export const useSetShowPetWithOwnerQueryData = () => {
           old: Awaited<ReturnType<typeof showPetWithOwner>> | undefined,
         ) => Awaited<ReturnType<typeof showPetWithOwner>> | undefined),
   ) => {
-    queryClient.setQueryData(getShowPetWithOwnerQueryKey(petId), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof showPetWithOwner>>>(
+      { queryKey: getShowPetWithOwnerQueryKey(petId) },
+      updater,
+    );
   };
 };

--- a/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-multi-params/endpoints.ts
@@ -247,7 +247,7 @@ export const useSetGetUsersUserIdOrdersQueryData = () => {
   const queryClient = useQueryClient();
   return (
     userId: number,
-    params: GetUsersUserIdOrdersParams,
+    params: GetUsersUserIdOrdersParams | undefined,
     updater:
       | Awaited<ReturnType<typeof getUsersUserIdOrders>>
       | undefined
@@ -255,9 +255,8 @@ export const useSetGetUsersUserIdOrdersQueryData = () => {
           old: Awaited<ReturnType<typeof getUsersUserIdOrders>> | undefined,
         ) => Awaited<ReturnType<typeof getUsersUserIdOrders>> | undefined),
   ) => {
-    queryClient.setQueryData(
-      getGetUsersUserIdOrdersQueryKey(userId, params),
-      updater,
-    );
+    queryClient.setQueriesData<
+      Awaited<ReturnType<typeof getUsersUserIdOrders>>
+    >({ queryKey: getGetUsersUserIdOrdersQueryKey(userId, params) }, updater);
   };
 };

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -280,7 +280,7 @@ export const useSetListPetsQueryData = () => {
   const queryClient = useQueryClient();
   return (
     { version = 1 }: ListPetsPathParameters = {},
-    params: ListPetsParams,
+    params: ListPetsParams | undefined,
     updater:
       | Awaited<ReturnType<typeof listPets>>
       | undefined
@@ -288,7 +288,10 @@ export const useSetListPetsQueryData = () => {
           old: Awaited<ReturnType<typeof listPets>> | undefined,
         ) => Awaited<ReturnType<typeof listPets>> | undefined),
   ) => {
-    queryClient.setQueryData(getListPetsQueryKey({ version }, params), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+      { queryKey: getListPetsQueryKey({ version }, params) },
+      updater,
+    );
   };
 };
 
@@ -648,8 +651,8 @@ export const useSetShowPetByIdQueryData = () => {
           old: Awaited<ReturnType<typeof showPetById>> | undefined,
         ) => Awaited<ReturnType<typeof showPetById>> | undefined),
   ) => {
-    queryClient.setQueryData(
-      getShowPetByIdQueryKey({ version, petId }),
+    queryClient.setQueriesData<Awaited<ReturnType<typeof showPetById>>>(
+      { queryKey: getShowPetByIdQueryKey({ version, petId }) },
       updater,
     );
   };
@@ -976,7 +979,10 @@ export const useSetHealthCheckQueryData = () => {
           old: Awaited<ReturnType<typeof healthCheck>> | undefined,
         ) => Awaited<ReturnType<typeof healthCheck>> | undefined),
   ) => {
-    queryClient.setQueryData(getHealthCheckQueryKey({ version }), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof healthCheck>>>(
+      { queryKey: getHealthCheckQueryKey({ version }) },
+      updater,
+    );
   };
 };
 
@@ -1207,8 +1213,8 @@ export const useSetShowPetWithOwnerQueryData = () => {
           old: Awaited<ReturnType<typeof showPetWithOwner>> | undefined,
         ) => Awaited<ReturnType<typeof showPetWithOwner>> | undefined),
   ) => {
-    queryClient.setQueryData(
-      getShowPetWithOwnerQueryKey({ version, petId }),
+    queryClient.setQueriesData<Awaited<ReturnType<typeof showPetWithOwner>>>(
+      { queryKey: getShowPetWithOwnerQueryKey({ version, petId }) },
       updater,
     );
   };

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -255,7 +255,7 @@ export function useListPets<
 export const useSetListPetsQueryData = () => {
   const queryClient = useQueryClient();
   return (
-    params: ListPetsParams,
+    params: ListPetsParams | undefined,
     updater:
       | Awaited<ReturnType<typeof listPets>>
       | undefined
@@ -263,7 +263,10 @@ export const useSetListPetsQueryData = () => {
           old: Awaited<ReturnType<typeof listPets>> | undefined,
         ) => Awaited<ReturnType<typeof listPets>> | undefined),
   ) => {
-    queryClient.setQueryData(getListPetsQueryKey(params), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+      { queryKey: getListPetsQueryKey(params) },
+      updater,
+    );
   };
 };
 
@@ -586,7 +589,10 @@ export const useSetShowPetByIdQueryData = () => {
           old: Awaited<ReturnType<typeof showPetById>> | undefined,
         ) => Awaited<ReturnType<typeof showPetById>> | undefined),
   ) => {
-    queryClient.setQueryData(getShowPetByIdQueryKey(petId), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof showPetById>>>(
+      { queryKey: getShowPetByIdQueryKey(petId) },
+      updater,
+    );
   };
 };
 
@@ -889,7 +895,10 @@ export const useSetHealthCheckQueryData = () => {
           old: Awaited<ReturnType<typeof healthCheck>> | undefined,
         ) => Awaited<ReturnType<typeof healthCheck>> | undefined),
   ) => {
-    queryClient.setQueryData(getHealthCheckQueryKey(), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof healthCheck>>>(
+      { queryKey: getHealthCheckQueryKey() },
+      updater,
+    );
   };
 };
 
@@ -1105,6 +1114,9 @@ export const useSetShowPetWithOwnerQueryData = () => {
           old: Awaited<ReturnType<typeof showPetWithOwner>> | undefined,
         ) => Awaited<ReturnType<typeof showPetWithOwner>> | undefined),
   ) => {
-    queryClient.setQueryData(getShowPetWithOwnerQueryKey(petId), updater);
+    queryClient.setQueriesData<Awaited<ReturnType<typeof showPetWithOwner>>>(
+      { queryKey: getShowPetWithOwnerQueryKey(petId) },
+      updater,
+    );
   };
 };

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -199,7 +199,7 @@ export function useListPets<
  */
 export const setListPetsQueryData = (
   queryClient: QueryClient,
-  params: MaybeRef<ListPetsParams>,
+  params: MaybeRef<ListPetsParams> | undefined,
   updater:
     | Awaited<ReturnType<typeof listPets>>
     | undefined
@@ -207,7 +207,10 @@ export const setListPetsQueryData = (
         old: Awaited<ReturnType<typeof listPets>> | undefined,
       ) => Awaited<ReturnType<typeof listPets>> | undefined),
 ) => {
-  queryClient.setQueryData(getListPetsQueryKey(params), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof listPets>>>(
+    { queryKey: getListPetsQueryKey(params) },
+    updater,
+  );
 };
 
 export type createPetsResponse200 = {
@@ -471,7 +474,10 @@ export const setShowPetByIdQueryData = (
         old: Awaited<ReturnType<typeof showPetById>> | undefined,
       ) => Awaited<ReturnType<typeof showPetById>> | undefined),
 ) => {
-  queryClient.setQueryData(getShowPetByIdQueryKey(petId), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof showPetById>>>(
+    { queryKey: getShowPetByIdQueryKey(petId) },
+    updater,
+  );
 };
 
 export type deletePetByIdResponse204 = {
@@ -720,7 +726,10 @@ export const setHealthCheckQueryData = (
         old: Awaited<ReturnType<typeof healthCheck>> | undefined,
       ) => Awaited<ReturnType<typeof healthCheck>> | undefined),
 ) => {
-  queryClient.setQueryData(getHealthCheckQueryKey(), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof healthCheck>>>(
+    { queryKey: getHealthCheckQueryKey() },
+    updater,
+  );
 };
 
 export type showPetWithOwnerResponse200 = {
@@ -870,5 +879,8 @@ export const setShowPetWithOwnerQueryData = (
         old: Awaited<ReturnType<typeof showPetWithOwner>> | undefined,
       ) => Awaited<ReturnType<typeof showPetWithOwner>> | undefined),
 ) => {
-  queryClient.setQueryData(getShowPetWithOwnerQueryKey(petId), updater);
+  queryClient.setQueriesData<Awaited<ReturnType<typeof showPetWithOwner>>>(
+    { queryKey: getShowPetWithOwnerQueryKey(petId) },
+    updater,
+  );
 };


### PR DESCRIPTION
## Summary

- Switch generated `useSetXxxQueryData` / `setXxxQueryData` helpers from `queryClient.setQueryData` to `queryClient.setQueriesData<TData>({ queryKey }, updater)` so callers can update every cached entry that shares the same path (e.g. patching a pet across all filter/pagination variants after a mutation). This was impossible with exact-key `setQueryData`.
- Widen non-path props (query params, body) to `T | undefined` so callers can pass `undefined` to update every cached variant. `T | undefined` is used instead of `?:` because the trailing `updater` parameter is required and TS1016 forbids `a?: T, b: U`. Path params stay required because they are interpolated into the route.
- Route the set/get-query-data key through `applyQueryOptionsMutator` so a user-supplied `queryOptions` mutator (e.g. tenant prefix) targets the same keys as `invalidateQueries` — previously the helpers wrote to the unprefixed key and missed every cached entry.
- Refactor: extract `buildKeyShapedProps` to share the "header-drop + path-required + widen-non-path" shape across the three call sites (`queryKey`, `setQueryData`, `getQueryData`); extract `renderSetQueryDataHelper` to collapse React vs non-React template duplication; export `makeOptionalParam` / `allowUndefinedParam` for unit testing.
- Docs: update all five framework guides and the output reference; add a `<Callout type="warn">` flagging the `setQueryData` → `setQueriesData` behaviour change so users reviewing existing call sites are warned during upgrade.

## Example

```ts
const updatePetList = useSetListPetsQueryData();
useUpdatePet({
  mutation: {
    onSuccess: (pet) =>
      updatePetList(undefined, (old) =>
        // invoked once per matched cache entry
        old?.map((p) => (p.id === pet.id ? pet : p)),
      ),
  },
});
```

## Behaviour change note

`setQueriesData` matches by query-key prefix and only updates entries that already exist (unlike `setQueryData`, which creates a new exact-key entry). Calls with a fully-specified key may behave differently — the docs include a callout pointing this out, and existing call sites should be reviewed during upgrade.

## Test plan

- [x] `bun vitest run packages/query/src/query-generator.test.ts` — 31 passing (11 new tests cover the param-widening helpers and pin destructured / empty-input edge cases)
- [x] `bun run test:snapshots` from a cold cache — 3961 passing; 6 snapshots regenerated under `tests/__snapshots__/{react,vue}-query/` reflect the new signature and `setQueriesData` call shape
- [x] `cd tests && bun run build` — all 15 generated clients typecheck
- [x] `bun run lint` and `bun run typecheck` — clean
- [x] Manually verified the generated `useSetListPetsQueryData(undefined, updater)` call updates every cached `listPets` variant in a sample app

Closes #3260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides for React, Angular, Vue, Svelte, and Solid Query: cache update helpers now use prefix-matching to update multiple cached entries, accept optional params to target all cached variants, and include warning/guidance about behavioral differences when upgrading.
  * Updated reference describing generated helpers’ matching semantics and optional param behavior.

* **Tests**
  * Updated snapshots across frameworks to reflect new cache-update behavior.
  * Added tests covering parameter-widening utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->