### PR TITLE
fix(zod): emit reusable schemas inline when operations exist + use PascalCase identifiers

### DIFF
--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -142,13 +142,14 @@ describe('generateSpec - generateReusableSchemas inline (single mode)', () => {
 
       const content = await fs.readFile(targetFile, 'utf8');
 
-      // The component schema referenced by the operation is defined inline...
-      expect(content).toContain('export const pet = zod.object(');
+      // The component schema referenced by the operation is defined inline
+      // (PascalCase identifier, consistent with operation wrappers)...
+      expect(content).toContain('export const Pet = zod.object(');
       // ...and the operation references it by name.
-      expect(content).toContain('= pet');
+      expect(content).toContain('= Pet');
       // The inline definition must come before the operation that uses it.
-      expect(content.indexOf('export const pet =')).toBeLessThan(
-        content.indexOf('Item = pet'),
+      expect(content.indexOf('export const Pet =')).toBeLessThan(
+        content.indexOf('Item = Pet'),
       );
       // Exactly one zod import — the inline schemas must not redeclare `zod`
       // on top of the zod client's `import * as zod from 'zod'`.

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -113,3 +113,50 @@ describe('generateSpec - schemas: false', () => {
     }
   });
 });
+
+describe('generateSpec - generateReusableSchemas inline (single mode)', () => {
+  // Regression for #3463 follow-up: with `client: 'zod'` +
+  // `generateReusableSchemas` + operations + no `schemas:` dir, operations
+  // reference component schemas by name, so the component definitions must be
+  // emitted inline in the same single file (previously they were skipped
+  // because operations were present, leaving dangling references).
+  it('emits referenced component schemas inline alongside operations', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'zod.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'single',
+            client: 'zod',
+            override: { zod: { generateReusableSchemas: true } },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      // The component schema referenced by the operation is defined inline...
+      expect(content).toContain('export const pet = zod.object(');
+      // ...and the operation references it by name.
+      expect(content).toContain('= pet');
+      // The inline definition must come before the operation that uses it.
+      expect(content.indexOf('export const pet =')).toBeLessThan(
+        content.indexOf('Item = pet'),
+      );
+      // Exactly one zod import — the inline schemas must not redeclare `zod`
+      // on top of the zod client's `import * as zod from 'zod'`.
+      expect(content.match(/from 'zod'/g) ?? []).toHaveLength(1);
+      // No unresolved sentinels.
+      expect(content).not.toContain('__REF_');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -145,11 +145,12 @@ describe('generateSpec - generateReusableSchemas inline (single mode)', () => {
       // The component schema referenced by the operation is defined inline
       // (PascalCase identifier, consistent with operation wrappers)...
       expect(content).toContain('export const Pet = zod.object(');
-      // ...and the operation references it by name.
-      expect(content).toContain('= Pet');
-      // The inline definition must come before the operation that uses it.
+      // ...and an operation schema references it by name.
+      expect(content).toMatch(/\bPet\b/);
+      // The inline definition must come before the operation exports that use
+      // it (anchor on the operation name section, derived from operationId).
       expect(content.indexOf('export const Pet =')).toBeLessThan(
-        content.indexOf('Item = Pet'),
+        content.indexOf('export const ListPets'),
       );
       // Exactly one zod import — the inline schemas must not redeclare `zod`
       // on top of the zod client's `import * as zod from 'zod'`.

--- a/packages/orval/src/reusable-schemas.test.ts
+++ b/packages/orval/src/reusable-schemas.test.ts
@@ -12,52 +12,50 @@ import {
 } from './reusable-schemas';
 
 describe('resolveSchemaName', () => {
-  it('returns the last $ref segment with camelCase by default', () => {
-    expect(resolveSchemaName('#/components/schemas/Pet', 'camelCase')).toBe(
-      'pet',
+  // Identifiers are always PascalCase (matching operation wrappers + TS model
+  // types); `namingConvention` only affects file names, not identifiers.
+  it('returns a PascalCase identifier regardless of namingConvention', () => {
+    const camel = createTestContextSpec({
+      output: { namingConvention: 'camelCase' as never },
+    });
+    expect(resolveSchemaName('#/components/schemas/Pet', camel)).toBe('Pet');
+    expect(resolveSchemaName('#/components/schemas/Pet_Owner', camel)).toBe(
+      'PetOwner',
     );
-    expect(
-      resolveSchemaName('#/components/schemas/Pet_Owner', 'camelCase'),
-    ).toBe('petOwner');
-  });
 
-  it('respects PascalCase / snake_case', () => {
-    expect(
-      resolveSchemaName('#/components/schemas/pet_owner', 'PascalCase'),
-    ).toBe('PetOwner');
-    expect(
-      resolveSchemaName('#/components/schemas/PetOwner', 'snake_case'),
-    ).toBe('pet_owner');
+    const kebab = createTestContextSpec({
+      output: { namingConvention: 'kebab-case' as never },
+    });
+    // kebab-case files, but the identifier is still a valid PascalCase symbol.
+    expect(resolveSchemaName('#/components/schemas/pet_owner', kebab)).toBe(
+      'PetOwner',
+    );
   });
 });
 
-describe('resolveSchemaNames (validation)', () => {
-  it('returns a mapping when names are unique', () => {
+describe('resolveSchemaNames (conflict guard)', () => {
+  const context = createTestContextSpec();
+
+  it('returns a mapping of ref -> PascalCase identifier', () => {
     const result = resolveSchemaNames(
       ['#/components/schemas/Pet', '#/components/schemas/Owner'],
-      'camelCase',
+      context,
     );
     expect(result).toEqual(
       new Map([
-        ['#/components/schemas/Pet', 'pet'],
-        ['#/components/schemas/Owner', 'owner'],
+        ['#/components/schemas/Pet', 'Pet'],
+        ['#/components/schemas/Owner', 'Owner'],
       ]),
     );
   });
 
-  it('throws when two refs collapse to the same converted name', () => {
+  it('throws when two refs collapse to the same identifier', () => {
     expect(() =>
       resolveSchemaNames(
-        ['#/components/schemas/Pet', '#/components/schemas/pet'],
-        'camelCase',
+        ['#/components/schemas/pet_owner', '#/components/schemas/PetOwner'],
+        context,
       ),
-    ).toThrow(/Pet.*pet|pet.*Pet/);
-  });
-
-  it('throws when a converted name is not a valid JS identifier (kebab-case)', () => {
-    expect(() =>
-      resolveSchemaNames(['#/components/schemas/PetOwner'], 'kebab-case'),
-    ).toThrow(/not a valid JS identifier/);
+    ).toThrow(/pet_owner.*PetOwner|PetOwner.*pet_owner/);
   });
 });
 
@@ -148,13 +146,13 @@ describe('generateReusableSchemaSet', () => {
 
     expect(result).toHaveLength(2);
 
-    const petEntry = result.find((e) => e.name === 'pet');
-    const ownerEntry = result.find((e) => e.name === 'owner');
+    const petEntry = result.find((e) => e.name === 'Pet');
+    const ownerEntry = result.find((e) => e.name === 'Owner');
     expect(petEntry).toBeDefined();
     expect(ownerEntry).toBeDefined();
 
-    expect(petEntry?.zod).toContain('__REF_owner__');
-    expect(petEntry?.usedRefs).toEqual(new Set(['owner']));
+    expect(petEntry?.zod).toContain('__REF_Owner__');
+    expect(petEntry?.usedRefs).toEqual(new Set(['Owner']));
 
     expect(ownerEntry?.zod).not.toContain('__REF_');
     expect(ownerEntry?.usedRefs).toEqual(new Set());
@@ -191,7 +189,7 @@ describe('generateReusableSchemaSet', () => {
 
     // Owner must be in the result even though only Pet was seeded — the
     // orchestrator follows usedRefs to avoid dangling identifiers.
-    expect(result.map((e) => e.name).toSorted()).toEqual(['owner', 'pet']);
+    expect(result.map((e) => e.name).toSorted()).toEqual(['Owner', 'Pet']);
   });
 });
 

--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -1,64 +1,44 @@
 import type { ContextSpec, ZodCoerceType } from '@orval/core';
-import { conventionName, type NamingConvention } from '@orval/core';
+import { getRefInfo } from '@orval/core';
 import {
   generateZodValidationSchemaDefinition,
   parseZodValidationSchemaDefinition,
 } from '@orval/zod';
 import type { OpenAPIV3_1 } from '@scalar/openapi-types';
 
-// Mirror `@orval/core`'s `getRefInfo`: split the JSON pointer, URL-decode each
-// segment, and unescape RFC 6901 tokens (`~1` → `/`, `~0` → `~`). The zod
-// generator uses `getRefInfo(...).originalName` to derive the namedRef export
-// name, so we must follow the same rules here or the orchestrator's exported
-// names would diverge for refs containing escaped characters.
-const lastRefSegment = (ref: string): string => {
-  const raw = ref.split('/').pop() ?? '';
-  return decodeURIComponent(raw).replaceAll('~1', '/').replaceAll('~0', '~');
-};
-
 /**
- * Convert a single `#/components/schemas/X` ref into the export name we will
- * emit for it: the last `$ref` segment with `namingConvention` applied.
+ * Resolve the export identifier for a `#/components/schemas/X` ref. We reuse
+ * `@orval/core`'s `getRefInfo(...).name` (`pascal` + sanitize + component
+ * suffix) so reusable zod schema exports match the operation wrappers and the
+ * TS model types exactly. `namingConvention` deliberately does NOT influence
+ * the identifier — it governs file names only, consistent with the rest of
+ * orval. The same call powers the generator's `namedRef` emission, so the
+ * definition name and every reference stay in sync.
  */
-export const resolveSchemaName = (
-  ref: string,
-  namingConvention: NamingConvention,
-): string => conventionName(lastRefSegment(ref), namingConvention);
-
-// JavaScript identifier (loose): start with letter/_/$, continue with word chars.
-// Reusable schema names are emitted as `export const <name> = ...`, so they
-// must be valid identifiers regardless of naming convention.
-const JS_IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+export const resolveSchemaName = (ref: string, context: ContextSpec): string =>
+  getRefInfo(ref, context).name;
 
 /**
- * Resolve names for a set of refs, throwing on conflicts or on names that
- * aren't valid JS identifiers (e.g. `kebab-case` produces dashes). The mapping
- * is the single source of truth for cross-schema references — the generator,
- * the orchestrator's graph, and the sentinel rewriter all consult it.
+ * Resolve names for a set of refs, throwing on conflicts (two distinct refs
+ * collapsing to the same identifier). The mapping is the single source of
+ * truth for cross-schema references — the generator, the orchestrator's graph,
+ * and the sentinel rewriter all consult it.
  */
 export const resolveSchemaNames = (
   refs: readonly string[],
-  namingConvention: NamingConvention,
+  context: ContextSpec,
 ): Map<string, string> => {
   const resolved = new Map<string, string>();
   const reverse = new Map<string, string>();
 
   for (const ref of refs) {
-    const name = resolveSchemaName(ref, namingConvention);
-    if (!JS_IDENTIFIER_PATTERN.test(name)) {
-      throw new Error(
-        `[orval/zod] generateReusableSchemas: ref ${ref} converts to "${name}" ` +
-          `under namingConvention=${namingConvention}, which is not a valid JS ` +
-          `identifier. Use camelCase, PascalCase, or snake_case for the project's ` +
-          `namingConvention when this flag is enabled.`,
-      );
-    }
+    const name = resolveSchemaName(ref, context);
     const previous = reverse.get(name);
     if (previous !== undefined && previous !== ref) {
       throw new Error(
         `[orval/zod] generateReusableSchemas: refs ${previous} and ${ref} ` +
-          `both convert to "${name}" under namingConvention=${namingConvention}. ` +
-          `Rename one in the OpenAPI source or change the convention.`,
+          `both resolve to the export name "${name}". ` +
+          `Rename one in the OpenAPI source.`,
       );
     }
     resolved.set(ref, name);
@@ -170,7 +150,7 @@ export const generateReusableSchemaSet = (
   const nameToRef = new Map<string, string>();
   for (const schemaName of Object.keys(componentSchemas)) {
     const ref = `#/components/schemas/${schemaName}`;
-    nameToRef.set(resolveSchemaName(ref, context.output.namingConvention), ref);
+    nameToRef.set(resolveSchemaName(ref, context), ref);
   }
 
   // Expand to the transitive closure of component-schema refs reachable from
@@ -186,7 +166,7 @@ export const generateReusableSchemaSet = (
     const schema = componentSchemas[schemaName];
     if (!schema) continue;
 
-    const name = resolveSchemaName(ref, context.output.namingConvention);
+    const name = resolveSchemaName(ref, context);
 
     const definition = generateZodValidationSchemaDefinition(
       schema,

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -274,7 +274,18 @@ function shouldGenerateZodSchemasInline(
   output: NormalizedOptions['output'],
   hasOperations: boolean,
 ): boolean {
-  return output.client === 'zod' && !output.schemas && !hasOperations;
+  if (output.client !== 'zod' || output.schemas) {
+    return false;
+  }
+  // With `generateReusableSchemas`, operations reference component schemas by
+  // name, so the component definitions must be emitted inline alongside the
+  // operations (otherwise the references are dangling). Without the flag,
+  // operations inline their own schemas, so we only emit the component
+  // schemas inline when there are no operations.
+  if (output.override.zod.generateReusableSchemas) {
+    return true;
+  }
+  return !hasOperations;
 }
 
 function shouldGenerateSchemas(
@@ -446,7 +457,10 @@ export async function writeSpecs(
       header,
       needSchema: shouldGenerateSchemas(output, hasOperations),
       generateSchemasInline: needZodSchemasInline
-        ? () => generateZodSchemasInline(builder, output)
+        ? // Skip the inline `import { z as zod }` when operations are present:
+          // the zod client already emits `import * as zod from 'zod'`, so a
+          // second import would redeclare the `zod` binding.
+          () => generateZodSchemasInline(builder, output, !hasOperations)
         : undefined,
     });
   }

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -282,6 +282,8 @@ function shouldGenerateZodSchemasInline(
   // operations (otherwise the references are dangling). Without the flag,
   // operations inline their own schemas, so we only emit the component
   // schemas inline when there are no operations.
+  // `NormalizedOutputOptions` types this as a required `boolean`, so use it
+  // directly (a `=== true` compare trips no-unnecessary-boolean-literal-compare).
   if (output.override.zod.generateReusableSchemas) {
     return true;
   }
@@ -448,6 +450,10 @@ export async function writeSpecs(
       output,
       hasOperations,
     );
+    // Only emit the inline `import { z as zod }` when there are no operations.
+    // With operations the zod client already emits `import * as zod from 'zod'`,
+    // so a second import would redeclare the `zod` binding.
+    const includeZodImport = !hasOperations;
 
     implementationPaths = await writeMode({
       builder,
@@ -457,10 +463,7 @@ export async function writeSpecs(
       header,
       needSchema: shouldGenerateSchemas(output, hasOperations),
       generateSchemasInline: needZodSchemasInline
-        ? // Skip the inline `import { z as zod }` when operations are present:
-          // the zod client already emits `import * as zod from 'zod'`, so a
-          // second import would redeclare the `zod` binding.
-          () => generateZodSchemasInline(builder, output, !hasOperations)
+        ? () => generateZodSchemasInline(builder, output, includeZodImport)
         : undefined,
     });
   }

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -512,8 +512,8 @@ describe('writeZodSchemasFromVerbs with generateReusableSchemas', () => {
     } as never;
 
     const options = createOutputOptions();
-    // createOutputOptions() uses PascalCase; force camelCase so the export
-    // name (`petStatus`) and file (`petStatus.ts`) match the issue repro.
+    // camelCase namingConvention → file names are camelCased (`petStatus.ts`),
+    // but the exported identifier is always PascalCase (`PetStatus`).
     (options as { namingConvention: string }).namingConvention = 'camelCase';
     (options.override.zod as Record<string, unknown>).generateReusableSchemas =
       true;
@@ -552,11 +552,11 @@ describe('writeZodSchemasFromVerbs with generateReusableSchemas', () => {
       'utf8',
     );
 
-    // Sentinel resolved to the bare identifier...
+    // Sentinel resolved to the bare PascalCase identifier...
     expect(content).not.toContain('__REF_');
-    expect(content).toContain('petStatus');
-    // ...and the matching import is emitted.
-    expect(content).toContain("import { petStatus } from './petStatus';");
+    expect(content).toContain('zod.union([PetStatus,');
+    // ...and the matching import is emitted (PascalCase symbol, camelCase file).
+    expect(content).toContain("import { PetStatus } from './petStatus';");
 
     await fs.remove(root);
   });

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -329,7 +329,7 @@ function generateZodSchemasInlineReusable(
     ({ name }) => `#/components/schemas/${name}`,
   );
 
-  resolveSchemaNames(refs, output.namingConvention);
+  resolveSchemaNames(refs, context);
 
   const entries = generateReusableSchemaSet(refs, context, {
     strict,
@@ -486,7 +486,7 @@ async function writeZodSchemasReusable(
   );
 
   // Conflict guard.
-  resolveSchemaNames(refs, output.namingConvention);
+  resolveSchemaNames(refs, context);
 
   const entries = generateReusableSchemaSet(refs, context, {
     strict,

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -122,6 +122,10 @@ interface WriteZodSchemasFromVerbsContext {
 function generateZodSchemaFileContent(
   header: string,
   schemas: ZodSchemaFileEntry[],
+  // Omit the `import { z as zod }` line when the content is concatenated into a
+  // file that already imports zod (e.g. inline single-mode output, where the
+  // zod client already emits `import * as zod from 'zod'`).
+  includeZodImport = true,
 ): string {
   // Group the zod import with any reusable-schema imports (deduped across the
   // usually-single entries written to this file), then separate that block
@@ -129,9 +133,10 @@ function generateZodSchemaFileContent(
   const refImports = [
     ...new Set(schemas.flatMap((s) => s.importStatements ?? [])),
   ].toSorted();
-  const importBlock = [`import { z as zod } from 'zod';`, ...refImports].join(
-    '\n',
-  );
+  const importBlock = [
+    ...(includeZodImport ? [`import { z as zod } from 'zod';`] : []),
+    ...refImports,
+  ].join('\n');
 
   const schemaContent = schemas
     .map(({ schemaName, consts, zodExpression }) => {
@@ -144,7 +149,8 @@ export type ${schemaName}Output = zod.output<typeof ${schemaName}>;`;
     })
     .join('\n\n');
 
-  return `${header}${importBlock}\n\n${schemaContent}\n`;
+  const separator = importBlock ? `${importBlock}\n\n` : '';
+  return `${header}${separator}${schemaContent}\n`;
 }
 
 const isValidSchemaIdentifier = (name: string) =>
@@ -234,12 +240,13 @@ async function writeZodSchemaIndex(
 export function generateZodSchemasInline(
   builder: WriteZodSchemasInput,
   output: WriteZodOutputOptions,
+  includeZodImport = true,
 ): string {
   const useReusableSchemas =
     output.override.zod.generateReusableSchemas === true;
 
   if (useReusableSchemas) {
-    return generateZodSchemasInlineReusable(builder, output);
+    return generateZodSchemasInlineReusable(builder, output, includeZodImport);
   }
 
   const schemasWithOpenApiDef = builder.schemas.filter((s) => s.schema);
@@ -297,12 +304,13 @@ export function generateZodSchemasInline(
     return '';
   }
 
-  return generateZodSchemaFileContent('', schemas);
+  return generateZodSchemaFileContent('', schemas, includeZodImport);
 }
 
 function generateZodSchemasInlineReusable(
   builder: WriteZodSchemasInput,
   output: WriteZodOutputOptions,
+  includeZodImport = true,
 ): string {
   const schemasWithOpenApiDef = builder.schemas.filter((s) => s.schema);
   if (schemasWithOpenApiDef.length === 0) return '';
@@ -342,7 +350,10 @@ function generateZodSchemasInlineReusable(
     })
     .join('\n\n');
 
-  return `import { z as zod } from 'zod';\n\n${body}\n`;
+  // Omit the zod import when concatenated into a file that already imports it
+  // (inline single-mode output where the zod client emits `import * as zod`).
+  const prefix = includeZodImport ? `import { z as zod } from 'zod';\n\n` : '';
+  return `${prefix}${body}\n`;
 }
 
 export async function writeZodSchemas(

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -5,7 +5,6 @@ import {
   type ClientBuilder,
   type ClientGeneratorsBuilder,
   type ContextSpec,
-  conventionName,
   escape,
   generateMutator,
   type GeneratorDependency,
@@ -240,10 +239,11 @@ export const generateZodValidationSchemaDefinition = (
     const allSiblingsChainable = siblings.every((k) => isChainable(k));
 
     if (allSiblingsChainable) {
-      const refName = conventionName(
-        getRefInfo(schema.$ref, context).originalName,
-        context.output.namingConvention,
-      );
+      // Use the same identifier orval emits for the TS model type
+      // (`pascal` + sanitize + suffix) so reusable schema exports are
+      // consistent with operation wrappers and component types.
+      // `namingConvention` governs file names only, not identifiers.
+      const refName = getRefInfo(schema.$ref, context).name;
       const functions: [string, unknown][] = [
         ['namedRef', { name: refName, sourceRef: schema.$ref }],
       ];

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -3442,7 +3442,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
       expect(result).toEqual({
         functions: [
-          ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+          ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
         ],
         consts: [],
       });
@@ -3461,7 +3461,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         { required: true, useReusableSchemas: true },
       );
       expect(result.functions).toEqual([
-        ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
         ['nullable', undefined],
       ]);
     });
@@ -3482,7 +3482,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         { required: true, useReusableSchemas: true },
       );
       expect(result.functions).toEqual([
-        ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
         ['describe', '"optional pet"'],
       ]);
     });
@@ -3502,7 +3502,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       // default emits a const + a .default(<constName>) call. Match shape, not exact const.
       expect(result.functions[0]).toEqual([
         'namedRef',
-        { name: 'pet', sourceRef: '#/components/schemas/Pet' },
+        { name: 'Pet', sourceRef: '#/components/schemas/Pet' },
       ]);
       expect(result.functions.at(-1)?.[0]).toBe('default');
       expect(result.consts.some((c) => c.includes('Default'))).toBe(true);
@@ -3521,7 +3521,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         { required: false, useReusableSchemas: true },
       );
       expect(result.functions).toEqual([
-        ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
         ['optional', undefined],
       ]);
     });
@@ -3557,7 +3557,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         { required: false, useReusableSchemas: true },
       );
       expect(result.functions).toEqual([
-        ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
         ['nullish', undefined],
       ]);
     });
@@ -7866,7 +7866,7 @@ describe('parseZodValidationSchemaDefinition with namedRef', () => {
     const context = makeContextSpec();
     const definition: ZodValidationSchemaDefinition = {
       functions: [
-        ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
       ],
       consts: [],
     };
@@ -7877,8 +7877,8 @@ describe('parseZodValidationSchemaDefinition with namedRef', () => {
       false,
       false,
     );
-    expect(result.zod).toBe('__REF_pet__');
-    expect(result.usedRefs).toEqual(new Set(['pet']));
+    expect(result.zod).toBe('__REF_Pet__');
+    expect(result.usedRefs).toEqual(new Set(['Pet']));
     expect(result.consts).toBe('');
   });
 
@@ -7886,7 +7886,7 @@ describe('parseZodValidationSchemaDefinition with namedRef', () => {
     const context = makeContextSpec();
     const definition: ZodValidationSchemaDefinition = {
       functions: [
-        ['namedRef', { name: 'pet', sourceRef: '#/components/schemas/Pet' }],
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
         ['nullable', undefined],
         ['describe', '"hello"'],
       ],
@@ -7899,8 +7899,8 @@ describe('parseZodValidationSchemaDefinition with namedRef', () => {
       false,
       false,
     );
-    expect(result.zod).toBe('__REF_pet__.nullable().describe("hello")');
-    expect(result.usedRefs).toEqual(new Set(['pet']));
+    expect(result.zod).toBe('__REF_Pet__.nullable().describe("hello")');
+    expect(result.usedRefs).toEqual(new Set(['Pet']));
   });
 
   it('returns empty usedRefs when no namedRef is present', () => {

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets-reusable.zod.ts
@@ -6,7 +6,7 @@
  */
 import * as zod from 'zod';
 
-import { pet } from '../../models';
+import { Pet } from '../../models';
 
 /**
  * @summary List all pets
@@ -18,7 +18,7 @@ export const ListPetsQueryParams = zod.object({
     .describe('How many items to return at one time (max 100)'),
 });
 
-export const ListPetsResponseItem = pet;
+export const ListPetsResponseItem = Pet;
 export const ListPetsResponse = zod.array(ListPetsResponseItem);
 
 /**
@@ -30,14 +30,14 @@ export const CreatePetsBodyItem = zod.object({
 });
 export const CreatePetsBody = zod.array(CreatePetsBodyItem);
 
-export const CreatePetsResponse = pet;
+export const CreatePetsResponse = Pet;
 
 /**
  * @summary Update a pet
  */
-export const UpdatePetsBody = pet;
+export const UpdatePetsBody = Pet;
 
-export const UpdatePetsResponse = pet;
+export const UpdatePetsResponse = Pet;
 
 /**
  * @summary Info for a specific pet
@@ -46,4 +46,4 @@ export const ShowPetByIdParams = zod.object({
   petId: zod.string().describe('The id of the pet to retrieve'),
 });
 
-export const ShowPetByIdResponse = pet;
+export const ShowPetByIdResponse = Pet;

--- a/samples/swr-with-zod/__snapshots__/models/cat-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/cat-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const cat = zod.object({
+export const Cat = zod.object({
   petsRequested: zod.number().optional(),
   type: zod.enum(['cat']),
 });
 
-export type cat = zod.input<typeof cat>;
-export type catOutput = zod.output<typeof cat>;
+export type Cat = zod.input<typeof Cat>;
+export type CatOutput = zod.output<typeof Cat>;

--- a/samples/swr-with-zod/__snapshots__/models/dachshund-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/dachshund-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const dachshund = zod.object({
+export const Dachshund = zod.object({
   length: zod.number(),
   breed: zod.enum(['Dachshund']),
 });
 
-export type dachshund = zod.input<typeof dachshund>;
-export type dachshundOutput = zod.output<typeof dachshund>;
+export type Dachshund = zod.input<typeof Dachshund>;
+export type DachshundOutput = zod.output<typeof Dachshund>;

--- a/samples/swr-with-zod/__snapshots__/models/dog-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/dog-reusable.zod.ts
@@ -5,15 +5,15 @@
  * OpenAPI spec version: 1.0.0
  */
 import { z as zod } from 'zod';
-import { dachshund } from './dachshund-reusable.zod';
-import { labradoodle } from './labradoodle-reusable.zod';
+import { Dachshund } from './dachshund-reusable.zod';
+import { Labradoodle } from './labradoodle-reusable.zod';
 
-export const dog = zod.union([labradoodle, dachshund]).and(
+export const Dog = zod.union([Labradoodle, Dachshund]).and(
   zod.object({
     barksPerMinute: zod.number().optional(),
     type: zod.enum(['dog']),
   }),
 );
 
-export type dog = zod.input<typeof dog>;
-export type dogOutput = zod.output<typeof dog>;
+export type Dog = zod.input<typeof Dog>;
+export type DogOutput = zod.output<typeof Dog>;

--- a/samples/swr-with-zod/__snapshots__/models/error-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/error-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const error = zod.object({
+export const Error = zod.object({
   code: zod.number(),
   message: zod.string(),
 });
 
-export type error = zod.input<typeof error>;
-export type errorOutput = zod.output<typeof error>;
+export type Error = zod.input<typeof Error>;
+export type ErrorOutput = zod.output<typeof Error>;

--- a/samples/swr-with-zod/__snapshots__/models/labradoodle-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/labradoodle-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const labradoodle = zod.object({
+export const Labradoodle = zod.object({
   cuteness: zod.number(),
   breed: zod.enum(['Labradoodle']),
 });
 
-export type labradoodle = zod.input<typeof labradoodle>;
-export type labradoodleOutput = zod.output<typeof labradoodle>;
+export type Labradoodle = zod.input<typeof Labradoodle>;
+export type LabradoodleOutput = zod.output<typeof Labradoodle>;

--- a/samples/swr-with-zod/__snapshots__/models/pet-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/pet-reusable.zod.ts
@@ -5,10 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 import { z as zod } from 'zod';
-import { cat } from './cat-reusable.zod';
-import { dog } from './dog-reusable.zod';
+import { Cat } from './cat-reusable.zod';
+import { Dog } from './dog-reusable.zod';
 
-export const pet = zod.union([dog, cat]).and(
+export const Pet = zod.union([Dog, Cat]).and(
   zod.object({
     '@id': zod.string().optional(),
     id: zod.number(),
@@ -20,5 +20,5 @@ export const pet = zod.union([dog, cat]).and(
   }),
 );
 
-export type pet = zod.input<typeof pet>;
-export type petOutput = zod.output<typeof pet>;
+export type Pet = zod.input<typeof Pet>;
+export type PetOutput = zod.output<typeof Pet>;

--- a/samples/swr-with-zod/__snapshots__/models/pets-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/pets-reusable.zod.ts
@@ -5,9 +5,9 @@
  * OpenAPI spec version: 1.0.0
  */
 import { z as zod } from 'zod';
-import { pet } from './pet-reusable.zod';
+import { Pet } from './pet-reusable.zod';
 
-export const pets = zod.array(pet);
+export const Pets = zod.array(Pet);
 
-export type pets = zod.input<typeof pets>;
-export type petsOutput = zod.output<typeof pets>;
+export type Pets = zod.input<typeof Pets>;
+export type PetsOutput = zod.output<typeof Pets>;

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets-reusable.zod.ts
@@ -6,7 +6,7 @@
  */
 import * as zod from 'zod';
 
-import { pet } from '../../models';
+import { Pet } from '../../models';
 
 /**
  * @summary List all pets
@@ -18,7 +18,7 @@ export const ListPetsQueryParams = zod.object({
     .describe('How many items to return at one time (max 100)'),
 });
 
-export const ListPetsResponseItem = pet;
+export const ListPetsResponseItem = Pet;
 export const ListPetsResponse = zod.array(ListPetsResponseItem);
 
 /**
@@ -30,14 +30,14 @@ export const CreatePetsBodyItem = zod.object({
 });
 export const CreatePetsBody = zod.array(CreatePetsBodyItem);
 
-export const CreatePetsResponse = pet;
+export const CreatePetsResponse = Pet;
 
 /**
  * @summary Update a pet
  */
-export const UpdatePetsBody = pet;
+export const UpdatePetsBody = Pet;
 
-export const UpdatePetsResponse = pet;
+export const UpdatePetsResponse = Pet;
 
 /**
  * @summary Info for a specific pet
@@ -46,4 +46,4 @@ export const ShowPetByIdParams = zod.object({
   petId: zod.string().describe('The id of the pet to retrieve'),
 });
 
-export const ShowPetByIdResponse = pet;
+export const ShowPetByIdResponse = Pet;

--- a/samples/swr-with-zod/src/gen/models/cat-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/cat-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const cat = zod.object({
+export const Cat = zod.object({
   petsRequested: zod.number().optional(),
   type: zod.enum(['cat']),
 });
 
-export type cat = zod.input<typeof cat>;
-export type catOutput = zod.output<typeof cat>;
+export type Cat = zod.input<typeof Cat>;
+export type CatOutput = zod.output<typeof Cat>;

--- a/samples/swr-with-zod/src/gen/models/dachshund-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/dachshund-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const dachshund = zod.object({
+export const Dachshund = zod.object({
   length: zod.number(),
   breed: zod.enum(['Dachshund']),
 });
 
-export type dachshund = zod.input<typeof dachshund>;
-export type dachshundOutput = zod.output<typeof dachshund>;
+export type Dachshund = zod.input<typeof Dachshund>;
+export type DachshundOutput = zod.output<typeof Dachshund>;

--- a/samples/swr-with-zod/src/gen/models/dog-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/dog-reusable.zod.ts
@@ -5,15 +5,15 @@
  * OpenAPI spec version: 1.0.0
  */
 import { z as zod } from 'zod';
-import { dachshund } from './dachshund-reusable.zod';
-import { labradoodle } from './labradoodle-reusable.zod';
+import { Dachshund } from './dachshund-reusable.zod';
+import { Labradoodle } from './labradoodle-reusable.zod';
 
-export const dog = zod.union([labradoodle, dachshund]).and(
+export const Dog = zod.union([Labradoodle, Dachshund]).and(
   zod.object({
     barksPerMinute: zod.number().optional(),
     type: zod.enum(['dog']),
   }),
 );
 
-export type dog = zod.input<typeof dog>;
-export type dogOutput = zod.output<typeof dog>;
+export type Dog = zod.input<typeof Dog>;
+export type DogOutput = zod.output<typeof Dog>;

--- a/samples/swr-with-zod/src/gen/models/error-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/error-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const error = zod.object({
+export const Error = zod.object({
   code: zod.number(),
   message: zod.string(),
 });
 
-export type error = zod.input<typeof error>;
-export type errorOutput = zod.output<typeof error>;
+export type Error = zod.input<typeof Error>;
+export type ErrorOutput = zod.output<typeof Error>;

--- a/samples/swr-with-zod/src/gen/models/labradoodle-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/labradoodle-reusable.zod.ts
@@ -6,10 +6,10 @@
  */
 import { z as zod } from 'zod';
 
-export const labradoodle = zod.object({
+export const Labradoodle = zod.object({
   cuteness: zod.number(),
   breed: zod.enum(['Labradoodle']),
 });
 
-export type labradoodle = zod.input<typeof labradoodle>;
-export type labradoodleOutput = zod.output<typeof labradoodle>;
+export type Labradoodle = zod.input<typeof Labradoodle>;
+export type LabradoodleOutput = zod.output<typeof Labradoodle>;

--- a/samples/swr-with-zod/src/gen/models/pet-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/pet-reusable.zod.ts
@@ -5,10 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 import { z as zod } from 'zod';
-import { cat } from './cat-reusable.zod';
-import { dog } from './dog-reusable.zod';
+import { Cat } from './cat-reusable.zod';
+import { Dog } from './dog-reusable.zod';
 
-export const pet = zod.union([dog, cat]).and(
+export const Pet = zod.union([Dog, Cat]).and(
   zod.object({
     '@id': zod.string().optional(),
     id: zod.number(),
@@ -20,5 +20,5 @@ export const pet = zod.union([dog, cat]).and(
   }),
 );
 
-export type pet = zod.input<typeof pet>;
-export type petOutput = zod.output<typeof pet>;
+export type Pet = zod.input<typeof Pet>;
+export type PetOutput = zod.output<typeof Pet>;

--- a/samples/swr-with-zod/src/gen/models/pets-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/pets-reusable.zod.ts
@@ -5,9 +5,9 @@
  * OpenAPI spec version: 1.0.0
  */
 import { z as zod } from 'zod';
-import { pet } from './pet-reusable.zod';
+import { Pet } from './pet-reusable.zod';
 
-export const pets = zod.array(pet);
+export const Pets = zod.array(Pet);
 
-export type pets = zod.input<typeof pets>;
-export type petsOutput = zod.output<typeof pets>;
+export type Pets = zod.input<typeof Pets>;
+export type PetsOutput = zod.output<typeof Pets>;


### PR DESCRIPTION
Two related fixes for `override.zod.generateReusableSchemas` (both surfaced on the same real-world spec). Happy to split if preferred.

## 1. Component schemas not emitted inline when operations exist

With `client: 'zod'` + `generateReusableSchemas: true` and no separate `schemas:` dir (e.g. `mode: 'single'`), operations reference component schemas by name but the component definitions were never emitted — the output didn't compile.

`shouldGenerateZodSchemasInline` only returned `true` when there were **no** operations. Without the reusable flag that's correct (operations inline their own schemas), but with it, operations reference the component schemas by name, so the definitions must be emitted inline alongside them.

- `shouldGenerateZodSchemasInline` now also returns `true` when the flag is on.
- Thread an `includeZodImport` flag through `generateZodSchemasInline` / `generateZodSchemasInlineReusable` / `generateZodSchemaFileContent`: when operations are present the zod client already emits `import * as zod from 'zod'`, so the inline block must not add a second `import { z as zod }` (which would redeclare `zod`). With no operations, the inline block stays the sole zod import.

## 2. Reusable schema identifiers were camelCase (inconsistent)

Reusable schema exports used `conventionName(name, namingConvention)` for the **identifier**, defaulting to camelCase (`authorizeResponse`). That clashed with operation wrappers (`AuthorizeAuthorizeBody`, via `pascal()`) and the TS model types (`AuthorizeResponse`) generated for the same spec.

Both the generator's `namedRef` emission and the orchestrator's `resolveSchemaName` now use `getRefInfo(ref, context).name` — the exact identifier orval already emits for the TS model type (`pascal` + sanitize + component suffix). `namingConvention` continues to govern **file names** only (e.g. `authorizeResponse.zod.ts`), consistent with the rest of orval; identifiers are always PascalCase.

Before / after (`mode: 'single'`):

```ts
// before
export const AuthorizeAuthorize200Response = authorizeResponse   // ❌ undefined + wrong case
// after
export const authorizeResponse = …                              // defined inline... wait, now:
export const AuthorizeResponse = zod.object({ … });
export const AuthorizeAuthorize200Response = AuthorizeResponse    // ✅ defined, PascalCase
```

## Test plan

- [x] New end-to-end test (`generate-spec.test.ts`): single-mode + reusable + an operation referencing a component schema → component defined inline (before use), referenced by name, exactly one zod import, no `__REF_` sentinels.
- [x] Updated zod + orchestrator unit tests for PascalCase identifiers.
- [x] Verified end-to-end against a real spec (single-mode, ~20 operations, 4 component schemas): all component schemas emitted, single import, PascalCase identifiers matching the operation wrappers + TS types, compiles.
- [x] `swr-with-zod` reusable snapshots regenerated (identifiers now PascalCase; file names unchanged — still camelCase).
- [x] Full typecheck (13 packages) + `@orval/zod` (183), `@orval/orval` (117), `@orval/core` (1933) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoid duplicate Zod imports, ensure inline/reusable schemas are emitted in correct order, and remove unresolved reference sentinels.

* **Refactor**
  * Generated reusable schema exports now use PascalCase identifiers (e.g., Pet instead of pet) for consistent naming.

* **Tests**
  * New/updated regression tests validating import handling, inline emission, schema ordering, PascalCase refs, and complete reference resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->