### PR TITLE
test(core): add regression coverage for multi-tag operation dedup (#873)

### DIFF
--- a/tests/api-generation.spec.ts
+++ b/tests/api-generation.spec.ts
@@ -104,3 +104,40 @@ test('default issue-826 wraps bodies whose readonly props come from nested schem
     'nestedReadonlyObject?: NonReadonly<NestedReadonlyObject>',
   );
 });
+
+test('default issue-873 does not duplicate multi-tag operations across tag files', async () => {
+  // Regression for #873: an operation declaring multiple tags
+  // (`listPets` has `tags: [cats, dogs]` in multiple-tags.yaml) must be
+  // emitted only under its first tag. Emitting it under every tag duplicated
+  // the operation across tag files and made the workspace index re-export the
+  // same symbol twice, so the generated code failed to compile. Keep this
+  // focused assertion alongside the snapshot so #873 fails with a targeted
+  // message instead of a full-file snapshot diff.
+  const marker = 'export const listPets = (';
+
+  // [mode, first-tag file, later-tag file]
+  const modes = [
+    ['multiple-tags', ['cats.ts'], ['dogs.ts']],
+    ['multiple-tags-split', ['cats', 'cats.ts'], ['dogs', 'dogs.ts']],
+  ] as const;
+
+  for (const [mode, firstTag, laterTag] of modes) {
+    const firstTagContent = await readFile(
+      generated('default', mode, ...firstTag),
+      'utf8',
+    );
+    const laterTagContent = await readFile(
+      generated('default', mode, ...laterTag),
+      'utf8',
+    );
+
+    expect(
+      firstTagContent,
+      `${mode}: listPets should be emitted under its first tag`,
+    ).toContain(marker);
+    expect(
+      laterTagContent,
+      `${mode}: listPets must not be duplicated into a later tag`,
+    ).not.toContain(marker);
+  }
+});


### PR DESCRIPTION
## What this PR does

Adds a focused regression test for #873.

#873 reports that an operation declaring multiple tags (e.g. `tags: [cats, dogs]`) was generated and exposed once per tag in `tags` / `tags-split` mode, which duplicated the operation across tag files and made the workspace `index.ts` re-export the same symbol twice and fail to compile.

This behaviour is already fixed on `master`: `generateTargetForTags` buckets each operation by its first tag only (`packages/core/src/writers/target-tags.ts`). The existing `tests/specifications/multiple-tags.yaml` fixture (`listPets` has `tags: [cats, dogs]`) already exercises this path, but it is only covered by the broad file snapshots, so a regression would surface as an opaque snapshot diff rather than a clear signal.

This PR pins the behaviour explicitly, matching the existing focused-test pattern in `tests/api-generation.spec.ts` (see the #708 / #826 / #3103 tests): the test asserts that `listPets` is emitted under its first tag (`cats`) and is **not** duplicated into a later tag (`dogs`), for both `tags` and `tags-split` modes.

## Why

The duplication bug is fixed but had no targeted coverage. If the first-tag dedup logic regresses, this test fails with a clear message (`listPets must not be duplicated into a later tag`) instead of a full-file snapshot diff.

## Verification

- New test passes on `master`.
- Temporarily reverting the dedup (emitting each operation once per tag) makes the new test fail with the targeted message — confirming it actually guards the behaviour.
- No production code and no generated snapshots change; only `tests/api-generation.spec.ts` is touched.
- `format:check`, `typecheck`, `lint`, `test`, `test:snapshots`, and the generated-client typecheck (`--filter orval-tests build`) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test to verify correct behavior of multi-tag API generation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->