### PR TITLE
fix(core): update dynamic-ref tests to reflect correct $dynamicRef fallback behavior

### DIFF
--- a/packages/core/src/generators/dynamic-ref.test.ts
+++ b/packages/core/src/generators/dynamic-ref.test.ts
@@ -279,7 +279,7 @@ describe('generateSchemasDefinition with $dynamicRef', () => {
       );
     });
 
-    it('leaves BaseFolder shortcuts unknown without explicit binding', () => {
+    it('resolves BaseFolder shortcuts to BaseResource via $dynamicAnchor fallback', () => {
       const schemas = nestedWorkspaceSpec.components!.schemas!;
       const result = generateSchemasDefinition(
         schemas,
@@ -289,7 +289,7 @@ describe('generateSchemasDefinition with $dynamicRef', () => {
 
       const baseFolder = result.find((s) => s.name === 'BaseFolder');
       expect(baseFolder).toBeDefined();
-      expect(baseFolder!.model).toContain('unknown[]');
+      expect(baseFolder!.model).toContain('shortcuts: BaseResource[]');
     });
 
     it('resolves WorkspaceResource without unknown', () => {
@@ -468,7 +468,7 @@ describe('generateSchemasDefinition with $dynamicRef', () => {
     expect(container!.model).toContain('unknown');
   });
 
-  it('falls back to unknown for non-participating schema without explicit binding', () => {
+  it('resolves $dynamicRef to schema with matching $dynamicAnchor via fallback', () => {
     const unboundDynamicRefSpec: OpenApiDocument = {
       openapi: '3.1.0',
       info: { title: 'Test', version: '0.1.0' },
@@ -499,7 +499,8 @@ describe('generateSchemasDefinition with $dynamicRef', () => {
 
     const wrapper = result.find((s) => s.name === 'Wrapper');
     expect(wrapper).toBeDefined();
-    expect(wrapper!.model).toContain('unknown');
+    expect(wrapper!.model).toContain('User');
+    expect(wrapper!.model).not.toContain('unknown');
   });
 
   it('resolves $ref schema without dynamic bindings', () => {


### PR DESCRIPTION
## Summary

After PR #3446 was merged, two existing tests in `packages/core/src/generators/dynamic-ref.test.ts` started failing because they were written against the old (incorrect) `$dynamicRef` behavior — they expected `unknown` when no dynamic scope binding was found.

PR #3446 correctly implemented the JSON Schema 2020-12 spec fallback: when no matching `$dynamicAnchor` is found in the current dynamic scope, fall back to scanning `components.schemas` for a schema declaring that anchor. This means `$dynamicRef` now resolves properly instead of producing `unknown`.

## Failing tests (before this fix)

### Test 1 — `leaves BaseFolder shortcuts unknown without explicit binding`
- `BaseFolder.shortcuts` uses `$dynamicRef: '#resource'`
- `BaseResource` declares `$dynamicAnchor: 'resource'`
- Before PR #3446: resolved to `unknown[]`
- After PR #3446: correctly resolves to `BaseResource[]` via fallback

### Test 2 — `falls back to unknown for non-participating schema without explicit binding`
- `Wrapper.item` uses `$dynamicRef: '#item'`
- `User` declares `$dynamicAnchor: 'item'`
- Before PR #3446: resolved to `unknown`
- After PR #3446: correctly resolves to `User` via fallback

## Changes

- **`packages/core/src/generators/dynamic-ref.test.ts`** — Updated 2 tests to assert the correct (now-resolved) types instead of `unknown`:
  - Test name: `resolves BaseFolder shortcuts to BaseResource via $dynamicAnchor fallback` — asserts `shortcuts: BaseResource[]`
  - Test name: `resolves $dynamicRef to schema with matching $dynamicAnchor via fallback` — asserts `User` (not `unknown`)

All 1931 tests pass after this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for dynamic reference resolution in schema generation, verifying correct handling of `$dynamicAnchor` fallback behavior and ensuring proper type resolution without unintended type generation in generated models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->