### PR TITLE
fix(query): use nullish fallback for infinite query page params

### DIFF
--- a/packages/query/src/frameworks/angular.ts
+++ b/packages/query/src/frameworks/angular.ts
@@ -96,7 +96,7 @@ export const createAngularAdapter = ({
           if (param.type === GetterPropType.NAMED_PATH_PARAMS)
             return param.destructured;
           return param.name === 'params'
-            ? `{...params, '${queryParam}': pageParam || params?.['${queryParam}']}`
+            ? `{...params, '${queryParam}': pageParam ?? params?.['${queryParam}']}`
             : param.name;
         })
         .join(',');

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -93,7 +93,7 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => ({
         if (param.type === GetterPropType.NAMED_PATH_PARAMS)
           return param.destructured;
         return param.name === 'params'
-          ? `{...params, '${queryParam}': pageParam || params?.['${queryParam}']}`
+          ? `{...params, '${queryParam}': pageParam ?? params?.['${queryParam}']}`
           : param.name;
       })
       .join(',');

--- a/packages/query/src/frameworks/vue.ts
+++ b/packages/query/src/frameworks/vue.ts
@@ -79,7 +79,7 @@ export const createVueAdapter = ({
       .map((param) => {
         // Vue does NOT destructure named path params (keeps param.name)
         if (param.name === 'params') {
-          return `{...unref(params), '${queryParam}': pageParam || unref(params)?.['${queryParam}']}`;
+          return `{...unref(params), '${queryParam}': pageParam ?? unref(params)?.['${queryParam}']}`;
         }
 
         // Fetch-style request functions accept plain values, but axios-style

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -115,7 +115,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );
@@ -604,7 +604,7 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -115,7 +115,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );
@@ -604,7 +604,7 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );

--- a/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -100,7 +100,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       version,
       signal,
     );

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -100,7 +100,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       version,
       signal,
     );

--- a/tests/__snapshots__/react-query/error-type/endpoints.ts
+++ b/tests/__snapshots__/react-query/error-type/endpoints.ts
@@ -107,7 +107,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );

--- a/tests/__snapshots__/react-query/issue-1522/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-1522/endpoints.ts
@@ -129,7 +129,7 @@ export const useListHouseCatsInfiniteQueryOptions = <
   > = ({ signal, pageParam }) =>
     listHouseCats(
       houseId,
-      { ...params, page: pageParam || params?.['page'] },
+      { ...params, page: pageParam ?? params?.['page'] },
       { signal, ...fetchOptions },
     );
 

--- a/tests/__snapshots__/react-query/issue-708/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-708/endpoints.ts
@@ -104,7 +104,7 @@ export const getGetListInfiniteQueryOptions = <
     GetListParams['page']
   > = ({ signal, pageParam }) =>
     getList(
-      { ...params, page: pageParam || params?.['page'] },
+      { ...params, page: pageParam ?? params?.['page'] },
       { signal, ...fetchOptions },
     );
 

--- a/tests/__snapshots__/react-query/mutator-client/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator-client/endpoints.ts
@@ -112,7 +112,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       headers,
       version,
       signal,

--- a/tests/__snapshots__/react-query/mutator-multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator-multi-arguments/endpoints.ts
@@ -108,7 +108,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       requestOptions,
       signal,

--- a/tests/__snapshots__/react-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator/endpoints.ts
@@ -119,7 +119,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );
@@ -574,7 +574,7 @@ export const getListPetsSuspenseInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -173,7 +173,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       { signal, ...fetchOptions },
     );
 

--- a/tests/__snapshots__/svelte-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/mutator/endpoints.ts
@@ -90,7 +90,7 @@ export const getListPetsInfiniteQueryOptions = <
     pageParam,
   }) =>
     listPets(
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       version,
       signal,
     );

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -173,7 +173,7 @@ export const getListPetsInfiniteQueryOptions = <
   }) =>
     listPets(
       { version },
-      { ...params, limit: pageParam || params?.['limit'] },
+      { ...params, limit: pageParam ?? params?.['limit'] },
       { signal, ...fetchOptions },
     );
 

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -169,7 +169,7 @@ export const getListPetsInfiniteQueryOptions = <
     signal,
     pageParam,
   }) =>
-    listPets({ ...params, limit: pageParam || params?.['limit'] }, version, {
+    listPets({ ...params, limit: pageParam ?? params?.['limit'] }, version, {
       signal,
       ...fetchOptions,
     });

--- a/tests/__snapshots__/vue-query/infinite-query-with-built-in-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/infinite-query-with-built-in-fetch/endpoints.ts
@@ -136,7 +136,7 @@ export const getGetUsersUserIdOrdersInfiniteQueryOptions = <
   > = ({ signal, pageParam }) =>
     getUsersUserIdOrders(
       unref(userId),
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       { signal, ...fetchOptions },
     );
 

--- a/tests/__snapshots__/vue-query/infinite-query-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/infinite-query-with-custom-fetch/endpoints.ts
@@ -131,7 +131,7 @@ export const getGetUsersUserIdOrdersInfiniteQueryOptions = <
   > = ({ signal, pageParam }) =>
     getUsersUserIdOrders(
       unref(userId),
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       { signal, ...requestOptions },
     );
 

--- a/tests/__snapshots__/vue-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/vue-query/mutator/endpoints.ts
@@ -108,7 +108,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       version,
       signal,
     );

--- a/tests/__snapshots__/vue-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/vue-query/petstore/endpoints.ts
@@ -109,7 +109,7 @@ export const getListPetsInfiniteQueryOptions = <
     ListPetsParams['limit']
   > = ({ signal, pageParam }) =>
     listPets(
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       version,
       { signal, ...axiosOptions },
     );

--- a/tests/api-generation.spec.ts
+++ b/tests/api-generation.spec.ts
@@ -248,7 +248,7 @@ test('vue-query custom fetch infinite queries unref non-pagination params', asyn
   expect(content).toContain(
     `getUsersUserIdOrders(
       unref(userId),
-      { ...unref(params), limit: pageParam || unref(params)?.['limit'] },
+      { ...unref(params), limit: pageParam ?? unref(params)?.['limit'] },
       { signal, ...requestOptions },
     );`,
   );


### PR DESCRIPTION
Closes: #3390

Use nullish coalescing for infinite page params to preserve falsy values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination parameter handling in infinite queries across all frameworks (React Query, Vue Query, Svelte Query). Page parameters with a value of `0` are now correctly preserved instead of incorrectly falling back to default values, ensuring accurate pagination behavior when starting from page zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->