### PR TITLE
fix(core): support $dynamicAnchor fallback per JSON Schema spec

### DIFF
--- a/packages/core/src/resolvers/dynamic-ref.test.ts
+++ b/packages/core/src/resolvers/dynamic-ref.test.ts
@@ -623,6 +623,117 @@ describe('resolveDynamicRef', () => {
   });
 });
 
+describe('resolveDynamicRef — $dynamicAnchor fallback', () => {
+  it('falls back to $dynamicAnchor in another schema when not in scope', () => {
+    const spec = {
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          Pet: {
+            $dynamicAnchor: 'Pet',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+          Lizard: {
+            type: 'object',
+            properties: {
+              playmates: {
+                type: 'array',
+                items: { $dynamicRef: '#Pet' },
+              },
+            },
+          },
+        },
+      },
+    } as OpenApiDocument;
+    const context = { ...createContext(spec), dynamicScope: {} };
+
+    const result = resolveDynamicRef('Pet', context);
+
+    expect(result.resolvedTypeName).toBe('Pet');
+    expect(result.schema).toMatchObject({
+      properties: { name: { type: 'string' } },
+    });
+    expect(result.imports[0]).toEqual({
+      name: 'Pet',
+      schemaName: 'Pet',
+    });
+  });
+
+  it('still returns unknown when no schema declares the anchor anywhere', () => {
+    const spec = {
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          Pet: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+    } as OpenApiDocument;
+    const context = { ...createContext(spec), dynamicScope: {} };
+
+    const result = resolveDynamicRef('Pet', context);
+
+    expect(result.resolvedTypeName).toBe('unknown');
+    expect(result.schema).toEqual({});
+  });
+
+  it('prefers local scope over fallback', () => {
+    const spec = {
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          Pet: {
+            $dynamicAnchor: 'Pet',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+          Cat: {
+            $dynamicAnchor: 'Pet',
+            type: 'object',
+            properties: { meow: { type: 'boolean' } },
+          },
+        },
+      },
+    } as OpenApiDocument;
+    const context = {
+      ...createContext(spec),
+      dynamicScope: {
+        Pet: { name: 'Cat', schemaName: 'Cat' },
+      },
+    };
+
+    const result = resolveDynamicRef('Pet', context);
+
+    expect(result.resolvedTypeName).toBe('Cat');
+    expect(result.schema).toMatchObject({
+      properties: { meow: { type: 'boolean' } },
+    });
+  });
+
+  it('falls back when dynamicScope is undefined', () => {
+    const spec = {
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          Pet: {
+            $dynamicAnchor: 'Pet',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+    } as OpenApiDocument;
+    const context = createContext(spec);
+
+    const result = resolveDynamicRef('Pet', context);
+
+    expect(result.resolvedTypeName).toBe('Pet');
+  });
+});
+
 describe('null safety in $defs entries', () => {
   it('buildDynamicScope skips null $defs entries without throwing', () => {
     const spec = {

--- a/packages/core/src/resolvers/ref.ts
+++ b/packages/core/src/resolvers/ref.ts
@@ -444,7 +444,33 @@ export function resolveDynamicRef(
   resolvedTypeName: string;
 } {
   const scope = context.dynamicScope ?? {};
-  const scopeEntry = scope[anchorName];
+  let scopeEntry = scope[anchorName];
+
+  if (!scopeEntry) {
+    const schemas = (
+      (context.spec as Record<string, unknown>).components as
+        | Record<string, unknown>
+        | undefined
+    )?.schemas as Record<string, unknown> | undefined;
+
+    if (schemas && typeof schemas === 'object') {
+      for (const [schemaName, schemaObj] of Object.entries(schemas)) {
+        if (!schemaObj || typeof schemaObj !== 'object') continue;
+        const rec = schemaObj as Record<string, unknown>;
+        if (rec.$dynamicAnchor === anchorName) {
+          const refInfo = getRefInfo(
+            `#/components/schemas/${encodeJsonPointerSegment(schemaName)}`,
+            context,
+          );
+          scopeEntry = {
+            name: refInfo.name,
+            schemaName: refInfo.originalName,
+          };
+          break;
+        }
+      }
+    }
+  }
 
   if (!scopeEntry) {
     return {

--- a/samples/dynamic-ref/__snapshots__/api/petstore.ts
+++ b/samples/dynamic-ref/__snapshots__/api/petstore.ts
@@ -4,7 +4,7 @@
  * Petstore with dynamic references
  * Demonstrates OpenAPI 3.1 `$dynamicRef` / `$dynamicAnchor` for polymorphic schema dispatch.
  * The `Pet` base schema defines a `$dynamicAnchor` that is overridden by `Cat` and `Dog`.  Each schema has a `playmates` property using `$dynamicRef: '#Pet'` — which resolves to `Cat[]` inside Cat, and `Dog[]` inside Dog.
- * `Lizard` does NOT override the anchor, so its `playmates` falls back to `unknown` since only explicit bindings are resolved.
+ * `Lizard` does NOT override the anchor, so its `playmates` falls back to `Pet[]` via the `$dynamicAnchor` fallback per JSON Schema Draft 2020-12.
  *
  * OpenAPI spec version: 1.0.0
  */
@@ -53,7 +53,7 @@ export interface Lizard {
   petType: LizardPetType;
   name: string;
   lovesRocks?: boolean;
-  playmates?: unknown[];
+  playmates?: Pet[];
 }
 
 export const getPetstoreWithDynamicReferences = (

--- a/samples/dynamic-ref/api/petstore.ts
+++ b/samples/dynamic-ref/api/petstore.ts
@@ -4,7 +4,7 @@
  * Petstore with dynamic references
  * Demonstrates OpenAPI 3.1 `$dynamicRef` / `$dynamicAnchor` for polymorphic schema dispatch.
  * The `Pet` base schema defines a `$dynamicAnchor` that is overridden by `Cat` and `Dog`.  Each schema has a `playmates` property using `$dynamicRef: '#Pet'` — which resolves to `Cat[]` inside Cat, and `Dog[]` inside Dog.
- * `Lizard` does NOT override the anchor, so its `playmates` falls back to `unknown` since only explicit bindings are resolved.
+ * `Lizard` does NOT override the anchor, so its `playmates` falls back to `Pet[]` via the `$dynamicAnchor` fallback per JSON Schema Draft 2020-12.
  *
  * OpenAPI spec version: 1.0.0
  */
@@ -53,7 +53,7 @@ export interface Lizard {
   petType: LizardPetType;
   name: string;
   lovesRocks?: boolean;
-  playmates?: unknown[];
+  playmates?: Pet[];
 }
 
 export const getPetstoreWithDynamicReferences = (

--- a/samples/dynamic-ref/petstore-dynamic.yaml
+++ b/samples/dynamic-ref/petstore-dynamic.yaml
@@ -12,7 +12,8 @@ info:
     `Dog[]` inside Dog.
 
     `Lizard` does NOT override the anchor, so its `playmates` falls
-    back to `unknown` since only explicit bindings are resolved.
+    back to `Pet[]` via the `$dynamicAnchor` fallback per JSON Schema
+    Draft 2020-12.
 paths:
   /pets:
     get:


### PR DESCRIPTION
## Summary

When a `$dynamicRef` has no matching `$dynamicAnchor` in the current dynamic scope, `resolveDynamicRef()` now falls back to scanning `components.schemas` for a schema declaring the same anchor name.

Per JSON Schema Draft 2020-12, `$dynamicRef` should fall back to `$ref` behavior when no dynamic scope override exists. This means resolving the fragment within the same schema resource — which in an OpenAPI document means finding the `$dynamicAnchor` declared in another component schema.

## Before

```yaml
Lizard:
  # No $dynamicAnchor: Pet
  type: object
  properties:
    playmates:
      type: array
      items:
        $dynamicRef: "#Pet"  # → unknown[]
```

```ts
interface Lizard { playmates?: unknown[]; }
```

## After

```ts
interface Lizard { playmates?: Pet[]; }
```

## Changes

- **`packages/core/src/resolvers/ref.ts`** — Added fallback in `resolveDynamicRef()`: when anchor not in scope, scan `components.schemas` for a matching `$dynamicAnchor`
- **`packages/core/src/resolvers/dynamic-ref.test.ts`** — 4 new tests covering fallback, no-match, scope precedence, and undefined scope
- **`samples/dynamic-ref/`** — Updated sample, regenerated output, updated snapshot

## Why this is correct

The JSON Schema 2020-12 spec defines `$dynamicRef` resolution as:
1. If a matching `$dynamicAnchor` exists in the dynamic scope → use it
2. Otherwise, fall back to `$ref` behavior — resolve the fragment within the same schema resource

The old code skipped step 2 and returned `unknown`. This fix implements step 2 by searching `components.schemas` for the matching `$dynamicAnchor`, which is what `$ref: "#Pet"` would resolve to in the OpenAPI document.

Schemas with their own `$dynamicAnchor` override (e.g. Cat, Dog) already resolve via the local scope and never reach the fallback path.

Closes #3440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected dynamic reference resolution fallback. When an anchor isn't found in the current scope, the resolver now properly falls back to `$dynamicAnchor` declarations in schemas, resulting in more accurate generated types.

* **Tests**
  * Added comprehensive test coverage for dynamic reference fallback behavior, including edge cases and precedence validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->