### PR TITLE
fix(zod): parser generation when content-type contains charset precision

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1337,7 +1337,16 @@ const parseBodyAndResponse = ({
   // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
   // are skipped - unclear if this is correct behavior for root-level binary/text bodies.
   const contentEntries = Object.entries(resolvedRef.content ?? {});
-  const jsonContent = contentEntries.find(isMediaType('application/json'));
+
+  const jsonContent = contentEntries.find(
+    isMediaType(
+      // application/json
+      // application/geo+json
+      // application/ld+json
+      // application/manifest+json
+      String.raw`^application\/([\w-]+\+)?json$`,
+    ),
+  );
   const formDataContent = contentEntries.find(
     isMediaType('multipart/form-data'),
   );
@@ -1422,9 +1431,9 @@ const parseBodyAndResponse = ({
 };
 
 const isMediaType =
-  (expectedContentType: string) =>
+  (pattern: string) =>
   ([contentType]: [string, object]): boolean =>
-    contentType.split(';')[0].trim() === expectedContentType;
+    new RegExp(pattern).test(contentType.split(';')[0].trim());
 
 const getSingleResponse = (
   responses:

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1337,11 +1337,9 @@ const parseBodyAndResponse = ({
   // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
   // are skipped - unclear if this is correct behavior for root-level binary/text bodies.
   const contentEntries = Object.entries(resolvedRef.content ?? {});
-  const jsonContent = contentEntries.find(([contentType]) =>
-    contentType.startsWith('application/json'),
-  );
-  const formDataContent = contentEntries.find(([contentType]) =>
-    contentType.startsWith('multipart/form-data'),
+  const jsonContent = contentEntries.find(isMediaType('application/json'));
+  const formDataContent = contentEntries.find(
+    isMediaType('multipart/form-data'),
   );
   const [contentType, mediaType] = jsonContent
     ? (['application/json', jsonContent[1]] as const)
@@ -1357,7 +1355,6 @@ const parseBodyAndResponse = ({
       isArray: false,
     };
   }
-
   const encoding = mediaType.encoding;
 
   const resolvedJsonSchema = dereference(schema, context);
@@ -1395,7 +1392,6 @@ const parseBodyAndResponse = ({
       },
     };
   }
-
   const effectiveSchema =
     parseType === 'body'
       ? removeReadOnlyProperties(resolvedJsonSchema)
@@ -1424,6 +1420,12 @@ const parseBodyAndResponse = ({
     isArray: false,
   };
 };
+
+const isMediaType =
+  (expectedContentType: string) =>
+  ([contentType]: [string, object]): boolean =>
+    contentType.split(';')[0].trim() === expectedContentType;
+
 const getSingleResponse = (
   responses:
     | Record<string, OpenApiResponseObject | OpenApiReferenceObject | undefined>

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1335,13 +1335,18 @@ const parseBodyAndResponse = ({
     | OpenApiRequestBodyObject;
 
   // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
-  // are skipped - unclear if this is correct behavior for root-level binary/text bodies
-  const jsonMedia = resolvedRef.content?.['application/json'];
-  const formDataMedia = resolvedRef.content?.['multipart/form-data'];
-  const [contentType, mediaType] = jsonMedia
-    ? (['application/json', jsonMedia] as const)
-    : formDataMedia
-      ? (['multipart/form-data', formDataMedia] as const)
+  // are skipped - unclear if this is correct behavior for root-level binary/text bodies.
+  const contentEntries = Object.entries(resolvedRef.content ?? {});
+  const jsonContent = contentEntries.find(([contentType]) =>
+    contentType.startsWith('application/json'),
+  );
+  const formDataContent = contentEntries.find(([contentType]) =>
+    contentType.startsWith('multipart/form-data'),
+  );
+  const [contentType, mediaType] = jsonContent
+    ? (['application/json', jsonContent[1]] as const)
+    : formDataContent
+      ? (['multipart/form-data', formDataContent[1]] as const)
       : [undefined, undefined];
 
   const schema = mediaType?.schema;
@@ -1419,7 +1424,6 @@ const parseBodyAndResponse = ({
     isArray: false,
   };
 };
-
 const getSingleResponse = (
   responses:
     | Record<string, OpenApiResponseObject | OpenApiReferenceObject | undefined>
@@ -1431,7 +1435,6 @@ const getSingleResponse = (
 
   return responses['200'] ?? responses['2XX'] ?? responses['2xx'];
 };
-
 /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 
 export const parseParameters = ({

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1433,7 +1433,7 @@ const parseBodyAndResponse = ({
 const isMediaType =
   (pattern: string) =>
   ([contentType]: [string, object]): boolean =>
-    new RegExp(pattern).test(contentType.split(';')[0].trim());
+    new RegExp(pattern).test(contentType.split(';')[0].trim().toLowerCase());
 
 const getSingleResponse = (
   responses:

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -6275,6 +6275,119 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
 
 `);
   });
+
+  it('content type with charset precision: comprehensive content type handling', async () => {
+    // Matches type gen test structure in res-req-types.test.ts
+    const schema = {
+      pathRoute: '/upload-form',
+      context: {
+        spec: {
+          paths: {
+            '/upload-form': {
+              post: {
+                operationId: 'uploadForm',
+                requestBody: {
+                  required: true,
+                  content: {
+                    'multipart/form-data; charset=utf-8': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          encBinary: { type: 'string' },
+                          encText: { type: 'string' },
+                          cmtBinary: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                          },
+                          cmtText: {
+                            type: 'string',
+                            contentMediaType: 'application/xml',
+                          },
+                          encOverride: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                          },
+                          formatBinary: { type: 'string', format: 'binary' },
+                          base64Field: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                            contentEncoding: 'base64',
+                          },
+                          metadata: {
+                            type: 'object',
+                            properties: { name: { type: 'string' } },
+                          },
+                        },
+                        required: [
+                          'encBinary',
+                          'encText',
+                          'cmtBinary',
+                          'cmtText',
+                          'encOverride',
+                          'formatBinary',
+                          'base64Field',
+                          'metadata',
+                        ],
+                      },
+                      encoding: {
+                        encBinary: { contentType: 'image/png' },
+                        encText: { contentType: 'text/plain' },
+                        encOverride: { contentType: 'text/csv' },
+                        metadata: { contentType: 'application/json' },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json; charset=utf-8': {
+                        schema: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+    const result = await generateZod(
+      {
+        pathRoute: '/upload-form',
+        verb: 'post',
+        operationName: 'uploadForm',
+        override: zodOverride,
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+    // encBinary: encoding image/png → File
+    // encText: encoding text/plain → File | string
+    // cmtBinary: contentMediaType image/png → File
+    // cmtText: contentMediaType application/xml → File | string
+    // encOverride: encoding text/csv overrides contentMediaType image/png → File | string
+    // formatBinary: format: binary → File (same as instanceof check)
+    // base64Field: contentEncoding base64 → stays string
+    // metadata: object → object schema
+    expect(result.implementation)
+      .toBe(`export const UploadFormBody = zod.object({
+  "encBinary": zod.instanceof(File),
+  "encText": zod.instanceof(File).or(zod.string()),
+  "cmtBinary": zod.instanceof(File),
+  "cmtText": zod.instanceof(File).or(zod.string()),
+  "encOverride": zod.instanceof(File).or(zod.string()),
+  "formatBinary": zod.instanceof(File),
+  "base64Field": zod.string(),
+  "metadata": zod.object({
+  "name": zod.string().optional()
+})
+})
+
+`);
+  });
 });
 
 describe('zod split mode regressions', () => {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -6405,6 +6405,89 @@ export const UploadFormResponse = zod.object({
 
 `);
   });
+
+  it('json exotic content type: comprehensive content type handling', async () => {
+    const schema = {
+      pathRoute: '/upload-form',
+      context: {
+        spec: {
+          paths: {
+            '/upload-form': {
+              post: {
+                operationId: 'uploadForm',
+                requestBody: {
+                  required: true,
+                  content: {
+                    'application/geo+json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          success: { type: 'boolean' },
+                          uploaded: { type: 'number' },
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    content: {
+                      'application/manifest+json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            success: { type: 'boolean' },
+                            uploaded: { type: 'number' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+    const result = await generateZod(
+      {
+        pathRoute: '/upload-form',
+        verb: 'post',
+        operationName: 'uploadForm',
+        override: {
+          ...zodOverride,
+          zod: {
+            ...zodOverride.zod,
+            generate: { ...zodOverride.zod.generate, response: true },
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+    // encBinary: encoding image/png → File
+    // encText: encoding text/plain → File | string
+    // cmtBinary: contentMediaType image/png → File
+    // cmtText: contentMediaType application/xml → File | string
+    // encOverride: encoding text/csv overrides contentMediaType image/png → File | string
+    // formatBinary: format: binary → File (same as instanceof check)
+    // base64Field: contentEncoding base64 → stays string
+    // metadata: object → object schema
+    expect(result.implementation)
+      .toBe(`export const UploadFormBody = zod.object({
+  "success": zod.boolean().optional(),
+  "uploaded": zod.number().optional()
+})
+
+export const UploadFormResponse = zod.object({
+  "success": zod.boolean().optional(),
+  "uploaded": zod.number().optional()
+})
+
+`);
+  });
 });
 
 describe('zod split mode regressions', () => {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -6342,7 +6342,13 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
                   '200': {
                     content: {
                       'application/json; charset=utf-8': {
-                        schema: { type: 'string' },
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            success: { type: 'boolean' },
+                            uploaded: { type: 'number' },
+                          },
+                        },
                       },
                     },
                   },
@@ -6359,7 +6365,13 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
         pathRoute: '/upload-form',
         verb: 'post',
         operationName: 'uploadForm',
-        override: zodOverride,
+        override: {
+          ...zodOverride,
+          zod: {
+            ...zodOverride.zod,
+            generate: { ...zodOverride.zod.generate, response: true },
+          },
+        },
       } as unknown as Parameters<typeof generateZod>[0],
       schema,
       testOutput,
@@ -6384,6 +6396,11 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
   "metadata": zod.object({
   "name": zod.string().optional()
 })
+})
+
+export const UploadFormResponse = zod.object({
+  "success": zod.boolean().optional(),
+  "uploaded": zod.number().optional()
 })
 
 `);


### PR DESCRIPTION
### Reproduction

OpenAPI contract Content-Type may contain `charset` reference, like in the example below:

```yml
paths:
  /test-endpoint:
    get:
      operationId: getTestEndpoint
      description: This is a test endpoint
      responses:
        "200":
          description: return object.
          content:
            "application/json":
              schema:
                $ref: "#/components/schemas/ResponseObject"
        "400":
          description: Bad request.
          content:
            "application/json; charset=UTF-8":
              schema:
                type: object
                properties:
                  error:
                    type: string
                    description: Error message
              example:
                value:
                  $ref: examples/error.json
```

The issue was that parser for 200 was generated, but not for 400 because of the `charset=utf-8` precision.

### What this PR does

- Ignores charset in this case as this does not provide useful information for zod generation
- Does not take into account this possibility on other packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content-type detection to recognize media types with parameters (e.g., charset) and more reliably choose request/response content types; improved response selection priority (favoring 200 over other 2xx variants) for JSON and multipart/form-data scenarios.

* **Tests**
  * Added tests covering multipart/form-data requests with field-level encoding and charset-qualified JSON response content types to validate correct schema generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->