### PR TITLE
fix(zod): emit const declarations for single-item oneOf/anyOf

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1161,6 +1161,7 @@ ${Object.entries(mergedProperties)
       const unionArgs = args as ZodValidationSchemaDefinition[];
       // Can't use zod.union() with a single item
       if (unionArgs.length === 1) {
+        appendConstsChunk(unionArgs[0].consts.join('\n'));
         return unionArgs[0].functions
           .map((prop: [string, unknown]) => parseProperty(prop))
           .join('');

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2033,6 +2033,46 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
     });
 
+    it('emits const declarations for single-item oneOf with default values', () => {
+      // Simulate the intermediate representation produced when a single-item
+      // oneOf references an enum schema with a default value.
+      // Without the fix, the single-item shortcut in parseProperty discards
+      // the consts from the inner schema, producing a dangling reference.
+      const input: ZodValidationSchemaDefinition = {
+        functions: [
+          [
+            'oneOf',
+            [
+              {
+                functions: [
+                  ['enum', "['ACTIVE', 'INACTIVE']"],
+                  ['default', 'statusDefault'],
+                ],
+                consts: ['export const statusDefault = `ACTIVE`;'],
+              },
+            ],
+          ],
+          ['optional', undefined],
+        ],
+        consts: [],
+      };
+
+      const parsed = parseZodValidationSchemaDefinition(
+        input,
+        context,
+        false,
+        false,
+        false,
+      );
+
+      // The generated Zod code references statusDefault
+      expect(parsed.zod).toBe(
+        "zod.enum(['ACTIVE', 'INACTIVE']).default(statusDefault).optional()",
+      );
+      // The const declaration MUST be emitted (this was the bug — it was empty)
+      expect(parsed.consts).toBe('export const statusDefault = `ACTIVE`;');
+    });
+
     it('skips numeric constraints for enum literal unions (#3024)', () => {
       const schema: OpenApiSchemaObject = {
         type: 'number',


### PR DESCRIPTION
## Summary

- Fixes #3480
- The single-item `oneOf`/`anyOf` shortcut in `parseProperty` skipped `appendConstsChunk()`, silently dropping `export const` declarations for default values and producing references to undeclared variables
- Adds regression test that directly exercises the bug scenario

## Test plan

- [x] New test `emits const declarations for single-item oneOf with default values` confirms `parsed.consts` is emitted (was empty without fix)
- [x] Verified the test fails without the fix and passes with it
- [x] All 190 existing zod tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where constant declarations were incorrectly omitted in generated validation schemas for single-item unions.

* **Tests**
  * Added test coverage for constant declaration handling in single-item union schemas with default values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->