### PR TITLE
fix(angular): emit HttpClient generic for JSON primitive responses

### DIFF
--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -1017,6 +1017,80 @@ describe('angular HttpClient generator', () => {
       expect(impl).not.toContain('getPetById<TData');
       expect(impl).toContain('getPetById(');
       expect(impl).toContain('this.http.get(');
+      expect(impl).toContain("responseType: 'text'");
+      expect(impl).toContain('as Observable<string>');
+    });
+
+    it('emits HttpClient generic for JSON primitive string responses', () => {
+      const verbOption = createVerbOption({
+        operationId: 'authenticate',
+        operationName: 'authenticate',
+        verb: 'post',
+        route: '/api/auth',
+        pathRoute: '/api/auth',
+        params: [],
+        body: {
+          implementation: 'authenticateBody',
+          definition: 'AuthenticateBody',
+          imports: [],
+          schemas: [],
+          originalSchema: {} as never,
+          contentType: 'application/json',
+          formData: '',
+          formUrlEncoded: '',
+          isOptional: true,
+        },
+        props: [
+          {
+            name: 'authenticateBody',
+            definition: 'authenticateBody?: AuthenticateBody',
+            implementation: 'authenticateBody?: AuthenticateBody',
+            default: false,
+            required: false,
+            type: GetterPropType.BODY,
+          },
+        ],
+        response: baseResponse({
+          definition: { success: 'string', errors: 'Error' },
+          types: {
+            success: [createSuccessType('string', 'application/json')],
+            errors: [],
+          },
+          contentTypes: ['application/json'],
+        }),
+      });
+      const options = createGeneratorOptions({ route: '/api/auth' });
+
+      const impl = generateHttpClientImplementation(verbOption, options);
+
+      expect(impl).not.toContain('authenticate<TData');
+      expect(impl).toContain('this.http.post<string>');
+      expect(impl).toContain("if (options?.observe === 'events')");
+      expect(impl).toContain("if (options?.observe === 'response')");
+      expect(impl).not.toContain("responseType: 'text'");
+    });
+
+    it('casts Blob responses when responseType is injected', () => {
+      const verbOption = createVerbOption({
+        response: baseResponse({
+          definition: { success: 'Blob', errors: 'Error' },
+          types: {
+            success: [createSuccessType('Blob', 'application/octet-stream')],
+            errors: [],
+          },
+          contentTypes: ['application/octet-stream'],
+          isBlob: true,
+        }),
+      });
+      const options = createGeneratorOptions();
+
+      const impl = generateHttpClientImplementation(verbOption, options);
+
+      expect(impl).not.toContain('getPetById<TData');
+      expect(impl).toContain("responseType: 'blob'");
+      expect(impl).toContain('this.http.get(');
+      expect(impl).not.toContain('this.http.get<Blob>');
+      expect(impl).toContain('as Observable<Blob>');
     });
 
     it('skips generic TData for Blob response types', () => {
@@ -1064,7 +1138,7 @@ describe('angular HttpClient generator', () => {
       expect(impl).toContain('accept?: GetPetFileAccept');
       expect(impl).toContain('Observable<Pet | string>');
       expect(impl).toContain('this.http.get<Pet>');
-      expect(impl).toContain('as Observable<string>');
+      expect(impl).toContain('as Observable<any>');
       // Content-type dispatch logic
       expect(impl).toContain("responseType: 'json'");
       expect(impl).toContain("responseType: 'text'");

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -727,7 +727,7 @@ export const generateHttpClientImplementation = (
     if (accept.includes('json') || accept.includes('+json')) {
       return ${buildHttpClientCall(`<${parsedJsonReturnType}>`, buildOptionsObject('json'))}${jsonValidationPipe};
     } else if (accept.startsWith('text/') || accept.includes('xml')) {
-      return ${buildHttpClientCall('', buildOptionsObject('text'))} as Observable<string>;
+      return ${buildHttpClientCall('', buildOptionsObject('text'))} as Observable<any>;
     }${
       blobSuccessTypes.length > 0
         ? ` else {
@@ -741,25 +741,40 @@ export const generateHttpClientImplementation = (
 `;
   }
 
-  // When the validation pipe is active the runtime payload is always the
-  // parsed output type, so we emit `HttpClient.<verb><PetsOutput>(...)`
-  // rather than threading a caller-overridable `TData` through the call.
-  const httpTypeArg = hasTDataGeneric
-    ? '<TData>'
-    : shouldValidateResponse && isModelType
-      ? `<${parsedDataType}>`
-      : '';
+  // Angular's HttpClient overloads conflict when both a type generic and an
+  // injected `responseType` (e.g. `'blob'` / `'text'`) are present — omit the
+  // generic and cast instead. JSON primitives still need `<string>` (etc.) because
+  // they use the default JSON overload without a custom `responseType`.
+  const hasInjectedResponseType = (optionsArgument: string) =>
+    typeof optionsArgument === 'string' &&
+    /\bresponseType:\s*['"]/.test(optionsArgument);
+  const httpCallExpr = (
+    optionsArgument: string,
+    observeKind: 'body' | 'events' | 'response',
+  ) => {
+    if (hasInjectedResponseType(optionsArgument)) {
+      const castType =
+        observeKind === 'events'
+          ? `HttpEvent<${observableDataType}>`
+          : observeKind === 'response'
+            ? `AngularHttpResponse<${observableDataType}>`
+            : observableDataType;
+      return `this.http.${verb}(${optionsArgument}) as Observable<${castType}>`;
+    }
+
+    return `this.http.${verb}<${observableDataType}>(${optionsArgument})`;
+  };
   const observeImplementation = isRequestOptions
     ? `${paramsDeclaration}if (options?.observe === 'events') {
-      return this.http.${verb}${httpTypeArg}(${observeOptions?.events ?? options})${eventValidationPipe};
+      return ${httpCallExpr(observeOptions?.events ?? options, 'events')}${eventValidationPipe};
     }
 
     if (options?.observe === 'response') {
-      return this.http.${verb}${httpTypeArg}(${observeOptions?.response ?? options})${responseValidationPipe};
+      return ${httpCallExpr(observeOptions?.response ?? options, 'response')}${responseValidationPipe};
     }
 
-    return this.http.${verb}${httpTypeArg}(${observeOptions?.body ?? options})${validationPipe};`
-    : `return this.http.${verb}${httpTypeArg}(${options})${validationPipe};`;
+    return ${httpCallExpr(observeOptions?.body ?? options, 'body')}${validationPipe};`
+    : `return ${httpCallExpr(options, 'body')}${validationPipe};`;
 
   return ` ${overloads}
   ${functionName}(

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -290,7 +290,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -395,7 +395,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -455,7 +455,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -515,7 +515,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -554,7 +554,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -562,14 +562,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -659,7 +659,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -667,14 +667,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
@@ -267,7 +267,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -368,7 +368,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -424,7 +424,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -480,7 +480,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -517,7 +517,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -525,14 +525,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -622,7 +622,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -630,14 +630,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -278,7 +278,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -379,7 +379,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -435,7 +435,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -491,7 +491,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -528,7 +528,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -536,14 +536,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -633,7 +633,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -641,14 +641,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -351,7 +351,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -407,7 +407,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -463,7 +463,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -500,7 +500,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -508,14 +508,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -605,7 +605,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -613,14 +613,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -515,7 +515,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -573,7 +573,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -492,7 +492,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -546,7 +546,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -290,7 +290,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -395,7 +395,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -455,7 +455,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -515,7 +515,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -554,7 +554,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -562,14 +562,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -659,7 +659,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -667,14 +667,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/src/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.service.ts
@@ -267,7 +267,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -368,7 +368,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -424,7 +424,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -480,7 +480,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -517,7 +517,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -525,14 +525,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -622,7 +622,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -630,14 +630,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -278,7 +278,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -379,7 +379,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -435,7 +435,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -491,7 +491,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -528,7 +528,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -536,14 +536,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -633,7 +633,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -641,14 +641,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -351,7 +351,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -407,7 +407,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -463,7 +463,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -500,7 +500,7 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -508,14 +508,14 @@ export class PetsService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/pets/${petId}/text`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
   /**
    * Upload image of the pet.
@@ -605,7 +605,7 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<Blob>>;
     }
 
     if (options?.observe === 'response') {
@@ -613,14 +613,14 @@ export class PetsService {
         responseType: 'blob',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<Blob>>;
     }
 
     return this.http.get(`/v${version}/pet/${petId}/downloadImage`, {
       responseType: 'blob',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<Blob>;
   }
 }
 

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -515,7 +515,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http
@@ -573,7 +573,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -492,7 +492,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -546,7 +546,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/tests/__snapshots__/angular/http-resource-both-tags-split/health/health.service.ts
+++ b/tests/__snapshots__/angular/http-resource-both-tags-split/health/health.service.ts
@@ -74,7 +74,7 @@ export class HealthService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -82,13 +82,13 @@ export class HealthService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 }

--- a/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
+++ b/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
@@ -197,7 +197,7 @@ export class AngularMultiContentQueryParamsTestService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<string>;
+      ) as Observable<any>;
     }
 
     return this.http.post<Item>(
@@ -257,7 +257,7 @@ export class AngularMultiContentQueryParamsTestService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<string>;
+      }) as Observable<any>;
     }
 
     return this.http.get<Items>(`/items`, {

--- a/tests/__snapshots__/angular/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/named-parameters/endpoints.ts
@@ -349,7 +349,7 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -357,14 +357,14 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 
   /**

--- a/tests/__snapshots__/angular/petstore/endpoints.ts
+++ b/tests/__snapshots__/angular/petstore/endpoints.ts
@@ -358,7 +358,7 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -366,14 +366,14 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 
   /**

--- a/tests/__snapshots__/angular/split/endpoints.service.ts
+++ b/tests/__snapshots__/angular/split/endpoints.service.ts
@@ -351,7 +351,7 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -359,14 +359,14 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 
   /**

--- a/tests/__snapshots__/angular/tags-split/health/health.service.ts
+++ b/tests/__snapshots__/angular/tags-split/health/health.service.ts
@@ -82,7 +82,7 @@ export class HealthService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -90,13 +90,13 @@ export class HealthService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 }

--- a/tests/__snapshots__/angular/tags/health.ts
+++ b/tests/__snapshots__/angular/tags/health.ts
@@ -87,7 +87,7 @@ export class HealthService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -95,14 +95,14 @@ export class HealthService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/v${version}/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 }
 

--- a/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
@@ -334,7 +334,7 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'events',
-      });
+      }) as Observable<HttpEvent<string>>;
     }
 
     if (options?.observe === 'response') {
@@ -342,14 +342,14 @@ export class SwaggerPetstoreService {
         responseType: 'text',
         ...(options as Omit<NonNullable<typeof options>, 'observe'>),
         observe: 'response',
-      });
+      }) as Observable<AngularHttpResponse<string>>;
     }
 
     return this.http.get(`/health`, {
       responseType: 'text',
       ...(options as Omit<NonNullable<typeof options>, 'observe'>),
       observe: 'body',
-    });
+    }) as Observable<string>;
   }
 
   /**


### PR DESCRIPTION
Fixes #3456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type casting for multi-content HTTP responses when using Accept headers
  * Added explicit Observable type assertions for different response modes (`events`, `response`, `body`)
  * Enhanced handling of Blob and string response types with proper type narrowing

* **Tests**
  * Extended test coverage for HTTP response typing behavior with non-model response handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->