### PR TITLE
fix(zod): emit reusable schemas for sanitized component names

### DIFF
--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -375,6 +375,51 @@ describe('writeZodSchemas with generateReusableSchemas', () => {
 
     await fs.remove(root);
   });
+
+  it('emits schemas whose raw name differs from the sanitized model name', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-reuse-raw-'));
+    const schemasPath = path.join(root, 'schemas');
+
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            Page_Item_: {
+              type: 'object',
+              properties: { total: { type: 'number' } },
+              required: ['total'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        {
+          name: 'PageItem',
+          schema: { $ref: '#/components/schemas/Page_Item_' },
+        },
+      ],
+    } satisfies Parameters<typeof writeZodSchemas>[0];
+
+    const options = createOutputOptions();
+    (options.override.zod as Record<string, unknown>).generateReusableSchemas =
+      true;
+
+    await writeZodSchemas(builder, schemasPath, '.ts', '', options);
+
+    const fileExists = await fs.pathExists(
+      path.join(schemasPath, 'PageItem.ts'),
+    );
+    expect(fileExists).toBe(true);
+
+    const content = await fs.readFile(
+      path.join(schemasPath, 'PageItem.ts'),
+      'utf8',
+    );
+    expect(content).toContain('export const PageItem = ');
+
+    await fs.remove(root);
+  });
 });
 
 describe('writeZodSchemasFromVerbs with generateReusableSchemas', () => {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -447,17 +447,22 @@ async function writeZodSchemasReusable(
     output: output as ContextSpec['output'],
   };
 
-  // Roots = every component schema in the builder list. This matches today's
-  // writeZodSchemas behavior of emitting all of them (the `schemas: { type: 'zod' }`
-  // path passes the full schema list in via builder.schemas).
-  const refs = builder.schemas
-    .map(({ name }) => `#/components/schemas/${name}`)
-    .filter((ref) => {
-      const schemaName = ref.slice('#/components/schemas/'.length);
-      const componentSchemas = (builder.spec.components?.schemas ??
-        {}) as Record<string, unknown>;
-      return componentSchemas[schemaName] !== undefined;
-    });
+  // Roots = every component schema, keyed by its RAW OpenAPI name taken
+  // straight from `spec.components.schemas`. We must NOT derive these from
+  // `builder.schemas`, whose `name` is the sanitized model identifier (e.g.
+  // `PaginatedResponse_Asset_` becomes `PaginatedResponseAsset`): operation
+  // files reference component schemas by `resolveSchemaName(<raw $ref>)`, so
+  // building roots from sanitized names and then filtering them against the
+  // raw-keyed `components.schemas` silently dropped every schema whose name
+  // needs sanitizing. Those schemas were never emitted, yet the operation
+  // files still imported them — producing dangling imports that don't compile.
+  const componentSchemas = (builder.spec.components?.schemas ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const refs = Object.keys(componentSchemas).map(
+    (schemaName) => `#/components/schemas/${schemaName}`,
+  );
 
   // Conflict guard.
   resolveSchemaNames(refs, output.namingConvention);


### PR DESCRIPTION
Closes #3460 

## Problem

With `zod` client + `override.zod.generateReusableSchemas: true`, orval emits `import { … } from "./schemas"` for component schemas it never generates, producing uncompilable output

`writeZodSchemasReusable` built its root refs from `builder.schemas[].name`, the sanitized model identifier (e.g. `PaginatedResponse_Asset_` becomes `PaginatedResponseAsset`), then filtered them against the raw-keyed `spec.components.schemas`. Every schema whose name needs sanitizing failed that filter and was dropped from the roots. Schemas reached as nested `$ref`s still surfaced via `nameToRef`, but ones
referenced only at the top level of an operation never did.

## Fix

Derive root refs straight from the raw `spec.components.schemas` keys, matching the names operation files import.

## Tests

Added a regression case (`builder.schemas` name `PageItem` vs raw key `Page_Item_`);