### PR TITLE
fix(core): support CallExpression init in mutator parser

### DIFF
--- a/packages/core/src/generators/__tests__/mutator-test-files/call-expression-tests/factory-default-export.ts
+++ b/packages/core/src/generators/__tests__/mutator-test-files/call-expression-tests/factory-default-export.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Regression fixture for https://github.com/orval-labs/orval/issues/3402:
+// a default export whose initializer is a CallExpression. esbuild lowers
+// `export default <expr>` into a variable declarator + named-export
+// specifier, so this exercises the same code path as the named-export
+// variant.
+const make = (cfg: object) => (req: object) => Promise.resolve(req);
+export default make({});

--- a/packages/core/src/generators/__tests__/mutator-test-files/call-expression-tests/factory-named-export.ts
+++ b/packages/core/src/generators/__tests__/mutator-test-files/call-expression-tests/factory-named-export.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Regression fixture for https://github.com/orval-labs/orval/issues/3402:
+// a named export whose initializer is a CallExpression (factory pattern,
+// e.g. `axios.create({...})`). Kept dependency-free so the bundle is
+// self-contained.
+const make = (cfg: object) => (req: object) => Promise.resolve(req);
+export const customInstance = make({});

--- a/packages/core/src/generators/mutator-info.test.ts
+++ b/packages/core/src/generators/mutator-info.test.ts
@@ -277,4 +277,30 @@ describe('getMutatorInfo', () => {
       expect(result).toEqual({ numberOfParams: 1 });
     });
   });
+
+  describe('factory call expression', () => {
+    // Regression test for https://github.com/orval-labs/orval/issues/3402.
+    // When a mutator is defined as `export const foo = makeFactory(...)` or
+    // `export default makeFactory(...)` (e.g. `axios.create({...})`), the
+    // declarator's init is a CallExpression. parseFunction must treat it as
+    // a single-arg callable so orval emits `customInstance({...})` calls.
+    it('should treat a named export initialized by a CallExpression as a 1-arg function', async () => {
+      const result = await getMutatorInfo(
+        path.join(basePath, 'call-expression-tests', 'factory-named-export.ts'),
+        { namedExport: 'customInstance' },
+      );
+      expect(result).toEqual({ numberOfParams: 1 });
+    });
+
+    it('should treat a default export initialized by a CallExpression as a 1-arg function', async () => {
+      const result = await getMutatorInfo(
+        path.join(
+          basePath,
+          'call-expression-tests',
+          'factory-default-export.ts',
+        ),
+      );
+      expect(result).toEqual({ numberOfParams: 1 });
+    });
+  });
 });

--- a/packages/core/src/generators/mutator-info.ts
+++ b/packages/core/src/generators/mutator-info.ts
@@ -98,6 +98,16 @@ function parseFile(
   }
 }
 
+// Default for mutator exports whose initializer is a CallExpression
+// (factory pattern, e.g. `axios.create({...})`). The AST cannot reveal
+// the returned callable's arity, so we assume the orval standard
+// contract: a single-arg mutator invoked as
+// `customInstance({ url, method, data, ... })`.
+// See https://github.com/orval-labs/orval/issues/3402.
+function standardMutatorInfo(): GeneratorMutatorParsingInfo {
+  return { numberOfParams: 1 };
+}
+
 function parseFunction(
   ast: Program,
   funcName: string,
@@ -156,6 +166,11 @@ function parseFunction(
   if (declaration?.init) {
     if ('name' in declaration.init) {
       return parseFunction(ast, declaration.init.name);
+    }
+
+    // Init is a factory CallExpression — see standardMutatorInfo() above.
+    if (declaration.init.type === 'CallExpression') {
+      return standardMutatorInfo();
     }
 
     if (


### PR DESCRIPTION
Fixes #3402.

When a mutator is defined as `export const foo = factory(...)` — for example the canonical `export const axios = axiosDefault.create({ baseURL: '...' })` — orval rejects it with:

```
🛑 Your mutator file doesn't have the <name> exported function
```

even though the export plainly exists and is callable. Generation aborts before any code is emitted. The same surface error message was reported for dynamic `import()` and fixed in #3401, but the `CallExpression`-init case is a separate root cause that this PR addresses. Long-standing — originally raised as #1370 (closed without action, 2022) and discussion #1373; resurfaced via a comment on #1634.

## Root cause

`parseFunction` in `packages/core/src/generators/mutator-info.ts` branches on `VariableDeclarator.init` and handles only `Identifier` (alias), `ArrowFunctionExpression`/`FunctionExpression`, and function-body `ReturnStatement` → `CallExpression`. A top-level `CallExpression` init has no `name`, `params`, or function `body`, so every guard misses it and the function falls through to `undefined`. `parseFile` then returns `undefined`, and `mutator.ts:79` throws the misleading "doesn't have the X exported function" error.

## Fix

Add a small helper `standardMutatorInfo()` at module scope and a new branch in `parseFunction` that delegates to it when the init is a `CallExpression`:

```ts
// Default for mutator exports whose initializer is a CallExpression
// (factory pattern, e.g. `axios.create({...})`). The AST cannot reveal
// the returned callable's arity, so we assume the orval standard
// contract: a single-arg mutator invoked as
// `customInstance({ url, method, data, ... })`.
function standardMutatorInfo(): GeneratorMutatorParsingInfo {
  return { numberOfParams: 1 };
}

// ...inside parseFunction's VariableDeclarator branch:
if (declaration.init.type === 'CallExpression') {
  return standardMutatorInfo();
}
```

**Why `numberOfParams: 1`** — looking at `mutator.ts:86–99`:
- `0` would mark the export as a hook (`useFoo()()`), wrong for `axios.create()`.
- `1` produces `customInstance({ url, method, data, ... })`, matching `axios(config)`.
- `>1` would inject an extra `options` arg colliding with axios's config-merge.

It's the only value that does not introduce a regression for existing users, and matches the default chosen by #3401 for the dynamic-import fixture.

**Why one branch covers `export default` too** — esbuild lowers `export default <expr>` into a `VariableDeclarator { init: ... } + ExportNamedDeclaration` specifier (verified empirically with esbuild 0.27.4), so both shapes flow through the same code path.

## Tests

Two regression tests under a new `__tests__/mutator-test-files/call-expression-tests/` subdirectory (mirroring the `dynamic-import-tests/` precedent from #3401):

- `factory-named-export.ts` — `export const customInstance = make({});`
- `factory-default-export.ts` — `export default make({});`

Both fixtures are dependency-free (a self-contained `(cfg) => (req) => Promise.resolve(req)` factory) so they don't pull `axios` into the test set.

TDD verified: both tests fail with `undefined` on `master` and pass after the patch.

## Out of scope

- **Option B (`override.mutator.numberOfArguments` config field)** — touches the public config surface; deferred to a separate discussion if demand arises. The issue body frames B as optional.
- **`FunctionDeclaration` whose `ReturnStatement` returns a `CallExpression`-shaped factory** — that path already falls through to `{ numberOfParams: params.length }` and is not the reported repro.
- **Spec-level snapshot regression** — bug is at the mutator-detection layer; existing snapshots for `numberOfParams: 1` mutators already cover downstream emission. #3401 set the unit-test-only precedent for this layer.

## Verification

- `bun run test packages/core/.../mutator-info.test.ts` — 30/30 pass
- `bun run build --force` — 12/12
- `bun run typecheck` — 12/12
- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run test` — 1933/1933
- `bun run test:snapshots` — 4279/4279, **0 snapshots written** (purely additive to a previously-undefined path; no existing output moved)
- `bun run --filter orval-tests build` — 16 clients pass + mock verify pass

## Related

- #1370 — original 2022 report (closed without resolution)
- discussion #1373 — same content, still open; only comment is a custom-`client` workaround, not a fix
- #1634 / PR #3401 — same surface error message, different root cause (dynamic `import()` parsing); fixed
- @mkarajohn's 2026 comment on #1634 — recent recurrence of *this* bug specifically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of mutators exported via factory call expressions

* **Tests**
  * Added regression test coverage for factory call expression mutators with both named and default exports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->