### PR TITLE
feat(mcp): return registerd tools variable

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -212,7 +212,7 @@ export const generateServer = (
           : `() => ${verbOption.operationName}Handler(options)`;
 
       const toolImplementation = `
-server.registerTool(
+tools.${verbOption.operationName} = server.registerTool(
   '${jsStringEscape(verbOption.operationName)}',
   {
     description: '${jsStringEscape(verbOption.summary ?? '')}',${inputSchemaImplementation}
@@ -252,14 +252,15 @@ server.registerTool(
   const importHandlersImplementation = `import {\n${importHandlers}\n} from './handlers';`;
 
   const createMcpServerImplementation = `
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (options?: RequestInit): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: '${camel(info.title)}Server',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 ${toolImplementations}
 
-  return server;
+  return { server, tools };
 };
 `;
 
@@ -272,7 +273,8 @@ ${toolImplementations}
     : `{ ${serverFunctionName} }`;
 
   const importMcpServer = `import {
-  McpServer
+  McpServer,
+  type RegisteredTool,
 } from '@modelcontextprotocol/sdk/server/mcp.js';
 `;
 
@@ -288,7 +290,7 @@ ${importTransport}
 
   const customServerConnectImplementation = `\n${serverFunctionName}(createMcpServer);\n`;
   const stdioServerConnectImplementation = `
-const server = createMcpServer();
+const { server } = createMcpServer();
 const transport = new StdioServerTransport();
 
 server.connect(transport).then(() => {

--- a/samples/mcp/custom-server/__snapshots__/server.ts
+++ b/samples/mcp/custom-server/__snapshots__/server.ts
@@ -13,7 +13,10 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  McpServer,
+  type RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { customServer } from '../custom-server';
 
@@ -45,13 +48,16 @@ import {
   DeleteUserParams,
 } from './tool-schemas.zod';
 
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: 'swaggerPetstoreOpenAPI30Server',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 
-  server.registerTool(
+  tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',
     {
       description: 'Finds Pets by status.',
@@ -62,7 +68,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => findPetsByStatusHandler(args, options),
   );
 
-  server.registerTool(
+  tools.findPetsByTags = server.registerTool(
     'findPetsByTags',
     {
       description: 'Finds Pets by tags.',
@@ -73,7 +79,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => findPetsByTagsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.getPetById = server.registerTool(
     'getPetById',
     {
       description: 'Find pet by ID.',
@@ -84,7 +90,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getPetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.updatePetWithForm = server.registerTool(
     'updatePetWithForm',
     {
       description: 'Updates a pet in the store with form data.',
@@ -96,7 +102,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => updatePetWithFormHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deletePet = server.registerTool(
     'deletePet',
     {
       description: 'Deletes a pet.',
@@ -107,7 +113,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deletePetHandler(args, options),
   );
 
-  server.registerTool(
+  tools.getInventory = server.registerTool(
     'getInventory',
     {
       description: 'Returns pet inventories by status.',
@@ -115,7 +121,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => getInventoryHandler(options),
   );
 
-  server.registerTool(
+  tools.getOrderById = server.registerTool(
     'getOrderById',
     {
       description: 'Find purchase order by ID.',
@@ -126,7 +132,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getOrderByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deleteOrder = server.registerTool(
     'deleteOrder',
     {
       description: 'Delete purchase order by identifier.',
@@ -137,7 +143,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deleteOrderHandler(args, options),
   );
 
-  server.registerTool(
+  tools.loginUser = server.registerTool(
     'loginUser',
     {
       description: 'Logs user into the system.',
@@ -148,7 +154,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => loginUserHandler(args, options),
   );
 
-  server.registerTool(
+  tools.logoutUser = server.registerTool(
     'logoutUser',
     {
       description: 'Logs out current logged in user session.',
@@ -156,7 +162,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => logoutUserHandler(options),
   );
 
-  server.registerTool(
+  tools.getUserByName = server.registerTool(
     'getUserByName',
     {
       description: 'Get user by user name.',
@@ -167,7 +173,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getUserByNameHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deleteUser = server.registerTool(
     'deleteUser',
     {
       description: 'Delete user resource.',
@@ -178,7 +184,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deleteUserHandler(args, options),
   );
 
-  return server;
+  return { server, tools };
 };
 
 customServer(createMcpServer);

--- a/samples/mcp/custom-server/custom-server.ts
+++ b/samples/mcp/custom-server/custom-server.ts
@@ -1,11 +1,19 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  McpServer,
+  RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPTransport } from '@hono/mcp';
 import { Hono } from 'hono';
 
-export const customServer = (createMcpServer: () => McpServer) => {
+export const customServer = (
+  createMcpServer: () => {
+    server: McpServer;
+    tools: Record<string, RegisteredTool>;
+  },
+) => {
   const app = new Hono();
 
-  const server = createMcpServer();
+  const { server } = createMcpServer();
   const transport = new StreamableHTTPTransport();
 
   app.all('/mcp', async (c) => {

--- a/samples/mcp/custom-server/src/server.ts
+++ b/samples/mcp/custom-server/src/server.ts
@@ -13,7 +13,10 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  McpServer,
+  type RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { customServer } from '../custom-server';
 
@@ -45,13 +48,16 @@ import {
   DeleteUserParams,
 } from './tool-schemas.zod';
 
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: 'swaggerPetstoreOpenAPI30Server',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 
-  server.registerTool(
+  tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',
     {
       description: 'Finds Pets by status.',
@@ -62,7 +68,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => findPetsByStatusHandler(args, options),
   );
 
-  server.registerTool(
+  tools.findPetsByTags = server.registerTool(
     'findPetsByTags',
     {
       description: 'Finds Pets by tags.',
@@ -73,7 +79,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => findPetsByTagsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.getPetById = server.registerTool(
     'getPetById',
     {
       description: 'Find pet by ID.',
@@ -84,7 +90,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getPetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.updatePetWithForm = server.registerTool(
     'updatePetWithForm',
     {
       description: 'Updates a pet in the store with form data.',
@@ -96,7 +102,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => updatePetWithFormHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deletePet = server.registerTool(
     'deletePet',
     {
       description: 'Deletes a pet.',
@@ -107,7 +113,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deletePetHandler(args, options),
   );
 
-  server.registerTool(
+  tools.getInventory = server.registerTool(
     'getInventory',
     {
       description: 'Returns pet inventories by status.',
@@ -115,7 +121,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => getInventoryHandler(options),
   );
 
-  server.registerTool(
+  tools.getOrderById = server.registerTool(
     'getOrderById',
     {
       description: 'Find purchase order by ID.',
@@ -126,7 +132,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getOrderByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deleteOrder = server.registerTool(
     'deleteOrder',
     {
       description: 'Delete purchase order by identifier.',
@@ -137,7 +143,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deleteOrderHandler(args, options),
   );
 
-  server.registerTool(
+  tools.loginUser = server.registerTool(
     'loginUser',
     {
       description: 'Logs user into the system.',
@@ -148,7 +154,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => loginUserHandler(args, options),
   );
 
-  server.registerTool(
+  tools.logoutUser = server.registerTool(
     'logoutUser',
     {
       description: 'Logs out current logged in user session.',
@@ -156,7 +162,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => logoutUserHandler(options),
   );
 
-  server.registerTool(
+  tools.getUserByName = server.registerTool(
     'getUserByName',
     {
       description: 'Get user by user name.',
@@ -167,7 +173,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getUserByNameHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deleteUser = server.registerTool(
     'deleteUser',
     {
       description: 'Delete user resource.',
@@ -178,7 +184,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deleteUserHandler(args, options),
   );
 
-  return server;
+  return { server, tools };
 };
 
 customServer(createMcpServer);

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -13,7 +13,10 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  McpServer,
+  type RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
@@ -45,13 +48,16 @@ import {
   DeleteUserParams,
 } from './tool-schemas.zod';
 
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: 'swaggerPetstoreOpenAPI30Server',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 
-  server.registerTool(
+  tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',
     {
       description: 'Finds Pets by status.',
@@ -62,7 +68,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => findPetsByStatusHandler(args, options),
   );
 
-  server.registerTool(
+  tools.findPetsByTags = server.registerTool(
     'findPetsByTags',
     {
       description: 'Finds Pets by tags.',
@@ -73,7 +79,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => findPetsByTagsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.getPetById = server.registerTool(
     'getPetById',
     {
       description: 'Find pet by ID.',
@@ -84,7 +90,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getPetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.updatePetWithForm = server.registerTool(
     'updatePetWithForm',
     {
       description: 'Updates a pet in the store with form data.',
@@ -96,7 +102,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => updatePetWithFormHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deletePet = server.registerTool(
     'deletePet',
     {
       description: 'Deletes a pet.',
@@ -107,7 +113,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deletePetHandler(args, options),
   );
 
-  server.registerTool(
+  tools.getInventory = server.registerTool(
     'getInventory',
     {
       description: 'Returns pet inventories by status.',
@@ -115,7 +121,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => getInventoryHandler(options),
   );
 
-  server.registerTool(
+  tools.getOrderById = server.registerTool(
     'getOrderById',
     {
       description: 'Find purchase order by ID.',
@@ -126,7 +132,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getOrderByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deleteOrder = server.registerTool(
     'deleteOrder',
     {
       description: 'Delete purchase order by identifier.',
@@ -137,7 +143,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deleteOrderHandler(args, options),
   );
 
-  server.registerTool(
+  tools.loginUser = server.registerTool(
     'loginUser',
     {
       description: 'Logs user into the system.',
@@ -148,7 +154,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => loginUserHandler(args, options),
   );
 
-  server.registerTool(
+  tools.logoutUser = server.registerTool(
     'logoutUser',
     {
       description: 'Logs out current logged in user session.',
@@ -156,7 +162,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => logoutUserHandler(options),
   );
 
-  server.registerTool(
+  tools.getUserByName = server.registerTool(
     'getUserByName',
     {
       description: 'Get user by user name.',
@@ -167,7 +173,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => getUserByNameHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deleteUser = server.registerTool(
     'deleteUser',
     {
       description: 'Delete user resource.',
@@ -178,10 +184,10 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deleteUserHandler(args, options),
   );
 
-  return server;
+  return { server, tools };
 };
 
-const server = createMcpServer();
+const { server } = createMcpServer();
 const transport = new StdioServerTransport();
 
 server

--- a/tests/__snapshots__/mcp/custom-server/server.ts
+++ b/tests/__snapshots__/mcp/custom-server/server.ts
@@ -5,7 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  McpServer,
+  type RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { customServer } from '../../../mutators/mcp-custom-server';
 
@@ -26,13 +29,16 @@ import {
   ShowPetWithOwnerParams,
 } from './tool-schemas.zod';
 
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: 'swaggerPetstoreServer',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 
-  server.registerTool(
+  tools.listPets = server.registerTool(
     'listPets',
     {
       description: 'List all pets',
@@ -43,7 +49,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => listPetsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.createPets = server.registerTool(
     'createPets',
     {
       description: 'Create a pet',
@@ -55,7 +61,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => createPetsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.showPetById = server.registerTool(
     'showPetById',
     {
       description: 'Info for a specific pet',
@@ -66,7 +72,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => showPetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deletePetById = server.registerTool(
     'deletePetById',
     {
       description: 'Deletes a specific pet',
@@ -77,7 +83,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deletePetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.healthCheck = server.registerTool(
     'healthCheck',
     {
       description: 'health check',
@@ -85,7 +91,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => healthCheckHandler(options),
   );
 
-  server.registerTool(
+  tools.showPetWithOwner = server.registerTool(
     'showPetWithOwner',
     {
       description: 'combinate nullable and $ref',
@@ -96,7 +102,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => showPetWithOwnerHandler(args, options),
   );
 
-  return server;
+  return { server, tools };
 };
 
 customServer(createMcpServer);

--- a/tests/__snapshots__/mcp/single/server.ts
+++ b/tests/__snapshots__/mcp/single/server.ts
@@ -5,7 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  McpServer,
+  type RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
@@ -26,13 +29,16 @@ import {
   ShowPetWithOwnerParams,
 } from './tool-schemas.zod';
 
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: 'swaggerPetstoreServer',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 
-  server.registerTool(
+  tools.listPets = server.registerTool(
     'listPets',
     {
       description: 'List all pets',
@@ -43,7 +49,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => listPetsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.createPets = server.registerTool(
     'createPets',
     {
       description: 'Create a pet',
@@ -55,7 +61,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => createPetsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.showPetById = server.registerTool(
     'showPetById',
     {
       description: 'Info for a specific pet',
@@ -66,7 +72,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => showPetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deletePetById = server.registerTool(
     'deletePetById',
     {
       description: 'Deletes a specific pet',
@@ -77,7 +83,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deletePetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.healthCheck = server.registerTool(
     'healthCheck',
     {
       description: 'health check',
@@ -85,7 +91,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => healthCheckHandler(options),
   );
 
-  server.registerTool(
+  tools.showPetWithOwner = server.registerTool(
     'showPetWithOwner',
     {
       description: 'combinate nullable and $ref',
@@ -96,10 +102,10 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => showPetWithOwnerHandler(args, options),
   );
 
-  return server;
+  return { server, tools };
 };
 
-const server = createMcpServer();
+const { server } = createMcpServer();
 const transport = new StdioServerTransport();
 
 server

--- a/tests/__snapshots__/mcp/zod-schema-response/server.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/server.ts
@@ -5,7 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  McpServer,
+  type RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
@@ -26,13 +29,16 @@ import {
   ShowPetWithOwnerParams,
 } from './tool-schemas.zod';
 
-const createMcpServer = (options?: RequestInit) => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   const server = new McpServer({
     name: 'swaggerPetstoreServer',
     version: '1.0.0',
   });
+  const tools: Record<string, RegisteredTool> = {};
 
-  server.registerTool(
+  tools.listPets = server.registerTool(
     'listPets',
     {
       description: 'List all pets',
@@ -43,7 +49,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => listPetsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.createPets = server.registerTool(
     'createPets',
     {
       description: 'Create a pet',
@@ -55,7 +61,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => createPetsHandler(args, options),
   );
 
-  server.registerTool(
+  tools.showPetById = server.registerTool(
     'showPetById',
     {
       description: 'Info for a specific pet',
@@ -66,7 +72,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => showPetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.deletePetById = server.registerTool(
     'deletePetById',
     {
       description: 'Deletes a specific pet',
@@ -77,7 +83,7 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => deletePetByIdHandler(args, options),
   );
 
-  server.registerTool(
+  tools.healthCheck = server.registerTool(
     'healthCheck',
     {
       description: 'health check',
@@ -85,7 +91,7 @@ const createMcpServer = (options?: RequestInit) => {
     () => healthCheckHandler(options),
   );
 
-  server.registerTool(
+  tools.showPetWithOwner = server.registerTool(
     'showPetWithOwner',
     {
       description: 'combinate nullable and $ref',
@@ -96,10 +102,10 @@ const createMcpServer = (options?: RequestInit) => {
     (args) => showPetWithOwnerHandler(args, options),
   );
 
-  return server;
+  return { server, tools };
 };
 
-const server = createMcpServer();
+const { server } = createMcpServer();
 const transport = new StdioServerTransport();
 
 server

--- a/tests/mutators/mcp-custom-server.ts
+++ b/tests/mutators/mcp-custom-server.ts
@@ -1,6 +1,14 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  McpServer,
+  RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 
-export const customServer = (_createMcpServer: () => McpServer) => {
+export const customServer = (
+  _createMcpServer: () => {
+    server: McpServer;
+    tools: Record<string, RegisteredTool>;
+  },
+) => {
   // Custom server implementation (e.g. Streamable HTTP transport)
   // Users can call createMcpServer() per-request for stateless HTTP mode
 };


### PR DESCRIPTION
## Summary

`createMcpServer` now returns `{ server, tools }` instead of just `server`. The `tools` object (`Record<string, RegisteredTool>`) provides direct access to each registered tool's `enable()` / `disable()` / `update()` / `remove()` methods.

### Before

```typescript
// No way to access registered tools
const server = createMcpServer();
```

### After

```
const { server, tools } = createMcpServer();

// Dynamically disable a tool
tools.listPets.disable();

// Update tool description
tools.listPets.update({ description: 'Updated description' });

// Re-enable the tool
tools.listPets.enable();
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * MCP server factories now return both the server instance and a typed tools registry, providing structured access to registered tools across generated code, samples, and tests.
  * Runtime startup flows updated to consume the new return shape so samples and stdio-based entrypoints continue to initialize correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->