### PR TITLE
fix(core): parse mutator with latest ecmaVersion to support dynamic import

### DIFF
--- a/packages/core/src/generators/__tests__/mutator-test-files/dynamic-import-tests/dynamic-import-named-export.ts
+++ b/packages/core/src/generators/__tests__/mutator-test-files/dynamic-import-tests/dynamic-import-named-export.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Mutator that performs a dynamic import in its body.
+// Regression fixture for https://github.com/orval-labs/orval/issues/1634:
+// esbuild preserves dynamic `import()` in ESM output even when targeting es6,
+// so the bundled code parsed by acorn contains an `import()` expression.
+export const customInstance = async <T>(_config: {
+  url: string;
+}): Promise<T> => {
+  const mod = await import('node:os');
+  return mod as unknown as T;
+};

--- a/packages/core/src/generators/mutator-info.test.ts
+++ b/packages/core/src/generators/mutator-info.test.ts
@@ -259,4 +259,22 @@ describe('getMutatorInfo', () => {
       expect(result).toEqual({ numberOfParams: 0 });
     });
   });
+
+  describe('dynamic import', () => {
+    // Regression test for https://github.com/orval-labs/orval/issues/1634.
+    // esbuild preserves dynamic `import()` in its ESM output, so the bundled
+    // code handed to acorn contains an `import()` expression. Acorn must be
+    // able to parse it; otherwise the named export is reported as missing.
+    it('should find named export when body contains await import()', async () => {
+      const result = await getMutatorInfo(
+        path.join(
+          basePath,
+          'dynamic-import-tests',
+          'dynamic-import-named-export.ts',
+        ),
+        { namedExport: 'customInstance' },
+      );
+      expect(result).toEqual({ numberOfParams: 1 });
+    });
+  });
 });

--- a/packages/core/src/generators/mutator-info.ts
+++ b/packages/core/src/generators/mutator-info.ts
@@ -1,12 +1,8 @@
-import { type ecmaVersion, Parser, type Program } from 'acorn';
+import { Parser, type Program } from 'acorn';
 import { build, type BuildOptions } from 'esbuild';
 import { isArray } from 'remeda';
 
-import type {
-  GeneratorMutatorParsingInfo,
-  Tsconfig,
-  TsConfigTarget,
-} from '../types';
+import type { GeneratorMutatorParsingInfo, Tsconfig } from '../types';
 
 export async function getMutatorInfo(
   filePath: string,
@@ -34,11 +30,7 @@ export async function getMutatorInfo(
     tsconfig?.compilerOptions,
   );
 
-  return parseFile(
-    code,
-    namedExport,
-    getEcmaVersion(tsconfig?.compilerOptions?.target),
-  );
+  return parseFile(code, namedExport);
 }
 
 async function bundleFile(
@@ -74,10 +66,17 @@ async function bundleFile(
 function parseFile(
   file: string,
   name: string,
-  ecmaVersion: ecmaVersion = 6,
 ): GeneratorMutatorParsingInfo | undefined {
   try {
-    const ast = Parser.parse(file, { ecmaVersion, sourceType: 'module' });
+    // `file` is esbuild's bundled output, not the user's source. esbuild may
+    // emit any modern syntax (notably dynamic `import()`, which it preserves
+    // even when targeting es6 in ESM mode), so we parse with the latest
+    // ecmaVersion to avoid spurious SyntaxErrors that would mask the export
+    // we are looking for. See https://github.com/orval-labs/orval/issues/1634.
+    const ast = Parser.parse(file, {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    });
 
     const foundSpecifier = ast.body
       .filter((x) => x.type === 'ExportNamedDeclaration')
@@ -199,21 +198,5 @@ function parseFunction(
         numberOfParams: declaration.init.params.length,
       };
     }
-  }
-}
-
-function getEcmaVersion(target?: TsConfigTarget): ecmaVersion | undefined {
-  if (!target) {
-    return;
-  }
-
-  if (target.toLowerCase() === 'esnext') {
-    return 'latest';
-  }
-
-  try {
-    return Number(target.toLowerCase().replace('es', '')) as ecmaVersion;
-  } catch {
-    return;
   }
 }


### PR DESCRIPTION
Fixes #1634.

## Problem

When a custom mutator (or any module bundled with it) contains a dynamic `import()` expression, orval bails out with:

```
Your mutator file doesn't have the customInstance exported function
```

even though the named export does exist. The issue reproduces on the current `master` (8.11.0).

## Root cause

`getMutatorInfo` in `packages/core/src/generators/mutator-info.ts` works in two steps:

1. **Bundle** the mutator file with esbuild (`format: 'esm'`, target derived from the user's tsconfig).
2. **Parse** the bundled output with acorn to locate the named export and count its parameters.

The parser was being called with `ecmaVersion: 6` whenever the user had no tsconfig `target` (the `getEcmaVersion` helper returns `undefined` in that case, and `parseFile` falls back to the default of `6`). esbuild, however, preserves dynamic `import()` in its ESM output regardless of the target — `import()` is the one bit of modern syntax that does not get lowered for an ESM bundle. Acorn at `ecmaVersion: 6` (ES2015) cannot parse `import()` (introduced in ES2020) and throws `Unexpected token`, which the surrounding `try/catch` swallows. The end result is `parseFile` returning `undefined`, and `generateMutator` reporting the export as missing.

The `getEcmaVersion(tsconfig.target)` plumbing was also conceptually misplaced: `parseFile` parses esbuild's generated output, not the user's source. Restricting the parser to whatever the user happened to target only ever produced false negatives — it never produced a useful constraint.

## Fix

- Always parse esbuild's bundled output with `ecmaVersion: 'latest'`. Acorn is only used here to read an AST (no `eval`, no execution), so widening the accepted-syntax set is strictly an improvement.
- Drop the now-unused `getEcmaVersion` helper and the `TsConfigTarget`/`ecmaVersion` imports it required.
- `bundleFile` still threads `tsconfig.compilerOptions.target` to esbuild — that one affects what esbuild emits and is unrelated to the parser fix.

## Test

Added a regression unit test in `mutator-info.test.ts` with a fixture (`dynamic-import-named-export.ts`) whose body performs `await import('node:os')`. The test fails on `master` (`expected undefined to deeply equal { numberOfParams: 1 }`) and passes after the fix.

## Out of scope

The same issue thread mentions a second symptom (custom mutator exported as `axiosDefault.create(...)` is not detected) — that is a different bug in `parseFunction` (it does not currently treat `CallExpression` results as callable) and is tracked separately in #3402 (which also links back to the long-standing #1370 / discussion #1373).

## Verification

- `bun run build --force`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` (1751 passed)
- `bun run test:snapshots` (4082 passed)
- `bun run --filter orval-tests build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of dynamic imports with named exports in generated code.

* **Improvements**
  * Updated module parsing to use the latest ECMAScript standard for enhanced compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
