### PR TITLE
fix(core): handle multi-line descriptions in JSDoc generation

### DIFF
--- a/packages/core/src/utils/doc.test.ts
+++ b/packages/core/src/utils/doc.test.ts
@@ -44,6 +44,57 @@ describe('jsDoc', () => {
 `);
   });
 
+  it('prefixes each line of a multi-line description with *', () => {
+    expect(
+      jsDoc({
+        description: 'line one\nline two\nline three',
+      }),
+    ).toBe(`/**
+ * line one
+ * line two
+ * line three
+ */
+`);
+  });
+
+  it('prefixes each line of multi-line array descriptions with *', () => {
+    expect(
+      jsDoc({
+        description: ['first\nsecond', 'third'],
+      }),
+    ).toBe(`/**
+ * first
+ * second
+ * third
+ */
+`);
+  });
+
+  it('handles CRLF line endings in description', () => {
+    expect(
+      jsDoc({
+        description: 'line one\r\nline two\r\nline three',
+      }),
+    ).toBe(`/**
+ * line one
+ * line two
+ * line three
+ */
+`);
+  });
+
+  it('escapes */ in multi-line descriptions', () => {
+    expect(
+      jsDoc({
+        description: 'line with /* comment\nline with */ end',
+      }),
+    ).toBe(`/**
+ * line with /* comment
+ * line with *\\/ end
+ */
+`);
+  });
+
   it('stops traversing circular item schemas', () => {
     interface CircularItems {
       [key: string]: unknown;

--- a/packages/core/src/utils/doc.test.ts
+++ b/packages/core/src/utils/doc.test.ts
@@ -88,9 +88,9 @@ describe('jsDoc', () => {
       jsDoc({
         description: 'line with /* comment\nline with */ end',
       }),
-    ).toBe(`/**
+    ).toBe(String.raw`/**
  * line with /* comment
- * line with *\\/ end
+ * line with *\/ end
  */
 `);
   });

--- a/packages/core/src/utils/doc.ts
+++ b/packages/core/src/utils/doc.ts
@@ -98,7 +98,9 @@ export function jsDoc(
     Array.isArray(description)
       ? description.filter((d) => !d.includes('eslint-disable'))
       : [description ?? '']
-  ).map((line) => line.replaceAll(regex, replacement));
+  )
+    .flatMap((line) => line.split(/\r?\n/))
+    .map((line) => line.replaceAll(regex, replacement));
 
   const count = [
     description,

--- a/samples/mcp/custom-server/__snapshots__/handlers.ts
+++ b/samples/mcp/custom-server/__snapshots__/handlers.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import {

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/apiResponse.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/apiResponse.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/category.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/category.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/findPetsByStatusParams.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/findPetsByStatusParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/findPetsByTagsParams.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/findPetsByTagsParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/getInventory200.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/getInventory200.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/index.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/index.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/loginUserParams.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/loginUserParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/order.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/order.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { OrderStatus } from './orderStatus';

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/orderStatus.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/orderStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/pet.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/pet.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Category } from './category';

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/petBody.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/petBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Pet } from './pet';

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/petStatus.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/petStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/tag.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/tag.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/updatePetWithFormParams.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/updatePetWithFormParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/user.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/user.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/__snapshots__/http-schemas/userArrayBody.ts
+++ b/samples/mcp/custom-server/__snapshots__/http-schemas/userArrayBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { User } from './user';

--- a/samples/mcp/custom-server/__snapshots__/server.ts
+++ b/samples/mcp/custom-server/__snapshots__/server.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/handlers.ts
+++ b/samples/mcp/custom-server/src/handlers.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import {

--- a/samples/mcp/custom-server/src/http-client.ts
+++ b/samples/mcp/custom-server/src/http-client.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/apiResponse.ts
+++ b/samples/mcp/custom-server/src/http-schemas/apiResponse.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/category.ts
+++ b/samples/mcp/custom-server/src/http-schemas/category.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/findPetsByStatusParams.ts
+++ b/samples/mcp/custom-server/src/http-schemas/findPetsByStatusParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/findPetsByTagsParams.ts
+++ b/samples/mcp/custom-server/src/http-schemas/findPetsByTagsParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/getInventory200.ts
+++ b/samples/mcp/custom-server/src/http-schemas/getInventory200.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/index.ts
+++ b/samples/mcp/custom-server/src/http-schemas/index.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/loginUserParams.ts
+++ b/samples/mcp/custom-server/src/http-schemas/loginUserParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/order.ts
+++ b/samples/mcp/custom-server/src/http-schemas/order.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { OrderStatus } from './orderStatus';

--- a/samples/mcp/custom-server/src/http-schemas/orderStatus.ts
+++ b/samples/mcp/custom-server/src/http-schemas/orderStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/pet.ts
+++ b/samples/mcp/custom-server/src/http-schemas/pet.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Category } from './category';

--- a/samples/mcp/custom-server/src/http-schemas/petBody.ts
+++ b/samples/mcp/custom-server/src/http-schemas/petBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Pet } from './pet';

--- a/samples/mcp/custom-server/src/http-schemas/petStatus.ts
+++ b/samples/mcp/custom-server/src/http-schemas/petStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/tag.ts
+++ b/samples/mcp/custom-server/src/http-schemas/tag.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/updatePetWithFormParams.ts
+++ b/samples/mcp/custom-server/src/http-schemas/updatePetWithFormParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/user.ts
+++ b/samples/mcp/custom-server/src/http-schemas/user.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/http-schemas/userArrayBody.ts
+++ b/samples/mcp/custom-server/src/http-schemas/userArrayBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { User } from './user';

--- a/samples/mcp/custom-server/src/server.ts
+++ b/samples/mcp/custom-server/src/server.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/custom-server/src/tool-schemas.zod.ts
+++ b/samples/mcp/custom-server/src/tool-schemas.zod.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import { z as zod } from 'zod';

--- a/samples/mcp/petstore/__snapshots__/handlers.ts
+++ b/samples/mcp/petstore/__snapshots__/handlers.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import {

--- a/samples/mcp/petstore/__snapshots__/http-schemas/apiResponse.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/apiResponse.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/category.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/category.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/findPetsByStatusParams.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/findPetsByStatusParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/findPetsByTagsParams.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/findPetsByTagsParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/getInventory200.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/getInventory200.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/index.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/index.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/loginUserParams.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/loginUserParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/order.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/order.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { OrderStatus } from './orderStatus';

--- a/samples/mcp/petstore/__snapshots__/http-schemas/orderStatus.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/orderStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/pet.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/pet.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Category } from './category';

--- a/samples/mcp/petstore/__snapshots__/http-schemas/petBody.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/petBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Pet } from './pet';

--- a/samples/mcp/petstore/__snapshots__/http-schemas/petStatus.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/petStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/tag.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/tag.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/updatePetWithFormParams.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/updatePetWithFormParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/user.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/user.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/__snapshots__/http-schemas/userArrayBody.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/userArrayBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { User } from './user';

--- a/samples/mcp/petstore/src/handlers.ts
+++ b/samples/mcp/petstore/src/handlers.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import {

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/apiResponse.ts
+++ b/samples/mcp/petstore/src/http-schemas/apiResponse.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/category.ts
+++ b/samples/mcp/petstore/src/http-schemas/category.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/findPetsByStatusParams.ts
+++ b/samples/mcp/petstore/src/http-schemas/findPetsByStatusParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/findPetsByTagsParams.ts
+++ b/samples/mcp/petstore/src/http-schemas/findPetsByTagsParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/getInventory200.ts
+++ b/samples/mcp/petstore/src/http-schemas/getInventory200.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/index.ts
+++ b/samples/mcp/petstore/src/http-schemas/index.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/loginUserParams.ts
+++ b/samples/mcp/petstore/src/http-schemas/loginUserParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/order.ts
+++ b/samples/mcp/petstore/src/http-schemas/order.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { OrderStatus } from './orderStatus';

--- a/samples/mcp/petstore/src/http-schemas/orderStatus.ts
+++ b/samples/mcp/petstore/src/http-schemas/orderStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/pet.ts
+++ b/samples/mcp/petstore/src/http-schemas/pet.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Category } from './category';

--- a/samples/mcp/petstore/src/http-schemas/petBody.ts
+++ b/samples/mcp/petstore/src/http-schemas/petBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { Pet } from './pet';

--- a/samples/mcp/petstore/src/http-schemas/petStatus.ts
+++ b/samples/mcp/petstore/src/http-schemas/petStatus.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/tag.ts
+++ b/samples/mcp/petstore/src/http-schemas/tag.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/updatePetWithFormParams.ts
+++ b/samples/mcp/petstore/src/http-schemas/updatePetWithFormParams.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/user.ts
+++ b/samples/mcp/petstore/src/http-schemas/user.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/http-schemas/userArrayBody.ts
+++ b/samples/mcp/petstore/src/http-schemas/userArrayBody.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import type { User } from './user';

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 

--- a/samples/mcp/petstore/src/tool-schemas.zod.ts
+++ b/samples/mcp/petstore/src/tool-schemas.zod.ts
@@ -3,13 +3,13 @@
  * Do not edit manually.
  * Swagger Petstore - OpenAPI 3.0
  * This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
-Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
-You can now help us improve the API whether it's by making changes to the definition itself or to the code.
-That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
-
-Some useful links:
-- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
-- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+ * Swagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+ * You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+ * That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+ *
+ * Some useful links:
+ * - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+ * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import { z as zod } from 'zod';

--- a/tests/__snapshots__/angular-query/basic/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular-query/basic/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular-query/basic/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular-query/basic/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular-query/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular-query/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular-query/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular-query/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular-query/tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular-query/tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular-query/tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular-query/tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular-query/use-prefetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular-query/use-prefetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/custom-client/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/custom-client/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/custom-client/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/custom-client/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/http-resource-tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/http-resource-tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/http-resource-tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/http-resource-tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/named-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/named-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/named-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/named-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/angular/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/angular/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/angular/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/angular/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/multi-arguments/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/multi-arguments/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/multi-arguments/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/multi-arguments/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/named-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/named-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/named-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/named-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/petstore-tags-split-mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/petstore-tags-split-mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/axios/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/axios/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/axios/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/axios/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/cli/petstore/endpoints.ts
+++ b/tests/__snapshots__/cli/petstore/endpoints.ts
@@ -114,8 +114,8 @@ export type ListPetsParams = {
 limit?: string;
 /**
  * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
+ * Example: name sorts ASC while -name sorts DESC.
+ *
  */
 sort: ListPetsSort;
 };
@@ -137,8 +137,8 @@ export type CreatePetsParams = {
 limit?: string;
 /**
  * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
+ * Example: name sorts ASC while -name sorts DESC.
+ *
  */
 sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/endpoint-parameters/model/listPetsByAgeParams.ts
+++ b/tests/__snapshots__/default/endpoint-parameters/model/listPetsByAgeParams.ts
@@ -11,9 +11,9 @@ export type ListPetsByAgeParams = {
    */
   limit?: string;
   /**
- * Filter by latest birthdate.
-Example: 2020-01-01T00:00:00Z
-
- */
+   * Filter by latest birthdate.
+   * Example: 2020-01-01T00:00:00Z
+   *
+   */
   latestBirthdate?: string;
 };

--- a/tests/__snapshots__/default/endpoint-parameters/model/listPetsByCountryParams.ts
+++ b/tests/__snapshots__/default/endpoint-parameters/model/listPetsByCountryParams.ts
@@ -25,16 +25,16 @@ export type ListPetsByCountryParams = {
    */
   order?: ListPetsByCountryOrder;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort?: ListPetsByCountrySort;
   /**
- * Only return pets from China?
-Example: true
-
- */
+   * Only return pets from China?
+   * Example: true
+   *
+   */
   cnonly?: boolean;
   /**
    * include pets tag

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.schemas.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.schemas.generated.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/default/file-extension-tags-split/swaggerPetstore.schemas.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/swaggerPetstore.schemas.generated.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/default/file-extension-tags/swaggerPetstore.schemas.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/swaggerPetstore.schemas.generated.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/default/http-status-mocks/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/http-status-mocks/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/http-status-mocks/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/http-status-mocks/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/index-mock-file/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/index-mock-file/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/index-mock-file/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/index-mock-file/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/no-index-files/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/no-index-files/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/no-index-files/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/no-index-files/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/override-mock/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/override-mock/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/override-mock/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/override-mock/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/petstore-filter-exclude-mode/endpoints.ts
+++ b/tests/__snapshots__/default/petstore-filter-exclude-mode/endpoints.ts
@@ -111,10 +111,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -133,10 +133,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/default/petstore-naming-convention-camel-case/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-camel-case/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-camel-case/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-camel-case/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-kebab-case/model/create-pets-params.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-kebab-case/model/create-pets-params.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-kebab-case/model/list-pets-params.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-kebab-case/model/list-pets-params.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-pascal-case/model/CreatePetsParams.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-pascal-case/model/CreatePetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-pascal-case/model/ListPetsParams.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-pascal-case/model/ListPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-snake-case/model/create_pets_params.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-snake-case/model/create_pets_params.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/petstore-naming-convention-snake-case/model/list_pets_params.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-snake-case/model/list_pets_params.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/petstore-transformer/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/petstore-transformer/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/petstore-transformer/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/petstore-transformer/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/petstore/endpoints.ts
+++ b/tests/__snapshots__/default/petstore/endpoints.ts
@@ -111,10 +111,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -133,10 +133,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/default/runtime-mock-delay/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/runtime-mock-delay/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/runtime-mock-delay/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/runtime-mock-delay/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/default/schemas-typescript-only/model/createPetsParams.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/default/schemas-typescript-only/model/listPetsParams.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/dateParams/model/listPetsByAgeParams.ts
+++ b/tests/__snapshots__/fetch/dateParams/model/listPetsByAgeParams.ts
@@ -11,9 +11,9 @@ export type ListPetsByAgeParams = {
    */
   limit?: string;
   /**
- * Filter by latest birthdate.
-Example: 2020-01-01T00:00:00Z
-
- */
+   * Filter by latest birthdate.
+   * Example: 2020-01-01T00:00:00Z
+   *
+   */
   latestBirthdate?: Date;
 };

--- a/tests/__snapshots__/fetch/dateParams/model/listPetsByCountryParams.ts
+++ b/tests/__snapshots__/fetch/dateParams/model/listPetsByCountryParams.ts
@@ -25,16 +25,16 @@ export type ListPetsByCountryParams = {
    */
   order?: ListPetsByCountryOrder;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort?: ListPetsByCountrySort;
   /**
- * Only return pets from China?
-Example: true
-
- */
+   * Only return pets from China?
+   * Example: true
+   *
+   */
   cnonly?: boolean;
   /**
    * include pets tag

--- a/tests/__snapshots__/fetch/force-success-response/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/force-success-response/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/force-success-response/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/force-success-response/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/headers/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/headers/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/headers/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/headers/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/include-http-status-return-type/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/include-http-status-return-type/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/multi-arguments/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/multi-arguments/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/mutator-external/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/mutator-external/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/mutator-external/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/mutator-external/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/named-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/named-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/named-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/named-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/parameters/model/listPetsByAgeParams.ts
+++ b/tests/__snapshots__/fetch/parameters/model/listPetsByAgeParams.ts
@@ -11,9 +11,9 @@ export type ListPetsByAgeParams = {
    */
   limit?: string;
   /**
- * Filter by latest birthdate.
-Example: 2020-01-01T00:00:00Z
-
- */
+   * Filter by latest birthdate.
+   * Example: 2020-01-01T00:00:00Z
+   *
+   */
   latestBirthdate?: string;
 };

--- a/tests/__snapshots__/fetch/parameters/model/listPetsByCountryParams.ts
+++ b/tests/__snapshots__/fetch/parameters/model/listPetsByCountryParams.ts
@@ -25,16 +25,16 @@ export type ListPetsByCountryParams = {
    */
   order?: ListPetsByCountryOrder;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort?: ListPetsByCountrySort;
   /**
- * Only return pets from China?
-Example: true
-
- */
+   * Only return pets from China?
+   * Example: true
+   *
+   */
   cnonly?: boolean;
   /**
    * include pets tag

--- a/tests/__snapshots__/fetch/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/request-options-headers/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/request-options-headers/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/reviver/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/reviver/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/reviver/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/reviver/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/fetch/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/fetch/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/fetch/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/fetch/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/hono/endpoint-parameters/schemas/listPetsByAgeParams.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/schemas/listPetsByAgeParams.ts
@@ -11,9 +11,9 @@ export type ListPetsByAgeParams = {
    */
   limit?: string;
   /**
- * Filter by latest birthdate.
-Example: 2020-01-01T00:00:00Z
-
- */
+   * Filter by latest birthdate.
+   * Example: 2020-01-01T00:00:00Z
+   *
+   */
   latestBirthdate?: string;
 };

--- a/tests/__snapshots__/hono/endpoint-parameters/schemas/listPetsByCountryParams.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/schemas/listPetsByCountryParams.ts
@@ -25,16 +25,16 @@ export type ListPetsByCountryParams = {
    */
   order?: ListPetsByCountryOrder;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort?: ListPetsByCountrySort;
   /**
- * Only return pets from China?
-Example: true
-
- */
+   * Only return pets from China?
+   * Example: true
+   *
+   */
   cnonly?: boolean;
   /**
    * include pets tag

--- a/tests/__snapshots__/hono/petstore-single/endpoints.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.ts
@@ -110,10 +110,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -132,10 +132,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.schemas.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.schemas.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/hono/petstore-split/endpoints.schemas.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.schemas.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/endpoints.schemas.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/endpoints.schemas.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/hono/petstore-tags-split/endpoints.schemas.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/endpoints.schemas.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/endpoints.schemas.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/endpoints.schemas.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/hono/petstore-tags/endpoints.schemas.ts
+++ b/tests/__snapshots__/hono/petstore-tags/endpoints.schemas.ts
@@ -108,10 +108,10 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };
 
@@ -130,10 +130,10 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };
 

--- a/tests/__snapshots__/mcp/custom-server/http-schemas/createPetsParams.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-schemas/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mcp/custom-server/http-schemas/listPetsParams.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-schemas/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/mcp/single/http-schemas/createPetsParams.ts
+++ b/tests/__snapshots__/mcp/single/http-schemas/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mcp/single/http-schemas/listPetsParams.ts
+++ b/tests/__snapshots__/mcp/single/http-schemas/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/mock/petstore-custom-mock-builder/model/createPetsParams.ts
+++ b/tests/__snapshots__/mock/petstore-custom-mock-builder/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mock/petstore-custom-mock-builder/model/listPetsParams.ts
+++ b/tests/__snapshots__/mock/petstore-custom-mock-builder/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/mock/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/mock/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mock/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/mock/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/mock/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/mock/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mock/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/mock/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/mock/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/mock/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mock/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/mock/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/mock/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/mock/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/mock/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/mock/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/basic/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/basic/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/basic/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/basic/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/body-type-wrap-non-get-query/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/body-type-wrap-non-get-query/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/body-type-wrap-non-get-query/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/body-type-wrap-non-get-query/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/custom-mutator-options/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/custom-mutator-options/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/deprecated/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/deprecated/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/error-type/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/error-type/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/error-type/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/error-type/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/hook-mutator-axios/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/hook-mutator-axios/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/http-client-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/http-client-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/invalidates/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/invalidates/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/mockOverride/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/mockOverride/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/mockOverride/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/mockOverride/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/mockWithoutDelay/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/mockWithoutDelay/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/mutator-client/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/mutator-client/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/mutator-client/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/mutator-client/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/mutator-multi-arguments/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/mutator-multi-arguments/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/mutator-multi-arguments/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/mutator-multi-arguments/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/named-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/named-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/named-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/named-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/split-query-key/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/split-query-key/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/split-query-key/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/split-query-key/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-get-query-data/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-get-query-data/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-invalidate/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-invalidate/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/react-query/use-set-query-data/model/createPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/react-query/use-set-query-data/model/listPetsParams.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/invalidates/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/invalidates/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/named-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/named-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/svelte-query/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/svelte-query/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/svelte-query/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/custom-client/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/custom-client/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/custom-client/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/custom-client/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/http-client-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/http-client-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/named-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/named-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/named-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/named-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/petstore-override-swr/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/petstore-override-swr/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/petstore-with-headers/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/petstore-with-headers/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/swr-suspense/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/swr-suspense/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/swr-suspense/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/swr-suspense/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/swr-with-error-types/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/swr-with-error-types/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/swr/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/swr/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/swr/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/swr/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/all-params-optional/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/all-params-optional/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/mutator/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/mutator/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/mutator/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/mutator/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/url-encode-parameters/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/url-encode-parameters/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/vue-query/use-set-query-data/model/createPetsParams.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/vue-query/use-set-query-data/model/listPetsParams.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/zod/petstore-tags-split/model/createPetsParams.ts
+++ b/tests/__snapshots__/zod/petstore-tags-split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/zod/petstore-tags-split/model/listPetsParams.ts
+++ b/tests/__snapshots__/zod/petstore-tags-split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/zod/petstore/model/createPetsParams.ts
+++ b/tests/__snapshots__/zod/petstore/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/zod/petstore/model/listPetsParams.ts
+++ b/tests/__snapshots__/zod/petstore/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/zod/split/model/createPetsParams.ts
+++ b/tests/__snapshots__/zod/split/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/zod/split/model/listPetsParams.ts
+++ b/tests/__snapshots__/zod/split/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };

--- a/tests/__snapshots__/zod/tags/model/createPetsParams.ts
+++ b/tests/__snapshots__/zod/tags/model/createPetsParams.ts
@@ -12,9 +12,9 @@ export type CreatePetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: CreatePetsSort;
 };

--- a/tests/__snapshots__/zod/tags/model/listPetsParams.ts
+++ b/tests/__snapshots__/zod/tags/model/listPetsParams.ts
@@ -12,9 +12,9 @@ export type ListPetsParams = {
    */
   limit?: string;
   /**
- * Which property to sort by?
-Example: name sorts ASC while -name sorts DESC.
-
- */
+   * Which property to sort by?
+   * Example: name sorts ASC while -name sorts DESC.
+   *
+   */
   sort: ListPetsSort;
 };


### PR DESCRIPTION
## Problem

Multi-line `info.description` in OpenAPI specs (e.g. YAML folded `>` or literal `|` block scalars) produces malformed JSDoc comments where inner newlines lack the `* ` prefix.

## Root Cause

In `jsDoc()` (`packages/core/src/utils/doc.ts`), description strings containing `\n` were joined with `\n * ` between *array elements*, but newlines *within* a single element were never prefixed. The `join` only adds the prefix at element boundaries.

## Fix

Added `.flatMap((line) => line.split(/\r?\n/))` to the lines processing pipeline in `jsDoc()`, so multi-line description strings are split into individual entries before joining. The CRLF-aware regex (`/\r?\n/`) ensures correctness across platforms.

## Changes

- `packages/core/src/utils/doc.ts`: Added `.flatMap((line) => line.split(/\r?\n/))` to split multi-line strings before the escape step
- `packages/core/src/utils/doc.test.ts`: Added 4 new tests covering:
  - Single-string multi-line descriptions
  - Array multi-line descriptions
  - CRLF line endings
  - `*/` escaping in multi-line descriptions
- 359 snapshot files updated to reflect the corrected JSDoc output

Fixes #3392