### PR TITLE
fix(mock): detect $ref in single-element allOf/oneOf/anyOf array items

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -661,3 +661,84 @@ describe('getMockScalar (post-upgrader OAS 3.0 example handling)', () => {
     expect(result.value).toBe('"relaxation"');
   });
 });
+
+describe('getMockScalar (array items $ref extraction and recursion guard)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    splitMockImplementations: [],
+    existingReferencedProperties: ['Foo'],
+    context: { output: { override: {} } } as ContextSpec,
+  };
+
+  it('returns [] when items.$ref is a circular reference', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'array' as const,
+        name: 'test-item',
+        items: { $ref: '#/components/schemas/Foo' },
+      },
+    });
+
+    expect(result.value).toBe('[]');
+  });
+
+  it('returns [] when items is allOf with a single circular $ref', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'array' as const,
+        name: 'test-item',
+        items: { allOf: [{ $ref: '#/components/schemas/Foo' }] },
+      },
+    });
+
+    expect(result.value).toBe('[]');
+  });
+
+  it('returns [] when items is oneOf with a single circular $ref', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'array' as const,
+        name: 'test-item',
+        items: { oneOf: [{ $ref: '#/components/schemas/Foo' }] },
+      },
+    });
+
+    expect(result.value).toBe('[]');
+  });
+
+  it('returns [] when items is anyOf with a single circular $ref', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'array' as const,
+        name: 'test-item',
+        items: { anyOf: [{ $ref: '#/components/schemas/Foo' }] },
+      },
+    });
+
+    expect(result.value).toBe('[]');
+  });
+
+  it('does not short-circuit for multi-element allOf even if one matches a visited ref', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'array' as const,
+        name: 'test-item',
+        items: {
+          allOf: [
+            { $ref: '#/components/schemas/Foo' },
+            { $ref: '#/components/schemas/Bar' },
+          ],
+        },
+      },
+    });
+
+    expect(result.value).not.toBe('[]');
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
@@ -9,6 +9,7 @@ import {
   EnumGeneration,
   escape,
   type GeneratorImport,
+  isReference,
   isString,
   mergeDeep,
   type MockOptions,
@@ -16,7 +17,7 @@ import {
   pascal,
 } from '@orval/core';
 
-import type { MockDefinition, MockSchemaObject } from '../../types';
+import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
 import { isFakerVersionV9 } from '../compatible-v9';
 import { DEFAULT_FORMAT_MOCK } from '../constants';
 import {
@@ -254,14 +255,23 @@ export function getMockScalar({
         return { value: '[]', imports: [], name: item.name };
       }
 
+      const itemsRef = extractItemsRef(item.items);
       if (
-        '$ref' in item.items &&
+        itemsRef &&
         existingReferencedProperties.includes(
-          pascal(item.items.$ref.split('/').pop() ?? ''),
+          pascal(itemsRef.split('/').pop() ?? ''),
         )
       ) {
         return { value: '[]', imports: [], name: item.name };
       }
+
+      // If `items` is a single-element `allOf`/`oneOf`/`anyOf` wrapping a
+      // `$ref`, treat it as a direct `$ref`. This avoids double-wrapping when
+      // the inner schema is an enum array (whose `getEnum` already emits
+      // `faker.helpers.arrayElements(...)`) and keeps recursion semantics in
+      // line with direct-$ref items.
+      const resolvedItems =
+        itemsRef && !('$ref' in item.items) ? { $ref: itemsRef } : item.items;
 
       const {
         value,
@@ -269,7 +279,7 @@ export function getMockScalar({
         imports: resolvedImports,
       } = resolveMockValue({
         schema: {
-          ...item.items,
+          ...resolvedItems,
           name: item.name,
           path: item.path ? `${item.path}.[]` : '#.[]',
         },
@@ -406,6 +416,26 @@ export function getMockScalar({
       });
     }
   }
+}
+
+// Returns the $ref string from array `items` — either direct ($ref on items
+// itself) or wrapped in a single-element allOf/oneOf/anyOf composition.
+// Multi-element compositions return undefined to preserve combine semantics.
+function extractItemsRef(items: MockSchema): string | undefined {
+  if (isReference(items)) {
+    return items.$ref;
+  }
+  for (const key of ['allOf', 'oneOf', 'anyOf'] as const) {
+    const composed = items[key] as MockSchema[] | undefined;
+    if (
+      Array.isArray(composed) &&
+      composed.length === 1 &&
+      isReference(composed[0])
+    ) {
+      return composed[0].$ref;
+    }
+  }
+  return;
 }
 
 function getItemType(item: MockSchemaObject) {


### PR DESCRIPTION
## Summary

- Adds `extractItemsRef` helper to detect `$ref` whether direct on `item.items` or wrapped in a single-element `allOf`/`oneOf`/`anyOf` composition
- Fixes recursion guard so self-referential array schemas emit `[]` instead of `undefined[]`
- Normalizes wrapped items to `{ $ref }` before `resolveMockValue`, preventing enum arrays from double-wrapping as `SomeEnum[][]`
- Only single-element compositions are unwrapped; multi-element compositions still flow through the combine path

## Reproduction

### Self-referential schema producing `undefined[]`

```yaml
components:
  schemas:
    Category:
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        subcategories:
          type: array
          items:
            allOf:
              - $ref: '#/components/schemas/Category'
```

**Before fix:** The recursion guard didn't fire because it only checked `item.items.$ref` (which is `undefined` when wrapped in `allOf`). The code recursed into `combineSchemasMock`, which eventually skipped the already-visited ref but left the parent array case generating `Array.from(...).map(() => undefined)` — producing `undefined[]`.

**After fix:** `extractItemsRef` unwraps the single-element `allOf` and the recursion guard correctly returns `[]`.

### Enum array double-wrapping as `PetStatus[][]`

```yaml
components:
  schemas:
    PetStatus:
      type: string
      enum: [available, pending, sold]
    Pet:
      type: object
      properties:
        name:
          type: string
        previousStatuses:
          type: array
          items:
            allOf:
              - $ref: '#/components/schemas/PetStatus'
```

**Before fix:** The `allOf`-wrapped items went through the composition path, so the outer array case never received the `enums` flag back from `resolveMockValue`. It wrapped the already-correct `faker.helpers.arrayElements(Object.values(PetStatus))` (which itself returns `PetStatus[]`) in an extra `Array.from(...).map(...)`, yielding `PetStatus[][]`.

**After fix:** The wrapped items are normalized to `{ $ref: '#/components/schemas/PetStatus' }` before calling `resolveMockValue`, which resolves the enum through the normal `$ref` path, properly propagates the `enums` flag, and the array case returns the value directly without double-wrapping.

## Test plan

- [x] Unit tests added for recursion guard with direct `$ref`, `allOf`, `oneOf`, `anyOf` wrappers
- [x] Negative test: multi-element `allOf` is not unwrapped
- [x] All existing tests pass (`npx vitest run packages/mock/src/faker/getters/scalar.test.ts` — 40 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock generation for array schemas with circular references. Now detects references even when wrapped by single-element composed schemas (allOf/oneOf/anyOf), returns an empty array for circular cases, and avoids incorrect short-circuits that could produce wrong mocks.

* **Tests**
  * Added tests covering array reference extraction and recursion prevention, including edge cases with nested composed schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->