### PR TITLE
fix(zod): handle content-type with charset suffix

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1335,13 +1335,27 @@ const parseBodyAndResponse = ({
     | OpenApiRequestBodyObject;
 
   // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
-  // are skipped - unclear if this is correct behavior for root-level binary/text bodies
-  const jsonMedia = resolvedRef.content?.['application/json'];
-  const formDataMedia = resolvedRef.content?.['multipart/form-data'];
-  const [contentType, mediaType] = jsonMedia
-    ? (['application/json', jsonMedia] as const)
-    : formDataMedia
-      ? (['multipart/form-data', formDataMedia] as const)
+  // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
+  // are skipped - unclear if this is correct behavior for root-level binary/text bodies.
+  const contentEntries = Object.entries(resolvedRef.content ?? {});
+
+  const jsonContent = contentEntries.find(
+    isMediaType(
+      // application/json
+      // application/geo+json
+      // application/ld+json
+      // application/manifest+json
+      // application/vnd.api+json (and other valid vendor subtypes)
+      String.raw`^application\/([^/;]+\+)?json$`,
+    ),
+  );
+  const formDataContent = contentEntries.find(
+    isMediaType(String.raw`^multipart\/form-data$`),
+  );
+  const [contentType, mediaType] = jsonContent
+    ? (['application/json', jsonContent[1]] as const)
+    : formDataContent
+      ? (['multipart/form-data', formDataContent[1]] as const)
       : [undefined, undefined];
 
   const schema = mediaType?.schema;
@@ -1352,7 +1366,6 @@ const parseBodyAndResponse = ({
       isArray: false,
     };
   }
-
   const encoding = mediaType.encoding;
 
   const resolvedJsonSchema = dereference(schema, context);
@@ -1419,6 +1432,11 @@ const parseBodyAndResponse = ({
     isArray: false,
   };
 };
+
+const isMediaType =
+  (pattern: string) =>
+  ([contentType]: [string, object]): boolean =>
+    new RegExp(pattern).test(contentType.split(';')[0].trim().toLowerCase());
 
 const getSingleResponse = (
   responses:

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -6275,6 +6275,136 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
 
 `);
   });
+
+  it('content type with charset precision: comprehensive content type handling', async () => {
+    // Matches type gen test structure in res-req-types.test.ts
+    const schema = {
+      pathRoute: '/upload-form',
+      context: {
+        spec: {
+          paths: {
+            '/upload-form': {
+              post: {
+                operationId: 'uploadForm',
+                requestBody: {
+                  required: true,
+                  content: {
+                    'multipart/form-data; charset=utf-8': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          encBinary: { type: 'string' },
+                          encText: { type: 'string' },
+                          cmtBinary: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                          },
+                          cmtText: {
+                            type: 'string',
+                            contentMediaType: 'application/xml',
+                          },
+                          encOverride: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                          },
+                          formatBinary: { type: 'string', format: 'binary' },
+                          base64Field: {
+                            type: 'string',
+                            contentMediaType: 'image/png',
+                            contentEncoding: 'base64',
+                          },
+                          metadata: {
+                            type: 'object',
+                            properties: { name: { type: 'string' } },
+                          },
+                        },
+                        required: [
+                          'encBinary',
+                          'encText',
+                          'cmtBinary',
+                          'cmtText',
+                          'encOverride',
+                          'formatBinary',
+                          'base64Field',
+                          'metadata',
+                        ],
+                      },
+                      encoding: {
+                        encBinary: { contentType: 'image/png' },
+                        encText: { contentType: 'text/plain' },
+                        encOverride: { contentType: 'text/csv' },
+                        metadata: { contentType: 'application/json' },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    content: {
+                      'application/json; charset=utf-8': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            success: { type: 'boolean' },
+                            uploaded: { type: 'number' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+    const result = await generateZod(
+      {
+        pathRoute: '/upload-form',
+        verb: 'post',
+        operationName: 'uploadForm',
+        override: {
+          ...zodOverride,
+          zod: {
+            ...zodOverride.zod,
+            generate: { ...zodOverride.zod.generate, response: true },
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+    // encBinary: encoding image/png → File
+    // encText: encoding text/plain → File | string
+    // cmtBinary: contentMediaType image/png → File
+    // cmtText: contentMediaType application/xml → File | string
+    // encOverride: encoding text/csv overrides contentMediaType image/png → File | string
+    // formatBinary: format: binary → File (same as instanceof check)
+    // base64Field: contentEncoding base64 → stays string
+    // metadata: object → object schema
+    expect(result.implementation)
+      .toBe(`export const UploadFormBody = zod.object({
+  "encBinary": zod.instanceof(File),
+  "encText": zod.instanceof(File).or(zod.string()),
+  "cmtBinary": zod.instanceof(File),
+  "cmtText": zod.instanceof(File).or(zod.string()),
+  "encOverride": zod.instanceof(File).or(zod.string()),
+  "formatBinary": zod.instanceof(File),
+  "base64Field": zod.string(),
+  "metadata": zod.object({
+  "name": zod.string().optional()
+})
+})
+
+export const UploadFormResponse = zod.object({
+  "success": zod.boolean().optional(),
+  "uploaded": zod.number().optional()
+})
+
+`);
+  });
 });
 
 describe('zod split mode regressions', () => {

--- a/tests/__snapshots__/default/schemas-zod-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/endpoints.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
@@ -39,6 +39,22 @@ export const ListPetsByCountryQueryParams = zod.object({
   tag: zod.array(zod.string()).optional().describe('include pets tag'),
 });
 
+export const listPetsByCountryResponseCountryCodeDefault = `UY`;
+
+export const ListPetsByCountryResponseItem = zod.object({
+  '@id': zod.string().optional(),
+  id: zod.number(),
+  name: zod.string(),
+  tag: zod.string().optional(),
+  age: zod.number().optional(),
+  countryCode: zod
+    .enum(['CN', 'UY'])
+    .default(listPetsByCountryResponseCountryCodeDefault),
+});
+export const ListPetsByCountryResponse = zod.array(
+  ListPetsByCountryResponseItem,
+);
+
 export const listPetsByAgePathAgeDefault = 5;
 
 export const ListPetsByAgeParams = zod.object({
@@ -59,3 +75,17 @@ export const ListPetsByAgeQueryParams = zod.object({
     .optional()
     .describe('Filter by latest birthdate.\nExample: 2020-01-01T00:00:00Z\n'),
 });
+
+export const listPetsByAgeResponseCountryCodeDefault = `UY`;
+
+export const ListPetsByAgeResponseItem = zod.object({
+  '@id': zod.string().optional(),
+  id: zod.number(),
+  name: zod.string(),
+  tag: zod.string().optional(),
+  age: zod.number().optional(),
+  countryCode: zod
+    .enum(['CN', 'UY'])
+    .default(listPetsByAgeResponseCountryCodeDefault),
+});
+export const ListPetsByAgeResponse = zod.array(ListPetsByAgeResponseItem);

--- a/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
@@ -22,6 +22,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 export const CreatePetsQueryParams = zod.object({
   limit: zod
     .string()

--- a/tests/__snapshots__/zod/branded-types/branded-types.ts
+++ b/tests/__snapshots__/zod/branded-types/branded-types.ts
@@ -31,6 +31,45 @@ export const ListPetsHeader = zod
   })
   .brand<'ListPetsHeader'>();
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod
+  .array(ListPetsResponseItem)
+  .brand<'ListPetsResponse'>();
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/zod/petstore-tags-split/pets/pets.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/petstore/endpoints.ts
+++ b/tests/__snapshots__/zod/petstore/endpoints.ts
@@ -46,6 +46,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/preprocess/preprocess.ts
+++ b/tests/__snapshots__/zod/preprocess/preprocess.ts
@@ -34,6 +34,46 @@ export const ListPetsHeader = zod.preprocess(
   }),
 );
 
+export const ListPetsResponseItem = zod.preprocess(
+  stripNill,
+  zod
+    .union([
+      zod
+        .union([
+          zod.object({
+            cuteness: zod.number(),
+            breed: zod.enum(['Labradoodle']),
+          }),
+          zod.object({
+            length: zod.number(),
+            breed: zod.enum(['Dachshund']),
+          }),
+        ])
+        .and(
+          zod.object({
+            barksPerMinute: zod.number().optional(),
+            type: zod.enum(['dog']),
+          }),
+        ),
+      zod.object({
+        petsRequested: zod.number().optional(),
+        type: zod.enum(['cat']),
+      }),
+    ])
+    .and(
+      zod.object({
+        '@id': zod.string().optional(),
+        id: zod.number(),
+        name: zod.string(),
+        tag: zod.string().optional(),
+        email: zod.string().email().optional(),
+        callingCode: zod.enum(['+33', '+420']).optional(),
+        country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+      }),
+    ),
+);
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/schemas-false/endpoints.ts
+++ b/tests/__snapshots__/zod/schemas-false/endpoints.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/split/endpoints.ts
+++ b/tests/__snapshots__/zod/split/endpoints.ts
@@ -25,6 +25,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */

--- a/tests/__snapshots__/zod/tags/pets.ts
+++ b/tests/__snapshots__/zod/tags/pets.ts
@@ -40,6 +40,43 @@ export const ListPetsHeader = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']).describe('Header parameters'),
 });
 
+export const ListPetsResponseItem = zod
+  .union([
+    zod
+      .union([
+        zod.object({
+          cuteness: zod.number(),
+          breed: zod.enum(['Labradoodle']),
+        }),
+        zod.object({
+          length: zod.number(),
+          breed: zod.enum(['Dachshund']),
+        }),
+      ])
+      .and(
+        zod.object({
+          barksPerMinute: zod.number().optional(),
+          type: zod.enum(['dog']),
+        }),
+      ),
+    zod.object({
+      petsRequested: zod.number().optional(),
+      type: zod.enum(['cat']),
+    }),
+  ])
+  .and(
+    zod.object({
+      '@id': zod.string().optional(),
+      id: zod.number(),
+      name: zod.string(),
+      tag: zod.string().optional(),
+      email: zod.string().email().optional(),
+      callingCode: zod.enum(['+33', '+420']).optional(),
+      country: zod.enum(["People's Republic of China", 'Uruguay']).optional(),
+    }),
+  );
+export const ListPetsResponse = zod.array(ListPetsResponseItem);
+
 /**
  * @summary Create a pet
  */


### PR DESCRIPTION
## Summary

Fixes #3285.

`packages/zod/src/index.ts` was looking up `application/json` and `multipart/form-data` by exact key, so:

- request/response bodies declared as `application/json; charset=utf-8` (or any other media-type parameter) silently fell through and no Zod parser was generated, and
- vendor JSON subtypes like `application/geo+json`, `application/ld+json`, `application/vnd.api+json` were ignored even though they are valid JSON.

This PR introduces a small `isMediaType` helper that strips media-type parameters and matches with a regex (`^application/([^/;]+\+)?json$` for JSON, `^multipart/form-data$` for form data), so all of the above now produce the same Zod schemas as the bare `application/json` case.

## Test Plan

- New regression test in `packages/zod/src/zod.test.ts` covering both shapes (multipart/form-data, parameterized JSON).
- 20 generated Zod snapshots under `tests/__snapshots__/.../*.zod.ts` are updated — the same petstore spec exposes a `ListPetsResponseItem`/`ListPetsResponse` that previously wasn't generated because its response key carried a charset suffix.
- `bun run format:check`, `bun run build`, `bun run typecheck`, `bun run lint`, `bun run test`, `bun run test:snapshots`, `bun run --filter orval-tests build` all green locally.

## Notes for reviewers

Supersedes #3404 and #3430 — both PRs implement the same `packages/zod/src/index.ts` change. This PR takes the zod fix and the legitimate `tests/__snapshots__/` drift from those, and leaves `samples/**` untouched. (The `samples/**` `undefined` → `void 0` substitutions in #3430 were producing snapshot mismatches on CI because the orval mock generator only emits `undefined`; see https://github.com/orval-labs/orval/pull/3430#issuecomment-4528982132 for the full diagnosis.)

Full credit to @pierre-isabel-bbc for the original fix in #3404 and @melloware for picking it up in #3430 — both are tagged as co-authors on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced JSON content type detection to support vendor-specific JSON formats (e.g., `application/*+json`) and charset parameters in media types.
  * Added response schema generation for API endpoints across multiple configurations.

* **Tests**
  * Added test coverage for content type handling with charset suffixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->