### PR TITLE
fix(zod): correct inline reusable schema emission (missing import + dropped defs)

### DIFF
--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -269,3 +269,75 @@ describe('generateSpec - generateReusableSchemas recursive ($ref to self)', () =
     }
   });
 });
+
+describe('generateSpec - generateReusableSchemas inline (pure-$ref operations)', () => {
+  // Regression: the zod client's `import * as zod from 'zod'` is usage-gated on
+  // the operations implementation. When every operation is a pure-`$ref` alias
+  // (`export const GetThingResponse = Thing`), the client emits NO zod import,
+  // so the inline schema block (which always uses zod) must supply it — else the
+  // generated file references `zod` with no import and fails to compile.
+  const PURE_REF_SPEC: OpenApiDocument = {
+    openapi: '3.1.0',
+    info: { title: 'PureRef', version: '1.0.0' },
+    paths: {
+      '/thing': {
+        get: {
+          operationId: 'getThing',
+          responses: {
+            '200': {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Thing' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Thing: {
+          type: 'object',
+          required: ['name'],
+          properties: { name: { type: 'string' } },
+        },
+      },
+    },
+  };
+
+  it('emits the zod import when no operation references zod directly', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'zod.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PURE_REF_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'single',
+            client: 'zod',
+            override: { zod: { generateReusableSchemas: true } },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      // The component schema is defined inline...
+      expect(content).toContain('export const Thing = zod.object(');
+      // ...the operation wrapper is a pure-$ref alias (no `zod.` usage)...
+      expect(content).toContain('export const GetThingResponse = Thing');
+      // ...and exactly one zod import is present (the bug emitted zero).
+      expect(content.match(/from 'zod'/g) ?? []).toHaveLength(1);
+      expect(content).not.toContain('__REF_');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -334,7 +334,9 @@ describe('generateSpec - generateReusableSchemas inline (pure-$ref operations)',
       // ...the operation wrapper is a pure-$ref alias (no `zod.` usage)...
       expect(content).toContain('export const GetThingResponse = Thing');
       // ...and exactly one zod import is present (the bug emitted zero).
-      expect(content.match(/from 'zod'/g) ?? []).toHaveLength(1);
+      // Match either quote style so the assertion survives generator quote
+      // changes while still asserting a single `zod` module import.
+      expect(content.match(/from ['"]zod['"]/g) ?? []).toHaveLength(1);
       expect(content).not.toContain('__REF_');
     } finally {
       await rm(workspace, { recursive: true, force: true });

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -450,10 +450,17 @@ export async function writeSpecs(
       output,
       hasOperations,
     );
-    // Only emit the inline `import { z as zod }` when there are no operations.
-    // With operations the zod client already emits `import * as zod from 'zod'`,
-    // so a second import would redeclare the `zod` binding.
-    const includeZodImport = !hasOperations;
+    // The zod client's `import * as zod from 'zod'` is a *usage-gated* dependency
+    // import: it's only emitted when an operation's generated schema actually
+    // references the `zod` token. When every operation is a pure-`$ref` alias
+    // (e.g. `export const FooResponse = Bar`), the client emits no zod import —
+    // so the inline schema block (which always uses zod) must supply it itself.
+    // When an operation does use zod the client already imports it, and a second
+    // import would redeclare the `zod` binding — so the inline block omits it.
+    const operationsUseZod = Object.values(builder.operations).some(
+      (operation) => /\bzod\b/.test(operation.implementation),
+    );
+    const includeZodImport = !operationsUseZod;
 
     implementationPaths = await writeMode({
       builder,

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -662,4 +662,38 @@ describe('generateZodSchemasInline with generateReusableSchemas', () => {
     // No sentinels.
     expect(result).not.toContain('__REF_');
   });
+
+  it('emits schemas whose raw name differs from the sanitized model name', () => {
+    // `__my_data` sanitizes to `_MyData`. The inline writer must seed from the
+    // RAW component keys; seeding from `builder.schemas` (sanitized) yields a
+    // ref (`#/components/schemas/_MyData`) absent from `components.schemas`, so
+    // the definition used to be dropped — leaving the operation wrapper that
+    // references it dangling.
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            __my_data: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        { name: '_MyData', schema: { $ref: '#/components/schemas/__my_data' } },
+      ],
+    } satisfies Parameters<typeof generateZodSchemasInline>[0];
+
+    const output = createOutputOptions();
+    (output.override.zod as Record<string, unknown>).generateReusableSchemas =
+      true;
+
+    const result = generateZodSchemasInline(builder, output);
+
+    expect(result).toContain('export const _MyData =');
+    expect(result).not.toContain('__REF_');
+  });
 });

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -371,9 +371,6 @@ function generateZodSchemasInlineReusable(
   output: WriteZodOutputOptions,
   includeZodImport = true,
 ): string {
-  const schemasWithOpenApiDef = builder.schemas.filter((s) => s.schema);
-  if (schemasWithOpenApiDef.length === 0) return '';
-
   const isZodV4 = !!output.packageJson && isZodVersionV4(output.packageJson);
   const strict = output.override.zod.strict.body;
   const coerce = output.override.zod.coerce.body;
@@ -384,9 +381,21 @@ function generateZodSchemasInlineReusable(
     output: output as ContextSpec['output'],
   };
 
-  const refs = schemasWithOpenApiDef.map(
-    ({ name }) => `#/components/schemas/${name}`,
+  // Seed from the RAW `components.schemas` keys, NOT `builder.schemas` (whose
+  // `name` is the *sanitized* model identifier, e.g. `__schema0` -> `_Schema0`).
+  // Building a ref from a sanitized name yields `#/components/schemas/_Schema0`,
+  // which doesn't exist in `components.schemas`, so the schema was silently
+  // dropped whenever it was reachable only from operations (when referenced by
+  // another component schema it survived via transitive expansion, masking the
+  // bug). Mirrors `writeZodSchemasReusable`, which already seeds from raw keys.
+  const componentSchemas = (builder.spec.components?.schemas ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const refs = Object.keys(componentSchemas).map(
+    (schemaName) => `#/components/schemas/${schemaName}`,
   );
+  if (refs.length === 0) return '';
 
   resolveSchemaNames(refs, context);
 


### PR DESCRIPTION
## Summary

Two pre-existing bugs in the **inline single-file** reusable-schema writer (`client: 'zod'` + `override.zod.generateReusableSchemas`, with no `schemas:` directory). Both produce output that does not compile. Found while working on #3467; fixed here independently.

### 1. Missing `import * as zod from 'zod'`

The zod client's import is a **usage-gated dependency import** — emitted only when an operation's generated schema references the `zod` token. When every operation is a pure-`$ref` alias, e.g.

```ts
export const GetThingResponse = Thing
```

the client emits no zod import. The inline schema block also skipped it (it keyed off `!hasOperations`), so the file ended up referencing `zod` with **no import at all**.

Now the inline block supplies the import unless an operation actually references `zod` (mirroring the client's own gate), so there is always exactly one zod import.

### 2. Dropped definitions for sanitized names

The inline writer seeded reusable refs from `builder.schemas`, whose `name` is the **sanitized** model identifier (`__schema0` → `_Schema0`). The resulting ref `#/components/schemas/_Schema0` doesn't exist in `components.schemas` (the real key is `__schema0`), so the definition was **silently dropped** whenever the schema was reachable only from operations — leaving the operation wrapper that references it dangling. (It survived when another component schema referenced it, via transitive expansion, which masked the bug.)

Now it seeds from the raw `components.schemas` keys, exactly like the per-file writer `writeZodSchemasReusable` already does (see its comment, added in #3465).

## Test plan

- [x] New unit test (`write-zod-specs`): `generateZodSchemasInline` emits a schema whose raw name needs sanitizing (`__my_data` → `_MyData`)
- [x] New e2e test (`generate-spec`): a spec whose only operation is a pure-`$ref` alias yields exactly one `from 'zod'` import (previously zero)
- [x] Existing inline test (operation that *does* use `zod`) still asserts exactly one import — no double-import regression
- [x] Generated output type-checks under `strict` on **zod v3 and v4** for both scenarios
- [x] `lint`, `typecheck`, and full `orval` suite (119 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure Zod import is emitted only when generated operations require it (fixes missing/extra import for pure `$ref` responses).
  * Fix reusable-schema detection to correctly recognize component schemas from raw spec keys and eliminate leftover reference placeholders.

* **Tests**
  * Added regression tests for inline schema generation with pure `$ref` operations and correct Zod import behavior.
  * Added tests for component schema naming edge cases to prevent sentinel markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->