### PR TITLE
feat(mcp): use `server.registerTool` instead of `server.tool`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -977,7 +977,7 @@
       "hono": "4.11.9",
     },
     "mcp": {
-      "@modelcontextprotocol/sdk": "1.26.0",
+      "@modelcontextprotocol/sdk": "1.29.0",
     },
     "react": {
       "@tanstack/react-query": "5.62.16",
@@ -1430,7 +1430,7 @@
 
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -4038,6 +4038,8 @@
 
     "@angular/cli/@angular-devkit/core": ["@angular-devkit/core@21.2.2", "", { "dependencies": { "ajv": "8.18.0", "ajv-formats": "3.0.1", "jsonc-parser": "3.3.1", "picomatch": "4.0.3", "rxjs": "7.8.2", "source-map": "0.7.6" }, "peerDependencies": { "chokidar": "^5.0.0" }, "optionalPeers": ["chokidar"] }, "sha512-xUeKGe4BDQpkz0E6fnAPIJXE0y0nqtap0KhJIBhvN7xi3NenIzTmoi6T9Yv5OOBUdLZbOm4SOel8MhdXiIBpAQ=="],
 
+    "@angular/cli/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
+
     "@angular/cli/listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
 
     "@angular/cli/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -4097,6 +4099,8 @@
     "@listr2/prompt-adapter-inquirer/listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
 
     "@mapbox/node-pre-gyp/nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
+
+    "@modelcontextprotocol/sdk/hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -4519,8 +4523,6 @@
     "ora/log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 
     "ora/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
-
-    "orval-tests/@tanstack/angular-query-experimental": ["@tanstack/angular-query-experimental@5.90.16", "", { "dependencies": { "@tanstack/query-core": "5.90.12" }, "optionalDependencies": { "@tanstack/query-devtools": "5.91.1" }, "peerDependencies": { "@angular/common": ">=16.0.0", "@angular/core": ">=16.0.0" } }, "sha512-ezXyxuaSA6kpwUxwrxo5Tf3B7KL7mb7cxhLnun/RMlw6h3ZQJzl1cJgrvN97+C0AeHoucmK7RwhEoIY12gY7WA=="],
 
     "parse-json/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
@@ -5163,10 +5165,6 @@
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "ora/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "orval-tests/@tanstack/angular-query-experimental/@tanstack/query-core": ["@tanstack/query-core@5.90.12", "", {}, "sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg=="],
-
-    "orval-tests/@tanstack/angular-query-experimental/@tanstack/query-devtools": ["@tanstack/query-devtools@5.91.1", "", {}, "sha512-l8bxjk6BMsCaVQH6NzQEE/bEgFy1hAs5qbgXl0xhzezlaQbPk6Mgz9BqEg2vTLPOHD8N4k+w/gdgCbEzecGyNg=="],
 
     "read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "@tanstack/react-query": "5.62.16"
     },
     "mcp": {
-      "@modelcontextprotocol/sdk": "1.26.0"
+      "@modelcontextprotocol/sdk": "1.29.0"
     }
   },
   "devEngines": {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -195,29 +195,28 @@ export const generateServer = (
       const pascalOperationName = pascal(verbOption.operationName);
       const inputSchemaTypes = [];
       if (verbOption.params.length > 0)
-        inputSchemaTypes.push(`  pathParams: ${pascalOperationName}Params`);
+        inputSchemaTypes.push(`pathParams: ${pascalOperationName}Params`);
       if (verbOption.queryParams)
-        inputSchemaTypes.push(
-          `  queryParams: ${pascalOperationName}QueryParams`,
-        );
+        inputSchemaTypes.push(`queryParams: ${pascalOperationName}QueryParams`);
       if (verbOption.body.definition)
-        inputSchemaTypes.push(`  bodyParams: ${pascalOperationName}Body`);
+        inputSchemaTypes.push(`bodyParams: ${pascalOperationName}Body`);
 
       const inputSchemaImplementation =
         inputSchemaTypes.length > 0
-          ? `  {
-  ${inputSchemaTypes.join(',\n  ')}
-  },`
+          ? `\n    inputSchema: {\n      ${inputSchemaTypes.join(',\n      ')}\n    },`
           : '';
 
-      const handlerCallImplementation = inputSchemaImplementation
-        ? `(args) => ${verbOption.operationName}Handler(args, options)`
-        : `() => ${verbOption.operationName}Handler(options)`;
+      const handlerCallImplementation =
+        inputSchemaTypes.length > 0
+          ? `(args) => ${verbOption.operationName}Handler(args, options)`
+          : `() => ${verbOption.operationName}Handler(options)`;
 
       const toolImplementation = `
-server.tool(
+server.registerTool(
   '${jsStringEscape(verbOption.operationName)}',
-  '${jsStringEscape(verbOption.summary ?? '')}',${inputSchemaImplementation ? `\n${inputSchemaImplementation}` : ''}
+  {
+    description: '${jsStringEscape(verbOption.summary ?? '')}',${inputSchemaImplementation}
+  },
   ${handlerCallImplementation}
 );`;
 

--- a/samples/mcp/custom-server/__snapshots__/server.ts
+++ b/samples/mcp/custom-server/__snapshots__/server.ts
@@ -51,101 +51,129 @@ const createMcpServer = (options?: RequestInit) => {
     version: '1.0.0',
   });
 
-  server.tool(
+  server.registerTool(
     'findPetsByStatus',
-    'Finds Pets by status.',
     {
-      queryParams: FindPetsByStatusQueryParams,
+      description: 'Finds Pets by status.',
+      inputSchema: {
+        queryParams: FindPetsByStatusQueryParams,
+      },
     },
     (args) => findPetsByStatusHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'findPetsByTags',
-    'Finds Pets by tags.',
     {
-      queryParams: FindPetsByTagsQueryParams,
+      description: 'Finds Pets by tags.',
+      inputSchema: {
+        queryParams: FindPetsByTagsQueryParams,
+      },
     },
     (args) => findPetsByTagsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'getPetById',
-    'Find pet by ID.',
     {
-      pathParams: GetPetByIdParams,
+      description: 'Find pet by ID.',
+      inputSchema: {
+        pathParams: GetPetByIdParams,
+      },
     },
     (args) => getPetByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'updatePetWithForm',
-    'Updates a pet in the store with form data.',
     {
-      pathParams: UpdatePetWithFormParams,
-      queryParams: UpdatePetWithFormQueryParams,
+      description: 'Updates a pet in the store with form data.',
+      inputSchema: {
+        pathParams: UpdatePetWithFormParams,
+        queryParams: UpdatePetWithFormQueryParams,
+      },
     },
     (args) => updatePetWithFormHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deletePet',
-    'Deletes a pet.',
     {
-      pathParams: DeletePetParams,
+      description: 'Deletes a pet.',
+      inputSchema: {
+        pathParams: DeletePetParams,
+      },
     },
     (args) => deletePetHandler(args, options),
   );
 
-  server.tool('getInventory', 'Returns pet inventories by status.', () =>
-    getInventoryHandler(options),
+  server.registerTool(
+    'getInventory',
+    {
+      description: 'Returns pet inventories by status.',
+    },
+    () => getInventoryHandler(options),
   );
 
-  server.tool(
+  server.registerTool(
     'getOrderById',
-    'Find purchase order by ID.',
     {
-      pathParams: GetOrderByIdParams,
+      description: 'Find purchase order by ID.',
+      inputSchema: {
+        pathParams: GetOrderByIdParams,
+      },
     },
     (args) => getOrderByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deleteOrder',
-    'Delete purchase order by identifier.',
     {
-      pathParams: DeleteOrderParams,
+      description: 'Delete purchase order by identifier.',
+      inputSchema: {
+        pathParams: DeleteOrderParams,
+      },
     },
     (args) => deleteOrderHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'loginUser',
-    'Logs user into the system.',
     {
-      queryParams: LoginUserQueryParams,
+      description: 'Logs user into the system.',
+      inputSchema: {
+        queryParams: LoginUserQueryParams,
+      },
     },
     (args) => loginUserHandler(args, options),
   );
 
-  server.tool('logoutUser', 'Logs out current logged in user session.', () =>
-    logoutUserHandler(options),
+  server.registerTool(
+    'logoutUser',
+    {
+      description: 'Logs out current logged in user session.',
+    },
+    () => logoutUserHandler(options),
   );
 
-  server.tool(
+  server.registerTool(
     'getUserByName',
-    'Get user by user name.',
     {
-      pathParams: GetUserByNameParams,
+      description: 'Get user by user name.',
+      inputSchema: {
+        pathParams: GetUserByNameParams,
+      },
     },
     (args) => getUserByNameHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deleteUser',
-    'Delete user resource.',
     {
-      pathParams: DeleteUserParams,
+      description: 'Delete user resource.',
+      inputSchema: {
+        pathParams: DeleteUserParams,
+      },
     },
     (args) => deleteUserHandler(args, options),
   );

--- a/samples/mcp/custom-server/src/server.ts
+++ b/samples/mcp/custom-server/src/server.ts
@@ -51,101 +51,129 @@ const createMcpServer = (options?: RequestInit) => {
     version: '1.0.0',
   });
 
-  server.tool(
+  server.registerTool(
     'findPetsByStatus',
-    'Finds Pets by status.',
     {
-      queryParams: FindPetsByStatusQueryParams,
+      description: 'Finds Pets by status.',
+      inputSchema: {
+        queryParams: FindPetsByStatusQueryParams,
+      },
     },
     (args) => findPetsByStatusHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'findPetsByTags',
-    'Finds Pets by tags.',
     {
-      queryParams: FindPetsByTagsQueryParams,
+      description: 'Finds Pets by tags.',
+      inputSchema: {
+        queryParams: FindPetsByTagsQueryParams,
+      },
     },
     (args) => findPetsByTagsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'getPetById',
-    'Find pet by ID.',
     {
-      pathParams: GetPetByIdParams,
+      description: 'Find pet by ID.',
+      inputSchema: {
+        pathParams: GetPetByIdParams,
+      },
     },
     (args) => getPetByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'updatePetWithForm',
-    'Updates a pet in the store with form data.',
     {
-      pathParams: UpdatePetWithFormParams,
-      queryParams: UpdatePetWithFormQueryParams,
+      description: 'Updates a pet in the store with form data.',
+      inputSchema: {
+        pathParams: UpdatePetWithFormParams,
+        queryParams: UpdatePetWithFormQueryParams,
+      },
     },
     (args) => updatePetWithFormHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deletePet',
-    'Deletes a pet.',
     {
-      pathParams: DeletePetParams,
+      description: 'Deletes a pet.',
+      inputSchema: {
+        pathParams: DeletePetParams,
+      },
     },
     (args) => deletePetHandler(args, options),
   );
 
-  server.tool('getInventory', 'Returns pet inventories by status.', () =>
-    getInventoryHandler(options),
+  server.registerTool(
+    'getInventory',
+    {
+      description: 'Returns pet inventories by status.',
+    },
+    () => getInventoryHandler(options),
   );
 
-  server.tool(
+  server.registerTool(
     'getOrderById',
-    'Find purchase order by ID.',
     {
-      pathParams: GetOrderByIdParams,
+      description: 'Find purchase order by ID.',
+      inputSchema: {
+        pathParams: GetOrderByIdParams,
+      },
     },
     (args) => getOrderByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deleteOrder',
-    'Delete purchase order by identifier.',
     {
-      pathParams: DeleteOrderParams,
+      description: 'Delete purchase order by identifier.',
+      inputSchema: {
+        pathParams: DeleteOrderParams,
+      },
     },
     (args) => deleteOrderHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'loginUser',
-    'Logs user into the system.',
     {
-      queryParams: LoginUserQueryParams,
+      description: 'Logs user into the system.',
+      inputSchema: {
+        queryParams: LoginUserQueryParams,
+      },
     },
     (args) => loginUserHandler(args, options),
   );
 
-  server.tool('logoutUser', 'Logs out current logged in user session.', () =>
-    logoutUserHandler(options),
+  server.registerTool(
+    'logoutUser',
+    {
+      description: 'Logs out current logged in user session.',
+    },
+    () => logoutUserHandler(options),
   );
 
-  server.tool(
+  server.registerTool(
     'getUserByName',
-    'Get user by user name.',
     {
-      pathParams: GetUserByNameParams,
+      description: 'Get user by user name.',
+      inputSchema: {
+        pathParams: GetUserByNameParams,
+      },
     },
     (args) => getUserByNameHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deleteUser',
-    'Delete user resource.',
     {
-      pathParams: DeleteUserParams,
+      description: 'Delete user resource.',
+      inputSchema: {
+        pathParams: DeleteUserParams,
+      },
     },
     (args) => deleteUserHandler(args, options),
   );

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -51,101 +51,129 @@ const createMcpServer = (options?: RequestInit) => {
     version: '1.0.0',
   });
 
-  server.tool(
+  server.registerTool(
     'findPetsByStatus',
-    'Finds Pets by status.',
     {
-      queryParams: FindPetsByStatusQueryParams,
+      description: 'Finds Pets by status.',
+      inputSchema: {
+        queryParams: FindPetsByStatusQueryParams,
+      },
     },
     (args) => findPetsByStatusHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'findPetsByTags',
-    'Finds Pets by tags.',
     {
-      queryParams: FindPetsByTagsQueryParams,
+      description: 'Finds Pets by tags.',
+      inputSchema: {
+        queryParams: FindPetsByTagsQueryParams,
+      },
     },
     (args) => findPetsByTagsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'getPetById',
-    'Find pet by ID.',
     {
-      pathParams: GetPetByIdParams,
+      description: 'Find pet by ID.',
+      inputSchema: {
+        pathParams: GetPetByIdParams,
+      },
     },
     (args) => getPetByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'updatePetWithForm',
-    'Updates a pet in the store with form data.',
     {
-      pathParams: UpdatePetWithFormParams,
-      queryParams: UpdatePetWithFormQueryParams,
+      description: 'Updates a pet in the store with form data.',
+      inputSchema: {
+        pathParams: UpdatePetWithFormParams,
+        queryParams: UpdatePetWithFormQueryParams,
+      },
     },
     (args) => updatePetWithFormHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deletePet',
-    'Deletes a pet.',
     {
-      pathParams: DeletePetParams,
+      description: 'Deletes a pet.',
+      inputSchema: {
+        pathParams: DeletePetParams,
+      },
     },
     (args) => deletePetHandler(args, options),
   );
 
-  server.tool('getInventory', 'Returns pet inventories by status.', () =>
-    getInventoryHandler(options),
+  server.registerTool(
+    'getInventory',
+    {
+      description: 'Returns pet inventories by status.',
+    },
+    () => getInventoryHandler(options),
   );
 
-  server.tool(
+  server.registerTool(
     'getOrderById',
-    'Find purchase order by ID.',
     {
-      pathParams: GetOrderByIdParams,
+      description: 'Find purchase order by ID.',
+      inputSchema: {
+        pathParams: GetOrderByIdParams,
+      },
     },
     (args) => getOrderByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deleteOrder',
-    'Delete purchase order by identifier.',
     {
-      pathParams: DeleteOrderParams,
+      description: 'Delete purchase order by identifier.',
+      inputSchema: {
+        pathParams: DeleteOrderParams,
+      },
     },
     (args) => deleteOrderHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'loginUser',
-    'Logs user into the system.',
     {
-      queryParams: LoginUserQueryParams,
+      description: 'Logs user into the system.',
+      inputSchema: {
+        queryParams: LoginUserQueryParams,
+      },
     },
     (args) => loginUserHandler(args, options),
   );
 
-  server.tool('logoutUser', 'Logs out current logged in user session.', () =>
-    logoutUserHandler(options),
+  server.registerTool(
+    'logoutUser',
+    {
+      description: 'Logs out current logged in user session.',
+    },
+    () => logoutUserHandler(options),
   );
 
-  server.tool(
+  server.registerTool(
     'getUserByName',
-    'Get user by user name.',
     {
-      pathParams: GetUserByNameParams,
+      description: 'Get user by user name.',
+      inputSchema: {
+        pathParams: GetUserByNameParams,
+      },
     },
     (args) => getUserByNameHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deleteUser',
-    'Delete user resource.',
     {
-      pathParams: DeleteUserParams,
+      description: 'Delete user resource.',
+      inputSchema: {
+        pathParams: DeleteUserParams,
+      },
     },
     (args) => deleteUserHandler(args, options),
   );

--- a/tests/__snapshots__/mcp/custom-server/server.ts
+++ b/tests/__snapshots__/mcp/custom-server/server.ts
@@ -32,50 +32,66 @@ const createMcpServer = (options?: RequestInit) => {
     version: '1.0.0',
   });
 
-  server.tool(
+  server.registerTool(
     'listPets',
-    'List all pets',
     {
-      queryParams: ListPetsQueryParams,
+      description: 'List all pets',
+      inputSchema: {
+        queryParams: ListPetsQueryParams,
+      },
     },
     (args) => listPetsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'createPets',
-    'Create a pet',
     {
-      queryParams: CreatePetsQueryParams,
-      bodyParams: CreatePetsBody,
+      description: 'Create a pet',
+      inputSchema: {
+        queryParams: CreatePetsQueryParams,
+        bodyParams: CreatePetsBody,
+      },
     },
     (args) => createPetsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'showPetById',
-    'Info for a specific pet',
     {
-      pathParams: ShowPetByIdParams,
+      description: 'Info for a specific pet',
+      inputSchema: {
+        pathParams: ShowPetByIdParams,
+      },
     },
     (args) => showPetByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deletePetById',
-    'Deletes a specific pet',
     {
-      pathParams: DeletePetByIdParams,
+      description: 'Deletes a specific pet',
+      inputSchema: {
+        pathParams: DeletePetByIdParams,
+      },
     },
     (args) => deletePetByIdHandler(args, options),
   );
 
-  server.tool('healthCheck', 'health check', () => healthCheckHandler(options));
-
-  server.tool(
-    'showPetWithOwner',
-    'combinate nullable and $ref',
+  server.registerTool(
+    'healthCheck',
     {
-      pathParams: ShowPetWithOwnerParams,
+      description: 'health check',
+    },
+    () => healthCheckHandler(options),
+  );
+
+  server.registerTool(
+    'showPetWithOwner',
+    {
+      description: 'combinate nullable and $ref',
+      inputSchema: {
+        pathParams: ShowPetWithOwnerParams,
+      },
     },
     (args) => showPetWithOwnerHandler(args, options),
   );

--- a/tests/__snapshots__/mcp/single/server.ts
+++ b/tests/__snapshots__/mcp/single/server.ts
@@ -32,50 +32,66 @@ const createMcpServer = (options?: RequestInit) => {
     version: '1.0.0',
   });
 
-  server.tool(
+  server.registerTool(
     'listPets',
-    'List all pets',
     {
-      queryParams: ListPetsQueryParams,
+      description: 'List all pets',
+      inputSchema: {
+        queryParams: ListPetsQueryParams,
+      },
     },
     (args) => listPetsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'createPets',
-    'Create a pet',
     {
-      queryParams: CreatePetsQueryParams,
-      bodyParams: CreatePetsBody,
+      description: 'Create a pet',
+      inputSchema: {
+        queryParams: CreatePetsQueryParams,
+        bodyParams: CreatePetsBody,
+      },
     },
     (args) => createPetsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'showPetById',
-    'Info for a specific pet',
     {
-      pathParams: ShowPetByIdParams,
+      description: 'Info for a specific pet',
+      inputSchema: {
+        pathParams: ShowPetByIdParams,
+      },
     },
     (args) => showPetByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deletePetById',
-    'Deletes a specific pet',
     {
-      pathParams: DeletePetByIdParams,
+      description: 'Deletes a specific pet',
+      inputSchema: {
+        pathParams: DeletePetByIdParams,
+      },
     },
     (args) => deletePetByIdHandler(args, options),
   );
 
-  server.tool('healthCheck', 'health check', () => healthCheckHandler(options));
-
-  server.tool(
-    'showPetWithOwner',
-    'combinate nullable and $ref',
+  server.registerTool(
+    'healthCheck',
     {
-      pathParams: ShowPetWithOwnerParams,
+      description: 'health check',
+    },
+    () => healthCheckHandler(options),
+  );
+
+  server.registerTool(
+    'showPetWithOwner',
+    {
+      description: 'combinate nullable and $ref',
+      inputSchema: {
+        pathParams: ShowPetWithOwnerParams,
+      },
     },
     (args) => showPetWithOwnerHandler(args, options),
   );

--- a/tests/__snapshots__/mcp/zod-schema-response/server.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/server.ts
@@ -32,50 +32,66 @@ const createMcpServer = (options?: RequestInit) => {
     version: '1.0.0',
   });
 
-  server.tool(
+  server.registerTool(
     'listPets',
-    'List all pets',
     {
-      queryParams: ListPetsQueryParams,
+      description: 'List all pets',
+      inputSchema: {
+        queryParams: ListPetsQueryParams,
+      },
     },
     (args) => listPetsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'createPets',
-    'Create a pet',
     {
-      queryParams: CreatePetsQueryParams,
-      bodyParams: CreatePetsBody,
+      description: 'Create a pet',
+      inputSchema: {
+        queryParams: CreatePetsQueryParams,
+        bodyParams: CreatePetsBody,
+      },
     },
     (args) => createPetsHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'showPetById',
-    'Info for a specific pet',
     {
-      pathParams: ShowPetByIdParams,
+      description: 'Info for a specific pet',
+      inputSchema: {
+        pathParams: ShowPetByIdParams,
+      },
     },
     (args) => showPetByIdHandler(args, options),
   );
 
-  server.tool(
+  server.registerTool(
     'deletePetById',
-    'Deletes a specific pet',
     {
-      pathParams: DeletePetByIdParams,
+      description: 'Deletes a specific pet',
+      inputSchema: {
+        pathParams: DeletePetByIdParams,
+      },
     },
     (args) => deletePetByIdHandler(args, options),
   );
 
-  server.tool('healthCheck', 'health check', () => healthCheckHandler(options));
-
-  server.tool(
-    'showPetWithOwner',
-    'combinate nullable and $ref',
+  server.registerTool(
+    'healthCheck',
     {
-      pathParams: ShowPetWithOwnerParams,
+      description: 'health check',
+    },
+    () => healthCheckHandler(options),
+  );
+
+  server.registerTool(
+    'showPetWithOwner',
+    {
+      description: 'combinate nullable and $ref',
+      inputSchema: {
+        pathParams: ShowPetWithOwnerParams,
+      },
     },
     (args) => showPetWithOwnerHandler(args, options),
   );

--- a/tests/scripts/typecheck-generated.mjs
+++ b/tests/scripts/typecheck-generated.mjs
@@ -44,7 +44,7 @@ for (const folder of folders) {
 
   // Bun's flat node_modules makes the MCP SDK resolve `zod` to the project's v3.25
   // which ships both v3 and v4 compat types. The SDK's zod-compat.d.ts loads both
-  // type systems, causing exponential type inference in server.tool() calls.
+  // type systems, causing exponential type inference in server.registerTool() calls.
   // Yarn avoided this by nesting a separate zod@4.x for the SDK.
   // server.ts is pure glue — handlers, schemas and HTTP client are still fully checked.
   if (folder === 'mcp') {


### PR DESCRIPTION
## Summary
- Update `@modelcontextprotocol/sdk` from `1.26.0` to `1.29.0`
- Migrate generated code from deprecated `server.tool()` to `server.registerTool()`, which is the recommended API in the latest version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@modelcontextprotocol/sdk` to version 1.29.0 for latest SDK improvements and bug fixes.

* **Refactor**
  * Modernized MCP tool registration API to use an object-based configuration format for improved code clarity and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->