### PR TITLE
feat(zod): add generateMeta to attach .meta() to component schemas (zod v4)

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1112,6 +1112,28 @@ Behavior:
 - The `namingConvention` must produce valid JavaScript identifiers (`camelCase`, `PascalCase`, or `snake_case`). `kebab-case` is rejected with a clear error because it would emit dashed exports.
 - **Trade-off — `readOnly` on shared component schemas:** without this flag, request bodies generated from `$ref` schemas strip `readOnly: true` properties so they don't appear in input validators. With this flag on, request and response endpoints share the same exported schema, so `readOnly` properties remain in body validators too. Either avoid `readOnly` on component schemas you share between requests and responses, or split into separate request/response schemas in the OpenAPI source.
 
+### generateMeta
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+Attach registry metadata to generated **component** schemas via [`.meta()`](https://zod.dev/metadata) (zod v4 only): `id` is the schema name, plus `description` and `deprecated` when the OpenAPI schema provides them.
+
+```ts
+// override: { zod: { generateMeta: true } }
+export const Pet = zod
+  .object({ name: zod.string() })
+  .meta({ id: 'Pet', description: 'A pet in the store', deprecated: true });
+```
+
+Behavior:
+
+- Applies only to **component** schemas emitted as named exports (`schemas: { type: 'zod' }`, or `client: 'zod'` + [`generateReusableSchemas`](#generatereusableschemas)). Operation wrapper schemas are left untouched, so registry `id`s stay unique.
+- `id` is always emitted; `description`/`deprecated` only when present. Property-level descriptions still use `.describe()`.
+- **zod v3** has no `.meta()` — the option is a no-op there, and descriptions continue to emit via `.describe()`.
+- The registry `id` makes [`z.toJSONSchema()`](https://zod.dev/json-schema) reference the schema as `#/$defs/<id>`, round-tripping the component structure.
+
 ---
 
 ## override.effect

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -96,6 +96,7 @@ const createOutput = (
         },
         generateEachHttpStatus: false,
         generateReusableSchemas: false,
+        generateMeta: false,
         useBrandedTypes: false,
         dateTimeOptions: {},
         timeOptions: {},

--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -107,6 +107,7 @@ const createOutput = (
         generateEachHttpStatus: false,
         useBrandedTypes: false,
         generateReusableSchemas: false,
+        generateMeta: false,
         dateTimeOptions: {},
         timeOptions: {},
       },

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -122,6 +122,7 @@ export function createTestContextSpec({
         generateEachHttpStatus: false,
         useBrandedTypes: false,
         generateReusableSchemas: false,
+        generateMeta: false,
         dateTimeOptions: {},
         timeOptions: { precision: 3 },
       },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -753,6 +753,14 @@ export interface ZodOptions {
    * instead of inlining. Default `false`. See `docs/superpowers/specs/2026-05-26-reusable-zod-schemas-design.md`.
    */
   generateReusableSchemas?: boolean;
+  /**
+   * When true (zod v4 only), attaches registry metadata to generated
+   * **component** schemas via `.meta({ id, description?, deprecated? })`: `id` is
+   * the schema name, plus `description`/`deprecated` when the OpenAPI schema
+   * provides them. On zod v3 (which has no `.meta()`) descriptions still emit
+   * via `.describe()`. Default `false`.
+   */
+  generateMeta?: boolean;
 }
 
 export interface EffectOptions {
@@ -796,6 +804,7 @@ export interface NormalizedZodOptions {
   generateEachHttpStatus: boolean;
   useBrandedTypes: boolean;
   generateReusableSchemas: boolean;
+  generateMeta: boolean;
   dateTimeOptions: ZodDateTimeOptions;
   timeOptions: ZodTimeOptions;
 }

--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -118,6 +118,7 @@ function createMockContext(): ContextSpec {
           generateEachHttpStatus: false,
           useBrandedTypes: false,
           generateReusableSchemas: false,
+          generateMeta: false,
           dateTimeOptions: {},
           timeOptions: { precision: 3 },
         },

--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -137,6 +137,8 @@ export interface GenerateReusableSchemaSetOptions {
   strict: boolean;
   isZodV4: boolean;
   coerce?: boolean | ZodCoerceType[];
+  /** Emit `.meta({ id, ... })` on each schema (zod v4). See `ZodOptions.generateMeta`. */
+  generateMeta?: boolean;
 }
 
 /**
@@ -183,7 +185,11 @@ export const generateReusableSchemaSet = (
       name,
       options.strict,
       options.isZodV4,
-      { required: true, useReusableSchemas: true },
+      {
+        required: true,
+        useReusableSchemas: true,
+        emitMeta: options.generateMeta,
+      },
     );
 
     const parsed = parseZodValidationSchemaDefinition(

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -510,6 +510,7 @@ export async function normalizeOptions(
             outputOptions.override?.zod?.useBrandedTypes ?? false,
           generateReusableSchemas:
             outputOptions.override?.zod?.generateReusableSchemas ?? false,
+          generateMeta: outputOptions.override?.zod?.generateMeta ?? false,
           dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {
             offset: true,
           },
@@ -894,6 +895,7 @@ function normalizeOperationsAndTags(
                     useBrandedTypes: zod.useBrandedTypes ?? false,
                     generateReusableSchemas:
                       zod.generateReusableSchemas ?? false,
+                    generateMeta: zod.generateMeta ?? false,
                     dateTimeOptions: zod.dateTimeOptions ?? { offset: true },
                     timeOptions: zod.timeOptions ?? {},
                   },

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -746,4 +746,66 @@ describe('generateZodSchemasInline with generateReusableSchemas', () => {
     expect(result).not.toContain('.meta(');
     expect(result).toContain(".describe('A pet')");
   });
+
+  it('keeps the use-site .describe() chained AFTER .meta() on the named export (zod v4)', () => {
+    // A `$ref` with a `description` sibling renders at the use site as
+    // `<RefName>.describe('use site desc')`. The named export ends with
+    // `.meta(...)` — so the full runtime form is `Pet.meta(...).describe(...)`,
+    // which in zod v4 is exactly the documented pattern for "reference to Pet
+    // with a context-specific description": `z.toJSONSchema` produces
+    // `{ description: 'use site desc', $ref: '#/$defs/Pet' }` and the parent
+    // schema stays valid at runtime. This test pins that arrangement so the
+    // namedRef + emitMeta interaction can't silently regress.
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              type: 'object',
+              description: 'a pet',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+            Owner: {
+              type: 'object',
+              properties: {
+                pet: {
+                  $ref: '#/components/schemas/Pet',
+                  description: 'the owner pet',
+                },
+              },
+              required: ['pet'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        { name: 'Pet', schema: { $ref: '#/components/schemas/Pet' } },
+        { name: 'Owner', schema: { $ref: '#/components/schemas/Owner' } },
+      ],
+    } satisfies Parameters<typeof generateZodSchemasInline>[0];
+
+    const output = createOutputOptions();
+    const zodOverride = output.override.zod as Record<string, unknown>;
+    zodOverride.generateReusableSchemas = true;
+    zodOverride.generateMeta = true;
+    (output as { packageJson?: unknown }).packageJson = {
+      dependencies: { zod: '4.0.0' },
+    };
+
+    const result = generateZodSchemasInline(builder, output);
+
+    // Pet's definition carries the meta...
+    expect(result).toContain(".meta({ id: 'Pet', description: 'a pet' })");
+    // ...and the property use site chains describe onto the named ref —
+    // `Pet.describe(...)` (NOT a fresh `.meta()` reusing Pet's id, which would
+    // collide in the global registry).
+    // namedRef path emits `.describe(...)` with double quotes; main path with
+    // single — tolerate either so this doesn't trip on a formatter swap.
+    expect(result).toMatch(/"?pet"?:\s*Pet\.describe\(['"]the owner pet['"]\)/);
+    // Owner's definition still gets its own meta (no description on Owner).
+    expect(result).toMatch(/export const Owner\b/);
+    expect(result).toContain(".meta({ id: 'Owner' })");
+  });
 });

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -696,4 +696,54 @@ describe('generateZodSchemasInline with generateReusableSchemas', () => {
     expect(result).toContain('export const _MyData =');
     expect(result).not.toContain('__REF_');
   });
+
+  const metaBuilder = () =>
+    ({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              type: 'object',
+              description: 'A pet',
+              deprecated: true,
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [{ name: 'Pet', schema: { $ref: '#/components/schemas/Pet' } }],
+    }) satisfies Parameters<typeof generateZodSchemasInline>[0];
+
+  it('attaches .meta({ id, description, deprecated }) on zod v4 when generateMeta is on', () => {
+    const output = createOutputOptions();
+    const zodOverride = output.override.zod as Record<string, unknown>;
+    zodOverride.generateReusableSchemas = true;
+    zodOverride.generateMeta = true;
+    (output as { packageJson?: unknown }).packageJson = {
+      dependencies: { zod: '4.0.0' },
+    };
+
+    const result = generateZodSchemasInline(metaBuilder(), output);
+
+    expect(result).toContain(
+      ".meta({ id: 'Pet', description: 'A pet', deprecated: true })",
+    );
+  });
+
+  it('falls back to .describe() (no .meta) on zod v3 even when generateMeta is on', () => {
+    const output = createOutputOptions();
+    const zodOverride = output.override.zod as Record<string, unknown>;
+    zodOverride.generateReusableSchemas = true;
+    zodOverride.generateMeta = true;
+    (output as { packageJson?: unknown }).packageJson = {
+      dependencies: { zod: '3.23.0' },
+    };
+
+    const result = generateZodSchemasInline(metaBuilder(), output);
+
+    expect(result).not.toContain('.meta(');
+    expect(result).toContain(".describe('A pet')");
+  });
 });

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -65,6 +65,7 @@ interface WriteZodOutputOptions {
         body: boolean | ZodCoerceType[];
       };
       generateReusableSchemas?: boolean;
+      generateMeta?: boolean;
     };
   };
 }
@@ -341,6 +342,7 @@ export function generateZodSchemasInline(
       isZodV4,
       {
         required: true,
+        emitMeta: output.override.zod.generateMeta,
       },
     );
 
@@ -403,6 +405,7 @@ function generateZodSchemasInlineReusable(
     strict,
     isZodV4,
     coerce,
+    generateMeta: output.override.zod.generateMeta,
   });
 
   const rewritten = rewriteReusableSchemas(entries);
@@ -470,6 +473,7 @@ export async function writeZodSchemas(
       isZodV4,
       {
         required: true,
+        emitMeta: output.override.zod.generateMeta,
       },
     );
 
@@ -553,6 +557,7 @@ async function writeZodSchemasReusable(
     strict,
     isZodV4,
     coerce,
+    generateMeta: output.override.zod.generateMeta,
   });
 
   const rewritten = rewriteReusableSchemas(entries);

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -123,6 +123,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         generateEachHttpStatus: false,
         useBrandedTypes: false,
         generateReusableSchemas: false,
+        generateMeta: false,
         dateTimeOptions: {},
         timeOptions: { precision: 3 },
       },

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -220,6 +220,13 @@ export const generateZodValidationSchemaDefinition = (
      * placeholder instead of being inlined.
      */
     useReusableSchemas?: boolean;
+    /**
+     * When true (and `isZodV4`), the top-level (named component) schema emits a
+     * `.meta({ id, description?, deprecated? })` instead of `.describe(...)`.
+     * Set ONLY for top-level component-schema generation — recursive calls omit
+     * it, so nested schemas keep `.describe()` and never get a duplicate `id`.
+     */
+    emitMeta?: boolean;
   },
 ): ZodValidationSchemaDefinition => {
   if (!schema) return { functions: [], consts: [] };
@@ -322,6 +329,31 @@ export const generateZodValidationSchemaDefinition = (
   constNameRegistry[name] = constsCounter;
 
   const functions: [string, unknown][] = [];
+
+  // Emit the schema's trailing description/metadata. On zod v4 with `emitMeta`
+  // (top-level component schemas only) this is a single `.meta({ id, ... })`
+  // carrying the schema name as `id` plus description/deprecated when present;
+  // otherwise it falls back to the plain `.describe(...)`. Called from both
+  // return points (the multi-type union exit and the main exit) so every schema
+  // shape is covered. `.meta()` must be the LAST modifier in the chain — zod v4
+  // turns `.meta({id}).describe(...)` into a `$ref` wrapper, whereas
+  // `.describe(...).meta({id})` (and a lone `.meta`) stay flat.
+  const pushDescriptionOrMeta = () => {
+    const description =
+      typeof schema.description === 'string' ? schema.description : undefined;
+    const deprecated =
+      'deprecated' in schema && schema.deprecated === true ? true : undefined;
+
+    if (rules?.emitMeta && isZodV4) {
+      const meta: Record<string, unknown> = { id: name };
+      if (description !== undefined) meta.description = description;
+      if (deprecated) meta.deprecated = true;
+      functions.push(['meta', meta]);
+    } else if (description !== undefined) {
+      functions.push(['describe', `'${jsStringEscape(description)}'`]);
+    }
+  };
+
   const type = resolveZodType(schema);
   const required = rules?.required ?? false;
   const hasDefault = schema.default !== undefined;
@@ -526,6 +558,8 @@ export const generateZodValidationSchemaDefinition = (
     } else if (!required) {
       functions.push(['optional', undefined]);
     }
+
+    pushDescriptionOrMeta();
 
     return { functions, consts };
   }
@@ -946,9 +980,7 @@ export const generateZodValidationSchemaDefinition = (
     functions.push(['default', defaultVarName]);
   }
 
-  if (schema.description) {
-    functions.push(['describe', `'${jsStringEscape(schema.description)}'`]);
-  }
+  pushDescriptionOrMeta();
 
   return { functions, consts: unique(consts) };
 };
@@ -1005,6 +1037,26 @@ export const parseZodValidationSchemaDefinition = (
       const refArgs = args as { name: string; sourceRef: string };
       usedRefs.add(refArgs.name);
       return `__REF_${refArgs.name}__`;
+    }
+
+    // `.meta({ id, description?, deprecated? })` — registry metadata for zod v4.
+    // Built explicitly (rather than via stringify) so the description is
+    // JS-string-escaped and the field order is stable: id, description,
+    // deprecated.
+    if (fn === 'meta') {
+      const metaArgs = args as {
+        id: string;
+        description?: string;
+        deprecated?: boolean;
+      };
+      const parts = [`id: '${jsStringEscape(metaArgs.id)}'`];
+      if (metaArgs.description !== undefined) {
+        parts.push(`description: '${jsStringEscape(metaArgs.description)}'`);
+      }
+      if (metaArgs.deprecated) {
+        parts.push('deprecated: true');
+      }
+      return `.meta({ ${parts.join(', ')} })`;
     }
 
     // File | string for text contentMediaType/encoding (user can pass string, runtime wraps in Blob)

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -339,8 +339,14 @@ export const generateZodValidationSchemaDefinition = (
   // turns `.meta({id}).describe(...)` into a `$ref` wrapper, whereas
   // `.describe(...).meta({id})` (and a lone `.meta`) stay flat.
   const pushDescriptionOrMeta = () => {
+    // Empty-string descriptions are treated as absent — preserves the prior
+    // `if (schema.description)` falsy-check semantics (which skipped both `''`
+    // and `undefined`), so this change never emits a no-op `.describe('')` or
+    // `description: ''` in meta.
     const description =
-      typeof schema.description === 'string' ? schema.description : undefined;
+      typeof schema.description === 'string' && schema.description.length > 0
+        ? schema.description
+        : undefined;
     const deprecated =
       'deprecated' in schema && schema.deprecated === true ? true : undefined;
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -7915,3 +7915,149 @@ describe('parseZodValidationSchemaDefinition with namedRef', () => {
     expect(result.usedRefs).toEqual(new Set());
   });
 });
+
+describe('generateMeta (.meta())', () => {
+  const ctx = {
+    output: { override: { useDates: false } },
+  } as ContextSpec;
+
+  it('folds id + description + deprecated into a single .meta() on zod v4', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      description: 'A pet',
+      deprecated: true,
+      required: ['id'],
+      properties: {
+        id: { type: 'integer' },
+        name: { type: 'string', description: 'nested' },
+      },
+    };
+
+    const def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Pet',
+      true,
+      true,
+      { required: true, emitMeta: true },
+    );
+
+    const meta = def.functions.find((fn) => fn[0] === 'meta');
+    expect(meta?.[1]).toEqual({
+      id: 'Pet',
+      description: 'A pet',
+      deprecated: true,
+    });
+    // The top-level describe is folded into meta (not emitted separately).
+    expect(def.functions.some((fn) => fn[0] === 'describe')).toBe(false);
+
+    const parsed = parseZodValidationSchemaDefinition(
+      def,
+      ctx,
+      false,
+      true,
+      true,
+    );
+    expect(parsed.zod).toContain(
+      ".meta({ id: 'Pet', description: 'A pet', deprecated: true })",
+    );
+    // Nested property descriptions still use .describe().
+    expect(parsed.zod).toContain(".describe('nested')");
+  });
+
+  it('emits id-only meta when the schema has no description or deprecated', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      properties: { x: { type: 'string' } },
+    };
+
+    const def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Plain',
+      false,
+      true,
+      { required: true, emitMeta: true },
+    );
+    const parsed = parseZodValidationSchemaDefinition(
+      def,
+      ctx,
+      false,
+      false,
+      true,
+    );
+    expect(parsed.zod).toContain(".meta({ id: 'Plain' })");
+  });
+
+  it('falls back to .describe() on zod v3 (no .meta())', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      description: 'A name',
+      deprecated: true,
+    };
+
+    const def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Name',
+      false,
+      false,
+      { required: true, emitMeta: true },
+    );
+    expect(def.functions.some((fn) => fn[0] === 'meta')).toBe(false);
+
+    const parsed = parseZodValidationSchemaDefinition(
+      def,
+      ctx,
+      false,
+      false,
+      false,
+    );
+    expect(parsed.zod).toContain(".describe('A name')");
+    expect(parsed.zod).not.toContain('.meta(');
+  });
+
+  it('does not emit meta unless emitMeta is set (even on v4)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      description: 'A name',
+    };
+
+    const def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Name',
+      false,
+      true,
+      { required: true },
+    );
+    expect(def.functions.some((fn) => fn[0] === 'meta')).toBe(false);
+
+    const parsed = parseZodValidationSchemaDefinition(
+      def,
+      ctx,
+      false,
+      false,
+      true,
+    );
+    expect(parsed.zod).toContain(".describe('A name')");
+  });
+
+  it('emits meta on a multi-type (type array) top-level schema', () => {
+    const schema = {
+      type: ['string', 'number'],
+      description: 'either',
+    } as unknown as OpenApiSchemaObject;
+
+    const def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Either',
+      false,
+      true,
+      { required: true, emitMeta: true },
+    );
+    const meta = def.functions.find((fn) => fn[0] === 'meta');
+    expect(meta?.[1]).toEqual({ id: 'Either', description: 'either' });
+  });
+});

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -8060,4 +8060,49 @@ describe('generateMeta (.meta())', () => {
     const meta = def.functions.find((fn) => fn[0] === 'meta');
     expect(meta?.[1]).toEqual({ id: 'Either', description: 'either' });
   });
+
+  it('treats an empty-string description as absent (preserves prior semantics)', () => {
+    // Old code used `if (schema.description)` which skipped `''`; the helper
+    // matches that — no `.describe('')` and no `description: ''` in meta.
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      description: '',
+    };
+
+    // v4 + emitMeta: id-only, no description key in the meta object.
+    const v4Def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Empty',
+      false,
+      true,
+      { required: true, emitMeta: true },
+    );
+    const v4Meta = v4Def.functions.find((fn) => fn[0] === 'meta');
+    expect(v4Meta?.[1]).toEqual({ id: 'Empty' });
+
+    // v3 fallback (no emitMeta path): no `.describe('')` emitted.
+    const v3Def = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Empty',
+      false,
+      false,
+      { required: true, emitMeta: true },
+    );
+    expect(v3Def.functions.some((fn) => fn[0] === 'describe')).toBe(false);
+
+    // No-emitMeta + v4: still no `.describe('')` (matches old falsy-check
+    // semantics; was already the case before this PR, asserted here as a
+    // regression anchor).
+    const offDef = generateZodValidationSchemaDefinition(
+      schema,
+      ctx,
+      'Empty',
+      false,
+      true,
+      { required: true },
+    );
+    expect(offDef.functions.some((fn) => fn[0] === 'describe')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `override.zod.generateMeta` (default `false`). When enabled on **zod v4**, each generated **component** schema gets registry metadata via [`.meta()`](https://zod.dev/metadata):

```ts
// override: { zod: { generateMeta: true } }
export const Pet = zod
  .object({ id: zod.number(), name: zod.string().describe('the pet name') })
  .meta({ id: 'Pet', description: 'A pet in the store', deprecated: true });
```

- `id` is the schema name (always); `description` and `deprecated` are included only when the OpenAPI schema provides them.
- This makes schemas self-describing and lets [`z.toJSONSchema()`](https://zod.dev/json-schema) reference them by `id` (`#/$defs/Pet`), round-tripping the component structure.

## Design

- **Generator fold:** a top-level-only `emitMeta` rule folds the schema's trailing `.describe(...)` into a single `.meta({ id, description?, deprecated? })` on zod v4; **nested property descriptions keep `.describe()`**. Handled at both generator exit points (multi-type union + main).
- **Ordering matters:** `.meta()` is emitted *last*. Verified against zod 4.3.6 that `.meta({id}).describe(...)` wraps the schema in a `$ref` indirection, whereas `.describe(...).meta({id})` (and a lone `.meta`) stay flat.
- **Scope = component schemas only** (named exports — `schemas: { type: 'zod' }` or `client: 'zod'` + `generateReusableSchemas`). Operation wrapper schemas are intentionally left untouched, so zod's global-registry `id`s never collide.
- **zod v3:** no `.meta()` exists — the option is a silent no-op and descriptions still emit via `.describe()`.

## Test plan

- [x] Generator unit tests: v4 folds id+description+deprecated into one `.meta()`; id-only when no description/deprecated; **nested keeps `.describe()`**; v3 falls back to `.describe()`; `emitMeta` off → no `.meta()`; multi-type (type-array) top-level schema gets meta
- [x] Parser unit: `['meta', {...}]` → `.meta({ id: 'X', description: '...', deprecated: true })`
- [x] Wiring tests (`write-zod-specs`): config → `.meta()` on zod v4; `.describe()` (no `.meta`) on zod v3
- [x] Generated v4 output type-checks under `strict`; `z.toJSONSchema()` surfaces `id` / `description` / `deprecated` (nested description preserved)
- [x] `lint`, `typecheck`, and full suites pass — core 1933, zod 188, orval 119
- [x] Docs: new `### generateMeta` section under `override.zod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zod.generateMeta (default: false) to optionally include registry metadata (id, description, deprecated) on generated Zod component schemas (emits .meta() on Zod v4, falls back to .describe() on v3).
* **Documentation**
  * Docs updated to describe the new option, its defaults, and cross-version behavior.
* **Tests**
  * Expanded tests and updated defaults to validate generateMeta behavior and regressions.
* **Types**
  * Public configuration types updated to expose the new option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->