### PR TITLE
fix(core): read x-enum-varnames from parameter level for primitive query enums

### DIFF
--- a/packages/core/src/getters/query-params.test.ts
+++ b/packages/core/src/getters/query-params.test.ts
@@ -136,6 +136,47 @@ describe('getQueryParams getter', () => {
     });
   }
 
+  it('uses x-enum-varnames on the parameter itself for primitive enums (post Swagger 2 upgrade)', () => {
+    // After Swagger 2 → OAS 3 upgrade, primitive enum params end up with
+    // `schema` holding the type/enum but `x-enum-varnames` left at the
+    // parameter level.
+    const constContext = createTestContextSpec({
+      override: {
+        enumGenerationType: EnumGeneration.CONST,
+      },
+    });
+
+    const result = getQueryParams({
+      queryParams: [
+        {
+          parameter: {
+            name: 'sortBy',
+            in: 'query',
+            schema: {
+              type: 'integer',
+              enum: [0, 1, 2],
+            },
+            // @ts-expect-error vendor extension
+            'x-enum-varnames': [
+              'SORT_BY_UNSPECIFIED',
+              'SORT_BY_START',
+              'SORT_BY_END',
+            ],
+          },
+          imports: [],
+        },
+      ],
+      operationName: 'list',
+      context: constContext,
+    });
+
+    const enumDep = result?.deps[0];
+    expect(enumDep?.model).toContain('SORT_BY_UNSPECIFIED: 0');
+    expect(enumDep?.model).toContain('SORT_BY_START: 1');
+    expect(enumDep?.model).toContain('SORT_BY_END: 2');
+    expect(enumDep?.model).not.toContain('NUMBER_');
+  });
+
   it('queryParamWithDescription should be documented', () => {
     const result = getQueryParams({
       queryParams: [

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -230,12 +230,19 @@ function getQueryParamsTypes(
 
     if (resolvedValue.isEnum && !resolvedValue.isRef) {
       const enumName = queryName;
+      // Vendor extensions like `x-enum-varnames` may live on the parameter
+      // itself rather than inside `schema` — notably after a Swagger 2 → OAS 3
+      // upgrade, which moves standard schema fields into `schema` but leaves
+      // vendor extensions at the parameter level.
+      const parameterAsSchema = parameter as OpenApiSchemaObject;
       const enumValue = getEnum(
         resolvedValue.value,
         enumName,
-        getEnumNames(resolvedValue.originalSchema),
+        getEnumNames(resolvedValue.originalSchema) ??
+          getEnumNames(parameterAsSchema),
         context.output.override.enumGenerationType,
-        getEnumDescriptions(resolvedValue.originalSchema),
+        getEnumDescriptions(resolvedValue.originalSchema) ??
+          getEnumDescriptions(parameterAsSchema),
         context.output.override.namingConvention.enum,
       );
 


### PR DESCRIPTION
## Summary

- When a Swagger 2.0 spec is upgraded to OpenAPI 3 by `@scalar/openapi-upgrader`, only whitelisted standard schema fields (`type`, `enum`, `format`, ...) are moved into the parameter's `schema`. Vendor extensions like `x-enum-varnames` are left at the parameter level.
- As a result, primitive enum query parameters lost their varnames after upgrade and fell back to `NUMBER_0`, `NUMBER_1`, ... in the generated enum. Array-enum parameters were not affected because `x-enum-varnames` was already nested inside `items` (which the upgrader preserves as-is).
- Fall back to the parameter object itself for `x-enum-varnames` / `x-enum-descriptions` when the resolved schema does not carry them.

## Test plan

- [x] Added a unit test in `packages/core/src/getters/query-params.test.ts` covering a primitive integer query param whose `x-enum-varnames` lives at the parameter level (post Swagger 2 upgrade shape).
- [x] `vitest run packages/core` — all 171 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Query parameter enums now use vendor-provided names and descriptions as fallbacks, producing clearer, more consistent enum mappings across schema upgrades.

* **Tests**
  * Added a test to verify integer query enums respect provided vendor varnames and avoid generic fallback names, ensuring reliable enum generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->