### PR TITLE
fix(query): emit plain SolidMutationOptions for user-facing mutation param (#3365)

### DIFF
--- a/packages/query/src/dependencies.test.ts
+++ b/packages/query/src/dependencies.test.ts
@@ -5,6 +5,8 @@ import {
   isQueryV5,
   isQueryV5WithDataTagError,
   isQueryV5WithInfiniteQueryOptionsError,
+  isSolidQueryWithRenamedOptionsTypes,
+  isSolidQueryWithUsePrefix,
 } from './dependencies';
 
 describe('isQueryV5', () => {
@@ -110,5 +112,59 @@ describe('isQueryV5WithDataTagError', () => {
 
     // ^5.0.0 stripped to 5.0.0 by compareVersions, which is < 5.62.0
     expect(isQueryV5WithDataTagError(packageJson, 'react-query')).toBe(false);
+  });
+});
+
+describe('isSolidQueryWithUsePrefix', () => {
+  it('should return true for 5.71.5 (boundary)', () => {
+    const packageJson: PackageJson = {
+      resolvedVersions: { '@tanstack/solid-query': '5.71.5' },
+    };
+    expect(isSolidQueryWithUsePrefix(packageJson)).toBe(true);
+  });
+
+  it('should return false for 5.71.4', () => {
+    const packageJson: PackageJson = {
+      resolvedVersions: { '@tanstack/solid-query': '5.71.4' },
+    };
+    expect(isSolidQueryWithUsePrefix(packageJson)).toBe(false);
+  });
+
+  it('should return false when solid-query is not installed', () => {
+    expect(isSolidQueryWithUsePrefix({})).toBe(false);
+  });
+});
+
+describe('isSolidQueryWithRenamedOptionsTypes', () => {
+  it('should return true for 5.100.6 (boundary — Solid prefix dropped)', () => {
+    const packageJson: PackageJson = {
+      resolvedVersions: { '@tanstack/solid-query': '5.100.6' },
+    };
+    expect(isSolidQueryWithRenamedOptionsTypes(packageJson)).toBe(true);
+  });
+
+  it('should return true for 5.100.10', () => {
+    const packageJson: PackageJson = {
+      resolvedVersions: { '@tanstack/solid-query': '5.100.10' },
+    };
+    expect(isSolidQueryWithRenamedOptionsTypes(packageJson)).toBe(true);
+  });
+
+  it('should return false for 5.100.5 (just below boundary)', () => {
+    const packageJson: PackageJson = {
+      resolvedVersions: { '@tanstack/solid-query': '5.100.5' },
+    };
+    expect(isSolidQueryWithRenamedOptionsTypes(packageJson)).toBe(false);
+  });
+
+  it('should return false for 5.90.21 (well below boundary)', () => {
+    const packageJson: PackageJson = {
+      resolvedVersions: { '@tanstack/solid-query': '5.90.21' },
+    };
+    expect(isSolidQueryWithRenamedOptionsTypes(packageJson)).toBe(false);
+  });
+
+  it('should return false when solid-query is not installed', () => {
+    expect(isSolidQueryWithRenamedOptionsTypes({})).toBe(false);
   });
 });

--- a/packages/query/src/dependencies.ts
+++ b/packages/query/src/dependencies.ts
@@ -285,8 +285,25 @@ const VUE_QUERY_DEPENDENCIES: GeneratorDependency[] = [
 
 const getSolidQueryImports = (
   prefix: 'use' | 'create',
+  hasRenamedOptionsTypes: boolean,
 ): GeneratorDependency[] => {
   const capitalized = prefix === 'use' ? 'Use' : 'Create';
+  // Solid Query renamed the plain options interfaces in v5.100.6, dropping the
+  // `Solid` prefix: `SolidQueryOptions` → `QueryOptions`, `SolidInfiniteQueryOptions` →
+  // `InfiniteQueryOptions`, `SolidMutationOptions` → `MutationOptions`. The
+  // `Use*Options` / `Create*Options` Accessor aliases keep their names but
+  // are still imported because queries use them as the user-facing
+  // `options.query` param type (Solid's `useQuery` overloads rely on that
+  // shape so the `initialData?` discrimination keeps working).
+  const queryOptionsTypeName = hasRenamedOptionsTypes
+    ? 'QueryOptions'
+    : 'SolidQueryOptions';
+  const infiniteQueryOptionsTypeName = hasRenamedOptionsTypes
+    ? 'InfiniteQueryOptions'
+    : 'SolidInfiniteQueryOptions';
+  const mutationOptionsTypeName = hasRenamedOptionsTypes
+    ? 'MutationOptions'
+    : 'SolidMutationOptions';
   return [
     {
       exports: [
@@ -295,10 +312,9 @@ const getSolidQueryImports = (
         { name: `${prefix}Mutation`, values: true },
         { name: `${capitalized}QueryOptions` },
         { name: `${capitalized}InfiniteQueryOptions` },
-        { name: `${capitalized}MutationOptions` },
-        { name: 'SolidQueryOptions' },
-        { name: 'SolidInfiniteQueryOptions' },
-        { name: 'SolidMutationOptions' },
+        { name: queryOptionsTypeName },
+        { name: infiniteQueryOptionsTypeName },
+        { name: mutationOptionsTypeName },
         { name: 'QueryFunction' },
         { name: 'MutationFunction' },
         { name: `${capitalized}QueryResult` },
@@ -393,6 +409,7 @@ export const getSolidQueryDependencies: ClientDependenciesBuilder = (
     ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
     ...getSolidQueryImports(
       isSolidQueryWithUsePrefix(packageJson) ? 'use' : 'create',
+      isSolidQueryWithRenamedOptionsTypes(packageJson),
     ),
   ];
 };
@@ -559,6 +576,33 @@ export const isSolidQueryWithUsePrefix = (
 
   // https://github.com/TanStack/query/blob/v5.71.5/packages/solid-query/src/index.ts
   return compareVersions(withoutRc, '5.71.5');
+};
+
+/**
+ * Solid Query renamed its plain options interfaces in v5.100.6, dropping the
+ * `Solid` prefix:
+ *   - `SolidQueryOptions` → `QueryOptions`
+ *   - `SolidInfiniteQueryOptions` → `InfiniteQueryOptions`
+ *   - `SolidMutationOptions` → `MutationOptions`
+ *
+ * The Accessor wrappers `UseQueryOptions` / `UseInfiniteQueryOptions` /
+ * `UseMutationOptions` keep the same names but reference the renamed
+ * interfaces internally.
+ *
+ * https://github.com/TanStack/query/commit/<rename-commit>
+ */
+export const isSolidQueryWithRenamedOptionsTypes = (
+  packageJson: PackageJson | undefined,
+) => {
+  const version = getPackageByQueryClient(packageJson, 'solid-query');
+
+  if (!version) {
+    return false;
+  }
+
+  const withoutRc = version.split('-')[0];
+
+  return compareVersions(withoutRc, '5.100.6');
 };
 
 const getPackageByQueryClient = (

--- a/packages/query/src/framework-adapter.ts
+++ b/packages/query/src/framework-adapter.ts
@@ -185,8 +185,26 @@ export interface FrameworkAdapter {
   getQueryOptionsDefinitionPrefix(): string;
 
   /**
-   * Get the options type name for return types of getOptions functions.
-   * Solid: 'SolidQueryOptions' / 'SolidMutationOptions'. Others: use prefix + type.
+   * Get the plain (non-Accessor) options interface name for this framework.
+   *
+   * Used as:
+   *   - the helper function's return type for queries, infinite queries, and
+   *     mutations (`isReturnType: true`), AND
+   *   - the user-facing `options.mutation` parameter type
+   *     (`isReturnType: false`, mutation only — issue #3365).
+   *
+   * Queries intentionally keep the prefix-based `Use*Options` / `Create*Options`
+   * for the user-facing param: in Solid Query that aliases an `Accessor<…>`,
+   * which is the shape `useQuery`'s `Undefined/DefinedInitialDataOptions`
+   * overloads accept, preserving the `initialData?` discrimination at the call
+   * site.
+   *
+   * Solid Query overrides this with `SolidQueryOptions` / `SolidMutationOptions`
+   * (pre-v5.100.6) or `QueryOptions` / `MutationOptions` (v5.100.6+).
+   *
+   * Other adapters can leave this undefined and fall back to the prefix-based
+   * default (`UseMutationOptions`, `CreateMutationOptions`, …), which IS the
+   * plain options shape in their target libraries.
    */
   getOptionsReturnTypeName?(
     type: 'query' | 'infiniteQuery' | 'mutation',

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -18,6 +18,7 @@ import {
   isQueryV5WithInfiniteQueryOptionsError,
   isQueryV5WithMutationContextOnSuccess,
   isQueryV5WithRequiredContextOnSuccess,
+  isSolidQueryWithRenamedOptionsTypes,
   isSolidQueryWithUsePrefix,
   isSvelteQueryV3,
   isSvelteQueryV6,
@@ -143,6 +144,7 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => ({
       queryParam,
       isReturnType: false,
       initialData,
+      adapter: adapter as FrameworkAdapter,
     });
 
     if (!isRequestOptions) {
@@ -297,6 +299,8 @@ export const createFrameworkAdapter = ({
 
     case OutputClientConst.SOLID_QUERY: {
       const hasSolidQueryWithUsePrefix = isSolidQueryWithUsePrefix(packageJson);
+      const hasSolidQueryWithRenamedOptionsTypes =
+        isSolidQueryWithRenamedOptionsTypes(packageJson);
       return withDefaults(
         createSolidAdapter({
           hasQueryV5: _hasQueryV5,
@@ -308,6 +312,8 @@ export const createFrameworkAdapter = ({
           hasQueryV5WithRequiredContextOnSuccess:
             _hasQueryV5WithRequiredContextOnSuccess,
           hasSolidQueryUsePrefix: hasSolidQueryWithUsePrefix,
+          hasSolidQueryRenamedOptionsTypes:
+            hasSolidQueryWithRenamedOptionsTypes,
         }),
       );
     }

--- a/packages/query/src/frameworks/solid.ts
+++ b/packages/query/src/frameworks/solid.ts
@@ -24,6 +24,7 @@ export const createSolidAdapter = ({
   hasQueryV5WithMutationContextOnSuccess,
   hasQueryV5WithRequiredContextOnSuccess,
   hasSolidQueryUsePrefix,
+  hasSolidQueryRenamedOptionsTypes,
 }: {
   hasQueryV5: boolean;
   hasQueryV5WithDataTagError: boolean;
@@ -31,6 +32,7 @@ export const createSolidAdapter = ({
   hasQueryV5WithMutationContextOnSuccess: boolean;
   hasQueryV5WithRequiredContextOnSuccess: boolean;
   hasSolidQueryUsePrefix: boolean;
+  hasSolidQueryRenamedOptionsTypes: boolean;
 }): FrameworkAdapterConfig => ({
   outputClient: OutputClient.SOLID_QUERY,
   hookPrefix: hasSolidQueryUsePrefix ? 'use' : 'create',
@@ -47,11 +49,26 @@ export const createSolidAdapter = ({
   getOptionsReturnTypeName(
     type: 'query' | 'infiniteQuery' | 'mutation',
   ): string | undefined {
-    // Solid Query uses SolidQueryOptions for queries, SolidInfiniteQueryOptions for infinite queries,
-    // and SolidMutationOptions for mutations (these are accessors)
-    if (type === 'mutation') return 'SolidMutationOptions';
-    if (type === 'infiniteQuery') return 'SolidInfiniteQueryOptions';
-    return 'SolidQueryOptions';
+    // Solid Query exposes plain (non-Accessor) options interfaces. The
+    // Accessor-wrapped `Use*Options` / `Create*Options` variants cannot be
+    // used here because the generated code passes options as a plain object
+    // (`{ ...options.mutation }`) before the call site wraps the whole result
+    // in an accessor (`useMutation(() => mutationOptions(...))`).
+    //
+    // v5.100.6 renamed these interfaces to drop the `Solid` prefix.
+    if (type === 'mutation') {
+      return hasSolidQueryRenamedOptionsTypes
+        ? 'MutationOptions'
+        : 'SolidMutationOptions';
+    }
+    if (type === 'infiniteQuery') {
+      return hasSolidQueryRenamedOptionsTypes
+        ? 'InfiniteQueryOptions'
+        : 'SolidInfiniteQueryOptions';
+    }
+    return hasSolidQueryRenamedOptionsTypes
+      ? 'QueryOptions'
+      : 'SolidQueryOptions';
   },
 
   getQueryKeyPrefix(): string {

--- a/packages/query/src/query-options.test.ts
+++ b/packages/query/src/query-options.test.ts
@@ -1,8 +1,12 @@
-import type { GetterParams } from '@orval/core';
+import type { GetterParams, PackageJson } from '@orval/core';
 import { describe, expect, it } from 'vitest';
 
 import { createFrameworkAdapter } from './frameworks';
-import { generateQueryOptions, QueryType } from './query-options';
+import {
+  generateQueryOptions,
+  getQueryOptionsDefinition,
+  QueryType,
+} from './query-options';
 
 const param = (name: string): GetterParams[number] => ({
   name,
@@ -61,5 +65,130 @@ describe('generateQueryOptions enabled emission (issue #3241)', () => {
       adapter,
     });
     expect(out).not.toContain('petId !== null');
+  });
+});
+
+describe('getQueryOptionsDefinition — solid-query type names (issue #3365)', () => {
+  const solidPkg = (version: string): PackageJson => ({
+    resolvedVersions: { '@tanstack/solid-query': version },
+  });
+
+  const buildArgs = (adapter: ReturnType<typeof createFrameworkAdapter>) => ({
+    operationName: 'createPet',
+    definitions: 'data: Pet',
+    prefix: adapter.getQueryOptionsDefinitionPrefix(),
+    hasQueryV5: adapter.hasQueryV5,
+    hasQueryV5WithInfiniteQueryOptionsError:
+      adapter.hasQueryV5WithInfiniteQueryOptionsError,
+    adapter,
+  });
+
+  it('uses SolidMutationOptions for the user-facing options.mutation param on solid-query <5.100.6 (not the Accessor UseMutationOptions)', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'solid-query',
+      packageJson: solidPkg('5.99.0'),
+    });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      isReturnType: false,
+    });
+    expect(out).toContain('SolidMutationOptions<');
+    expect(out).not.toContain('UseMutationOptions<');
+  });
+
+  it('uses SolidMutationOptions for the helper return type on solid-query <5.100.6', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'solid-query',
+      packageJson: solidPkg('5.99.0'),
+    });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      isReturnType: true,
+    });
+    expect(out).toContain('SolidMutationOptions<');
+  });
+
+  it('uses MutationOptions (no Solid prefix) for solid-query >=5.100.6', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'solid-query',
+      packageJson: solidPkg('5.100.6'),
+    });
+    const userFacing = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      isReturnType: false,
+    });
+    const returnType = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      isReturnType: true,
+    });
+    expect(userFacing).toContain('MutationOptions<');
+    expect(userFacing).not.toContain('SolidMutationOptions<');
+    expect(userFacing).not.toContain('UseMutationOptions<');
+    expect(returnType).toContain('MutationOptions<');
+    expect(returnType).not.toContain('SolidMutationOptions<');
+  });
+
+  it('keeps the Accessor-shape Partial<UseQueryOptions<…>> for the user-facing options.query param on solid-query (preserves useQuery overload discrimination)', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'solid-query',
+      packageJson: solidPkg('5.99.0'),
+    });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      type: QueryType.QUERY,
+      isReturnType: false,
+    });
+    expect(out).toContain('Partial<UseQueryOptions<');
+  });
+
+  it('emits SolidQueryOptions<…> for the helper return type on solid-query (isReturnType true)', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'solid-query',
+      packageJson: solidPkg('5.99.0'),
+    });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      type: QueryType.QUERY,
+      isReturnType: true,
+    });
+    expect(out).toContain('SolidQueryOptions<');
+  });
+
+  it('emits QueryOptions<…> (renamed) for the helper return type on solid-query >=5.100.6', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'solid-query',
+      packageJson: solidPkg('5.100.10'),
+    });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      type: QueryType.QUERY,
+      isReturnType: true,
+    });
+    expect(out).toContain('QueryOptions<');
+    expect(out).not.toContain('SolidQueryOptions<');
+  });
+
+  it('leaves react-query emitting Partial<UseQueryOptions<…>> for the user-facing param under v5 (UseQueryOptions IS the plain options in react-query)', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'react-query',
+      packageJson: {
+        resolvedVersions: { '@tanstack/react-query': '5.90.0' },
+      } as PackageJson,
+    });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      type: QueryType.QUERY,
+      isReturnType: false,
+    });
+    expect(out).toContain('Partial<UseQueryOptions<');
+  });
+
+  it('leaves react-query emitting UseMutationOptions<…> for the user-facing mutation param', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      isReturnType: false,
+    });
+    expect(out).toContain('UseMutationOptions<');
   });
 });

--- a/packages/query/src/query-options.ts
+++ b/packages/query/src/query-options.ts
@@ -129,7 +129,12 @@ export const getQueryOptionsDefinition = ({
       >`
         : '';
 
-    // Use adapter's custom options type name for return types if available
+    // Use adapter's custom options type name for return types if available.
+    // For the user-facing query param (isReturnType: false), keep the
+    // prefix-based fallback — Solid Query intentionally emits its `Use*Options`
+    // Accessor type there so the discriminator at the `useQuery` call site
+    // (which only has `UndefinedInitialDataOptions` / `DefinedInitialDataOptions`
+    // overloads) keeps working. See [issue #3365] for the mutation-side fix.
     const optionsTypeName =
       isReturnType && adapter?.getOptionsReturnTypeName
         ? adapter.getOptionsReturnTypeName(
@@ -166,11 +171,12 @@ export const getQueryOptionsDefinition = ({
     }${optionTypeInitialDataPostfix}`;
   }
 
-  // Mutation options
-  const mutationOptionsTypeName =
-    isReturnType && adapter?.getOptionsReturnTypeName
-      ? adapter.getOptionsReturnTypeName('mutation')
-      : undefined;
+  // Mutation options — use the adapter's plain-options type name for both
+  // helper return type and user-facing `options.mutation` param (see comment
+  // above for the Solid Query rationale).
+  const mutationOptionsTypeName = adapter?.getOptionsReturnTypeName
+    ? adapter.getOptionsReturnTypeName('mutation')
+    : undefined;
 
   return mutationOptionsTypeName
     ? `${mutationOptionsTypeName}<Awaited<ReturnType<${


### PR DESCRIPTION
# PR body

Closes #3365.

The generated `options.mutation?:` parameter for `solid-query` is typed with `UseMutationOptions<…>` (or `CreateMutationOptions<…>` on pre-`use`-prefix versions). In `@tanstack/solid-query` v5.71.5+ those names are aliases for `Accessor<SolidMutationOptions<…>>` — i.e. a function type, not an options object. Callers therefore can't pass a literal `{ mutation: { onSuccess, … } }`: TypeScript rejects it with `"object literal may only specify known properties, and 'onSuccess' does not exist in type 'UseMutationOptions<…>'"`. The runtime still spreads the value as a plain object (`{ ...options.mutation }`), so the only reason the existing samples "compiled" is that no caller could legally produce a shape that exercised the bug.

## Root cause

`packages/query/src/query-options.ts` only consults the framework adapter's plain-options type name (`getOptionsReturnTypeName`) when emitting the helper's *return type*. For the user-facing `options.mutation?:` parameter it falls back to the prefix-based `${prefix}MutationOptions<…>`, which on solid resolves to the Accessor alias. The adapter exposes the correct plain type (`SolidMutationOptions`) but it was never used on this code path.

## Fix

- Drop the `isReturnType` gate around the mutation branch in `getQueryOptionsDefinition` so the adapter's plain-options name is used for both the helper return type and the user-facing param.
- Pass `adapter` through the default `generateQueryArguments` in `frameworks/index.ts` so the mutation branch can reach it.
- Detect the v5.100.6 type rename (`SolidMutationOptions` → `MutationOptions`, plus the matching `Query`/`InfiniteQuery` renames) via a new `isSolidQueryWithRenamedOptionsTypes` helper, plumb a `hasSolidQueryRenamedOptionsTypes` flag into `createSolidAdapter`, and pick the right name in both `getOptionsReturnTypeName` and `getSolidQueryImports`.
- Drop the now-unused `Use*MutationOptions` / `Create*MutationOptions` imports for solid; keep the query-side `Use*QueryOptions` / `Use*InfiniteQueryOptions` aliases because queries still need them (see below).

## Why queries are intentionally left alone

`useQuery` in `@tanstack/solid-query` only has two public overloads — `UndefinedInitialDataOptions<…>` and `DefinedInitialDataOptions<…>` — and both are themselves `Accessor<…>` types. The current `options.query?: Partial<UseQueryOptions<…>>` shape (an Accessor under `Partial<>`) is what makes the `initialData?` discrimination at the call site work. Switching it to `Partial<SolidQueryOptions<…>>` widens the inferred return of `getXxxQueryOptions(...)` to include `initialData?: TData | undefined`, which no longer matches the `initialData?: undefined` overload — verified against the `solid-query-basic` sample with `tsc --noEmit`. Fixing the query side properly would mean generating `Undefined/DefinedInitialDataOptions` overloads the way the react-query path does, which is a larger change and out of scope for this fix.

## Testing

- 8 new unit tests in `packages/query/src/dependencies.test.ts` (version-boundary detection at 5.71.5 and 5.100.6) and `packages/query/src/query-options.test.ts` (mutation user-param + return type, both before and after the rename; plus a react-query non-regression check).
- All 127 `@orval/query` tests pass; all 3982 `orval-tests` snapshot tests pass.
- `samples/solid-query/basic` and `samples/solid-query/custom-fetch` `tsc --noEmit` both pass against `@tanstack/solid-query@5.90.x`.

## Not in this PR

A follow-up will wire `tests/configs/solid-query.config.ts` and `solid-start.config.ts` into `tests/api-generation.spec.ts` so this whole class of bugs is caught at snapshot-test time. Flagged separately because it adds ~350 mechanically-generated snapshot files and is worth a maintainer ack first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Solid Query integration now automatically detects installed version and generates appropriate type names for TanStack Query v5.100.6+ option interfaces
  * Updated type generation logic to emit correct option type identifiers based on the installed Solid Query version

* **Tests**
  * Added comprehensive test coverage validating option type name generation for Solid Query across version boundaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->