### PR TITLE
fix(zod): parser generation when content-type contains charset precision

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1350,7 +1350,7 @@ const parseBodyAndResponse = ({
     ),
   );
   const formDataContent = contentEntries.find(
-    isMediaType('multipart/form-data'),
+    isMediaType(String.raw`^multipart\/form-data$`),
   );
   const [contentType, mediaType] = jsonContent
     ? (['application/json', jsonContent[1]] as const)

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1335,13 +1335,27 @@ const parseBodyAndResponse = ({
     | OpenApiRequestBodyObject;
 
   // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
-  // are skipped - unclear if this is correct behavior for root-level binary/text bodies
-  const jsonMedia = resolvedRef.content?.['application/json'];
-  const formDataMedia = resolvedRef.content?.['multipart/form-data'];
-  const [contentType, mediaType] = jsonMedia
-    ? (['application/json', jsonMedia] as const)
-    : formDataMedia
-      ? (['multipart/form-data', formDataMedia] as const)
+  // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
+  // are skipped - unclear if this is correct behavior for root-level binary/text bodies.
+  const contentEntries = Object.entries(resolvedRef.content ?? {});
+
+  const jsonContent = contentEntries.find(
+    isMediaType(
+      // application/json
+      // application/geo+json
+      // application/ld+json
+      // application/manifest+json
+      // application/vnd.api+json (and other valid vendor subtypes)
+      String.raw`^application\/([^/;]+\+)?json$`,
+    ),
+  );
+  const formDataContent = contentEntries.find(
+    isMediaType('multipart/form-data'),
+  );
+  const [contentType, mediaType] = jsonContent
+    ? (['application/json', jsonContent[1]] as const)
+    : formDataContent
+      ? (['multipart/form-data', formDataContent[1]] as const)
       : [undefined, undefined];
 
   const schema = mediaType?.schema;
@@ -1352,7 +1366,6 @@ const parseBodyAndResponse = ({
       isArray: false,
     };
   }
-
   const encoding = mediaType.encoding;
 
   const resolvedJsonSchema = dereference(schema, context);
@@ -1419,6 +1432,11 @@ const parseBodyAndResponse = ({
     isArray: false,
   };
 };
+
+const isMediaType =
+  (pattern: string) =>
+  ([contentType]: [string, object]): boolean =>
+    new RegExp(pattern).test(contentType.split(';')[0].trim().toLowerCase());
 
 const getSingleResponse = (
   responses:

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -6275,6 +6275,136 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
 
 `);
   });
+
+  it('content type with charset precision: comprehensive content type handling', async () => {
+    // Matches type gen test structure in res-req-types.test.ts
+    const schema = {
+      pathRoute: '/upload-form',
+      context: {
+        spec: {
+          paths: {
+            '/upload-form': {
+              post: {
+                operationId: 'uploadForm',
+                requestBody: {
+                  required: true,
+                  content: {
+                    'multipart/form-data; charset=utf-8': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          encBinary: { type: 'string' },
+                          encText: { type: 'string' },
+                          cmtBinary: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                          },
+                          cmtText: {
+                            type: 'string',
+                            contentMediaType: 'application/xml',
+                          },
+                          encOverride: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                          },
+                          formatBinary: { type: 'string', format: 'binary' },
+                          base64Field: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                            contentEncoding: 'base64',
+                          },
+                          metadata: {
+                            type: 'object',
+                            properties: { name: { type: 'string' } },
+                          },
+                        },
+                        required: [
+                          'encBinary',
+                          'encText',
+                          'cmtBinary',
+                          'cmtText',
+                          'encOverride',
+                          'formatBinary',
+                          'base64Field',
+                          'metadata',
+                        ],
+                      },
+                      encoding: {
+                        encBinary: { contentType: 'image/png' },
+                        encText: { contentType: 'text/plain' },
+                        encOverride: { contentType: 'text/csv' },
+                        metadata: { contentType: 'application/json' },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json; charset=utf-8': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            success: { type: 'boolean' },
+                            uploaded: { type: 'number' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+    const result = await generateZod(
+      {
+        pathRoute: '/upload-form',
+        verb: 'post',
+        operationName: 'uploadForm',
+        override: {
+          ...zodOverride,
+          zod: {
+            ...zodOverride.zod,
+            generate: { ...zodOverride.zod.generate, response: true },
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+    // encBinary: encoding image/png → File
+    // encText: encoding text/plain → File | string
+    // cmtBinary: contentMediaType image/png → File
+    // cmtText: contentMediaType application/xml → File | string
+    // encOverride: encoding text/csv overrides contentMediaType image/png → File | string
+    // formatBinary: format: binary → File (same as instanceof check)
+    // base64Field: contentEncoding base64 → stays string
+    // metadata: object → object schema
+    expect(result.implementation)
+      .toBe(`export const UploadFormBody = zod.object({
+  "encBinary": zod.instanceof(File),
+  "encText": zod.instanceof(File).or(zod.string()),
+  "cmtBinary": zod.instanceof(File),
+  "cmtText": zod.instanceof(File).or(zod.string()),
+  "encOverride": zod.instanceof(File).or(zod.string()),
+  "formatBinary": zod.instanceof(File),
+  "base64Field": zod.string(),
+  "metadata": zod.object({
+  "name": zod.string().optional()
+})
+})
+
+export const UploadFormResponse = zod.object({
+  "success": zod.boolean().optional(),
+  "uploaded": zod.number().optional()
+})
+
+`);
+  });
 });
 
 describe('zod split mode regressions', () => {

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.msw.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.msw.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.msw.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.msw.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.msw.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.msw.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/src/api/http-both/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/src/api/http-client/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-app/src/api/http-resource/pets/pets.msw.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.msw.ts
@@ -36,7 +36,7 @@ export const getSearchPetsResponseMock = (): Pets =>
     phone: (() =>
       faker.helpers.arrayElement([
         `+1${faker.string.numeric({ length: 10 })}`,
-        undefined,
+        void 0,
       ]))(),
     requiredNullableString: faker.helpers.arrayElement([
       faker.helpers.arrayElement([
@@ -80,7 +80,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -121,7 +121,7 @@ export const getListPetsResponseMock = (): Pets =>
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -144,17 +144,17 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
     status: faker.helpers.arrayElement(['available', 'pending', 'sold']),
     requiredNullableString: null,
     optionalNullableString: faker.helpers.arrayElement([
       faker.word.sample(),
       null,
-      undefined,
+      void 0,
     ]),
     phone: faker.helpers.arrayElement([
       `+1${faker.string.numeric({ length: 10 })}`,
-      undefined,
+      void 0,
     ]),
   }))();
 
@@ -183,7 +183,7 @@ export const getUpdatePetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([
@@ -229,7 +229,7 @@ export const getPatchPetByIdResponseMock = (
       phone: (() =>
         faker.helpers.arrayElement([
           `+1${faker.string.numeric({ length: 10 })}`,
-          undefined,
+          void 0,
         ]))(),
       requiredNullableString: faker.helpers.arrayElement([
         faker.helpers.arrayElement([

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.msw.ts
@@ -87,7 +87,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getUpdatePetResponseMock = (

--- a/samples/angular-query/src/api/endpoints/pets/pets.msw.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.msw.ts
@@ -87,7 +87,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getUpdatePetResponseMock = (

--- a/samples/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -141,7 +141,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -141,7 +141,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -41,5 +41,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -44,7 +44,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -41,5 +41,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -44,7 +44,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -22,5 +22,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -22,5 +22,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-app/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -74,5 +74,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -77,7 +77,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -74,5 +74,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -77,7 +77,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/solid-start/basic/src/api/endpoints/petstore.faker.ts
+++ b/samples/solid-start/basic/src/api/endpoints/petstore.faker.ts
@@ -22,5 +22,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();

--- a/samples/solid-start/basic/src/api/endpoints/petstore.msw.ts
+++ b/samples/solid-start/basic/src/api/endpoints/petstore.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -22,5 +22,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();

--- a/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -22,5 +22,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -25,7 +25,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.string.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.string.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -42,5 +42,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/vue-query-basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -45,7 +45,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.faker.ts
@@ -42,5 +42,5 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();

--- a/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
+++ b/samples/vue-query/vue-query-basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.msw.ts
@@ -45,7 +45,7 @@ export const getShowPetByIdResponseMock = () =>
   (() => ({
     id: faker.number.int({ min: 1, max: 99 }),
     name: faker.person.firstName(),
-    tag: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    tag: faker.helpers.arrayElement([faker.word.sample(), void 0]),
   }))();
 
 export const getListPetsMockHandler = (

--- a/tests/__snapshots__/default/schemas-zod-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/endpoints.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
@@ -39,6 +39,22 @@ export const ListPetsByCountryQueryParams = zod.object({
   tag: zod.array(zod.string()).optional().describe('include pets tag'),
 });
 
+export const listPetsByCountryResponseCountryCodeDefault = `UY`;
+
+export const ListPetsByCountryResponseItem = zod.object({
+  '@id': zod.string().optional(),
+  id: zod.number(),
+  name: zod.string(),
+  tag: zod.string().optional(),
+  age: zod.number().optional(),
+  countryCode: zod
+    .enum(['CN', 'UY'])
+    .default(listPetsByCountryResponseCountryCodeDefault),
+});
+export const ListPetsByCountryResponse = zod.array(
+  ListPetsByCountryResponseItem,
+);
+
 export const listPetsByAgePathAgeDefault = 5;
 
 export const ListPetsByAgeParams = zod.object({
@@ -59,3 +75,17 @@ export const ListPetsByAgeQueryParams = zod.object({
     .optional()
     .describe('Filter by latest birthdate.\nExample: 2020-01-01T00:00:00Z\n'),
 });
+
+export const listPetsByAgeResponseCountryCodeDefault = `UY`;
+
+export const ListPetsByAgeResponseItem = zod.object({
+  '@id': zod.string().optional(),
+  id: zod.number(),
+  name: zod.string(),
+  tag: zod.string().optional(),
+  age: zod.number().optional(),
+  countryCode: zod
+    .enum(['CN', 'UY'])
+    .default(listPetsByAgeResponseCountryCodeDefault),
+});
+export const ListPetsByAgeResponse = zod.array(ListPetsByAgeResponseItem);

--- a/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/zod/branded-types/branded-types.ts
+++ b/tests/__snapshots__/zod/branded-types/branded-types.ts
@@ -31,6 +31,45 @@ export const ListPetsHeader = zod
   })
   .brand<'ListPetsHeader'>();
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod
+  .array(ListPetsResponseItem)
+  .brand<'ListPetsResponse'>();
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/zod/petstore-tags-split/pets/pets.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/petstore/endpoints.ts
+++ b/tests/__snapshots__/zod/petstore/endpoints.ts
@@ -46,6 +46,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/preprocess/preprocess.ts
+++ b/tests/__snapshots__/zod/preprocess/preprocess.ts
@@ -34,6 +34,46 @@ export const ListPetsHeader = zod.preprocess(
   }),
 );
 
+export const ListPetsResponseItem = zod.preprocess(
+  stripNill,
+  zod
+    .union([
+      zod
+        .union([
+          zod.object({
+            cuteness: zod.number(),
+            breed: zod.enum(['Labradoodle']),
+          }),
+          zod.object({
+            length: zod.number(),
+            breed: zod.enum(['Dachshund']),
+          }),
+        ])
+        .and(
+          zod.object({
+            barksPerMinute: zod.number().optional(),
+            type: zod.enum(['dog']),
+          }),
+        ),
+      zod.object({
+        petsRequested: zod.number().optional(),
+        type: zod.enum(['cat']),
+      }),
+    ])
+    .and(
+      zod.object({
+        '@id': zod.string().optional(),
+        id: zod.number(),
+        name: zod.string(),
+        tag: zod.string().optional(),
+        email: zod.string().email().optional(),
+        callingCode: zod.enum(['+33', '+420']).optional(),
+        country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+      }),
+    ),
+);
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/schemas-false/endpoints.ts
+++ b/tests/__snapshots__/zod/schemas-false/endpoints.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/split/endpoints.ts
+++ b/tests/__snapshots__/zod/split/endpoints.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/tags/pets.ts
+++ b/tests/__snapshots__/zod/tags/pets.ts
@@ -40,6 +40,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */


### PR DESCRIPTION
Fix #3420


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content-type matching to correctly handle charset/parameterized media types (e.g., `application/json; charset=utf-8`) and multipart form-data.

* **Tests**
  * Added regression test covering multipart/form-data and JSON content keys with charset suffixes.

* **Chores**
  * Generated mock outputs updated to emit missing/nullable values using an equivalent sentinel (e.g., `void 0`).
  * Added generated response schemas for the ListPets endpoint in snapshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->