### PR TITLE
style(ci): format release-publish workflow with prettier

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write # Required for NPM OIDC
+  id-token: write  # Required for NPM OIDC
 
 jobs:
   publish:

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for NPM OIDC
+  id-token: write # Required for NPM OIDC
 
 jobs:
   publish:
@@ -25,8 +25,8 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false  # never use caching in release builds
-    
+          package-manager-cache: false # never use caching in release builds
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for NPM OIDC
+  id-token: write # Required for NPM OIDC
 
 jobs:
   publish:


### PR DESCRIPTION
The `release-publish.yaml` workflow was not formatted according to the project's Prettier config, causing `bun run format:check` to fail and blocking other PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved build process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->