### PR TITLE
fix: deduplicate name collisions with generateReusableSchema (#3478)

### DIFF
--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -268,6 +268,98 @@ describe('generateSpec - generateReusableSchemas recursive ($ref to self)', () =
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  // The split-mode writer merges `extraImports` (TS-body refs the zod runtime
+  // collapses, e.g. a `propertyNames` $ref) into per-file imports. Inline
+  // single-file mode resolves everything in the same file and discards
+  // `extraImports`; a regression that started threading those names into the
+  // inline output as bogus `from './X'` lines wouldn't be caught by the
+  // split-mode test alone.
+  const RECURSIVE_PROPERTY_NAMES_SPEC: OpenApiDocument = {
+    openapi: '3.1.0',
+    info: { title: 'RecursivePropertyNames', version: '1.0.0' },
+    paths: {
+      '/trees': {
+        get: {
+          operationId: 'listTrees',
+          responses: {
+            '200': {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Tree' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Tree: {
+          type: 'object',
+          properties: {
+            children: {
+              type: 'object',
+              propertyNames: { $ref: '#/components/schemas/RelationType' },
+              additionalProperties: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/Tree' },
+              },
+            },
+          },
+        },
+        RelationType: {
+          type: 'string',
+          enum: ['parent', 'child', 'sibling'],
+        },
+      },
+    },
+  };
+
+  it('emits no sibling imports in single mode even when the recursive TS body references another component', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'zod.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: RECURSIVE_PROPERTY_NAMES_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'single',
+            client: 'zod',
+            override: { zod: { generateReusableSchemas: true } },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      // Both component schemas are emitted inline...
+      expect(content).toContain(
+        'export const Tree: zod.ZodType<Tree> = zod.object(',
+      );
+      expect(content).toContain('export const RelationType = zod.enum(');
+      // ...and the recursive type references the inline RelationType through
+      // the `Record<>` key.
+      expect(content).toMatch(/Record<\s*RelationType/);
+      // No sibling imports leaked through `extraImports`: every component
+      // (including `RelationType`) lives in this same file.
+      expect(content).not.toMatch(/from '\.\/RelationType'/);
+      expect(content).not.toMatch(/from '\.\/Tree'/);
+      expect(content).not.toContain('__REF_');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('generateSpec - generateReusableSchemas inline (pure-$ref operations)', () => {
@@ -337,6 +429,195 @@ describe('generateSpec - generateReusableSchemas inline (pure-$ref operations)',
       // Match either quote style so the assertion survives generator quote
       // changes while still asserting a single `zod` module import.
       expect(content.match(/from ['"]zod['"]/g) ?? []).toHaveLength(1);
+      expect(content).not.toContain('__REF_');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('generateSpec - generateReusableSchemas wrapper/import name collision (#3478)', () => {
+  // Regression: when pascal(operationId) + 'Response' equals an imported
+  // component schema name, the operation wrapper used to be emitted with the
+  // same identifier as the import:
+  //
+  //   import { ListPetsResponse } from "./schemas";
+  //   export const ListPetsResponseItem = ListPetsResponse;     // TDZ self-ref
+  //   export const ListPetsResponse = zod.array(...);            // shadows import
+  //
+  // TypeScript rejects this with TS7022. The fix appends a `Schema` suffix to
+  // the wrapper (and its `Item` companion) when the chosen name would collide
+  // with an imported ref, leaving the import's meaning intact.
+  const COLLISION_SPEC: OpenApiDocument = {
+    openapi: '3.1.0',
+    info: { title: 'Collision', version: '1.0.0' },
+    paths: {
+      '/pets': {
+        get: {
+          operationId: 'listPets',
+          responses: {
+            '200': {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/ListPetsResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        ListPetsResponse: {
+          type: 'object',
+          required: ['id', 'name'],
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            name: { type: 'string' },
+          },
+        },
+      },
+    },
+  };
+
+  it('renames the operation wrapper to avoid shadowing the imported component schema', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'zod.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: COLLISION_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'single',
+            client: 'zod',
+            override: { zod: { generateReusableSchemas: true } },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      // The component schema retains its name.
+      expect(content).toContain('export const ListPetsResponse = zod.object(');
+      // The operation wrapper is renamed with a `Schema` suffix so the array
+      // initializer references the imported (`ListPetsResponse`) component
+      // instead of itself.
+      expect(content).toContain(
+        'export const ListPetsResponseSchemaItem = ListPetsResponse',
+      );
+      expect(content).toContain(
+        'export const ListPetsResponseSchema = zod.array(ListPetsResponseSchemaItem)',
+      );
+      // Crucially, the pre-fix bug pattern (the operation wrapper redeclaring
+      // the imported name) must NOT appear.
+      expect(content).not.toMatch(
+        /export const ListPetsResponse = zod\.array\(/,
+      );
+      expect(content).not.toContain('__REF_');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  // When the base name AND its `Schema`-suffixed companion both already exist
+  // as imported components, the allocator's counter branch (`Schema1`) must
+  // fire. The above test only exercises the single-suffix path; nothing here
+  // would catch a regression that broke the `while (collides(candidate))`
+  // loop.
+  const DOUBLE_COLLISION_SPEC: OpenApiDocument = {
+    openapi: '3.1.0',
+    info: { title: 'DoubleCollision', version: '1.0.0' },
+    paths: {
+      '/pets': {
+        get: {
+          operationId: 'listPets',
+          responses: {
+            '200': {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['first', 'second'],
+                    properties: {
+                      first: { $ref: '#/components/schemas/ListPetsResponse' },
+                      second: {
+                        $ref: '#/components/schemas/ListPetsResponseSchema',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        ListPetsResponse: {
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'string' } },
+        },
+        ListPetsResponseSchema: {
+          type: 'object',
+          required: ['name'],
+          properties: { name: { type: 'string' } },
+        },
+      },
+    },
+  };
+
+  it('falls through to the numeric-counter suffix when both base and `Schema` collide', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'zod.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: DOUBLE_COLLISION_SPEC },
+          output: {
+            target: './zod.ts',
+            mode: 'single',
+            client: 'zod',
+            override: { zod: { generateReusableSchemas: true } },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      // Both component schemas keep their names.
+      expect(content).toContain('export const ListPetsResponse = zod.object(');
+      expect(content).toContain(
+        'export const ListPetsResponseSchema = zod.object(',
+      );
+      // The operation wrapper picks `Schema1` because `Schema` is already
+      // taken by a component import.
+      expect(content).toMatch(
+        /export const ListPetsResponseSchema1 = zod\.object\(/,
+      );
+      // Neither component declaration is shadowed by an operation wrapper.
+      expect(
+        content.match(/export const ListPetsResponse = /g) ?? [],
+      ).toHaveLength(1);
+      expect(
+        content.match(/export const ListPetsResponseSchema = /g) ?? [],
+      ).toHaveLength(1);
       expect(content).not.toContain('__REF_');
     } finally {
       await rm(workspace, { recursive: true, force: true });

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -5,6 +5,7 @@ import fs from 'fs-extra';
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildSiblingImports,
   generateZodSchemasInline,
   writeZodSchemas,
   writeZodSchemasFromVerbs,
@@ -481,6 +482,185 @@ describe('writeZodSchemas with generateReusableSchemas', () => {
     expect(nodeContent).not.toContain('__REF_');
 
     await fs.remove(root);
+  });
+
+  it('imports type-only refs that the recursive TS body uses but the zod runtime drops', async () => {
+    // A recursive schema whose TS type references a sibling component only
+    // through `propertyNames` (record-key constraint). The zod runtime
+    // collapses record keys to `zod.string()`, so that sibling never appears
+    // in the entry's `usedRefs`. Pre-fix the split-mode writer derived imports
+    // purely from `usedRefs`, leaving the rendered `Partial<Record<KeyType,
+    // ...>>` referencing an unimported `KeyType` (TS2304).
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-reuse-pn-'));
+    const schemasPath = path.join(root, 'schemas');
+
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            // `Tree` recurses through its `children` map. The map keys are
+            // constrained by `RelationType` (propertyNames $ref); the values
+            // are arrays of self-references.
+            Tree: {
+              type: 'object',
+              properties: {
+                children: {
+                  type: 'object',
+                  propertyNames: {
+                    $ref: '#/components/schemas/RelationType',
+                  },
+                  additionalProperties: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Tree' },
+                  },
+                },
+              },
+            },
+            RelationType: {
+              type: 'string',
+              enum: ['parent', 'child', 'sibling'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        { name: 'Tree', schema: { $ref: '#/components/schemas/Tree' } },
+        {
+          name: 'RelationType',
+          schema: { $ref: '#/components/schemas/RelationType' },
+        },
+      ],
+    } satisfies Parameters<typeof writeZodSchemas>[0];
+
+    const options = createOutputOptions();
+    options.override.zod.generateReusableSchemas = true;
+
+    await writeZodSchemas(builder, schemasPath, '.ts', '', options);
+
+    const treeContent = await fs.readFile(
+      path.join(schemasPath, 'Tree.ts'),
+      'utf8',
+    );
+
+    // The recursive TS type references RelationType through the record key.
+    expect(treeContent).toMatch(/Record<\s*RelationType/);
+    // And that sibling is imported so the file compiles.
+    expect(treeContent).toMatch(
+      /import \{ RelationType \} from '\.\/RelationType'/,
+    );
+    // `resolveValue` reports `Tree` itself in its imports for the recursive
+    // body; the writer must filter self-refs so `Tree.ts` doesn't import from
+    // `./Tree`.
+    expect(treeContent).not.toMatch(/from '\.\/Tree'/);
+    expect(treeContent).not.toContain('__REF_');
+
+    // The bug's mechanism: the zod runtime collapses `propertyNames` to a
+    // plain string key (`zod.record(zod.string(), ...)`), so `RelationType`
+    // never enters `usedRefs` from the runtime path. Pin that here — if the
+    // runtime ever started carrying the propertyNames ref through to the zod
+    // expression, `RelationType` would land in `usedRefs` directly and the
+    // `extraImports` path would no longer be load-bearing for this case.
+    expect(treeContent).toMatch(/zod\.record\(\s*zod\.string\(\)/);
+    expect(treeContent).not.toMatch(/zod\.record\(\s*RelationType/);
+
+    // RelationType itself is emitted as a sibling file; the import above
+    // would dangle without this. Asserting the emission keeps "what's
+    // imported" and "what's written" in lockstep.
+    expect(await fs.pathExists(path.join(schemasPath, 'RelationType.ts'))).toBe(
+      true,
+    );
+
+    await fs.remove(root);
+  });
+});
+
+describe('buildSiblingImports', () => {
+  // The helper is exported for these tests because no `resolveValue` caller
+  // that feeds `renderReusableSchemaEntry` produces aliased imports today —
+  // an integration test can't reach the alias branch through a real spec.
+  // Driving the helper directly pins the contract.
+  const componentNames = new Set(['Foo', 'Bar', 'Baz']);
+
+  it('emits one bare import per name from usedRefs', () => {
+    const out = buildSiblingImports({
+      usedRefs: ['Foo', 'Bar'],
+      extraImports: [],
+      entryName: 'Entry',
+      componentNames,
+      namingConvention: 'PascalCase',
+      importExt: '',
+    });
+
+    expect(out).toBe(
+      `import { Bar } from './Bar';\nimport { Foo } from './Foo';`,
+    );
+  });
+
+  it('emits an aliased import when extraImports carries `alias`', () => {
+    const out = buildSiblingImports({
+      usedRefs: [],
+      extraImports: [{ name: 'Foo', alias: 'FooBis' }],
+      entryName: 'Entry',
+      componentNames,
+      namingConvention: 'PascalCase',
+      importExt: '',
+    });
+
+    // Filename derives from the export `name`; the alias only changes the
+    // local binding.
+    expect(out).toBe(`import { Foo as FooBis } from './Foo';`);
+  });
+
+  it('lets an aliased extraImports entry override a bare usedRefs entry for the same name', () => {
+    const out = buildSiblingImports({
+      usedRefs: ['Foo'],
+      extraImports: [{ name: 'Foo', alias: 'FooBis' }],
+      entryName: 'Entry',
+      componentNames,
+      namingConvention: 'PascalCase',
+      importExt: '',
+    });
+
+    // The recursive TS body uses the local binding (`FooBis`); the aliased
+    // form has to win, otherwise the body refers to an unbound name.
+    expect(out).toBe(`import { Foo as FooBis } from './Foo';`);
+  });
+
+  it('drops self-refs and non-component names', () => {
+    const out = buildSiblingImports({
+      usedRefs: ['Entry', 'Foo'],
+      extraImports: [
+        { name: 'Entry', alias: 'EntryBis' },
+        { name: 'NotAComponent' },
+        { name: 'Bar' },
+      ],
+      entryName: 'Entry',
+      componentNames,
+      namingConvention: 'PascalCase',
+      importExt: '',
+    });
+
+    expect(out).toBe(
+      `import { Bar } from './Bar';\nimport { Foo } from './Foo';`,
+    );
+  });
+
+  it('sorts by source name (stable across `extraImports` and `usedRefs` order)', () => {
+    const out = buildSiblingImports({
+      usedRefs: ['Foo'],
+      extraImports: [{ name: 'Baz' }, { name: 'Bar', alias: 'BarBis' }],
+      entryName: 'Entry',
+      componentNames,
+      namingConvention: 'PascalCase',
+      importExt: '',
+    });
+
+    expect(out).toBe(
+      `import { Bar as BarBis } from './Bar';\n` +
+        `import { Baz } from './Baz';\n` +
+        `import { Foo } from './Foo';`,
+    );
   });
 });
 

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -27,6 +27,7 @@ import fs from 'fs-extra';
 
 import {
   generateReusableSchemaSet,
+  resolveSchemaName,
   resolveSchemaNames,
   type ReusableSchemaEntry,
   rewriteReusableSchemas,
@@ -173,10 +174,38 @@ export type ${schemaName}Output = zod.output<typeof ${schemaName}>;`;
  * typing through the recursion (instead of collapsing recursive positions to
  * `unknown`).
  */
+/**
+ * One sibling import the recursive TS type body needs. `name` is the export
+ * name in the sibling file (also the basis for the filename); `alias`, when
+ * set, is the local binding in this file — emitted as
+ * `import { name as alias } from ...`. The aliasing path is triggered by
+ * `generateInterface`'s self-name disambiguation (`<X>Bis`); recursive
+ * component bodies don't exercise it today but the writer carries `alias`
+ * through so any future producer Just Works.
+ */
+interface ExtraImport {
+  name: string;
+  alias?: string;
+}
+
+interface RenderedReusableSchemaEntry {
+  content: string;
+  /**
+   * Imports this entry needs that are NOT already captured in `entry.usedRefs`.
+   * Recursive entries render a TypeScript type body via the model generator;
+   * names the type body references (e.g. an `AssetRelationType` used as a
+   * `Record<>` key from `propertyNames`) won't appear in `usedRefs` because
+   * the zod runtime collapses them (record keys become `zod.string()`). The
+   * split-mode writer merges these into its per-file import list so the
+   * emitted TS type compiles. Empty for acyclic entries.
+   */
+  extraImports: ExtraImport[];
+}
+
 function renderReusableSchemaEntry(
   entry: ReusableSchemaEntry,
   context: ContextSpec,
-): string {
+): RenderedReusableSchemaEntry {
   const consts = entry.consts ? `${entry.consts}\n\n` : '';
 
   if (entry.isRecursive) {
@@ -195,26 +224,97 @@ function renderReusableSchemaEntry(
           | OpenApiReferenceObject
           | undefined)
       : undefined;
-    const typeBody = schema
-      ? resolveValue({ schema, name: entry.name, context }).value
-      : 'unknown';
+    const resolved = schema
+      ? resolveValue({ schema, name: entry.name, context })
+      : undefined;
+    const typeBody = resolved ? resolved.value : 'unknown';
+    // Dedupe by local binding name (`alias ?? name`). When `resolveValue`
+    // surfaces the same component twice — e.g. once aliased, once not —
+    // collapsing on the binding key keeps both the file's import list and the
+    // generated TS body internally consistent.
+    const seen = new Set<string>();
+    const extraImports: ExtraImport[] = [];
+    for (const imp of resolved?.imports ?? []) {
+      if (!imp.name || imp.name === entry.name) continue;
+      const bindingKey = imp.alias ?? imp.name;
+      if (seen.has(bindingKey)) continue;
+      seen.add(bindingKey);
+      extraImports.push({
+        name: imp.name,
+        ...(imp.alias ? { alias: imp.alias } : {}),
+      });
+    }
 
-    return (
-      `${consts}export type ${entry.name} = ${typeBody};\n\n` +
-      `export const ${entry.name}: zod.ZodType<${entry.name}> = ${entry.zod};\n\n` +
-      `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`
-    );
+    return {
+      content:
+        `${consts}export type ${entry.name} = ${typeBody};\n\n` +
+        `export const ${entry.name}: zod.ZodType<${entry.name}> = ${entry.zod};\n\n` +
+        `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`,
+      extraImports,
+    };
   }
 
-  return (
-    `${consts}export const ${entry.name} = ${entry.zod};\n\n` +
-    `export type ${entry.name} = zod.input<typeof ${entry.name}>;\n` +
-    `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`
-  );
+  return {
+    content:
+      `${consts}export const ${entry.name} = ${entry.zod};\n\n` +
+      `export type ${entry.name} = zod.input<typeof ${entry.name}>;\n` +
+      `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`,
+    extraImports: [],
+  };
 }
 
 const isValidSchemaIdentifier = (name: string) =>
   /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+
+/**
+ * Build the sibling-file `import { … } from './…'` block for one reusable
+ * schema file. Two sources feed in:
+ *   - `usedRefs` — names from the zod runtime expression. Sourced from the
+ *     sentinel parser, so always unaliased.
+ *   - `extraImports` — names the recursive TS body needs that the zod runtime
+ *     collapsed (`propertyNames` $refs, etc.). May carry `alias`.
+ * Keyed by export name (`name`) so an aliased `extraImports` entry overrides
+ * a bare `usedRefs` entry — the recursive TS body uses the local binding, so
+ * the aliased form has to win for the file to compile. Self-refs and
+ * non-component identifiers are filtered out.
+ *
+ * Exported for unit-test coverage of the alias-propagation path; no
+ * `resolveValue` producer surfaces aliases here today, so the integration
+ * tests can't exercise it.
+ */
+export function buildSiblingImports({
+  usedRefs,
+  extraImports,
+  entryName,
+  componentNames,
+  namingConvention,
+  importExt,
+}: {
+  usedRefs: Iterable<string>;
+  extraImports: readonly ExtraImport[];
+  entryName: string;
+  componentNames: ReadonlySet<string>;
+  namingConvention: NamingConvention;
+  importExt: string;
+}): string {
+  const importsByName = new Map<string, ExtraImport>();
+  for (const name of usedRefs) {
+    if (name === entryName) continue;
+    importsByName.set(name, { name });
+  }
+  for (const imp of extraImports) {
+    if (imp.name === entryName || !componentNames.has(imp.name)) continue;
+    importsByName.set(imp.name, imp);
+  }
+  return [...importsByName.values()]
+    .toSorted((a, b) => a.name.localeCompare(b.name))
+    .map(({ name, alias }) => {
+      const importedFile = conventionName(name, namingConvention);
+      const spec = alias ? `${name} as ${alias}` : name;
+      return `import { ${spec} } from './${importedFile}${importExt}';`;
+    })
+    .join('\n');
+}
 
 const isPrimitiveSchemaName = (name: string) =>
   ['string', 'number', 'boolean', 'void', 'unknown', 'Blob'].includes(name);
@@ -410,8 +510,11 @@ function generateZodSchemasInlineReusable(
 
   const rewritten = rewriteReusableSchemas(entries);
 
+  // Single-file inline mode emits every component schema in one file, so
+  // recursive entries' TS-type references resolve in-file with no extra
+  // imports — discard `extraImports` here.
   const body = rewritten
-    .map((entry) => renderReusableSchemaEntry(entry, context))
+    .map((entry) => renderReusableSchemaEntry(entry, context).content)
     .join('\n\n');
 
   // Omit the zod import when concatenated into a file that already imports it
@@ -562,23 +665,33 @@ async function writeZodSchemasReusable(
 
   const rewritten = rewriteReusableSchemas(entries);
 
+  // Render bodies first so each entry's `extraImports` (names referenced only
+  // by the recursive TS type body, e.g. an `AssetRelationType` used as a
+  // `Record<>` key the zod runtime collapses to `zod.string()`) can be merged
+  // into the per-file import list before assembling the file content.
+  const componentNames = new Set(
+    Object.keys(builder.spec.components?.schemas ?? {}).map((schemaName) =>
+      resolveSchemaName(`#/components/schemas/${schemaName}`, context),
+    ),
+  );
   for (const entry of rewritten) {
     const fileName = conventionName(entry.name, output.namingConvention);
     const filePath = path.join(schemasPath, `${fileName}${fileExtension}`);
     const importExt = fileExtension.replace(/\.ts$/, '');
-    const imports = [...entry.usedRefs]
-      .filter((r) => r !== entry.name)
-      .toSorted()
-      .map((r) => {
-        const importedFile = conventionName(r, output.namingConvention);
-        return `import { ${r} } from './${importedFile}${importExt}';`;
-      })
-      .join('\n');
+    const rendered = renderReusableSchemaEntry(entry, context);
+    const imports = buildSiblingImports({
+      usedRefs: entry.usedRefs,
+      extraImports: rendered.extraImports,
+      entryName: entry.name,
+      componentNames,
+      namingConvention: output.namingConvention,
+      importExt,
+    });
 
     const fileContent =
       `${header}import { z as zod } from 'zod';\n` +
       (imports ? `${imports}\n\n` : '\n') +
-      `${renderReusableSchemaEntry(entry, context)}\n`;
+      `${rendered.content}\n`;
 
     await fs.outputFile(filePath, fileContent);
   }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -2052,42 +2052,93 @@ const generateZodRoute = async (
         : `.brand<"${name}">()`
       : '';
 
+  // With `generateReusableSchemas`, operations import component schemas by
+  // their PascalCase name from a sibling schemas module. When an operation's
+  // own pascalized wrapper name (e.g. `ListPetsResponse` from operationId
+  // `listPets`) matches an imported ref, the generated `export const` shadows
+  // the import and produces a self-referential initializer that TS rejects
+  // with TS7022. Detect the collision and append `Schema` (with a counter for
+  // further collisions) so the import keeps its meaning. For the array case
+  // both the wrapper and its `Item` companion are checked together so they
+  // stay in sync. The original name is preserved when there is no collision,
+  // so non-colliding operations are unaffected.
+  //
+  // `localTaken` seeds from the imported refs and accumulates the names this
+  // call hands out, so wrappers within the same operation (`Params`, `Body`,
+  // per-status `Response`, …) can't pick a name another wrapper just claimed.
+  // The fixed suffixes already keep these distinct in practice, but tracking
+  // allocations removes the implicit invariant — future suffix additions stay
+  // safe by construction.
+  const localTaken = new Set(allUsedRefs);
+  const allocateExportName = (baseName: string, hasItem: boolean): string => {
+    const collides = (name: string) =>
+      localTaken.has(name) || (hasItem && localTaken.has(`${name}Item`));
+    const reserve = (name: string) => {
+      localTaken.add(name);
+      if (hasItem) localTaken.add(`${name}Item`);
+    };
+    if (!collides(baseName)) {
+      reserve(baseName);
+      return baseName;
+    }
+    let counter = 0;
+    let candidate = `${baseName}Schema`;
+    while (collides(candidate)) {
+      counter += 1;
+      candidate = `${baseName}Schema${counter}`;
+    }
+    reserve(candidate);
+    return candidate;
+  };
+
+  const paramsName = allocateExportName(`${pascalOperationName}Params`, false);
+  const queryParamsName = allocateExportName(
+    `${pascalOperationName}QueryParams`,
+    false,
+  );
+  const headerName = allocateExportName(`${pascalOperationName}Header`, false);
+  const bodyName = allocateExportName(
+    `${pascalOperationName}Body`,
+    parsedBody.isArray,
+  );
+
   return {
     implementation: [
       ...(inputParams.consts ? [inputParams.consts] : []),
       ...(inputParams.zod
         ? [
-            `export const ${pascalOperationName}Params = ${inputParams.zod}${brand(`${pascalOperationName}Params`)}`,
+            `export const ${paramsName} = ${inputParams.zod}${brand(paramsName)}`,
           ]
         : []),
       ...(inputQueryParams.consts ? [inputQueryParams.consts] : []),
       ...(inputQueryParams.zod
         ? [
-            `export const ${pascalOperationName}QueryParams = ${inputQueryParams.zod}${brand(`${pascalOperationName}QueryParams`)}`,
+            `export const ${queryParamsName} = ${inputQueryParams.zod}${brand(queryParamsName)}`,
           ]
         : []),
       ...(inputHeaders.consts ? [inputHeaders.consts] : []),
       ...(inputHeaders.zod
         ? [
-            `export const ${pascalOperationName}Header = ${inputHeaders.zod}${brand(`${pascalOperationName}Header`)}`,
+            `export const ${headerName} = ${inputHeaders.zod}${brand(headerName)}`,
           ]
         : []),
       ...(inputBody.consts ? [inputBody.consts] : []),
       ...(inputBody.zod
         ? [
             parsedBody.isArray
-              ? `export const ${pascalOperationName}BodyItem = ${inputBody.zod}
-export const ${pascalOperationName}Body = zod.array(${pascalOperationName}BodyItem)${
+              ? `export const ${bodyName}Item = ${inputBody.zod}
+export const ${bodyName} = zod.array(${bodyName}Item)${
                   parsedBody.rules?.min ? `.min(${parsedBody.rules.min})` : ''
                 }${
                   parsedBody.rules?.max ? `.max(${parsedBody.rules.max})` : ''
-                }${brand(`${pascalOperationName}Body`)}`
-              : `export const ${pascalOperationName}Body = ${inputBody.zod}${brand(`${pascalOperationName}Body`)}`,
+                }${brand(bodyName)}`
+              : `export const ${bodyName} = ${inputBody.zod}${brand(bodyName)}`,
           ]
         : []),
       ...inputResponses.flatMap((inputResponse, index) => {
-        const operationResponse = pascal(
-          `${operationName}-${responses[index][0]}-response`,
+        const operationResponse = allocateExportName(
+          pascal(`${operationName}-${responses[index][0]}-response`),
+          parsedResponses[index].isArray,
         );
         return [
           ...(inputResponse.consts ? [inputResponse.consts] : []),


### PR DESCRIPTION
Two zod + `generateReusableSchemas` bugs. Both make `tsc` reject the generated output.

### 1. Operation wrapper shadows imported component schema (#3478)

When `pascal(operationId)` plus a wrapper suffix matches a sibling component schema's import name, the wrapper's `export const` shadows the import with a self-referential initializer:

  ```ts
import { ListPetsResponse } from "./schemas";

export const ListPetsResponseItem = ListPetsResponse;            // self-ref
export const ListPetsResponse = zod.array(ListPetsResponseItem); // shadows import
```

tsc rejects this with TS7022 ("implicitly has type 'any' because it is referenced ... in its own initializer"). generateZodRoute now runs each operation export name through a collision check against allUsedRefs. On collision it appends Schema (with a numeric counter for chained collisions) so the import survives:

```ts
import { ListPetsResponse } from "./schemas";

export const ListPetsResponseSchemaItem = ListPetsResponse;
export const ListPetsResponseSchema = zod.array(ListPetsResponseSchemaItem);
```

### 2. Recursive reusable schema drops type-only imports

When generateReusableSchemas emits a recursive component to its own file, renderReusableSchemaEntry renders the TS type via the model generator (resolveValue) and pins the schema to it as `const X: zod.ZodType<X>`.

A name that the TS type body needs but the zod runtime collapses never enters usedRefs. The clearest case: `propertyNames: { $ref: KeyType }` becomes `zod.record(zod.string(), ...)` in the runtime expression, dropping KeyType. The rendered TS type still references KeyType, so tsc fails

Example from a JSON-Schema spec with propertyNames constraining a Record<> key:

```yaml
 Pet:
    type: object
    required: [id, name]
    properties:
      id: { type: integer }
      name: { type: string }
      relatives:
        type: object
        propertyNames: { $ref: '#/components/schemas/PetRelation' }
        additionalProperties:
          type: array
          items: { $ref: '#/components/schemas/Pet' }
  PetRelation:
    type: string
    enum: [parent, sibling, offspring]
```

```ts
// Before
import { z as zod } from 'zod';
// PetRelation: never imported

export type Pet = {
  id: number;
  name: string;
  relatives?: Partial<Record<PetRelation, Pet[]>>; // TS2304
};

export const Pet: zod.ZodType<Pet> = zod.object({ ... });
```

```ts
// After
import { z as zod } from 'zod';
import { PetRelation } from './petRelation';

export type Pet = {
  id: number;
  name: string;
  relatives?: Partial<Record<PetRelation, Pet[]>>;
 };

export const Pet: zod.ZodType<Pet> = zod.object({ ... });
```

#3467 introduced the recursive-schema emission path; this bug was already present and surfaced while verifying #3478 against a real spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented generated export name collisions that could shadow imported component schemas or cause self-referential initializer errors; export names now adapt to avoid redeclaration.
  * Fixed recursive/reusable-schema emission so required type-only imports are included in split mode and no unresolved reference sentinels appear in outputs.

* **Tests**
  * Added regression tests for naming collisions (including double-collision fallbacks) and recursive-schema generation across single-file and split modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orval-labs/orval/pull/3485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->