### PR TITLE
fix(zod): resolve __REF__ sentinels in operation schema files

### DIFF
--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -313,6 +313,15 @@ export const computeLazyEdges = (graph: Graph): Set<string> =>
 const SENTINEL_PATTERN = /__REF_([A-Za-z_$][A-Za-z0-9_$]*)__/g;
 
 /**
+ * Replace every `__REF_<name>__` sentinel with the bare identifier. Use this
+ * for schemas that sit at the top of the dependency graph (operation params,
+ * bodies, responses) — they can never participate in a cycle with the
+ * component schemas they reference, so every ref is a direct (non-lazy) one.
+ */
+export const rewriteSentinelsToDirect = (zod: string): string =>
+  zod.replace(SENTINEL_PATTERN, (_match, refName: string) => refName);
+
+/**
  * Replace every `__REF_<name>__` sentinel with either the bare identifier or
  * `zod.lazy(() => <name>)` based on whether the edge closes a cycle, then
  * reorder entries so that every non-lazy reference is emitted AFTER its

--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -319,7 +319,7 @@ const SENTINEL_PATTERN = /__REF_([A-Za-z_$][A-Za-z0-9_$]*)__/g;
  * component schemas they reference, so every ref is a direct (non-lazy) one.
  */
 export const rewriteSentinelsToDirect = (zod: string): string =>
-  zod.replace(SENTINEL_PATTERN, (_match, refName: string) => refName);
+  zod.replaceAll(SENTINEL_PATTERN, (_match, refName: string) => refName);
 
 /**
  * Replace every `__REF_<name>__` sentinel with either the bare identifier or

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -436,6 +436,85 @@ describe('writeZodSchemasFromVerbs with generateReusableSchemas', () => {
 
     await fs.remove(root);
   });
+
+  // Regression for #3463: an operation param/body/response that references a
+  // component schema (e.g. a nullable enum query param) must rewrite the
+  // `__REF_<name>__` sentinel to the bare identifier AND emit the import.
+  it('rewrites sentinels and emits imports for refs in operation schemas', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-verbs-ref-'));
+    const schemasPath = path.join(root, 'schemas');
+
+    const verbOptions = {
+      findPetsByStatus: {
+        operationName: 'findPetsByStatus',
+        originalOperation: {
+          parameters: [
+            {
+              name: 'status',
+              in: 'query',
+              required: false,
+              schema: {
+                anyOf: [
+                  { $ref: '#/components/schemas/PetStatus' },
+                  { type: 'null' },
+                ],
+              },
+            },
+          ],
+        },
+        response: { types: { success: [], errors: [] } },
+      },
+    } as never;
+
+    const options = createOutputOptions();
+    // createOutputOptions() uses PascalCase; force camelCase so the export
+    // name (`petStatus`) and file (`petStatus.ts`) match the issue repro.
+    (options as { namingConvention: string }).namingConvention = 'camelCase';
+    (options.override.zod as Record<string, unknown>).generateReusableSchemas =
+      true;
+    const ctx = {
+      output: {
+        override: {
+          useDates: false,
+          zod: { dateTimeOptions: {}, timeOptions: {} },
+        },
+      },
+      spec: {
+        components: {
+          schemas: {
+            PetStatus: {
+              type: 'string',
+              enum: ['available', 'pending', 'sold'],
+            },
+          },
+        },
+      } as never,
+      target: '',
+      workspace: '',
+    } satisfies MinimalVerbsContext;
+
+    await writeZodSchemasFromVerbs(
+      verbOptions,
+      schemasPath,
+      '.ts',
+      '',
+      options,
+      ctx,
+    );
+
+    const content = await fs.readFile(
+      path.join(schemasPath, 'findPetsByStatusParams.ts'),
+      'utf8',
+    );
+
+    // Sentinel resolved to the bare identifier...
+    expect(content).not.toContain('__REF_');
+    expect(content).toContain('petStatus');
+    // ...and the matching import is emitted.
+    expect(content).toContain("import { petStatus } from './petStatus';");
+
+    await fs.remove(root);
+  });
 });
 
 describe('generateZodSchemasInline with generateReusableSchemas', () => {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -26,12 +26,15 @@ import {
   generateReusableSchemaSet,
   resolveSchemaNames,
   rewriteReusableSchemas,
+  rewriteSentinelsToDirect,
 } from './reusable-schemas';
 
 interface ZodSchemaFileEntry {
   schemaName: string;
   consts: string;
   zodExpression: string;
+  /** Pre-rendered `import { x } from './x'` lines for reusable-schema refs. */
+  importStatements?: string[];
 }
 
 type ZodSchemaFileToWrite = ZodSchemaFileEntry & {
@@ -120,6 +123,13 @@ function generateZodSchemaFileContent(
   header: string,
   schemas: ZodSchemaFileEntry[],
 ): string {
+  // Dedupe imports across the (usually single) entries written to this file.
+  const importLines = [
+    ...new Set(schemas.flatMap((s) => s.importStatements ?? [])),
+  ].toSorted();
+  const importsBlock =
+    importLines.length > 0 ? `${importLines.join('\n')}\n` : '';
+
   const schemaContent = schemas
     .map(({ schemaName, consts, zodExpression }) => {
       const schemaConsts = consts ? `${consts}\n` : '';
@@ -132,7 +142,7 @@ export type ${schemaName}Output = zod.output<typeof ${schemaName}>;`;
     .join('\n\n');
 
   return `${header}import { z as zod } from 'zod';
-
+${importsBlock}
 ${schemaContent}
 `;
 }
@@ -735,11 +745,30 @@ export async function writeZodSchemasFromVerbs(
       isZodV4,
     );
 
+    // Operation schemas sit at the top of the dependency graph, so any
+    // `__REF_<name>__` sentinel resolves to a direct (non-lazy) reference.
+    // Rewrite them to bare identifiers and emit the matching imports, the
+    // same way `generateZod` does for the operation files (issue #3463).
+    let zodExpression = parsedZodDefinition.zod;
+    let importStatements: string[] | undefined;
+    if (useReusableSchemas && parsedZodDefinition.usedRefs.size > 0) {
+      zodExpression = rewriteSentinelsToDirect(zodExpression);
+      const importExt = fileExtension.replace(/\.ts$/, '');
+      importStatements = [...parsedZodDefinition.usedRefs]
+        .filter((refName) => refName !== name)
+        .toSorted()
+        .map((refName) => {
+          const importedFile = conventionName(refName, output.namingConvention);
+          return `import { ${refName} } from './${importedFile}${importExt}';`;
+        });
+    }
+
     schemasToWrite.push({
       schemaName: name,
       filePath,
       consts: parsedZodDefinition.consts,
-      zodExpression: parsedZodDefinition.zod,
+      zodExpression,
+      importStatements,
     });
   }
 

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -123,12 +123,15 @@ function generateZodSchemaFileContent(
   header: string,
   schemas: ZodSchemaFileEntry[],
 ): string {
-  // Dedupe imports across the (usually single) entries written to this file.
-  const importLines = [
+  // Group the zod import with any reusable-schema imports (deduped across the
+  // usually-single entries written to this file), then separate that block
+  // from the schema content with a single blank line.
+  const refImports = [
     ...new Set(schemas.flatMap((s) => s.importStatements ?? [])),
   ].toSorted();
-  const importsBlock =
-    importLines.length > 0 ? `${importLines.join('\n')}\n` : '';
+  const importBlock = [`import { z as zod } from 'zod';`, ...refImports].join(
+    '\n',
+  );
 
   const schemaContent = schemas
     .map(({ schemaName, consts, zodExpression }) => {
@@ -141,10 +144,7 @@ export type ${schemaName}Output = zod.output<typeof ${schemaName}>;`;
     })
     .join('\n\n');
 
-  return `${header}import { z as zod } from 'zod';
-${importsBlock}
-${schemaContent}
-`;
+  return `${header}${importBlock}\n\n${schemaContent}\n`;
 }
 
 const isValidSchemaIdentifier = (name: string) =>


### PR DESCRIPTION
Closes #3463

## Problem

With `client: 'zod'` + `override.zod.generateReusableSchemas: true`, the per-operation schema files written by `writeZodSchemasFromVerbs` (e.g. `FindPetsByStatusParams.ts`) keep unresolved `__REF_<name>__` sentinels and omit the matching imports, so they don't compile.

A nullable enum query param produced:

```ts
export const FindPetsByStatusParams = zod.object({
  "status": zod.union([__REF_petStatus__, zod.null()]).optional()
})
```

## Root cause

Three passes generate zod output with `generateReusableSchemas`:

- `generateZod` (operation client files) — already rewrites sentinels + emits imports.
- `writeZodSchemasReusable` (component schema files) — already rewrites via `rewriteReusableSchemas`.
- `writeZodSchemasFromVerbs` (per-operation schema files) — ran the generator + parser but wrote `parsedZodDefinition.zod` **verbatim**, leaving `__REF_<name>__` sentinels and emitting no imports.

The parser already returns `usedRefs`; this pass simply never consumed it.

## Fix

- Add `rewriteSentinelsToDirect` to the orchestrator (`reusable-schemas.ts`). Operation schemas sit at the top of the dependency graph, so they can't be in a cycle with the component schemas they reference — every ref resolves to a direct (non-lazy) identifier.
- In `writeZodSchemasFromVerbs`, when the flag is on and the parsed definition has `usedRefs`, rewrite the sentinels to bare identifiers and build the matching `import { <name> } from './<file>'` lines.
- Thread per-file import statements through `generateZodSchemaFileContent` (deduped; empty for the non-reusable callers, so their output is unchanged).

After the fix:

```ts
import { petStatus } from './petStatus';

export const FindPetsByStatusParams = zod.object({
  "status": zod.union([petStatus, zod.null()]).optional()
})
```

## Test plan

- [x] New regression test in `write-zod-specs.test.ts`: a nullable enum-ref query param now imports `petStatus` and references it directly, with no lingering `__REF_` sentinel.
- [x] Existing `write-zod-specs` tests pass; non-reusable callers of `generateZodSchemaFileContent` produce byte-identical output (empty imports block).
- [x] `swr-with-zod` sample regenerated — snapshots unchanged.
- [x] Full typecheck (13 packages) + `@orval/zod`, `@orval/orval`, `@orval/core` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reusable schema generation to correctly rewrite internal schema references and emit proper import statements for dependent schemas, preventing stray sentinel tokens in generated outputs.

* **Tests**
  * Added a regression test to ensure schema references are rewritten and corresponding imports are generated when reusable schema generation is enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->