### PR TITLE
test(query): assert full queryKey assignment in issue-708 regression test

### DIFF
--- a/tests/api-generation.spec.ts
+++ b/tests/api-generation.spec.ts
@@ -76,7 +76,14 @@ test('react-query issue-708 isolates the infinite query key from the regular one
   expect(queryKeyFn('Infinite')).toContain("'infinite'");
   expect(queryKeyFn('')).not.toContain("'infinite'");
 
-  // Each hook must consume its own key fn.
-  expect(content).toContain('getGetListInfiniteQueryKey(params)');
-  expect(content).toContain('getGetListQueryKey(params)');
+  // Each hook must consume its own key fn. Assert on the full `queryKey`
+  // assignment rather than the bare call: `getGetListQueryKey(params)` is a
+  // suffix of `getGetListInfiniteQueryKey(params)`, so a bare-call check would
+  // pass even if the regular hook never invoked its own key fn.
+  expect(content).toContain(
+    'queryOptions?.queryKey ?? getGetListInfiniteQueryKey(params)',
+  );
+  expect(content).toContain(
+    'queryOptions?.queryKey ?? getGetListQueryKey(params)',
+  );
 });


### PR DESCRIPTION
## What this PR does

Follow-up to #3372. Tightens one assertion in the issue-708 regression test.

## Why

The test verified that each hook consumes its own query key fn with:

```ts
expect(content).toContain('getGetListInfiniteQueryKey(params)');
expect(content).toContain('getGetListQueryKey(params)');
```

`'getGetListQueryKey(params)'` is a **suffix** of `'getGetListInfiniteQueryKey(params)'`, so the second assertion was already satisfied by the infinite hook's call. It would **not** fail if the regular hook stopped invoking its own key fn — which is exactly the regression the line was meant to catch. (Raised by Copilot on #3372 after merge.)

## Change

Assert on the full `queryKey` assignment instead of the bare call:

```ts
expect(content).toContain('queryOptions?.queryKey ?? getGetListInfiniteQueryKey(params)');
expect(content).toContain('queryOptions?.queryKey ?? getGetListQueryKey(params)');
```

`queryOptions?.queryKey ?? getGetListQueryKey(params)` is not a substring of the infinite hook's assignment, so each check is now tied to its own hook and a missing call actually fails the test.

Test-only change; `pnpm test:snapshots` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced regression testing to ensure query functionality resolves keys correctly and prevents accidental misuse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->