### PR TITLE
test(core): pin optional-by-default requestBody behavior (#2028)

### DIFF
--- a/packages/core/src/getters/body.test.ts
+++ b/packages/core/src/getters/body.test.ts
@@ -156,6 +156,71 @@ describe('getBody', () => {
 
     expect(result.isOptional).toBe(false);
   });
+
+  // Regression: #2028 — when an OpenAPI 3.0 spec leaves `required` off the
+  // requestBody, orval used to emit a required body parameter. The fix in
+  // PR #3263 treats `required !== true` as optional. This test pins the
+  // exact shape from #2028: an inline requestBody whose content schema is a
+  // `$ref` to components/schemas (not a $ref on the requestBody itself).
+  it('treats inline request bodies with a $ref schema and no required flag as optional (#2028)', () => {
+    const context = createContext();
+    context.spec.components = {
+      ...context.spec.components,
+      schemas: {
+        ...context.spec.components?.schemas,
+        BodyDto: {
+          type: 'object',
+          properties: {
+            x: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const result = getBody({
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/BodyDto' },
+          },
+        },
+      },
+      operationName: 'createThing',
+      context,
+    });
+
+    expect(result.isOptional).toBe(true);
+  });
+
+  it('treats referenced request bodies marked required: false as optional', () => {
+    const context = createContext();
+    context.spec.components = {
+      ...context.spec.components,
+      requestBodies: {
+        SearchPetsBody: {
+          required: false,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = getBody({
+      requestBody: { $ref: '#/components/requestBodies/SearchPetsBody' },
+      operationName: 'searchPets',
+      context,
+    });
+
+    expect(result.isOptional).toBe(true);
+  });
 });
 
 describe('getBodiesByContentType', () => {


### PR DESCRIPTION
## Summary

Adds regression coverage for #2028 ("Orval does not support optional by default requestBody that OpenAPI 3.0 specifies").

I could not reproduce #2028 on current `master` (v8.11.0). PR #3263 (merged 2026-04-22, primarily an Angular `httpResource` fix) bundled a `fix(core)` commit that changed `packages/core/src/getters/body.ts` from `bodySchema.required !== undefined` to `bodySchema.required !== true`, which is the OpenAPI 3.0 spec-compliant rule #2028 asked for. That PR's title/description don't mention #2028, so the rule isn't traceable from the issue thread.

`body.test.ts` was updated in #3263 to cover three optional-body cases (inline + no `required`, `$ref` + no `required`, `$ref` + `required: true`). This PR is **test-only** — it locks in two cases that were not explicitly covered:

- **#2028's exact spec shape**: an inline `requestBody` whose `content.application/json.schema` is a `$ref` to `components/schemas/...`, with **no `required` field**. The `$ref`-as-schema variant inside an inline body is the structure the reporter posted, and is the only case here that fails when reverted to the pre-#3263 rule (manually verified locally).
- **`$ref` requestBody marked `required: false`**: the explicit-false branch of `components/requestBodies`. Not strictly a #2028 regression (the pre-#3263 rule also passed this), but the existing tests only cover omitted vs `required: true`, so this fills the symmetric gap.

## Verification

```bash
# Reporter's spec on the reporter's version: bug reproduces
npx orval@7.7.0 ...  → bodyDto: BodyDto
# Same spec on v8.9.0 (first release after #3263): fixed
npx orval@8.9.0 ...  → bodyDto?: BodyDto
# v8.11.0 (current latest): still fixed
npx orval@8.11.0 ... → bodyDto?: BodyDto
```

Quality gates on this branch:

```
bun run test --run body.test.ts   # 11 passed (9 existing + 2 new)
bun run test --run                # 1765 passed (@orval/core full suite)
bun run lint                      # clean (24 tasks)
bun run typecheck                 # clean (12 tasks)
```

## Notes

Not auto-closing #2028 — the rule change in #3263 was a drive-by inside an Angular PR, and the original maintainer position on #2028 (~2025-04) was "by design". Leaving the close decision to maintainers in case the policy change should be reverted instead of pinned.

Refs #2028


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for OpenAPI request body optionality behavior. Tests validate that request bodies are correctly identified as optional when the required flag is omitted or explicitly set to false, covering scenarios with both inline content schemas that reference external definitions and standalone request body references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->