### PR TITLE
fix(zod): narrow string literals per-value in object defaults (#3399)

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -344,15 +344,19 @@ export const generateZodValidationSchemaDefinition = (
       // OpenApiSchemaObject defines default as 'any'
       defaultValue = `new Date("${escape(schema.default)}")`;
     } else if (isObject(schema.default)) {
+      // Narrow string literals individually with `as const` so `zod.enum([...])`
+      // properties accept the emitted default (#3244). Whole-object/array
+      // `as const` would make nested arrays `readonly`, which zod v4's
+      // `.default()` rejects against its mutable parameter type (#3399).
       const entries = Object.entries(schema.default)
         .map(([key, value]) => {
           if (isString(value)) {
-            return `${key}: "${escape(value)}"`;
+            return `${key}: "${escape(value)}" as const`;
           }
 
           if (Array.isArray(value)) {
             const arrayItems = value.map((item) =>
-              isString(item) ? `"${escape(item)}"` : `${item}`,
+              isString(item) ? `"${escape(item)}" as const` : `${item}`,
             );
             return `${key}: [${arrayItems.join(', ')}]`;
           }
@@ -366,10 +370,7 @@ export const generateZodValidationSchemaDefinition = (
             return `${key}: ${value}`;
         })
         .join(', ');
-      // `as const` preserves literal types so `zod.enum([...])` properties
-      // accept the emitted default (#3244).
-      defaultValue =
-        entries.length === 0 ? `{} as const` : `{ ${entries} } as const`;
+      defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;
     } else {
       // OpenApiSchemaObject defines default as 'any'
       const rawStringified = stringify(schema.default);

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1574,7 +1574,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['default', 'testObjectDefaultDefault'],
         ],
         consts: [
-          'export const testObjectDefaultDefault = { name: "Fluffy", age: 3 } as const;',
+          'export const testObjectDefaultDefault = { name: "Fluffy" as const, age: 3 };',
         ],
       });
 
@@ -1589,7 +1589,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'zod.object({\n  "name": zod.string().optional(),\n  "age": zod.number().optional()\n}).default(testObjectDefaultDefault)',
       );
       expect(parsed.consts).toBe(
-        'export const testObjectDefaultDefault = { name: "Fluffy", age: 3 } as const;',
+        'export const testObjectDefaultDefault = { name: "Fluffy" as const, age: 3 };',
       );
     });
 
@@ -2329,7 +2329,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
     });
 
-    it('appends "as const" to object defaults so enum properties keep literal types (#3244)', () => {
+    it('narrows string literals in object defaults so enum properties keep literal types (#3244)', () => {
       const schemaWithObjectEnumDefault: OpenApiSchemaObject = {
         type: 'object',
         required: ['enabled', 'value'],
@@ -2350,11 +2350,78 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
 
       expect(result.consts).toEqual([
-        'export const enumPropertiesObjectDefault = { enabled: true, value: "a" } as const;',
+        'export const enumPropertiesObjectDefault = { enabled: true, value: "a" as const };',
       ]);
       expect(result.functions).toContainEqual([
         'default',
         'enumPropertiesObjectDefault',
+      ]);
+    });
+
+    it('keeps array values mutable in object defaults so zod.default() accepts them (#3399)', () => {
+      const schemaWithArrayInObjectDefault: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          checklist: {
+            type: 'object',
+            nullable: true,
+            additionalProperties: { type: 'object' },
+          },
+          available_indexes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+            },
+          },
+        },
+        // eslint-disable-next-line unicorn/no-null
+        default: { checklist: null, available_indexes: [] },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithArrayInObjectDefault,
+        context,
+        'settings',
+        false,
+        false,
+        { required: false },
+      );
+
+      // The default object must NOT carry a top-level `as const`, otherwise
+      // empty/literal arrays inside become `readonly` and fail zod v4's
+      // `.default()` overload check (regression introduced by #3339).
+      expect(result.consts).toEqual([
+        'export const settingsDefault = { checklist: null, available_indexes: [] };',
+      ]);
+      expect(result.consts[0]).not.toContain('as const');
+      expect(result.functions).toContainEqual(['default', 'settingsDefault']);
+    });
+
+    it('narrows string array items in object defaults so enum-array properties keep literal types', () => {
+      const schemaWithEnumArrayInObjectDefault: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string', enum: ['a', 'b', 'c'] },
+          },
+        },
+        default: { tags: ['a', 'b'] },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithEnumArrayInObjectDefault,
+        context,
+        'taggedObject',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toEqual([
+        'export const taggedObjectDefault = { tags: ["a" as const, "b" as const] };',
       ]);
     });
 


### PR DESCRIPTION
## Summary

- Closes #3399 — zod object defaults containing arrays produced `TS2769` since 8.10.0 because the whole-object `as const` from PR #3339 made nested arrays `readonly`, which zod v4's `.default()` rejects against its mutable parameter type.
- Switches the emitted default to apply `as const` only to individual string literal values (including strings inside arrays), instead of wrapping the whole object/array literal. This preserves the enum literal narrowing that #3244 / #3339 needed while keeping arrays and objects mutable.

### Before (`8.10.0` – `8.11.0`, regression)

```ts
// Whole-object as const → nested [] becomes `readonly never[]` → TS2769
export const settingsDefault = { checklist: null, available_indexes: [] } as const;
```

### After

```ts
// Per-value narrowing → arrays/objects stay mutable, strings keep literal types
export const settingsDefault = { checklist: null, available_indexes: [] };
// Enum literal narrowing still works for string properties:
export const enumPropertiesObjectDefault = { enabled: true, value: "a" as const };
// And for enum-array properties:
export const taggedObjectDefault = { tags: ["a" as const, "b" as const] };
```

I verified end-to-end against zod `4.4.3` (the version in the repro) that:
- the minimal repro from #3399 (object default with empty array) now type-checks,
- the original #3244 case (object default with enum-typed string property) still type-checks,
- the combined case (object default with enum-typed array property) also type-checks.

## Test plan

- [x] `bun vitest run packages/zod` — 170 tests pass, including the new regression test for #3399 and the updated #3244 test
- [x] `bun run --filter @orval/zod lint`
- [x] `bun run build`
- [x] `bunx turbo run test:snapshots --filter='./samples/**' --filter=orval-tests` — 4070 snapshot tests pass, no snapshot drift
- [x] Verified the emitted output against `zod@4.4.3` with `tsc --noEmit --strict` using the issue's exact repro plus the #3244 and enum-array cases
- [x] No new/untracked files under `tests/__snapshots__`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced default value generation for object-based validation schemas to better preserve literal types for string properties and enum-derived values
  * Fixed type handling of arrays within object defaults to maintain proper mutability while ensuring full Zod v4 compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->