### PR TITLE
test(query): add regression coverage for react-query onMutate option (#1177)

### DIFF
--- a/tests/regressions/react-query.ts
+++ b/tests/regressions/react-query.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData } from '@tanstack/react-query';
 
 import {
+  useCreatePets,
   useListPets,
   useListPetsInfinite,
 } from '../generated/react-query/mutator/endpoints';
@@ -40,3 +41,22 @@ export const useHookWithPlaceHolderData = () => {
 
   return names;
 };
+
+// Regression test for https://github.com/orval-labs/orval/issues/1177
+//
+// The generated TanStack Query mutation hook must accept an `onMutate`
+// callback through its `mutation` option. `onMutate` is part of TanStack's
+// `UseMutationOptions`; if orval ever narrows that option type (as it did when
+// #1177 was filed), this function stops compiling and fails the typecheck.
+export const useCreatePetsWithOnMutate = () =>
+  useCreatePets({
+    mutation: {
+      onMutate: (variables) => {
+        // `variables` must be the typed mutation input, not `any`.
+        void variables.data;
+        // @ts-expect-error - a key absent from the mutation input must error;
+        // this proves `variables` is strongly typed (not `any`).
+        void variables.notAField;
+      },
+    },
+  });

--- a/tests/scripts/typecheck-generated.mjs
+++ b/tests/scripts/typecheck-generated.mjs
@@ -34,7 +34,10 @@ for (const folder of folders) {
 
   const config = {
     extends: './tsconfig.json',
-    include: [`generated/${folder}`, 'mutators'],
+    // `regressions` holds hand-written compile-time tests that import generated
+    // code and exercise its public types (e.g. the #1177 onMutate regression),
+    // so a narrowed option type fails the typecheck.
+    include: [`generated/${folder}`, 'mutators', 'regressions'],
   };
 
   // Bun's flat node_modules makes the MCP SDK resolve `zod` to the project's v3.25


### PR DESCRIPTION
## Goals

Issue #1177 reported that `onMutate` was missing from the options of generated TanStack Query mutation hooks. On current orval this is **already fixed** — the generated `useXxx` hook exposes its `mutation` option as `UseMutationOptions<...>`, which (extending TanStack's `MutationObserverOptions`) includes `onMutate`. However, there was no regression test guarding it: `query-options.test.ts` only string-matches the `UseMutationOptions<` type name, which would still pass if the type were narrowed (e.g. `Omit<UseMutationOptions, 'onMutate'>`).

This PR adds a real, compile-time regression test:

- **`tests/regressions/react-query.ts`** — adds a consumption test that calls a generated mutation hook (`useCreatePets`) with `mutation.onMutate`. If orval ever narrows the mutation option type (as it did when #1177 was filed), this file stops compiling. A `@ts-expect-error` line also asserts the `onMutate` `variables` argument stays strongly typed.
- **`tests/scripts/typecheck-generated.mjs`** — wires the existing `tests/regressions` directory into the per-client `tsconfig` `include`. This directory already held hand-written files importing generated code, but was not referenced by any `tsconfig`, so it was never type-checked. It is now checked in CI alongside `generated/` and `mutators/`.

Verified that removing `onMutate` from the generated mutation option type makes `bun run --filter orval-tests build` fail in `tests/regressions/react-query.ts`, and that all 15 generated clients type-check with the change in place.

Closes #1177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced TypeScript regression testing for generated React Query mutation hooks to validate callback support and type safety. Expanded test coverage to include the `regressions` directory for comprehensive compile-time validation of generated types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->