### PR TITLE
feat: add option to inject params in generated zod schemas

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1080,6 +1080,65 @@ Control which schemas are generated.
 
 Add preprocess functions to schemas.
 
+### params
+
+**Type:** [`Mutator`](#mutator)
+
+Inject a Zod `params` argument (e.g. `{ error: ... }`) into every generated validator. The referenced function is called once per validator at schema construction time and receives codegen-time context (operation, location, schema name, field path, validator name). Whatever it returns is passed as the trailing argument of the call.
+
+Useful for i18n error keys, branded error messages, or any field-aware customisation that Zod's global error map cannot disambiguate on its own (because `issue.path` does not carry operation/schema identity).
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      override: {
+        zod: {
+          params: { path: './zod-params.ts', name: 'zodParams' },
+        },
+      },
+    },
+  },
+});
+```
+
+```ts title="zod-params.ts"
+import type { ZodParamsContext } from 'orval';
+import { i18n } from './i18n';
+
+export const zodParams = (ctx: ZodParamsContext) => ({
+  error: (issue: { input: unknown; path: PropertyKey[] }) =>
+    i18n.t(
+      `errors.${ctx.schemaName}.${ctx.fieldPath.join('.')}.${ctx.validator}`,
+      { value: issue.input },
+    ),
+});
+```
+
+The `'schema'` location is used for shared component schemas emitted under [`generateReusableSchemas`](#generatereusableschemas). Component schemas have no single owning operation, so `operationId` is the empty string in that case — branch on `ctx.location === 'schema'` if your error keys need to fall back to a schema-only namespace.
+
+Generated output (excerpt):
+
+```ts
+import { zodParams } from './zod-params';
+
+export const CreateUserBody = zod.object({
+  email: zod
+    .string(zodParams({ operationId: 'createUser', location: 'body', schemaName: 'CreateUserBody', fieldPath: ['email'], validator: 'string' }))
+    .email(zodParams({ operationId: 'createUser', location: 'body', schemaName: 'CreateUserBody', fieldPath: ['email'], validator: 'email' })),
+});
+```
+
+Injection scope:
+
+- Applied to base types (`string`, `number`, `boolean`, `bigint`, `date`, `integer`), constraints (`min`, `max`, `gt`, `lt`, `multipleOf`, `regex`, `length`), formats (`email`, `url`, `uuid`, `hostname`, `datetime`, `time`), and `literal`, `enum`, `instanceof`, `stringFormat`.
+- Skipped on modifiers (`optional`, `nullable`, `nullish`, `default`, `describe`) and structural calls (`object`, `array`, `tuple`, `union`, `rest`, `passthrough`, `strict`).
+- `fieldPath` only includes object property names, mirroring Zod's own `issue.path`. Array indices and tuple positions are not appended — the inner element of `{ tags: array<string> }` and a top-level `tags: string` both see `fieldPath: ['tags']`. Use the `validator` field to distinguish a container (`'array'`, `'tuple'`) from its element (`'string'`, `'number'`).
+
+For static messages, return an object with a string `error`: `return { error: 'My message' }`. The function may return `undefined` to fall back to Zod defaults for a specific call.
+
+> The `{ error }` shape is Zod v4-only — on v3 it is silently ignored and the default message is used. If your project supports both Zod v3 and v4, return `{ message: 'My message' }` instead, which works on both.
+
 ### dateTimeOptions / timeOptions
 
 **Type:** `Object`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -744,6 +744,18 @@ export interface ZodOptions {
     body?: Mutator;
     response?: Mutator;
   };
+  /**
+   * Mutator referencing a function called once per emitted validator at schema
+   * construction time. It receives codegen-time context (operation, location,
+   * schema name, field path, validator name) and returns a Zod `params` object
+   * (e.g. `{ error: ... }`) that is appended as the trailing argument.
+   *
+   * The plural name follows Zod's own term for the validator's second argument
+   * (`z.string(params)`) and is unrelated to the singular `param` key used by
+   * `generate` / `coerce` / `preprocess` above, which refers to the path-parameter
+   * location.
+   */
+  params?: Mutator;
   dateTimeOptions?: ZodDateTimeOptions;
   timeOptions?: ZodTimeOptions;
   generateEachHttpStatus?: boolean;
@@ -802,6 +814,7 @@ export interface NormalizedZodOptions {
     body?: NormalizedMutator;
     response?: NormalizedMutator;
   };
+  params?: NormalizedMutator;
   generateEachHttpStatus: boolean;
   useBrandedTypes: boolean;
   generateReusableSchemas: boolean;

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -163,6 +163,236 @@ describe('generateSpec - generateReusableSchemas inline (single mode)', () => {
   });
 });
 
+describe('generateSpec - generateReusableSchemas inline + override.zod.params', () => {
+  // Regression: with `client: 'zod'` + `generateReusableSchemas: true` and no
+  // `output.schemas` dir, the inline-reusable writer emits component schemas
+  // into the operation file (single mode) or an adjacent `.schemas` file
+  // (split/tags). `override.zod.params` must be threaded through that path so
+  // the named `export const Pet = …` definitions get `zodParams(…)` injection
+  // — previously only the operation wrappers in `generateZodRoute` did,
+  // leaving the shared definitions uninjected.
+  it('injects zodParams on inline component schemas in single mode', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'zod.ts');
+    const mutatorFile = path.join(workspace, 'zod-params.ts');
+
+    try {
+      await fs.writeFile(
+        mutatorFile,
+        'export const zodParams = (_ctx: unknown) => ({});\n',
+      );
+
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'single',
+            client: 'zod',
+            override: {
+              zod: {
+                generateReusableSchemas: true,
+                params: { path: './zod-params.ts', name: 'zodParams' },
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      // Inline component schema is injected with location: 'schema' and the
+      // component's name (not an operation's) — that's the whole point of
+      // wiring this through the reusable path.
+      expect(content).toContain('export const Pet = zod.object(');
+      expect(content).toMatch(
+        /zodParams\(\{"operationId":"","location":"schema","schemaName":"Pet","fieldPath":\["name"\],"validator":"string"\}\)/,
+      );
+      // Exactly one zodParams import in single mode: the operation file
+      // builder already emits one via each verb's mutators array, and the
+      // inline schemas live in the same file — emitting a second `import
+      // { zodParams }` line would be a duplicate.
+      expect(
+        content.match(/import \{ zodParams \} from ['"]\.\/zod-params['"]/g) ??
+          [],
+      ).toHaveLength(1);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  // Split mode writes the inline schemas to a separate `<name>.schemas.ts`
+  // file with no other imports, so the params-mutator import has to be
+  // emitted from the inline writer itself — the outer operation file builder
+  // can't reach across files.
+  it('emits the zodParams import in the split-mode schemas file', async () => {
+    const workspace = await createTempWorkspace();
+    const schemasFile = path.join(workspace, 'zod.schemas.ts');
+    const targetFile = path.join(workspace, 'zod.ts');
+    const mutatorFile = path.join(workspace, 'zod-params.ts');
+
+    try {
+      await fs.writeFile(
+        mutatorFile,
+        'export const zodParams = (_ctx: unknown) => ({});\n',
+      );
+
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'split',
+            client: 'zod',
+            override: {
+              zod: {
+                generateReusableSchemas: true,
+                params: { path: './zod-params.ts', name: 'zodParams' },
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const schemasContent = await fs.readFile(schemasFile, 'utf8');
+      const targetContent = await fs.readFile(targetFile, 'utf8');
+
+      // Injection lands in the schemas file...
+      expect(schemasContent).toContain('export const Pet = zod.object(');
+      expect(schemasContent).toMatch(
+        /zodParams\(\{"operationId":"","location":"schema","schemaName":"Pet","fieldPath":\["name"\],"validator":"string"\}\)/,
+      );
+      // ...with its own import (the operation file's import doesn't reach
+      // here — different file).
+      expect(schemasContent).toMatch(
+        /import \{ zodParams \} from ['"]\.\/zod-params['"]/,
+      );
+      // The operation file still imports zodParams independently (used by
+      // operation wrappers via `generateZodRoute`'s mutators array).
+      expect(targetContent).toMatch(
+        /import \{ zodParams \} from ['"]\.\/zod-params['"]/,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  // `tags` mode looks like `single` but isn't: per-tag operation files live
+  // alongside a separate `<name>.schemas.ts` file. The schemas file has no
+  // other imports either, so — same as `split` — it has to emit the params
+  // import from inside the inline writer. Pinning this so the case can't
+  // silently regress to "no import → `zodParams` undefined at runtime".
+  const TAGGED_SPEC: OpenApiDocument = {
+    ...PETSTORE_SPEC,
+    paths: {
+      '/pets': {
+        get: {
+          ...PETSTORE_SPEC.paths?.['/pets']?.get,
+          tags: ['pets'],
+        },
+      },
+    },
+  };
+
+  it('emits the zodParams import in the tags-mode schemas file', async () => {
+    const workspace = await createTempWorkspace();
+    const schemasFile = path.join(workspace, 'zod.schemas.ts');
+    const mutatorFile = path.join(workspace, 'zod-params.ts');
+
+    try {
+      await fs.writeFile(
+        mutatorFile,
+        'export const zodParams = (_ctx: unknown) => ({});\n',
+      );
+
+      const options = await normalizeOptions(
+        {
+          input: { target: TAGGED_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'tags',
+            client: 'zod',
+            override: {
+              zod: {
+                generateReusableSchemas: true,
+                params: { path: './zod-params.ts', name: 'zodParams' },
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const schemasContent = await fs.readFile(schemasFile, 'utf8');
+
+      expect(schemasContent).toContain('export const Pet = zod.object(');
+      expect(schemasContent).toMatch(
+        /zodParams\(\{"operationId":"","location":"schema","schemaName":"Pet","fieldPath":\["name"\],"validator":"string"\}\)/,
+      );
+      expect(schemasContent).toMatch(
+        /import \{ zodParams \} from ['"]\.\/zod-params['"]/,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('emits the zodParams import in the tags-split schemas file', async () => {
+    const workspace = await createTempWorkspace();
+    // In tags-split, operation files nest under `<dirname>/<tag>/<tag>.ts`
+    // but the inline schemas file stays at the root next to `zod-params.ts`.
+    const schemasFile = path.join(workspace, 'zod.schemas.ts');
+    const mutatorFile = path.join(workspace, 'zod-params.ts');
+
+    try {
+      await fs.writeFile(
+        mutatorFile,
+        'export const zodParams = (_ctx: unknown) => ({});\n',
+      );
+
+      const options = await normalizeOptions(
+        {
+          input: { target: TAGGED_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'tags-split',
+            client: 'zod',
+            override: {
+              zod: {
+                generateReusableSchemas: true,
+                params: { path: './zod-params.ts', name: 'zodParams' },
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const schemasContent = await fs.readFile(schemasFile, 'utf8');
+
+      expect(schemasContent).toContain('export const Pet = zod.object(');
+      expect(schemasContent).toMatch(
+        /zodParams\(\{"operationId":"","location":"schema","schemaName":"Pet","fieldPath":\["name"\],"validator":"string"\}\)/,
+      );
+      expect(schemasContent).toMatch(
+        /import \{ zodParams \} from ['"]\.\/zod-params['"]/,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('generateSpec - generateReusableSchemas recursive ($ref to self)', () => {
   // Regression: a self-referential component schema is emitted as a single
   // reusable `const` whose initializer references itself through `zod.lazy`.

--- a/packages/orval/src/index.ts
+++ b/packages/orval/src/index.ts
@@ -2,3 +2,4 @@ export { generate as default, generate } from './generate';
 export { defineConfig, defineTransformer } from './utils/options';
 export type { Options } from '@orval/core';
 export * from '@orval/core';
+export type { ZodParamsContext } from '@orval/zod';

--- a/packages/orval/src/reusable-schemas.test.ts
+++ b/packages/orval/src/reusable-schemas.test.ts
@@ -158,6 +158,75 @@ describe('generateReusableSchemaSet', () => {
     expect(ownerEntry?.usedRefs).toEqual(new Set());
   });
 
+  it('injects paramsMutator with location: "schema" at every leaf validator when configured', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'integer' },
+              },
+              required: ['name', 'age'],
+            },
+          },
+        },
+      },
+    });
+
+    const paramsMutator = {
+      name: 'zodParams',
+      path: './zod-params',
+      default: false,
+      hasErrorType: false,
+      errorTypeName: '',
+      hasSecondArg: false,
+      hasThirdArg: false,
+      isHook: false,
+    };
+
+    const [entry] = generateReusableSchemaSet(
+      ['#/components/schemas/Pet'],
+      context,
+      { strict: false, isZodV4: false, paramsMutator },
+    );
+
+    // Component schemas have no owning operation, so operationId is empty.
+    // The `'schema'` location lets user-side `zodParams` branch on it.
+    expect(entry.zod).toContain(
+      `zodParams({"operationId":"","location":"schema","schemaName":"Pet","fieldPath":["name"],"validator":"string"})`,
+    );
+    expect(entry.zod).toContain(
+      `zodParams({"operationId":"","location":"schema","schemaName":"Pet","fieldPath":["age"],"validator":"number"})`,
+    );
+  });
+
+  it('emits no params injection when paramsMutator is not provided', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              type: 'object',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+          },
+        },
+      },
+    });
+
+    const [entry] = generateReusableSchemaSet(
+      ['#/components/schemas/Pet'],
+      context,
+      { strict: false, isZodV4: false },
+    );
+
+    expect(entry.zod).not.toContain('zodParams(');
+  });
+
   it('expands to the transitive closure of component-schema refs', () => {
     const context = createTestContextSpec({
       spec: {

--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -1,4 +1,4 @@
-import type { ContextSpec, ZodCoerceType } from '@orval/core';
+import type { ContextSpec, GeneratorMutator, ZodCoerceType } from '@orval/core';
 import { getRefInfo } from '@orval/core';
 import {
   generateZodValidationSchemaDefinition,
@@ -139,6 +139,14 @@ export interface GenerateReusableSchemaSetOptions {
   coerce?: boolean | ZodCoerceType[];
   /** Emit `.meta({ id, ... })` on each schema (zod v4). See `ZodOptions.generateMeta`. */
   generateMeta?: boolean;
+  /**
+   * When set, the user's `override.zod.params` mutator is invoked for every
+   * leaf validator inside each emitted component schema with a `'schema'`
+   * location and an empty `operationId` (component schemas are shared across
+   * operations). Consumers can branch on `ctx.location === 'schema'` to vary
+   * the injected params for shared definitions.
+   */
+  paramsMutator?: GeneratorMutator;
 }
 
 /**
@@ -198,6 +206,15 @@ export const generateReusableSchemaSet = (
       options.coerce ?? false,
       options.strict,
       options.isZodV4,
+      undefined,
+      options.paramsMutator
+        ? {
+            mutator: options.paramsMutator,
+            operationId: '',
+            location: 'schema',
+            schemaName: name,
+          }
+        : undefined,
     );
 
     entries.push({

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -504,6 +504,14 @@ export async function normalizeOptions(
                 }
               : {}),
           },
+          ...(outputOptions.override?.zod?.params
+            ? {
+                params: normalizeMutator(
+                  workspace,
+                  outputOptions.override.zod.params,
+                ),
+              }
+            : {}),
           generateEachHttpStatus:
             outputOptions.override?.zod?.generateEachHttpStatus ?? false,
           useBrandedTypes:
@@ -891,6 +899,11 @@ function normalizeOperationsAndTags(
                           }
                         : {}),
                     },
+                    ...(zod.params
+                      ? {
+                          params: normalizeMutator(workspace, zod.params),
+                        }
+                      : {}),
                     generateEachHttpStatus: zod.generateEachHttpStatus ?? false,
                     useBrandedTypes: zod.useBrandedTypes ?? false,
                     generateReusableSchemas:

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -7,6 +7,7 @@ import {
   fixCrossDirectoryImports,
   fixRegularSchemaImports,
   generateDependencyImports,
+  generateMutator,
   getFileInfo,
   getImportExtension,
   getMockFileExtensionByTypeName,
@@ -331,12 +332,27 @@ export async function writeSpecs(
       // also drives client/mock outputs) isn't dragged into the zod world.
       const fileExtension = output.schemaFileExtension;
 
+      // Reusable component schemas live as separate files under `schemasPath`,
+      // so we resolve the user's `override.zod.params` mutator once relative
+      // to that directory and pass it down. Each emitted schema file lives in
+      // the same dir, so the relative import is identical across files.
+      const schemasParamsMutator = output.override.zod.params
+        ? await generateMutator({
+            output: path.join(schemasPath, `__params__${fileExtension}`),
+            mutator: output.override.zod.params,
+            name: 'zodParams',
+            workspace,
+            tsconfig: output.tsconfig,
+          })
+        : undefined;
+
       await writeZodSchemas(
         builder,
         schemasPath,
         fileExtension,
         header,
         output,
+        schemasParamsMutator,
       );
 
       await writeZodSchemasFromVerbs(
@@ -462,6 +478,32 @@ export async function writeSpecs(
     );
     const includeZodImport = !operationsUseZod;
 
+    // Inline component schemas (when `generateReusableSchemas` is on without a
+    // dedicated `output.schemas` dir) need their own `paramsMutator` resolved
+    // relative to `output.target`. Per-operation mutators in `generateZodRoute`
+    // don't cover the shared `export const Pet = …` definitions emitted here,
+    // so without this the inlined components would silently skip injection.
+    const inlineSchemasParamsMutator =
+      needZodSchemasInline && output.override.zod.params
+        ? await generateMutator({
+            output: output.target,
+            mutator: output.override.zod.params,
+            name: 'zodParams',
+            workspace,
+            tsconfig: output.tsconfig,
+          })
+        : undefined;
+    // Every non-`single` mode (`split` / `tags` / `tags-split`) writes inline
+    // schemas to a separate `.schemas` file alongside the operation file(s),
+    // so they need their own params-mutator import. Only in `single` mode do
+    // the schemas concatenate into the operation file and inherit its import
+    // (emitted via each verb's `mutators` array in `generateZodRoute`) — re-
+    // emitting from inline would produce a duplicate `import` line there.
+    // With no operations at all, even in `single` mode the file builder has
+    // no operation mutators to lean on, so we still emit.
+    const isSchemasInSeparateFile = output.mode !== OutputMode.SINGLE;
+    const includeParamsImport = !hasOperations || isSchemasInSeparateFile;
+
     implementationPaths = await writeMode({
       builder,
       workspace,
@@ -470,7 +512,14 @@ export async function writeSpecs(
       header,
       needSchema: shouldGenerateSchemas(output, hasOperations),
       generateSchemasInline: needZodSchemasInline
-        ? () => generateZodSchemasInline(builder, output, includeZodImport)
+        ? () =>
+            generateZodSchemasInline(
+              builder,
+              output,
+              includeZodImport,
+              inlineSchemasParamsMutator,
+              includeParamsImport,
+            )
         : undefined,
     });
   }

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {
   type ContextSpec,
   conventionName,
+  type GeneratorMutator,
   getRefInfo,
   isComponentRef,
   type NamingConvention,
@@ -123,6 +124,29 @@ interface WriteZodSchemasFromVerbsContext {
   spec: ContextSpec['spec'];
   target: string;
   workspace: string;
+}
+
+/**
+ * Render the `import { ... } from '...'` line for a resolved
+ * `GeneratorMutator`. Mirrors the format produced by
+ * `generateMutatorImports` in `@orval/core` but inlined to avoid pulling in
+ * its full surface area for a single statement.
+ */
+function buildMutatorImportStatement(mutator: GeneratorMutator): string {
+  const importClause = mutator.default ? mutator.name : `{ ${mutator.name} }`;
+  return `import ${importClause} from '${mutator.path}';`;
+}
+
+/**
+ * Whole-word substring check for a resolved mutator alias inside generated
+ * code. Plain `String.includes` would false-positive when the user names the
+ * mutator something like `min` against `.min(1)`.
+ */
+function bodyReferencesMutator(
+  body: string,
+  mutator: GeneratorMutator,
+): boolean {
+  return new RegExp(String.raw`\b${mutator.name}\b`).test(body);
 }
 
 function generateZodSchemaFileContent(
@@ -401,12 +425,20 @@ export function generateZodSchemasInline(
   builder: WriteZodSchemasInput,
   output: WriteZodOutputOptions,
   includeZodImport = true,
+  paramsMutator?: GeneratorMutator,
+  includeParamsImport = false,
 ): string {
   const useReusableSchemas =
     output.override.zod.generateReusableSchemas === true;
 
   if (useReusableSchemas) {
-    return generateZodSchemasInlineReusable(builder, output, includeZodImport);
+    return generateZodSchemasInlineReusable(
+      builder,
+      output,
+      includeZodImport,
+      paramsMutator,
+      includeParamsImport,
+    );
   }
 
   const schemasWithOpenApiDef = builder.schemas.filter((s) => s.schema);
@@ -472,6 +504,8 @@ function generateZodSchemasInlineReusable(
   builder: WriteZodSchemasInput,
   output: WriteZodOutputOptions,
   includeZodImport = true,
+  paramsMutator?: GeneratorMutator,
+  includeParamsImport = false,
 ): string {
   const isZodV4 = !!output.packageJson && isZodVersionV4(output.packageJson);
   const strict = output.override.zod.strict.body;
@@ -506,6 +540,7 @@ function generateZodSchemasInlineReusable(
     isZodV4,
     coerce,
     generateMeta: output.override.zod.generateMeta,
+    paramsMutator,
   });
 
   const rewritten = rewriteReusableSchemas(entries);
@@ -519,7 +554,21 @@ function generateZodSchemasInlineReusable(
 
   // Omit the zod import when concatenated into a file that already imports it
   // (inline single-mode output where the zod client emits `import * as zod`).
-  const prefix = includeZodImport ? `import { z as zod } from 'zod';\n\n` : '';
+  const zodImport = includeZodImport ? `import { z as zod } from 'zod';\n` : '';
+  // In split modes (`split` / `tags-split`) the inline schemas are written to
+  // a separate `.schemas` file with no other imports, so the params-mutator
+  // import has to be emitted here. In `single` / `tags` modes the schemas are
+  // concatenated into the operation file, which already imports the same
+  // mutator via its per-verb mutators array (see `generateZodRoute`) — we
+  // skip emitting it again to avoid a duplicate import line.
+  const paramsImport =
+    paramsMutator &&
+    includeParamsImport &&
+    bodyReferencesMutator(body, paramsMutator)
+      ? `${buildMutatorImportStatement(paramsMutator)}\n`
+      : '';
+  const prefix =
+    zodImport || paramsImport ? `${zodImport}${paramsImport}\n` : '';
   return `${prefix}${body}\n`;
 }
 
@@ -529,6 +578,7 @@ export async function writeZodSchemas(
   fileExtension: string,
   header: string,
   output: WriteZodOutputOptions,
+  paramsMutator?: GeneratorMutator,
 ) {
   const useReusableSchemas = output.override.zod.generateReusableSchemas;
 
@@ -539,6 +589,7 @@ export async function writeZodSchemas(
       fileExtension,
       header,
       output,
+      paramsMutator,
     );
     return;
   }
@@ -625,6 +676,7 @@ async function writeZodSchemasReusable(
   fileExtension: string,
   header: string,
   output: WriteZodOutputOptions,
+  paramsMutator?: GeneratorMutator,
 ) {
   const isZodV4 = !!output.packageJson && isZodVersionV4(output.packageJson);
   const strict = output.override.zod.strict.body;
@@ -661,6 +713,7 @@ async function writeZodSchemasReusable(
     isZodV4,
     coerce,
     generateMeta: output.override.zod.generateMeta,
+    paramsMutator,
   });
 
   const rewritten = rewriteReusableSchemas(entries);
@@ -674,12 +727,21 @@ async function writeZodSchemasReusable(
       resolveSchemaName(`#/components/schemas/${schemaName}`, context),
     ),
   );
+
+  // When `override.zod.params` is set, each component schema may reference
+  // the user-provided mutator (e.g. `zodParams`). Pre-compute the import
+  // line once relative to `schemasPath`; every reusable schema file lives in
+  // the same directory, so the relative path is identical across files.
+  const paramsMutatorImport = paramsMutator
+    ? buildMutatorImportStatement(paramsMutator)
+    : undefined;
+
   for (const entry of rewritten) {
     const fileName = conventionName(entry.name, output.namingConvention);
     const filePath = path.join(schemasPath, `${fileName}${fileExtension}`);
     const importExt = fileExtension.replace(/\.ts$/, '');
     const rendered = renderReusableSchemaEntry(entry, context);
-    const imports = buildSiblingImports({
+    const refImports = buildSiblingImports({
       usedRefs: entry.usedRefs,
       extraImports: rendered.extraImports,
       entryName: entry.name,
@@ -687,6 +749,16 @@ async function writeZodSchemasReusable(
       namingConvention: output.namingConvention,
       importExt,
     });
+    // Only emit the params mutator import on files that actually reference it
+    // (schemas with no leaf validators — e.g. a pure `$ref` wrapper — won't).
+    const needsParamsImport =
+      !!paramsMutator && bodyReferencesMutator(entry.zod, paramsMutator);
+    const imports = [
+      ...(needsParamsImport && paramsMutatorImport
+        ? [paramsMutatorImport]
+        : []),
+      ...(refImports ? [refImports] : []),
+    ].join('\n');
 
     const fileContent =
       `${header}import { z as zod } from 'zod';\n` +

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -991,6 +991,59 @@ export const generateZodValidationSchemaDefinition = (
   return { functions, consts: unique(consts) };
 };
 
+/**
+ * Runtime shape passed to the user-supplied `override.zod.params` function for
+ * every emitted validator. Exported so consumers can type their function with
+ * `import type { ZodParamsContext } from 'orval'` instead of hand-writing it.
+ */
+export interface ZodParamsContext {
+  /** The OpenAPI `operationId`, or `''` for shared component schemas. */
+  operationId: string;
+  /** `'schema'` is used for shared component schemas with no owning operation. */
+  location: 'param' | 'query' | 'header' | 'body' | 'response' | 'schema';
+  /** Generated schema name, e.g. `CreateUserBody`, or the component name. */
+  schemaName: string;
+  /** Path to the current property within the schema. Only object property names are appended. */
+  fieldPath: string[];
+  /** The Zod method being emitted, e.g. `'string'`, `'min'`, `'email'`. */
+  validator: string;
+}
+
+export interface ZodParamsInjection extends Pick<
+  ZodParamsContext,
+  'operationId' | 'location' | 'schemaName'
+> {
+  mutator: GeneratorMutator;
+}
+
+const PARAMS_MODIFIER_VALIDATORS = new Set([
+  'optional',
+  'nullable',
+  'nullish',
+  'default',
+  'describe',
+  // Nullary / degenerate validators — either no params arg accepted in zod v3
+  // (e.g. .unknown(), .any(), .never(), .null(), .undefined(), .void()) or no
+  // meaningful error to attach (unknown/any accept everything).
+  'unknown',
+  'any',
+  'never',
+  'null',
+  'undefined',
+  'void',
+]);
+
+// Validators whose single argument is already a params-shaped options object
+// (e.g. `z.iso.datetime({ offset, precision })`). For these, the injected
+// params must merge into the existing object rather than be appended as a
+// second argument.
+const PARAMS_MERGE_INTO_OPTIONS_VALIDATORS = new Set([
+  'datetime',
+  'time',
+  'iso.datetime',
+  'iso.time',
+]);
+
 export const parseZodValidationSchemaDefinition = (
   input: ZodValidationSchemaDefinition,
   context: ContextSpec,
@@ -998,6 +1051,7 @@ export const parseZodValidationSchemaDefinition = (
   strict: boolean,
   isZodV4: boolean,
   preprocess?: GeneratorMutator,
+  paramsInjection?: ZodParamsInjection,
 ): { zod: string; consts: string; usedRefs: Set<string> } => {
   if (input.functions.length === 0) {
     return { zod: '', consts: '', usedRefs: new Set() };
@@ -1036,7 +1090,26 @@ export const parseZodValidationSchemaDefinition = (
     return '';
   };
 
-  const parseProperty = (property: [string, unknown]): string => {
+  const buildParamsArg = (
+    fn: string,
+    fieldPath: readonly string[],
+  ): string | undefined => {
+    if (!paramsInjection) return undefined;
+    if (PARAMS_MODIFIER_VALIDATORS.has(fn)) return undefined;
+    const ctx: ZodParamsContext = {
+      operationId: paramsInjection.operationId,
+      location: paramsInjection.location,
+      schemaName: paramsInjection.schemaName,
+      fieldPath: [...fieldPath],
+      validator: fn,
+    };
+    return `${paramsInjection.mutator.name}(${JSON.stringify(ctx)})`;
+  };
+
+  const parseProperty = (
+    property: [string, unknown],
+    fieldPath: readonly string[] = [],
+  ): string => {
     const [fn, args = ''] = property;
 
     if (fn === 'namedRef') {
@@ -1121,7 +1194,9 @@ export const parseZodValidationSchemaDefinition = (
         const mergedObjectString = `zod.${objectType}({
 ${Object.entries(mergedProperties)
   .map(([key, schema]) => {
-    const value = schema.functions.map((prop) => parseProperty(prop)).join('');
+    const value = schema.functions
+      .map((prop) => parseProperty(prop, [...fieldPath, key]))
+      .join('');
     appendConstsChunk(schema.consts.join('\n'));
     return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
   })
@@ -1140,7 +1215,7 @@ ${Object.entries(mergedProperties)
       let acc = '';
       for (const partSchema of allOfArgs) {
         const value = partSchema.functions
-          .map((prop) => parseProperty(prop))
+          .map((prop) => parseProperty(prop, fieldPath))
           .join('');
         const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
 
@@ -1163,7 +1238,7 @@ ${Object.entries(mergedProperties)
       if (unionArgs.length === 1) {
         appendConstsChunk(unionArgs[0].consts.join('\n'));
         return unionArgs[0].functions
-          .map((prop: [string, unknown]) => parseProperty(prop))
+          .map((prop: [string, unknown]) => parseProperty(prop, fieldPath))
           .join('');
       }
 
@@ -1175,7 +1250,9 @@ ${Object.entries(mergedProperties)
           functions: [string, unknown][];
           consts: string[];
         }) => {
-          const value = functions.map((prop) => parseProperty(prop)).join('');
+          const value = functions
+            .map((prop) => parseProperty(prop, fieldPath))
+            .join('');
           const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
           // consts are missing here
           appendConstsChunk(argConsts.join('\n'));
@@ -1189,7 +1266,7 @@ ${Object.entries(mergedProperties)
     if (fn === 'additionalProperties') {
       const additionalPropertiesArgs = args as ZodValidationSchemaDefinition;
       const value = additionalPropertiesArgs.functions
-        .map((prop: [string, unknown]) => parseProperty(prop))
+        .map((prop: [string, unknown]) => parseProperty(prop, fieldPath))
         .join('');
       const valueWithZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
       if (Array.isArray(additionalPropertiesArgs.consts)) {
@@ -1210,7 +1287,9 @@ ${Object.entries(mergedProperties)
       const parsedObject = `zod.${objectType}({
 ${Object.entries(objectArgs)
   .map(([key, schema]) => {
-    const value = schema.functions.map((prop) => parseProperty(prop)).join('');
+    const value = schema.functions
+      .map((prop) => parseProperty(prop, [...fieldPath, key]))
+      .join('');
     appendConstsChunk(schema.consts.join('\n'));
     return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
   })
@@ -1231,7 +1310,7 @@ ${Object.entries(objectArgs)
     if (fn === 'array') {
       const arrayArgs = args as ZodValidationSchemaDefinition;
       const value = arrayArgs.functions
-        .map((prop: [string, unknown]) => parseProperty(prop))
+        .map((prop: [string, unknown]) => parseProperty(prop, fieldPath))
         .join('');
       if (isString(arrayArgs.consts)) {
         appendConstsChunk(arrayArgs.consts);
@@ -1248,14 +1327,16 @@ ${Object.entries(objectArgs)
     if (fn === 'tuple') {
       return `zod.tuple([${(args as ZodValidationSchemaDefinition[])
         .map((x) => {
-          const value = x.functions.map((prop) => parseProperty(prop)).join('');
+          const value = x.functions
+            .map((prop) => parseProperty(prop, fieldPath))
+            .join('');
           return `${value.startsWith('.') ? 'zod' : ''}${value}`;
         })
         .join(',\n')}])`;
     }
     if (fn === 'rest') {
       return `.rest(zod${(args as ZodValidationSchemaDefinition).functions
-        .map((prop) => parseProperty(prop))
+        .map((prop) => parseProperty(prop, fieldPath))
         .join('')})`;
     }
     const shouldCoerceType =
@@ -1264,14 +1345,31 @@ ${Object.entries(objectArgs)
         ? coerceTypes.includes(fn as ZodCoerceType)
         : COERCIBLE_TYPES.has(fn));
 
+    const formattedArgs = formatFunctionArgs(args);
+    const paramsArg = buildParamsArg(fn, fieldPath);
+    let combinedArgs: string;
+    if (
+      paramsArg &&
+      formattedArgs &&
+      PARAMS_MERGE_INTO_OPTIONS_VALIDATORS.has(fn)
+    ) {
+      combinedArgs = `{ ...${formattedArgs}, ...${paramsArg} }`;
+    } else if (paramsArg) {
+      combinedArgs = formattedArgs
+        ? `${formattedArgs}, ${paramsArg}`
+        : paramsArg;
+    } else {
+      combinedArgs = formattedArgs;
+    }
+
     if (
       (fn !== 'date' && shouldCoerceType) ||
       (fn === 'date' && shouldCoerceType && context.output.override.useDates)
     ) {
-      return `.coerce.${fn}(${formatFunctionArgs(args)})`;
+      return `.coerce.${fn}(${combinedArgs})`;
     }
 
-    return `.${fn}(${formatFunctionArgs(args)})`;
+    return `.${fn}(${combinedArgs})`;
   };
 
   appendConstsChunk(input.consts.join('\n'));
@@ -1843,7 +1941,7 @@ export const parseParameters = ({
 };
 
 const generateZodRoute = async (
-  { operationName, verb, override }: GeneratorVerbOptions,
+  { operationId, operationName, verb, override }: GeneratorVerbOptions,
   { pathRoute, context, output }: GeneratorOptions,
 ) => {
   const isZodV4 =
@@ -1911,6 +2009,30 @@ const generateZodRoute = async (
       })
     : undefined;
 
+  const paramsMutator = override.zod.params
+    ? await generateMutator({
+        output,
+        mutator: override.zod.params,
+        name: `${operationName}ZodParams`,
+        workspace: context.workspace,
+        tsconfig: context.output.tsconfig,
+      })
+    : undefined;
+
+  const pascalOperationName = pascal(operationName);
+  const makeParamsInjection = (
+    location: ZodParamsInjection['location'],
+    schemaSuffix: string,
+  ): ZodParamsInjection | undefined =>
+    paramsMutator
+      ? {
+          mutator: paramsMutator,
+          operationId,
+          location,
+          schemaName: `${pascalOperationName}${schemaSuffix}`,
+        }
+      : undefined;
+
   let inputParams = parseZodValidationSchemaDefinition(
     parsedParameters.params,
     context,
@@ -1918,6 +2040,7 @@ const generateZodRoute = async (
     override.zod.strict.param,
     isZodV4,
     preprocessParams,
+    makeParamsInjection('param', 'Params'),
   );
 
   const preprocessQueryParams = override.zod.preprocess?.query
@@ -1937,6 +2060,7 @@ const generateZodRoute = async (
     override.zod.strict.query,
     isZodV4,
     preprocessQueryParams,
+    makeParamsInjection('query', 'QueryParams'),
   );
 
   const preprocessHeader = override.zod.preprocess?.header
@@ -1956,6 +2080,7 @@ const generateZodRoute = async (
     override.zod.strict.header,
     isZodV4,
     preprocessHeader,
+    makeParamsInjection('header', 'Header'),
   );
 
   const preprocessBody = override.zod.preprocess?.body
@@ -1975,6 +2100,7 @@ const generateZodRoute = async (
     override.zod.strict.body,
     isZodV4,
     preprocessBody,
+    makeParamsInjection('body', 'Body'),
   );
 
   const preprocessResponse = override.zod.preprocess?.response
@@ -1987,7 +2113,7 @@ const generateZodRoute = async (
       })
     : undefined;
 
-  const inputResponses = parsedResponses.map((parsedResponse) =>
+  const inputResponses = parsedResponses.map((parsedResponse, index) =>
     parseZodValidationSchemaDefinition(
       parsedResponse.input,
       context,
@@ -1995,6 +2121,10 @@ const generateZodRoute = async (
       override.zod.strict.response,
       isZodV4,
       preprocessResponse,
+      makeParamsInjection(
+        'response',
+        responses[index][0] ? `${responses[index][0]}Response` : 'Response',
+      ),
     ),
   );
 
@@ -2042,8 +2172,6 @@ const generateZodRoute = async (
       usedRefs: new Set<string>(),
     };
   }
-
-  const pascalOperationName = pascal(operationName);
 
   const useBrandedTypes = override.zod.useBrandedTypes;
   const brand = (name: string) =>
@@ -2164,7 +2292,15 @@ export const ${operationResponse} = zod.array(${operationResponse}Item)${
         ];
       }),
     ].join('\n\n'),
-    mutators: preprocessResponse ? [preprocessResponse] : [],
+    mutators: [
+      ...(preprocessResponse ? [preprocessResponse] : []),
+      // Unconditional even when this operation's parsed schemas don't
+      // reference `paramsMutator.name`: in `single` mode, inline component
+      // schemas (which DO reference it) rely on this entry to emit the
+      // import. The cost is one harmless `import { zodParams }` line on
+      // operations whose request/response have no leaf validators to inject.
+      ...(paramsMutator ? [paramsMutator] : []),
+    ],
     usedRefs: useReusableSchemas ? allUsedRefs : new Set<string>(),
   };
 };

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1,10 +1,42 @@
 import type {
   ContextSpec,
+  GeneratorMutator,
   GeneratorOptions,
+  NormalizedMutator,
   OpenApiSchemaObject,
 } from '@orval/core';
 import { PropertySortOrder } from '@orval/core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@orval/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@orval/core')>();
+  // Stub mutator resolution so generateZod can wire `override.zod.params` /
+  // `override.zod.preprocess` without touching the filesystem. Returns a
+  // GeneratorMutator-shaped stub for any supplied mutator config, mirroring
+  // the real generator's signature but skipping the file I/O it performs.
+  const generateMutator = vi.fn(
+    ({
+      mutator,
+      name,
+    }: {
+      mutator?: NormalizedMutator;
+      name: string;
+    }): GeneratorMutator | undefined => {
+      if (!mutator) return;
+      return {
+        name: mutator.name ?? name,
+        path: mutator.path,
+        default: mutator.default,
+        hasErrorType: false,
+        errorTypeName: '',
+        hasSecondArg: false,
+        hasThirdArg: false,
+        isHook: false,
+      };
+    },
+  );
+  return { ...actual, generateMutator };
+});
 
 import { createTestContextSpec } from '../../core/src/test-utils/context';
 import {
@@ -103,6 +135,451 @@ describe('parseZodValidationSchemaDefinition', () => {
 
     expect(parseResult.zod).toBe(
       'zod.object({\n  "queryParams": zod.record(zod.string(), zod.unknown())\n})',
+    );
+  });
+});
+
+describe('parseZodValidationSchemaDefinition with params injection', () => {
+  const ctx = {
+    output: {
+      override: { useDates: false },
+    },
+  } as ContextSpec;
+
+  const mutator = {
+    name: 'zodParams',
+    path: '/tmp/zod-params.ts',
+    default: false,
+    hasErrorType: false,
+    errorTypeName: '',
+    hasSecondArg: false,
+    hasThirdArg: false,
+    isHook: false,
+  };
+
+  const makeInjection = (overrides: Record<string, unknown> = {}) => ({
+    mutator,
+    operationId: 'createUser',
+    location: 'body' as const,
+    schemaName: 'CreateUserBody',
+    ...overrides,
+  });
+
+  it('injects params on leaf validators with nested fieldPath', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            user: {
+              functions: [
+                [
+                  'object',
+                  {
+                    email: {
+                      functions: [
+                        ['string', undefined],
+                        ['email', undefined],
+                      ],
+                      consts: [],
+                    },
+                  },
+                ],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    expect(zod).toContain(
+      'zod.string(zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["user","email"],"validator":"string"}))',
+    );
+    expect(zod).toContain(
+      '.email(zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["user","email"],"validator":"email"}))',
+    );
+  });
+
+  it('appends params after existing args for constrained validators', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            age: {
+              functions: [
+                ['number', undefined],
+                ['min', '0'],
+                ['max', '120'],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    expect(zod).toContain(
+      '.min(0, zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["age"],"validator":"min"}))',
+    );
+    expect(zod).toContain(
+      '.max(120, zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["age"],"validator":"max"}))',
+    );
+  });
+
+  it('skips nullary validators (unknown, any, never, null, undefined, void)', () => {
+    for (const fn of ['unknown', 'any', 'never', 'null', 'undefined', 'void']) {
+      const input: ZodValidationSchemaDefinition = {
+        functions: [
+          [
+            'object',
+            {
+              data: {
+                functions: [[fn, undefined]],
+                consts: [],
+              },
+            },
+          ],
+        ],
+        consts: [],
+      };
+
+      const { zod } = parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        false,
+        false,
+        false,
+        undefined,
+        makeInjection(),
+      );
+
+      expect(zod).toContain(`zod.${fn}()`);
+      expect(zod).not.toContain(`zod.${fn}(zodParams`);
+    }
+  });
+
+  it('skips modifiers (optional, nullable, nullish, default, describe)', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            note: {
+              functions: [
+                ['string', undefined],
+                ['nullable', undefined],
+                ['optional', undefined],
+                ['describe', `'hello'`],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    expect(zod).toContain('.nullable()');
+    expect(zod).toContain('.optional()');
+    expect(zod).toContain(".describe('hello')");
+    // modifier names never appear inside an injected mutator call
+    expect(zod).not.toMatch(/\.nullable\(zodParams/);
+    expect(zod).not.toMatch(/\.optional\(zodParams/);
+    expect(zod).not.toMatch(/\.describe\([^']*zodParams/);
+  });
+
+  it('does not inject params on structural calls (object, array, union)', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            tags: {
+              functions: [
+                [
+                  'array',
+                  {
+                    functions: [['string', undefined]],
+                    consts: [],
+                  },
+                ],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    // zod.object({...}) and .array(zod.string(...)) wrappers have no injected
+    // params; only the leaf zod.string does.
+    expect(zod).toMatch(/^zod\.object\(\{/);
+    expect(zod).toContain('.array(zod.string(zodParams(');
+    // params should never appear as the immediate argument of a structural call
+    expect(zod).not.toContain('zod.object(zodParams');
+    expect(zod).not.toContain('.array(zodParams');
+  });
+
+  it('merges into existing options for iso.datetime / datetime / iso.time / time', () => {
+    const cases: [string, string][] = [
+      ['iso.datetime', '{"offset":true}'],
+      ['datetime', '{"offset":true}'],
+      ['iso.time', '{"precision":3}'],
+      ['time', '{"precision":3}'],
+    ];
+
+    for (const [fn, optsArg] of cases) {
+      const input: ZodValidationSchemaDefinition = {
+        functions: [
+          [
+            'object',
+            {
+              when: {
+                functions: [
+                  ['string', undefined],
+                  [fn, optsArg],
+                ],
+                consts: [],
+              },
+            },
+          ],
+        ],
+        consts: [],
+      };
+
+      const { zod } = parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        false,
+        false,
+        false,
+        undefined,
+        makeInjection(),
+      );
+
+      // single merged-object argument, not two args
+      expect(zod).toContain(
+        `.${fn}({ ...${optsArg}, ...zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["when"],"validator":"${fn}"}) })`,
+      );
+      // negative: never the two-arg form
+      expect(zod).not.toContain(`.${fn}(${optsArg}, zodParams(`);
+    }
+  });
+
+  it('produces identical output when no injection is supplied', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            email: {
+              functions: [
+                ['string', undefined],
+                ['email', undefined],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+    );
+
+    expect(zod).not.toContain('zodParams(');
+    expect(zod).toContain('zod.string().email()');
+  });
+
+  it('propagates fieldPath through tuple positions without appending indices', () => {
+    // A tuple like `[string, number]` under `coords` propagates the container's
+    // fieldPath (`['coords']`) unchanged to every position. The `validator`
+    // field (`'string'` / `'number'`) is what distinguishes positions — this
+    // matches Zod's own `issue.path`, which also drops tuple indices.
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            coords: {
+              functions: [
+                [
+                  'tuple',
+                  [
+                    { functions: [['string', undefined]], consts: [] },
+                    { functions: [['number', undefined]], consts: [] },
+                  ],
+                ],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    expect(zod).toContain(
+      'zod.string(zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["coords"],"validator":"string"}))',
+    );
+    expect(zod).toContain(
+      'zod.number(zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["coords"],"validator":"number"}))',
+    );
+    // tuple itself is a structural container — no params on the call
+    expect(zod).not.toContain('zod.tuple(zodParams');
+  });
+
+  it('propagates fieldPath into additionalProperties record values', () => {
+    // `additionalProperties: { type: string }` emits `zod.record(zod.string(),
+    // zod.string(...))`. The inner `string` validator should see the container
+    // property's fieldPath (`['attrs']`), since the parser does not synthesize
+    // a per-key path segment for record values.
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            attrs: {
+              functions: [
+                [
+                  'additionalProperties',
+                  {
+                    functions: [['string', undefined]],
+                    consts: [],
+                  },
+                ],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    expect(zod).toContain(
+      'zod.record(zod.string(), zod.string(zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["attrs"],"validator":"string"})))',
+    );
+    // record() is structural and gets no injection of its own
+    expect(zod).not.toContain('zod.record(zodParams');
+  });
+
+  it('appends params after existing args for regex / length / multipleOf', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        [
+          'object',
+          {
+            slug: {
+              functions: [
+                ['string', undefined],
+                ['regex', '/^[a-z]+$/'],
+                ['length', '8'],
+              ],
+              consts: [],
+            },
+            amount: {
+              functions: [
+                ['number', undefined],
+                ['multipleOf', '5'],
+              ],
+              consts: [],
+            },
+          },
+        ],
+      ],
+      consts: [],
+    };
+
+    const { zod } = parseZodValidationSchemaDefinition(
+      input,
+      ctx,
+      false,
+      false,
+      false,
+      undefined,
+      makeInjection(),
+    );
+
+    expect(zod).toContain(
+      '.regex(/^[a-z]+$/, zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["slug"],"validator":"regex"}))',
+    );
+    expect(zod).toContain(
+      '.length(8, zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["slug"],"validator":"length"}))',
+    );
+    expect(zod).toContain(
+      '.multipleOf(5, zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["amount"],"validator":"multipleOf"}))',
     );
   });
 });
@@ -4068,6 +4545,67 @@ describe('generatePartOfSchemaGenerateZod', () => {
     expect(result.implementation).toBe(
       'export const TestHeader = zod.object({\n  "x-header": zod.string()\n})\n\n',
     );
+  });
+
+  it('wires override.zod.params end-to-end (schemaName + operationId + mutators array)', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationId: 'createCat',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            params: { path: './zod-params', name: 'zodParams' },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      basicApiSchema,
+      testOutput,
+    );
+
+    // Each part gets the pascal(operationName) + suffix as `schemaName`, and
+    // the raw OpenAPI `operationId` (not the transformed `operationName`).
+    expect(result.implementation).toContain(
+      'zod.string(zodParams({"operationId":"createCat","location":"param","schemaName":"TestParams","fieldPath":["id"],"validator":"string"}))',
+    );
+    expect(result.implementation).toContain(
+      'zod.number(zodParams({"operationId":"createCat","location":"query","schemaName":"TestQueryParams","fieldPath":["page"],"validator":"number"}))',
+    );
+    expect(result.implementation).toContain(
+      'zod.string(zodParams({"operationId":"createCat","location":"header","schemaName":"TestHeader","fieldPath":["x-header"],"validator":"string"}))',
+    );
+    expect(result.implementation).toContain(
+      'zod.string(zodParams({"operationId":"createCat","location":"body","schemaName":"TestBody","fieldPath":["name"],"validator":"string"}))',
+    );
+
+    // The resolved paramsMutator is returned so the import writer can emit
+    // the `import { zodParams } from './zod-params'` line in the operation file.
+    expect(result.mutators?.some((m) => m.name === 'zodParams')).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #3425 

Adds override.zod.params to inject a Zod params argument (e.g. { error: ... }) into each generated validator. The option takes a Mutator (same shape as the existing preprocess) pointing to a function. Orval calls that function once per validator at schema construction time with codegen-time context (operation, location, schema name, field path, validator name), and emits the return value as the trailing argument of the call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Zod params option to inject build-time parameters into generated validators (global, per-operation/tag, and component schemas); re-exported the Zod params context type.

* **Documentation**
  * Expanded Zod output docs with examples, where injection applies or is skipped, fieldPath semantics, and supported return shapes.

* **Tests**
  * Added coverage for injection placement, field-path propagation, special-merge rules, reusable-schema behavior, and no-injection regression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->