### PR TITLE
fix(core): preserve original input as cache key in pascal() to fix cache misses for uppercase inputs

### DIFF
--- a/packages/core/src/utils/case.ts
+++ b/packages/core/src/utils/case.ts
@@ -100,6 +100,7 @@ export function pascal(s = '') {
   }
 
   const isStartWithUnderscore = s.startsWith('_');
+  const cacheKey = s;
 
   if (regexps.upper.test(s)) {
     s = low(s);
@@ -113,7 +114,7 @@ export function pascal(s = '') {
     ? `_${pascalString}`
     : pascalString;
 
-  pascalMemory[s] = pascalWithUnderscore;
+  pascalMemory[cacheKey] = pascalWithUnderscore;
 
   return pascalWithUnderscore;
 }


### PR DESCRIPTION
## Problem

Calling `pascal('SNAKE_CASE')` twice results in a cache miss on the second call because `pascalMemory[s]` caches using the **mutated** `s` (lowercased via `s = low(s)` on line 105), not the original input. Since `'SNAKE_CASE' !== 'snake_case'`, the second lookup falls through and recomputes the result.

## Root Cause

In `packages/core/src/utils/case.ts`, the `pascal()` function mutates the parameter `s` (via `s = low(s)`) before writing to the cache at `pascalMemory[s] = pascalWithUnderscore`. After mutation, `s` holds the lowercased value, so the cache key stored is `'snake_case'` instead of `'SNAKE_CASE'`. Subsequent calls with the original uppercase input miss the cache.

## Changes

- Preserve the original `s` value in a `cacheKey` variable before mutation
- Use `pascalMemory[cacheKey]` instead of `pascalMemory[s]` for cache storage

## Tested

- The fix is a minimal 2-line change (one line added, one line modified)
- Cache now correctly returns cached results for all-uppercase inputs
- Existing pascal behavior is unchanged since the mutation flow is preserved

Closes #3493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal caching mechanism in utility functions to improve performance and code maintainability without affecting external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->