### PR TITLE
feat(zod): support $dynamicRef / $dynamicAnchor in zod schema generation

### DIFF
--- a/packages/core/src/resolvers/ref.ts
+++ b/packages/core/src/resolvers/ref.ts
@@ -442,6 +442,7 @@ export function resolveDynamicRef(
   schema: OpenApiSchemaObject;
   imports: GeneratorImport[];
   resolvedTypeName: string;
+  schemaName: string | undefined;
 } {
   const scope = context.dynamicScope ?? {};
   let scopeEntry = scope[anchorName];
@@ -484,6 +485,7 @@ export function resolveDynamicRef(
       schema: {},
       imports,
       resolvedTypeName: 'unknown',
+      schemaName: undefined,
     };
   }
 
@@ -492,6 +494,7 @@ export function resolveDynamicRef(
       schema: {},
       imports,
       resolvedTypeName: scopeEntry.name,
+      schemaName: undefined,
     };
   }
 
@@ -505,12 +508,14 @@ export function resolveDynamicRef(
       schema: resolvedSchema,
       imports: resolvedImports,
       resolvedTypeName,
+      schemaName: scopeEntry.schemaName,
     };
   } catch {
     return {
       schema: {},
       imports,
       resolvedTypeName: 'unknown',
+      schemaName: undefined,
     };
   }
 }

--- a/packages/orval/src/reusable-schemas.test.ts
+++ b/packages/orval/src/reusable-schemas.test.ts
@@ -376,3 +376,223 @@ describe('rewriteReusableSchemas', () => {
     expect(result[0].isRecursive).toBe(true);
   });
 });
+
+describe('generateReusableSchemaSet with $dynamicRef', () => {
+  it('discovers transitive refs through $dynamicRef', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              $dynamicAnchor: 'Pet',
+              type: 'object',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+            Lizard: {
+              type: 'object',
+              properties: {
+                friends: {
+                  type: 'array',
+                  items: { $dynamicRef: '#Pet' },
+                },
+              },
+              required: ['friends'],
+            },
+          },
+        },
+      },
+    });
+
+    const result = generateReusableSchemaSet(
+      ['#/components/schemas/Lizard'],
+      context,
+      { strict: false, isZodV4: false },
+    );
+
+    expect(result.map((e) => e.name).toSorted()).toEqual(['Lizard', 'Pet']);
+
+    const lizard = result.find((e) => e.name === 'Lizard');
+    expect(lizard?.zod).toContain('__REF_Pet__');
+    expect(lizard?.usedRefs).toEqual(new Set(['Pet']));
+  });
+
+  it('handles self-referential $dynamicRef with z.lazy', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              $dynamicAnchor: 'Pet',
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                playmates: {
+                  type: 'array',
+                  items: { $dynamicRef: '#Pet' },
+                },
+              },
+              required: ['name'],
+            },
+          },
+        },
+      },
+    });
+
+    const entries = generateReusableSchemaSet(
+      ['#/components/schemas/Pet'],
+      context,
+      { strict: false, isZodV4: false },
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].usedRefs).toEqual(new Set(['Pet']));
+
+    const rewritten = rewriteReusableSchemas(entries);
+    expect(rewritten[0].zod).toContain('zod.lazy(() => Pet)');
+    expect(rewritten[0].isRecursive).toBe(true);
+  });
+
+  it('resolves $dynamicRef through the component local dynamic scope', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              $dynamicAnchor: 'Pet',
+              type: 'object',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+            Cat: {
+              $dynamicAnchor: 'Pet',
+              type: 'object',
+              properties: {
+                meow: { type: 'boolean' },
+                playmates: {
+                  type: 'array',
+                  items: { $dynamicRef: '#Pet' },
+                },
+              },
+              required: ['meow'],
+            },
+          },
+        },
+      },
+    });
+
+    const entries = generateReusableSchemaSet(
+      ['#/components/schemas/Cat'],
+      context,
+      { strict: false, isZodV4: false },
+    );
+
+    expect(entries.map((e) => e.name)).toEqual(['Cat']);
+    expect(entries[0].usedRefs).toEqual(new Set(['Cat']));
+
+    const rewritten = rewriteReusableSchemas(entries);
+    expect(rewritten[0].zod).toContain('zod.lazy(() => Cat)');
+    expect(rewritten[0].zod).not.toContain('__REF_Pet__');
+  });
+
+  it('resolves $defs dynamic anchors in reusable schemas', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            User: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+            },
+            Container: {
+              type: 'object',
+              $defs: {
+                itemType: {
+                  $dynamicAnchor: 'itemType',
+                  $ref: '#/components/schemas/User',
+                },
+              },
+              properties: {
+                items: {
+                  type: 'array',
+                  items: { $dynamicRef: '#itemType' },
+                },
+              },
+              required: ['items'],
+            },
+          },
+        },
+      },
+    });
+
+    const entries = generateReusableSchemaSet(
+      ['#/components/schemas/Container'],
+      context,
+      { strict: false, isZodV4: false },
+    );
+
+    expect(entries.map((e) => e.name).toSorted()).toEqual([
+      'Container',
+      'User',
+    ]);
+    expect(entries.find((e) => e.name === 'Container')?.usedRefs).toEqual(
+      new Set(['User']),
+    );
+  });
+
+  it('handles mutual $dynamicRef cycle between two schemas', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Dog: {
+              $dynamicAnchor: 'Dog',
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                friends: {
+                  type: 'array',
+                  items: { $dynamicRef: '#Cat' },
+                },
+              },
+              required: ['name'],
+            },
+            Cat: {
+              $dynamicAnchor: 'Cat',
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                friends: {
+                  type: 'array',
+                  items: { $dynamicRef: '#Dog' },
+                },
+              },
+              required: ['name'],
+            },
+          },
+        },
+      },
+    });
+
+    const entries = generateReusableSchemaSet(
+      ['#/components/schemas/Dog'],
+      context,
+      { strict: false, isZodV4: false },
+    );
+
+    expect(entries.map((e) => e.name).toSorted()).toEqual(['Cat', 'Dog']);
+
+    const rewritten = rewriteReusableSchemas(entries);
+    const dog = rewritten.find((e) => e.name === 'Dog');
+    const cat = rewritten.find((e) => e.name === 'Cat');
+
+    expect(dog?.isRecursive).toBe(true);
+    expect(cat?.isRecursive).toBe(true);
+
+    const lazyCount = [dog?.zod, cat?.zod].filter((s) =>
+      s?.includes('zod.lazy'),
+    ).length;
+    expect(lazyCount).toBe(1);
+  });
+});

--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -1,5 +1,10 @@
-import type { ContextSpec, GeneratorMutator, ZodCoerceType } from '@orval/core';
-import { getRefInfo } from '@orval/core';
+import type {
+  ContextSpec,
+  GeneratorMutator,
+  OpenApiSchemaObject,
+  ZodCoerceType,
+} from '@orval/core';
+import { buildDynamicScope, getRefInfo } from '@orval/core';
 import {
   generateZodValidationSchemaDefinition,
   parseZodValidationSchemaDefinition,
@@ -186,10 +191,18 @@ export const generateReusableSchemaSet = (
     if (!schema) continue;
 
     const name = resolveSchemaName(ref, context);
+    const scopedContext: ContextSpec = {
+      ...context,
+      dynamicScope: buildDynamicScope(
+        schemaName,
+        schema as OpenApiSchemaObject,
+        context,
+      ),
+    };
 
     const definition = generateZodValidationSchemaDefinition(
       schema,
-      context,
+      scopedContext,
       name,
       options.strict,
       options.isZodV4,
@@ -202,7 +215,7 @@ export const generateReusableSchemaSet = (
 
     const parsed = parseZodValidationSchemaDefinition(
       definition,
-      context,
+      scopedContext,
       options.coerce ?? false,
       options.strict,
       options.isZodV4,

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -235,6 +235,47 @@ export const generateZodValidationSchemaDefinition = (
 ): ZodValidationSchemaDefinition => {
   if (!schema) return { functions: [], consts: [] };
 
+  const CHAINABLE_SIBLINGS = new Set(['nullable', 'default', 'description']);
+  const isChainable = (k: string) => CHAINABLE_SIBLINGS.has(k);
+
+  const applyChainableSiblings = (
+    functions: [string, unknown][],
+    consts: string[],
+    siblingSchema: OpenApiSchemaObject & {
+      nullable?: boolean;
+      default?: unknown;
+      description?: string;
+    },
+  ): void => {
+    const refRequired = rules?.required ?? false;
+    const refHasDefault = siblingSchema.default !== undefined;
+
+    if (!refRequired && siblingSchema.nullable) {
+      functions.push(['nullish', undefined]);
+    } else if (siblingSchema.nullable) {
+      functions.push(['nullable', undefined]);
+    } else if (!refRequired && !refHasDefault) {
+      functions.push(['optional', undefined]);
+    }
+
+    if (refHasDefault) {
+      const registry = rules?.constNameRegistry ?? {};
+      const counter = isNumber(registry[name]) ? registry[name] + 1 : 0;
+      registry[name] = counter;
+      const suffix = counter ? pascal(getNumberWord(counter)) : '';
+      const defaultVarName = `${name}Default${suffix}`;
+      const defaultLiteral = stringify(siblingSchema.default);
+      if (defaultLiteral !== undefined) {
+        consts.push(`export const ${defaultVarName} = ${defaultLiteral};`);
+        functions.push(['default', defaultVarName]);
+      }
+    }
+
+    if (typeof siblingSchema.description === 'string') {
+      functions.push(['describe', `"${escape(siblingSchema.description)}"`]);
+    }
+  };
+
   // Ref-aware path: emit a placeholder that the orchestrator will rewrite into
   // either a direct identifier or `z.lazy(() => Name)`.
   if (
@@ -244,75 +285,86 @@ export const generateZodValidationSchemaDefinition = (
     isComponentSchemaRef(schema.$ref)
   ) {
     const siblings = Object.keys(schema).filter((k) => k !== '$ref');
-
-    const CHAINABLE_SIBLINGS = new Set(['nullable', 'default', 'description']);
-    const isChainable = (k: string) => CHAINABLE_SIBLINGS.has(k);
     const allSiblingsChainable = siblings.every((k) => isChainable(k));
 
     if (allSiblingsChainable) {
-      // Use the same identifier orval emits for the TS model type
-      // (`pascal` + sanitize + suffix) so reusable schema exports are
-      // consistent with operation wrappers and component types.
-      // `namingConvention` governs file names only, not identifiers.
       const refName = getRefInfo(schema.$ref, context).name;
       const functions: [string, unknown][] = [
         ['namedRef', { name: refName, sourceRef: schema.$ref }],
       ];
       const consts: string[] = [];
 
-      const refSchema = schema as OpenApiSchemaObject & {
-        $ref: string;
-        nullable?: boolean;
-        default?: unknown;
-        description?: string;
-      };
-      const refRequired = rules.required ?? false;
-      const refHasDefault = refSchema.default !== undefined;
-
-      // Match the main-path modifier ordering: nullability/optional first,
-      // then default, then describe. Combining `.default()` with `.optional()`
-      // is wrong in zod — `.optional()` short-circuits on `undefined` before
-      // the inner default runs — so skip `.optional()` whenever a default is
-      // present (matches the existing non-reusable behaviour at line ~932).
-      if (!refRequired && refSchema.nullable) {
-        functions.push(['nullish', undefined]);
-      } else if (refSchema.nullable) {
-        functions.push(['nullable', undefined]);
-      } else if (!refRequired && !refHasDefault) {
-        functions.push(['optional', undefined]);
-      }
-
-      // .default(...) — emit a const for non-primitive defaults. Use the same
-      // constNameRegistry-based suffix that the rest of the generator uses so
-      // multiple defaults sharing `name` don't collide on `<name>Default`.
-      if (refHasDefault) {
-        const registry = rules.constNameRegistry ?? {};
-        const counter = isNumber(registry[name]) ? registry[name] + 1 : 0;
-        registry[name] = counter;
-        const suffix = counter ? pascal(getNumberWord(counter)) : '';
-        const defaultVarName = `${name}Default${suffix}`;
-        const defaultLiteral = stringify(refSchema.default);
-        if (defaultLiteral !== undefined) {
-          consts.push(`export const ${defaultVarName} = ${defaultLiteral};`);
-          functions.push(['default', defaultVarName]);
-        }
-      }
-
-      // .describe('...')
-      if (typeof refSchema.description === 'string') {
-        functions.push(['describe', `"${escape(refSchema.description)}"`]);
-      }
+      applyChainableSiblings(
+        functions,
+        consts,
+        schema as OpenApiSchemaObject & {
+          $ref: string;
+          nullable?: boolean;
+          default?: unknown;
+          description?: string;
+        },
+      );
 
       return { functions, consts };
     }
 
-    // Non-chainable sibling present — fall back to inlining at this site only.
-    // We reassign the local `schema` reference to the dereferenced form and let
-    // the rest of the function process it normally.
     logVerbose(
       `[orval/zod] $ref ${schema.$ref} has non-chainable siblings ` +
         `[${siblings.filter((s) => !isChainable(s)).join(', ')}]; falling back to inlining.`,
     );
+    schema = dereference(
+      schema as OpenApiSchemaObject | OpenApiReferenceObject,
+      context,
+    );
+  }
+
+  // Dynamic-ref-aware path: when useReusableSchemas is true, resolve the
+  // anchor and emit a namedRef sentinel if the target is a concrete component
+  // schema. The SCC pipeline then decides direct vs zod.lazy().
+  if (rules?.useReusableSchemas && isDynamicReference(schema)) {
+    const anchorName = getDynamicAnchorName(schema.$dynamicRef);
+    if (anchorName) {
+      const { resolvedTypeName, schemaName } = resolveDynamicRef(
+        anchorName,
+        context,
+      );
+
+      if (resolvedTypeName !== 'unknown' && schemaName) {
+        const siblings = Object.keys(schema).filter((k) => k !== '$dynamicRef');
+        const allSiblingsChainable = siblings.every((k) => isChainable(k));
+
+        if (allSiblingsChainable) {
+          const sourceRef = `${COMPONENT_SCHEMAS_PREFIX}${encodeSegment(schemaName)}`;
+          const functions: [string, unknown][] = [
+            ['namedRef', { name: resolvedTypeName, sourceRef }],
+          ];
+          const consts: string[] = [];
+
+          applyChainableSiblings(
+            functions,
+            consts,
+            schema as OpenApiSchemaObject & {
+              $dynamicRef: string;
+              nullable?: boolean;
+              default?: unknown;
+              description?: string;
+            },
+          );
+
+          return { functions, consts };
+        }
+
+        logVerbose(
+          `[orval/zod] $dynamicRef ${schema.$dynamicRef} has non-chainable siblings ` +
+            `[${siblings.filter((s) => !isChainable(s)).join(', ')}]; falling back to inlining.`,
+        );
+      }
+    }
+
+    // Not emitted as namedRef (non-chainable siblings, unresolvable anchor,
+    // or external ref) — dereference now so the main body sees a resolved
+    // schema with a proper type instead of the raw $dynamicRef (which
+    // resolveZodType classifies as 'unknown').
     schema = dereference(
       schema as OpenApiSchemaObject | OpenApiReferenceObject,
       context,

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable unicorn/no-array-reduce */
 
 import {
+  buildDynamicScope,
   camel,
   type ClientBuilder,
   type ClientGeneratorsBuilder,
@@ -11,10 +12,12 @@ import {
   type GeneratorMutator,
   type GeneratorOptions,
   type GeneratorVerbOptions,
+  getDynamicAnchorName,
   getFormDataFieldFileType,
   getNumberWord,
   getRefInfo,
   isBoolean,
+  isDynamicReference,
   isNumber,
   isObject,
   isString,
@@ -26,6 +29,7 @@ import {
   type OpenApiResponseObject,
   type OpenApiSchemaObject,
   pascal,
+  resolveDynamicRef,
   resolveRef,
   stringify,
   type ZodCoerceType,
@@ -1423,12 +1427,27 @@ function tryResolveRefSchema(
   }
 }
 
+const COMPONENT_SCHEMAS_PREFIX = '#/components/schemas/';
+
+function extractSchemaNameFromRef($ref: string): string | undefined {
+  if (!$ref.startsWith(COMPONENT_SCHEMAS_PREFIX)) return undefined;
+  const raw = $ref.slice(COMPONENT_SCHEMAS_PREFIX.length);
+  return decodeURIComponent(raw.replaceAll('~1', '/').replaceAll('~0', '~'));
+}
+
 /**
- * Recursively inlines all `$ref` references in an OpenAPI schema tree,
- * producing a fully-resolved schema suitable for Zod code generation.
+ * Recursively inlines all `$ref` and `$dynamicRef` references in an OpenAPI
+ * schema tree, producing a fully-resolved schema suitable for Zod code generation.
  *
  * Tracks visited `$ref` paths via `context.parents` to break circular
  * references (returning `{}` for cycles).
+ *
+ * `$dynamicRef` is resolved using the dynamic scope attached to `context`:
+ *  1. Look up the anchor name in `context.dynamicScope`.
+ *  2. If not found, fall back to scanning `components.schemas` for a schema
+ *     that declares `$dynamicAnchor` with the same name.
+ *  3. If resolved to a concrete schema, inline it (same as `$ref`).
+ *  4. If unresolved, external, or a generic parameter → return `{}`.
  */
 export const dereference = (
   schema: OpenApiSchemaObject | OpenApiReferenceObject,
@@ -1437,6 +1456,10 @@ export const dereference = (
   const refName = '$ref' in schema ? schema.$ref : undefined;
   if (refName && context.parents?.includes(refName)) {
     return {};
+  }
+
+  if (isDynamicReference(schema)) {
+    return dereferenceDynamicRef(schema, context);
   }
 
   const childContext: ContextSpec = {
@@ -1472,9 +1495,20 @@ export const dereference = (
     return {};
   }
 
-  const resolvedContext = childContext;
+  const resolvedContext = buildScopedContext(
+    childContext,
+    refName,
+    resolvedSchema,
+  );
 
-  return Object.entries(resolvedSchema).reduce<Record<string, unknown>>(
+  return dereferenceProperties(resolvedSchema, resolvedContext);
+};
+
+function dereferenceProperties(
+  schema: OpenApiSchemaObject,
+  context: ContextSpec,
+): OpenApiSchemaObject {
+  return Object.entries(schema).reduce<Record<string, unknown>>(
     (acc, [key, value]) => {
       if (key === 'properties' && isObject(value)) {
         acc[key] = Object.entries(value).reduce<
@@ -1482,21 +1516,102 @@ export const dereference = (
         >((props, [propKey, propSchema]) => {
           props[propKey] = dereference(
             propSchema as OpenApiSchemaObject | OpenApiReferenceObject,
-            resolvedContext,
+            context,
           );
           return props;
         }, {});
       } else if (key === 'default' || key === 'example' || key === 'examples') {
         acc[key] = value;
       } else {
-        acc[key] = dereferenceScalar(value, resolvedContext);
+        acc[key] = dereferenceScalar(value, context);
       }
 
       return acc;
     },
     {},
   ) as OpenApiSchemaObject;
-};
+}
+
+function buildScopedContext(
+  childContext: ContextSpec,
+  refName: string | undefined,
+  resolvedSchema: OpenApiSchemaObject,
+): ContextSpec {
+  if (!refName) return childContext;
+
+  const schemaName = extractSchemaNameFromRef(refName);
+  if (!schemaName) return childContext;
+
+  const schemaRecord = resolvedSchema as Record<string, unknown>;
+  const hasDynamicAnchor = typeof schemaRecord.$dynamicAnchor === 'string';
+  const defs = schemaRecord.$defs as Record<string, unknown> | undefined;
+  const hasDefsAnchors =
+    defs &&
+    typeof defs === 'object' &&
+    Object.values(defs).some(
+      (d) => d && typeof d === 'object' && '$dynamicAnchor' in d,
+    );
+
+  if (!hasDynamicAnchor && !hasDefsAnchors) return childContext;
+
+  return {
+    ...childContext,
+    dynamicScope: buildDynamicScope(schemaName, resolvedSchema, childContext),
+  };
+}
+
+function dereferenceDynamicRef(
+  schema: object & { $dynamicRef: string },
+  context: ContextSpec,
+): OpenApiSchemaObject {
+  const dynamicRef = schema.$dynamicRef;
+  const anchorName = getDynamicAnchorName(dynamicRef);
+  if (!anchorName) {
+    return {};
+  }
+
+  const dynamicRefPath = `$dynamicRef:${dynamicRef}`;
+  if (context.parents?.includes(dynamicRefPath)) {
+    return {};
+  }
+  const {
+    resolvedTypeName,
+    schema: resolvedSchema,
+    schemaName,
+  } = resolveDynamicRef(anchorName, context);
+
+  if (resolvedTypeName === 'unknown' || !isObject(resolvedSchema)) {
+    return {};
+  }
+
+  const childContext: ContextSpec = {
+    ...context,
+    parents: [...(context.parents ?? []), dynamicRefPath],
+  };
+
+  const scopedContext = buildScopedContext(
+    childContext,
+    schemaName
+      ? `${COMPONENT_SCHEMAS_PREFIX}${encodeSegment(schemaName)}`
+      : undefined,
+    resolvedSchema,
+  );
+
+  const siblingProperties = Object.fromEntries(
+    Object.entries(schema).filter(([key]) => key !== '$dynamicRef'),
+  );
+
+  const merged: OpenApiSchemaObject = {
+    ...(resolvedSchema as Record<string, unknown>),
+    ...siblingProperties,
+  } as OpenApiSchemaObject;
+
+  return dereferenceProperties(merged, scopedContext);
+}
+
+function encodeSegment(segment: string): string {
+  return segment.replaceAll('~', '~0').replaceAll('/', '~1');
+}
 
 /**
  * Generate zod schema for form-data request body.

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1553,6 +1553,10 @@ export const dereference = (
     resolvedSchema,
   );
 
+  if (isDynamicReference(resolvedSchema)) {
+    return dereferenceDynamicRef(resolvedSchema, resolvedContext);
+  }
+
   return dereferenceProperties(resolvedSchema, resolvedContext);
 };
 
@@ -1622,15 +1626,16 @@ function dereferenceDynamicRef(
     return {};
   }
 
-  const dynamicRefPath = `$dynamicRef:${dynamicRef}`;
-  if (context.parents?.includes(dynamicRefPath)) {
-    return {};
-  }
   const {
     resolvedTypeName,
     schema: resolvedSchema,
     schemaName,
   } = resolveDynamicRef(anchorName, context);
+
+  const dynamicRefPath = `$dynamicRef:${dynamicRef}@${schemaName ?? '?'}`;
+  if (context.parents?.includes(dynamicRefPath)) {
+    return {};
+  }
 
   if (resolvedTypeName === 'unknown' || !isObject(resolvedSchema)) {
     return {};

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -9156,6 +9156,112 @@ describe('$dynamicRef / $dynamicAnchor', () => {
       expect(itemsProps.id).toBeDefined();
     });
 
+    it('resolves $ref whose target is a root $dynamicRef', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              PetRef: {
+                $dynamicRef: '#Pet',
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference(
+        { $ref: '#/components/schemas/PetRef' },
+        ctx,
+      );
+
+      expect(resolved).toBeDefined();
+      expect((resolved as Record<string, unknown>).type).toBe('object');
+      const props = (resolved as Record<string, unknown>).properties as Record<
+        string,
+        unknown
+      >;
+      expect(props).toBeDefined();
+      expect(props.name).toBeDefined();
+    });
+
+    it('does not collide cycle keys across different dynamic scopes', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  playmates: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+              Cat: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: {
+                  meow: { type: 'boolean' },
+                  playmates: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+              Owner: {
+                type: 'object',
+                properties: {
+                  pet: { $ref: '#/components/schemas/Pet' },
+                  cat: { $ref: '#/components/schemas/Cat' },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference({ $ref: '#/components/schemas/Owner' }, ctx);
+
+      const pet = (resolved.properties as Record<string, unknown>).pet;
+      const cat = (resolved.properties as Record<string, unknown>).cat;
+
+      const petItems = (
+        (pet as Record<string, unknown>).properties as Record<string, unknown>
+      ).playmates;
+      const petItemsItems = (petItems as Record<string, unknown>).items;
+      expect((petItemsItems as Record<string, unknown>).type).toBe('object');
+      expect(
+        (
+          (petItemsItems as Record<string, unknown>).properties as Record<
+            string,
+            unknown
+          >
+        ).name,
+      ).toBeDefined();
+
+      const catItems = (
+        (cat as Record<string, unknown>).properties as Record<string, unknown>
+      ).playmates;
+      const catItemsItems = (catItems as Record<string, unknown>).items;
+      expect((catItemsItems as Record<string, unknown>).type).toBe('object');
+      expect(
+        (
+          (catItemsItems as Record<string, unknown>).properties as Record<
+            string,
+            unknown
+          >
+        ).meow,
+      ).toBeDefined();
+    });
+
     it('resolves $dynamicRef for non-identifier schema keys (hyphenated)', () => {
       const ctx = makeContextSpec({
         spec: {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -8684,3 +8684,507 @@ describe('generateMeta (.meta())', () => {
     expect(offDef.functions.some((fn) => fn[0] === 'describe')).toBe(false);
   });
 });
+
+function makeZodOverride(overrides: Record<string, unknown> = {}) {
+  return {
+    strict: {
+      param: false,
+      body: false,
+      response: false,
+      query: false,
+      header: false,
+    },
+    generate: {
+      param: false,
+      body: false,
+      response: true,
+      query: false,
+      header: false,
+    },
+    coerce: {
+      param: false,
+      body: false,
+      response: false,
+      query: false,
+      header: false,
+    },
+    generateEachHttpStatus: false,
+    dateTimeOptions: {},
+    timeOptions: {},
+    ...overrides,
+  };
+}
+
+describe('$dynamicRef / $dynamicAnchor', () => {
+  const petstoreComponents = {
+    Pet: {
+      $dynamicAnchor: 'Pet',
+      type: 'object',
+      properties: {
+        petType: { type: 'string' },
+        name: { type: 'string' },
+        playmates: {
+          type: 'array',
+          items: { $dynamicRef: '#Pet' },
+        },
+      },
+    },
+    Cat: {
+      $dynamicAnchor: 'Pet',
+      type: 'object',
+      properties: {
+        petType: { type: 'string', enum: ['cat'] },
+        name: { type: 'string' },
+        meow: { type: 'boolean' },
+        playmates: {
+          type: 'array',
+          items: { $dynamicRef: '#Pet' },
+        },
+      },
+    },
+    Lizard: {
+      type: 'object',
+      properties: {
+        petType: { type: 'string', enum: ['lizard'] },
+        name: { type: 'string' },
+        lovesRocks: { type: 'boolean' },
+        playmates: {
+          type: 'array',
+          items: { $dynamicRef: '#Pet' },
+        },
+      },
+    },
+  };
+
+  function makeApiSchema(paths: Record<string, unknown>) {
+    const baseContext = createTestContextSpec({
+      output: {
+        propertySortOrder: PropertySortOrder.ALPHABETICAL,
+      },
+    });
+    return {
+      pathRoute: Object.keys(paths)[0],
+      context: {
+        ...baseContext,
+        spec: {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1.0.0' },
+          paths,
+          components: { schemas: petstoreComponents },
+        },
+        output: {
+          ...baseContext.output,
+          override: {
+            ...baseContext.output.override,
+            zod: {
+              generateEachHttpStatus: false,
+            },
+          },
+        },
+      },
+    } as unknown as GeneratorOptions;
+  }
+
+  describe('dereference', () => {
+    it('resolves $dynamicRef via fallback when schema has no local $dynamicAnchor', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              Lizard: {
+                type: 'object',
+                properties: {
+                  playmates: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference(
+        {
+          $ref: '#/components/schemas/Lizard',
+        },
+        ctx,
+      );
+
+      const playmatesItems = (resolved.properties as Record<string, unknown>)
+        .playmates;
+      expect(playmatesItems).toBeDefined();
+      const items = (playmatesItems as Record<string, unknown>).items;
+      expect(items).toBeDefined();
+      expect((items as Record<string, unknown>).type).toBe('object');
+    });
+
+    it('resolves $dynamicRef via local scope when schema overrides $dynamicAnchor', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              Cat: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: {
+                  meow: { type: 'boolean' },
+                  playmates: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference({ $ref: '#/components/schemas/Cat' }, ctx);
+
+      const playmatesItems = (resolved.properties as Record<string, unknown>)
+        .playmates;
+      const items = (playmatesItems as Record<string, unknown>).items;
+      expect(items).toBeDefined();
+      expect((items as Record<string, unknown>).type).toBe('object');
+      const itemsProps = (items as Record<string, unknown>)
+        .properties as Record<string, unknown>;
+      expect(itemsProps).toBeDefined();
+      expect(itemsProps.meow).toBeDefined();
+    });
+
+    it('returns empty for external $dynamicRef', () => {
+      const ctx = makeContextSpec({
+        spec: { components: { schemas: {} } },
+      });
+
+      const resolved = dereference(
+        { $dynamicRef: 'other.json#node' } as never,
+        ctx,
+      );
+
+      expect(resolved).toEqual({});
+    });
+
+    it('returns empty for missing anchor', () => {
+      const ctx = makeContextSpec({
+        spec: { components: { schemas: {} } },
+      });
+
+      const resolved = dereference(
+        { $dynamicRef: '#nonexistent' } as never,
+        ctx,
+      );
+
+      expect(resolved).toEqual({});
+    });
+
+    it('breaks cycle for self-referential $dynamicRef', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  playmates: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference({ $ref: '#/components/schemas/Pet' }, ctx);
+
+      expect(resolved).toBeDefined();
+      const playmates = (resolved.properties as Record<string, unknown>)
+        .playmates;
+      const items = (playmates as Record<string, unknown>).items;
+      expect(items).toBeDefined();
+      const innerPlaymates = (
+        (items as Record<string, unknown>).properties as Record<string, unknown>
+      ).playmates;
+      const innerItems = (innerPlaymates as Record<string, unknown>).items;
+      expect(Object.keys(innerItems as object).length).toBe(0);
+    });
+
+    it('resolves $defs bound anchor to concrete schema', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              User: {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+              },
+              Container: {
+                type: 'object',
+                $defs: {
+                  itemType: {
+                    $dynamicAnchor: 'itemType',
+                    $ref: '#/components/schemas/User',
+                  },
+                },
+                properties: {
+                  items: {
+                    type: 'array',
+                    items: { $dynamicRef: '#itemType' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference(
+        { $ref: '#/components/schemas/Container' },
+        ctx,
+      );
+
+      const items = (
+        (resolved.properties as Record<string, unknown>).items as Record<
+          string,
+          unknown
+        >
+      ).items;
+      expect(items).toBeDefined();
+      expect((items as Record<string, unknown>).type).toBe('object');
+      const itemsProps = (items as Record<string, unknown>)
+        .properties as Record<string, unknown>;
+      expect(itemsProps).toBeDefined();
+      expect(itemsProps.id).toBeDefined();
+    });
+
+    it('resolves $dynamicRef for non-identifier schema keys (hyphenated)', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              'my-pet': {
+                $dynamicAnchor: 'MyPet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              'my-lizard': {
+                type: 'object',
+                properties: {
+                  friends: {
+                    type: 'array',
+                    items: { $dynamicRef: '#MyPet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference(
+        { $ref: '#/components/schemas/my-lizard' },
+        ctx,
+      );
+
+      const friends = (resolved.properties as Record<string, unknown>).friends;
+      const items = (friends as Record<string, unknown>).items;
+      expect(items).toBeDefined();
+      expect((items as Record<string, unknown>).type).toBe('object');
+      const itemsProps = (items as Record<string, unknown>)
+        .properties as Record<string, unknown>;
+      expect(itemsProps).toBeDefined();
+      expect(itemsProps.name).toBeDefined();
+    });
+  });
+
+  describe('e2e via generateZod', () => {
+    it('resolves fallback $dynamicRef in response (Lizard → Pet)', async () => {
+      const spec = makeApiSchema({
+        '/lizard': {
+          get: {
+            operationId: 'getLizard',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Lizard' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = await generateZod(
+        {
+          pathRoute: '/lizard',
+          verb: 'get',
+          operationName: 'getLizard',
+          override: { zod: makeZodOverride() },
+        } as unknown as Parameters<typeof generateZod>[0],
+        spec,
+        testOutput,
+      );
+
+      expect(result.implementation).toContain('"playmates"');
+      expect(result.implementation).toContain('"lovesRocks"');
+      expect(result.implementation).toContain('"name"');
+    });
+
+    it('resolves local override $dynamicRef in response (Cat → Cat)', async () => {
+      const spec = makeApiSchema({
+        '/cat': {
+          get: {
+            operationId: 'getCat',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Cat' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = await generateZod(
+        {
+          pathRoute: '/cat',
+          verb: 'get',
+          operationName: 'getCat',
+          override: { zod: makeZodOverride() },
+        } as unknown as Parameters<typeof generateZod>[0],
+        spec,
+        testOutput,
+      );
+
+      expect(result.implementation).toContain('"meow"');
+      expect(result.implementation).toContain('"playmates"');
+    });
+
+    it('emits zod.unknown() for missing anchor', async () => {
+      const baseContext = createTestContextSpec({
+        output: {
+          propertySortOrder: PropertySortOrder.ALPHABETICAL,
+        },
+      });
+      const spec = {
+        pathRoute: '/broken',
+        context: {
+          ...baseContext,
+          spec: {
+            openapi: '3.1.0',
+            info: { title: 'Test', version: '1.0.0' },
+            paths: {
+              '/broken': {
+                get: {
+                  operationId: 'getBroken',
+                  responses: {
+                    '200': {
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: {
+                              items: {
+                                type: 'array',
+                                items: { $dynamicRef: '#nonexistent' },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            components: { schemas: {} },
+          },
+          output: {
+            ...baseContext.output,
+            override: {
+              ...baseContext.output.override,
+              zod: { generateEachHttpStatus: false },
+            },
+          },
+        },
+      } as unknown as GeneratorOptions;
+
+      const result = await generateZod(
+        {
+          pathRoute: '/broken',
+          verb: 'get',
+          operationName: 'getBroken',
+          override: { zod: makeZodOverride() },
+        } as unknown as Parameters<typeof generateZod>[0],
+        spec,
+        testOutput,
+      );
+
+      expect(result.implementation).toContain('zod.unknown()');
+    });
+
+    it('handles $dynamicRef inside allOf', async () => {
+      const spec = makeApiSchema({
+        '/mixed': {
+          get: {
+            operationId: 'getMixed',
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      allOf: [
+                        { $ref: '#/components/schemas/Lizard' },
+                        {
+                          type: 'object',
+                          properties: {
+                            tag: { type: 'string' },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = await generateZod(
+        {
+          pathRoute: '/mixed',
+          verb: 'get',
+          operationName: 'getMixed',
+          override: { zod: makeZodOverride() },
+        } as unknown as Parameters<typeof generateZod>[0],
+        spec,
+        testOutput,
+      );
+
+      expect(result.implementation).toContain('"tag"');
+      expect(result.implementation).toContain('"playmates"');
+    });
+  });
+});

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4126,6 +4126,189 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
       expect(result.functions.some(([fn]) => fn === 'namedRef')).toBe(false);
     });
+
+    it('emits namedRef for $dynamicRef resolving to a component schema', () => {
+      const context = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              Lizard: {
+                type: 'object',
+                properties: {
+                  friends: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = generateZodValidationSchemaDefinition(
+        { $dynamicRef: '#Pet' } as never,
+        context,
+        'friends',
+        false,
+        false,
+        { required: true, useReusableSchemas: true },
+      );
+
+      expect(result.functions[0]).toEqual([
+        'namedRef',
+        { name: 'Pet', sourceRef: '#/components/schemas/Pet' },
+      ]);
+    });
+
+    it('emits namedRef for self-referential $dynamicRef', () => {
+      const context = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  playmates: {
+                    type: 'array',
+                    items: { $dynamicRef: '#Pet' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = generateZodValidationSchemaDefinition(
+        { $dynamicRef: '#Pet' } as never,
+        context,
+        'playmates',
+        false,
+        false,
+        { required: true, useReusableSchemas: true },
+      );
+
+      expect(result.functions[0]).toEqual([
+        'namedRef',
+        { name: 'Pet', sourceRef: '#/components/schemas/Pet' },
+      ]);
+    });
+
+    it('emits namedRef for $dynamicRef with nullable sibling', () => {
+      const context = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+        },
+      });
+
+      const result = generateZodValidationSchemaDefinition(
+        { $dynamicRef: '#Pet', nullable: true } as never,
+        context,
+        'friends',
+        false,
+        false,
+        { required: false, useReusableSchemas: true },
+      );
+
+      expect(result.functions[0]).toEqual([
+        'namedRef',
+        { name: 'Pet', sourceRef: '#/components/schemas/Pet' },
+      ]);
+      expect(result.functions[1]).toEqual(['nullish', undefined]);
+    });
+
+    it('falls back to empty for unresolvable $dynamicRef with useReusableSchemas', () => {
+      const context = makeContextSpec({
+        spec: { components: { schemas: {} } },
+      });
+
+      const result = generateZodValidationSchemaDefinition(
+        { $dynamicRef: '#nonexistent' } as never,
+        context,
+        'friends',
+        false,
+        false,
+        { required: true, useReusableSchemas: true },
+      );
+
+      expect(result.functions.some(([fn]) => fn === 'namedRef')).toBe(false);
+    });
+
+    it('falls back to inlining for $dynamicRef with non-chainable siblings', () => {
+      const context = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+        },
+      });
+
+      const result = generateZodValidationSchemaDefinition(
+        {
+          $dynamicRef: '#Pet',
+          properties: { extra: { type: 'string' } },
+        } as never,
+        context,
+        'friends',
+        false,
+        false,
+        { required: true, useReusableSchemas: true },
+      );
+
+      expect(result.functions.some(([fn]) => fn === 'namedRef')).toBe(false);
+    });
+
+    it('emits namedRef for $dynamicRef with hyphenated schema key', () => {
+      const context = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              'my-pet': {
+                $dynamicAnchor: 'MyPet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+        },
+      });
+
+      const result = generateZodValidationSchemaDefinition(
+        { $dynamicRef: '#MyPet' } as never,
+        context,
+        'friends',
+        false,
+        false,
+        { required: true, useReusableSchemas: true },
+      );
+
+      expect(result.functions[0]).toEqual([
+        'namedRef',
+        { name: 'MyPet', sourceRef: '#/components/schemas/my-pet' },
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Add full `$dynamicRef` / `$dynamicAnchor` support to the Zod code generator, covering both the inline dereference path and the reusable (SCC) schema pipeline.

### What changed

**`@orval/core` — `resolveDynamicRef`** (`packages/core/src/resolvers/ref.ts`)
- Return `schemaName` from `resolveDynamicRef` so callers can reconstruct the component `$ref` without an extra lookup.

**`@orval/zod` — Zod generator** (`packages/zod/src/index.ts`)
- **Inline dereference**: `dereference()` now handles `$dynamicRef` alongside `$ref`. It resolves the anchor via the dynamic scope (local `$dynamicAnchor` + `$defs` bindings), falls back to a global component scan, and cycles safely.
- **Reusable schema path**: a new early-exit branch emits `namedRef` sentinels for `$dynamicRef` when `useReusableSchemas` is enabled, letting the SCC pipeline decide `z.lazy()` vs direct reference.
- Extracted `applyChainableSiblings` helper shared by both `$ref` and `$dynamicRef` paths (nullable/default/description).
- Extracted `buildScopedContext`, `dereferenceDynamicRef`, `dereferenceProperties`, `encodeSegment` helpers.

**`orval` — Reusable schema orchestrator** (`packages/orval/src/reusable-schemas.ts`)
- `generateReusableSchemaSet` now builds a per-component scoped context via `buildDynamicScope(...)` before invoking the Zod generator and parser. This seeds the component's own `$dynamicAnchor` and `$defs` bindings into `context.dynamicScope`, preventing incorrect fallback when a component overrides another schema's anchor.

### Test coverage

**`packages/zod/src/zod.test.ts`** (+183 lines)
- Unit tests for `namedRef` emission: basic resolution, self-reference, nullable sibling, unresolvable anchor, non-chainable siblings, hyphenated schema keys.
- Unit tests for `dereference`: fallback resolution, local scope override, external refs, missing anchors, cycle breaking, `$defs` bound anchors, hyphenated keys.
- E2E tests via `generateZod`: Lizard→Pet fallback, Cat→Cat local override, missing anchor → `zod.unknown()`, `$dynamicRef` inside `allOf`.

**`packages/orval/src/reusable-schemas.test.ts`** (+220 lines)
- Transitive ref discovery through `$dynamicRef`.
- Self-referential `$dynamicRef` → `z.lazy`.
- Local dynamic scope override (Cat overrides Pet anchor → self-reference, not Pet).
- `$defs` dynamic anchors bound to concrete component schemas.
- Mutual `$dynamicRef` cycle between two schemas.

### Refs

Closes #3445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAPI 3.1 dynamic references/anchors with scoped resolution so dynamic targets resolve correctly within local component scope.
  * Emitted schema references now preserve common modifiers (nullable/default/description) when safe; otherwise they inline resolved schemas.
  * Cycle protection and sensible fallbacks: unresolved anchors produce an unknown/empty schema, and self/cyclic refs are handled safely.

* **Tests**
  * Added extensive tests covering dynamic ref resolution, scope isolation, self-references, mutual cycles, and end-to-end generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->