### PR TITLE
fix(core): decode ~0 tilde escapes in JSON Pointer refs

### DIFF
--- a/packages/core/src/getters/ref.test.ts
+++ b/packages/core/src/getters/ref.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { isComponentRef } from './ref';
+import type { ContextSpec } from '../types';
+import { getRefInfo, isComponentRef } from './ref';
+
+function createRefContext(): ContextSpec {
+  return {
+    target: 'core-test',
+    workspace: '/tmp',
+    spec: {},
+    output: {
+      override: {
+        components: {
+          schemas: { suffix: '' },
+        },
+      },
+    },
+  } as ContextSpec;
+}
 
 describe('isComponentRef', () => {
   it.each([
@@ -38,5 +54,44 @@ describe('isComponentRef', () => {
     // RFC 6901: literal "/" inside a name is encoded as "~1".
     // The decoded name is "My/Type" but the ref string segment has no literal slash.
     expect(isComponentRef('#/components/schemas/My~1Type')).toBe(true);
+  });
+});
+
+describe('getRefInfo', () => {
+  it('decodes ~0 tilde escape per RFC 6901', () => {
+    const info = getRefInfo(
+      '#/components/schemas/My~0Type',
+      createRefContext(),
+    );
+    expect(info.originalName).toBe('My~Type');
+  });
+
+  it('decodes both ~1 and ~0 in the same segment', () => {
+    const info = getRefInfo(
+      '#/components/schemas/Path~1To~0Thing',
+      createRefContext(),
+    );
+    expect(info.originalName).toBe('Path/To~Thing');
+  });
+
+  it('decodes order is ~1 then ~0', () => {
+    // "~01" should decode to "~1", not to "/" then "0"
+    const info = getRefInfo(
+      '#/components/schemas/Foo~01Bar',
+      createRefContext(),
+    );
+    expect(info.originalName).toBe('Foo~1Bar');
+  });
+
+  it('percent-decodes before tilde unescaping per RFC 6901 section 6', () => {
+    // %7E is the percent-encoding of "~", so %7E0 → ~0 → ~ and %7E1 → ~1 → /
+    expect(
+      getRefInfo('#/components/schemas/My%7E0Type', createRefContext())
+        .originalName,
+    ).toBe('My~Type');
+    expect(
+      getRefInfo('#/components/schemas/A%7E1B', createRefContext())
+        .originalName,
+    ).toBe('A/B');
   });
 });

--- a/packages/core/src/getters/ref.ts
+++ b/packages/core/src/getters/ref.ts
@@ -37,7 +37,8 @@ export function isComponentRef(ref: string): boolean {
   return COMPONENT_REF_PATTERN.test(ref);
 }
 
-const regex = new RegExp('~1', 'g');
+const TILDE_1 = /~1/g;
+const TILDE_0 = /~0/g;
 
 export interface RefInfo {
   name: string;
@@ -55,7 +56,11 @@ export function getRefInfo($ref: string, context: ContextSpec): RefInfo {
   const refPaths = ref
     .slice(1)
     .split('/')
-    .map((part) => decodeURIComponent(part.replaceAll(regex, '/')));
+    .map((part) =>
+      decodeURIComponent(part)
+        .replaceAll(TILDE_1, '/')
+        .replaceAll(TILDE_0, '~'),
+    );
 
   const getOverrideSuffix = (
     override: NormalizedOverrideOutput,

--- a/packages/core/src/resolvers/ref.test.ts
+++ b/packages/core/src/resolvers/ref.test.ts
@@ -198,6 +198,36 @@ describe('resolveRef', () => {
       resolveRef({ $ref: '#/components/schemas/NonExistent' }, context),
     ).toThrow('Oops... 🍻. Ref not found: #/components/schemas/NonExistent');
   });
+
+  it('resolves a schema whose component key contains a literal tilde', () => {
+    const context = createContext({
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          'My~Type': {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    });
+
+    const result = resolveRef(
+      { $ref: '#/components/schemas/My~0Type' },
+      context,
+    );
+
+    expect(result.schema).toMatchObject({
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    });
+    expect(result.imports[0]).toMatchObject({
+      name: 'MyType',
+      schemaName: 'My~Type',
+    });
+  });
 });
 
 describe('resolveExampleRefs', () => {


### PR DESCRIPTION
## Summary

`getRefInfo` in `packages/core/src/getters/ref.ts` now decodes both RFC 6901 JSON Pointer escape sequences in the correct order:

1. `~1` → `/`
2. `~0` → `~`

Previously only `~1` was decoded, leaving `~0` as a literal in the decoded path segment. This caused `$ref` values like `#/components/schemas/My~0Type` to resolve to `My~0Type` instead of `My~Type`.

## Test plan

- `getRefInfo` decodes `#/components/schemas/My~0Type` → `My~Type`
- `getRefInfo` decodes a segment containing both `~1` and `~0` (`Path~1To~0Thing` → `Path/To~Thing`)
- `getRefInfo` decodes `~01` → `~1` (validates that `~1` is replaced before `~0`)
- `resolveRef` resolves a schema whose component key contains a literal `~`

Closes #3413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reference decoding so component names with tildes (~) and JSON Pointer escape sequences are handled reliably (including proper percent-decoding and tilde unescaping).

* **Tests**
  * Added tests covering JSON Pointer unescaping edge cases and resolving refs that include literal tildes to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->