### PR TITLE
fix(mock): resolve circular suffix matching and combine recursion

### DIFF
--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -1,11 +1,10 @@
 import {
   type ContextSpec,
   type GeneratorImport,
+  getRefInfo,
   isReference,
   isSchema,
   type MockOptions,
-  pascal,
-  getRefInfo,
 } from '@orval/core';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';

--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -5,15 +5,16 @@ import {
   isSchema,
   type MockOptions,
   pascal,
+  getRefInfo,
 } from '@orval/core';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
 import { resolveMockValue } from '../resolvers';
 
-function getReferenceName(ref?: string): string {
+function getReferenceName(ref: string | undefined, context: ContextSpec): string {
   if (!ref) return '';
 
-  return pascal(ref.split('/').pop() ?? '');
+  return getRefInfo(ref, context).name;
 }
 
 interface CombineSchemasMockOptions {
@@ -154,7 +155,7 @@ export function combineSchemasMock({
   let value = separator === 'allOf' ? '' : 'faker.helpers.arrayElement([';
 
   for (const val of separatorItems) {
-    const refName = isReference(val) ? getReferenceName(val.$ref) : '';
+    const refName = isReference(val) ? getReferenceName(val.$ref, context) : '';
     // For allOf: skip if refName is in existingRefs AND this is an inline schema (not a top-level ref)
     // This allows top-level schemas (item.isRef=true) to get base properties from allOf
     // while preventing circular allOf chains in inline property schemas.

--- a/packages/mock/src/faker/getters/combine.ts
+++ b/packages/mock/src/faker/getters/combine.ts
@@ -11,7 +11,10 @@ import {
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
 import { resolveMockValue } from '../resolvers';
 
-function getReferenceName(ref: string | undefined, context: ContextSpec): string {
+function getReferenceName(
+  ref: string | undefined,
+  context: ContextSpec,
+): string {
   if (!ref) return '';
 
   return getRefInfo(ref, context).name;

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -18,7 +18,10 @@ import { combineSchemasMock } from './combine';
 
 export const overrideVarName = 'overrideResponse';
 
-function getReferenceName(ref: string | undefined, context: ContextSpec): string {
+function getReferenceName(
+  ref: string | undefined,
+  context: ContextSpec,
+): string {
   if (!ref) return '';
 
   return getRefInfo(ref, context).name;
@@ -164,7 +167,9 @@ export function getMockObject({
           // Fixes issue #910
           if (
             isReference(prop) &&
-            existingReferencedProperties.includes(getReferenceName(prop.$ref, context))
+            existingReferencedProperties.includes(
+              getReferenceName(prop.$ref, context),
+            )
           ) {
             if (isRequired) {
               const keyDefinition = getKey(key);

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -2,13 +2,12 @@ import {
   type ContextSpec,
   type GeneratorImport,
   getKey,
+  getRefInfo,
   isReference,
   type MockOptions,
   type OpenApiReferenceObject,
   type OpenApiSchemaObject,
-  pascal,
   PropertySortOrder,
-  getRefInfo,
 } from '@orval/core';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -8,6 +8,7 @@ import {
   type OpenApiSchemaObject,
   pascal,
   PropertySortOrder,
+  getRefInfo,
 } from '@orval/core';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
@@ -17,10 +18,10 @@ import { combineSchemasMock } from './combine';
 
 export const overrideVarName = 'overrideResponse';
 
-function getReferenceName(ref?: string): string {
+function getReferenceName(ref: string | undefined, context: ContextSpec): string {
   if (!ref) return '';
 
-  return pascal(ref.split('/').pop() ?? '');
+  return getRefInfo(ref, context).name;
 }
 
 interface GetMockObjectOptions {
@@ -163,7 +164,7 @@ export function getMockObject({
           // Fixes issue #910
           if (
             isReference(prop) &&
-            existingReferencedProperties.includes(getReferenceName(prop.$ref))
+            existingReferencedProperties.includes(getReferenceName(prop.$ref, context))
           ) {
             if (isRequired) {
               const keyDefinition = getKey(key);
@@ -236,7 +237,7 @@ export function getMockObject({
     if (
       isReference(additionalProperties) &&
       existingReferencedProperties.includes(
-        getReferenceName(additionalProperties.$ref),
+        getReferenceName(additionalProperties.$ref, context),
       )
     ) {
       return { value: `{}`, imports: [], name: schemaItem.name };

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -15,6 +15,7 @@ import {
   type MockOptions,
   type OpenApiSchemaObject,
   pascal,
+  getRefInfo,
 } from '@orval/core';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
@@ -269,7 +270,7 @@ export function getMockScalar({
       if (
         itemsRef &&
         existingReferencedProperties.includes(
-          pascal(itemsRef.split('/').pop() ?? ''),
+          getRefInfo(itemsRef, context).name,
         )
       ) {
         return { value: '[]', imports: [], name: item.name };

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -9,13 +9,12 @@ import {
   EnumGeneration,
   escape,
   type GeneratorImport,
+  getRefInfo,
   isReference,
   isString,
   mergeDeep,
   type MockOptions,
   type OpenApiSchemaObject,
-  pascal,
-  getRefInfo,
 } from '@orval/core';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';


### PR DESCRIPTION
Fixes #2802 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Mock generation now resolves schema references with contextual awareness, improving accuracy for nested and referenced models.
  * Recursion and cycle-prevention checks were enhanced to use context-resolved reference names, reducing incorrect or duplicate mock types.
  * More reliable mock outputs for multi-level schema hierarchies, especially for referenced properties and array items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->