### PR TITLE
fix: properly handle zod.generate options & use 2xx when 200 is not available

### DIFF
--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -273,6 +273,7 @@ describe('write-zod-specs regressions', () => {
           zod: {
             ...createOutputOptions().override.zod,
             generate: {
+              param: true,
               body: true,
               query: true,
               header: true,

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -29,6 +29,12 @@ const createOutputOptions = (): Parameters<typeof writeZodSchemas>[4] =>
         strict: {
           body: true,
         },
+        generate: {
+          body: true,
+          query: true,
+          header: true,
+          response: true,
+        },
         coerce: {
           body: false,
         },
@@ -233,6 +239,82 @@ describe('write-zod-specs regressions', () => {
     expect(fileContent).not.toContain(
       'export const DefaultedSchema = export const',
     );
+
+    await fs.remove(root);
+  });
+
+  it('honors response generate override in split zod output', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-'));
+    const schemasPath = path.join(root, 'schemas');
+
+    const context = {
+      output: {
+        override: {
+          useDates: false,
+          zod: {
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      },
+      spec: {},
+      target: '',
+      workspace: root,
+    } satisfies MinimalVerbsContext;
+
+    const verbOptions = {
+      getPet: {
+        operationName: 'getPet',
+        originalOperation: {
+          parameters: [],
+        },
+        override: {
+          ...createOutputOptions().override,
+          zod: {
+            ...createOutputOptions().override.zod,
+            generate: {
+              body: true,
+              query: true,
+              header: true,
+              response: false,
+            },
+          },
+        },
+        response: {
+          types: {
+            success: [
+              {
+                value: 'GetPetResponse',
+                originalSchema: {
+                  type: 'object',
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            ],
+            errors: [],
+          },
+        },
+      },
+    } satisfies Parameters<typeof writeZodSchemasFromVerbs>[0];
+
+    await writeZodSchemasFromVerbs(
+      verbOptions,
+      schemasPath,
+      '.ts',
+      '',
+      createOutputOptions(),
+      context,
+    );
+
+    if (await fs.pathExists(schemasPath)) {
+      const directoryFiles = await fs.readdir(schemasPath);
+
+      expect(directoryFiles).not.toContain('GetPetResponse.ts');
+    }
 
     await fs.remove(root);
   });

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import {
   type ContextSpec,
   conventionName,
-  type GeneratorVerbOptions,
   type NamingConvention,
   type NormalizedOutputOptions,
   type OpenApiParameterObject,
@@ -42,6 +41,13 @@ interface WriteZodOutputOptions {
       strict: {
         body: boolean;
       };
+      generate: {
+        param: boolean;
+        query: boolean;
+        header: boolean;
+        body: boolean;
+        response: boolean;
+      };
       coerce: {
         body: boolean | ZodCoerceType[];
       };
@@ -64,12 +70,28 @@ interface WriteZodVerbResponseType {
   originalSchema?: OpenApiSchemaObject;
 }
 
+interface WriteZodSchemasFromVerbsEntry {
+  operationName: string;
+  originalOperation: {
+    requestBody?: OpenApiRequestBodyObject | OpenApiReferenceObject;
+    parameters?: (OpenApiParameterObject | OpenApiReferenceObject)[];
+  };
+  response: {
+    types: {
+      success: WriteZodVerbResponseType[];
+      errors: WriteZodVerbResponseType[];
+    };
+  };
+  override?: {
+    zod: {
+      generate: WriteZodOutputOptions['override']['zod']['generate'];
+    };
+  };
+}
+
 type WriteZodSchemasFromVerbsInput = Record<
   string,
-  Pick<
-    GeneratorVerbOptions,
-    'operationName' | 'originalOperation' | 'response' | 'override'
-  >
+  WriteZodSchemasFromVerbsEntry
 >;
 
 interface WriteZodSchemasFromVerbsContext {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -379,8 +379,10 @@ export async function writeZodSchemasFromVerbs(
 
   const generateVerbsSchemas = verbOptionsArray.flatMap((verbOption) => {
     const operation = verbOption.originalOperation;
-    const shouldGenerate =
-      verbOption.override?.zod.generate ?? output.override.zod.generate;
+    const shouldGenerate = {
+      ...output.override.zod.generate,
+      ...verbOption.override?.zod.generate,
+    };
 
     const requestBody = operation.requestBody;
     const requestBodyContent =

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {
   type ContextSpec,
   conventionName,
+  type GeneratorVerbOptions,
   type NamingConvention,
   type NormalizedOutputOptions,
   type OpenApiParameterObject,
@@ -65,19 +66,10 @@ interface WriteZodVerbResponseType {
 
 type WriteZodSchemasFromVerbsInput = Record<
   string,
-  {
-    operationName: string;
-    originalOperation: {
-      requestBody?: OpenApiRequestBodyObject | OpenApiReferenceObject;
-      parameters?: (OpenApiParameterObject | OpenApiReferenceObject)[];
-    };
-    response: {
-      types: {
-        success: WriteZodVerbResponseType[];
-        errors: WriteZodVerbResponseType[];
-      };
-    };
-  }
+  Pick<
+    GeneratorVerbOptions,
+    'operationName' | 'originalOperation' | 'response' | 'override'
+  >
 >;
 
 interface WriteZodSchemasFromVerbsContext {
@@ -365,6 +357,8 @@ export async function writeZodSchemasFromVerbs(
 
   const generateVerbsSchemas = verbOptionsArray.flatMap((verbOption) => {
     const operation = verbOption.originalOperation;
+    const shouldGenerate =
+      verbOption.override?.zod.generate ?? output.override.zod.generate;
 
     const requestBody = operation.requestBody;
     const requestBodyContent =
@@ -392,16 +386,17 @@ export async function writeZodSchemasFromVerbs(
           : [undefined, undefined];
     const bodySchema = bodyMedia?.schema as OpenApiSchemaObject | undefined;
 
-    const bodySchemas = bodySchema
-      ? [
-          {
-            name: `${pascal(verbOption.operationName)}Body`,
-            schema: dereference(bodySchema, zodContext),
-            bodyContentType,
-            encoding: bodyMedia?.encoding,
-          },
-        ]
-      : [];
+    const bodySchemas =
+      shouldGenerate.body && bodySchema
+        ? [
+            {
+              name: `${pascal(verbOption.operationName)}Body`,
+              schema: dereference(bodySchema, zodContext),
+              bodyContentType,
+              encoding: bodyMedia?.encoding,
+            },
+          ]
+        : [];
 
     const parameters = operation.parameters;
 
@@ -410,7 +405,7 @@ export async function writeZodSchemasFromVerbs(
     );
 
     const queryParamsSchemas =
-      queryParams && queryParams.length > 0
+      shouldGenerate.query && queryParams && queryParams.length > 0
         ? [
             {
               name: `${pascal(verbOption.operationName)}Params`,
@@ -438,7 +433,7 @@ export async function writeZodSchemasFromVerbs(
     );
 
     const headerParamsSchemas =
-      headerParams && headerParams.length > 0
+      shouldGenerate.header && headerParams && headerParams.length > 0
         ? [
             {
               name: `${pascal(verbOption.operationName)}Headers`,
@@ -461,25 +456,27 @@ export async function writeZodSchemasFromVerbs(
           ]
         : [];
 
-    const responseSchemas = [
-      ...verbOption.response.types.success,
-      ...verbOption.response.types.errors,
-    ]
-      .filter(
-        (
-          responseType,
-        ): responseType is typeof responseType & {
-          originalSchema: OpenApiSchemaObject;
-        } =>
-          !!responseType.originalSchema &&
-          !responseType.isRef &&
-          isValidSchemaIdentifier(responseType.value) &&
-          !isPrimitiveSchemaName(responseType.value),
-      )
-      .map((responseType) => ({
-        name: responseType.value,
-        schema: dereference(responseType.originalSchema, zodContext),
-      }));
+    const responseSchemas = shouldGenerate.response
+      ? [
+          ...verbOption.response.types.success,
+          ...verbOption.response.types.errors,
+        ]
+          .filter(
+            (
+              responseType,
+            ): responseType is typeof responseType & {
+              originalSchema: OpenApiSchemaObject;
+            } =>
+              !!responseType.originalSchema &&
+              !responseType.isRef &&
+              isValidSchemaIdentifier(responseType.value) &&
+              !isPrimitiveSchemaName(responseType.value),
+          )
+          .map((responseType) => ({
+            name: responseType.value,
+            schema: dereference(responseType.originalSchema, zodContext),
+          }))
+      : [];
 
     return dedupeSchemasByName([
       ...bodySchemas,

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1419,6 +1419,18 @@ const parseBodyAndResponse = ({
   };
 };
 
+const getSingleResponse = (
+  responses:
+    | Record<string, OpenApiResponseObject | OpenApiReferenceObject | undefined>
+    | undefined,
+) => {
+  if (!responses) {
+    return undefined;
+  }
+
+  return responses['200'] ?? responses['2XX'] ?? responses['2xx'];
+};
+
 /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 
 export const parseParameters = ({
@@ -1639,7 +1651,7 @@ const generateZodRoute = async (
   const responses = (
     context.output.override.zod.generateEachHttpStatus
       ? Object.entries(spec[verb]?.responses ?? {})
-      : [['', spec[verb]?.responses?.[200]]]
+      : [['', getSingleResponse(spec[verb]?.responses)]]
   ) as [string, OpenApiResponseObject | OpenApiReferenceObject][];
   const parsedResponses = responses.map(([code, response]) =>
     parseBodyAndResponse({

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1425,7 +1425,7 @@ const getSingleResponse = (
     | undefined,
 ) => {
   if (!responses) {
-    return undefined;
+    return;
   }
 
   return responses['200'] ?? responses['2XX'] ?? responses['2xx'];

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -3525,6 +3525,83 @@ describe('generatePartOfSchemaGenerateZod', () => {
     );
   });
 
+  it('falls back to 2XX response when 200 is not present', async () => {
+    const wildcardResponseApiSchema = {
+      ...basicApiSchema,
+      context: {
+        ...basicApiSchema.context,
+        spec: {
+          ...basicApiSchema.context.spec,
+          paths: {
+            '/cats': {
+              post: {
+                ...basicApiSchema.context.spec.paths['/cats'].post,
+                responses: {
+                  '2XX': {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            name: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as typeof basicApiSchema;
+
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: false,
+              body: false,
+              response: true,
+              query: false,
+              header: false,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      wildcardResponseApiSchema,
+      testOutput,
+    );
+
+    expect(result.implementation).toBe(
+      'export const TestResponse = zod.object({\n  "name": zod.string().optional()\n})\n\n',
+    );
+  });
+
   it('Only generate request body', async () => {
     const result = await generateZod(
       {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -3526,6 +3526,9 @@ describe('generatePartOfSchemaGenerateZod', () => {
   });
 
   it('falls back to 2XX response when 200 is not present', async () => {
+    const basePostOperation =
+      basicApiSchema.context.spec.paths?.['/cats']?.post ?? {};
+
     const wildcardResponseApiSchema = {
       ...basicApiSchema,
       context: {
@@ -3535,7 +3538,7 @@ describe('generatePartOfSchemaGenerateZod', () => {
           paths: {
             '/cats': {
               post: {
-                ...basicApiSchema.context.spec.paths['/cats'].post,
+                ...basePostOperation,
                 responses: {
                   '2XX': {
                     content: {


### PR DESCRIPTION
Closes #3348



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global and per-operation controls to selectively enable/disable Zod schema generation for body, query, header, params, and responses
  * Response selection now falls back to a 2XX response when 200 is absent

* **Tests**
  * Added regression test ensuring response schema files are not generated when response generation is disabled
  * Added test confirming 2XX fallback is used for Zod generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->