### PR TITLE
fix(core): logger deduplication state leaking across instances

### DIFF
--- a/packages/core/src/utils/log-warning.test.ts
+++ b/packages/core/src/utils/log-warning.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getWarningCount, logWarning, resetWarnings } from './logger';
+import {
+  createLogger,
+  getWarningCount,
+  logWarning,
+  resetWarnings,
+} from './logger';
 
 describe('logWarning', () => {
   afterEach(() => {
@@ -27,5 +32,28 @@ describe('logWarning', () => {
     expect(getWarningCount()).toBe(1);
     resetWarnings();
     expect(getWarningCount()).toBe(0);
+  });
+});
+
+describe('createLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deduplicates messages per logger instance', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const firstLogger = createLogger('info');
+    const secondLogger = createLogger('info');
+
+    firstLogger.info('same message');
+    secondLogger.info('same message');
+    firstLogger.info('same message');
+
+    expect(log).toHaveBeenCalledTimes(3);
+    expect(log.mock.calls[0]).toEqual(['same message']);
+    expect(log.mock.calls[1]).toEqual(['same message']);
+    expect(log.mock.calls[2][0]).toBe('same message');
+    expect(log.mock.calls[2][1]).toContain('(x2)');
   });
 });

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -113,10 +113,6 @@ export const LogLevels: Record<LogLevel, number> = {
   info: 3,
 };
 
-let lastType: LogType | undefined;
-let lastMsg: string | undefined;
-let sameCount = 0;
-
 function clearScreen() {
   const repeatCount = process.stdout.rows - 2;
   const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : '';
@@ -135,6 +131,9 @@ export function createLogger(
   options: LoggerOptions = {},
 ): Logger {
   const { prefix = '[vite]', allowClearScreen = true } = options;
+  let lastType: LogType | undefined;
+  let lastMsg: string | undefined;
+  let sameCount = 0;
 
   const thresh = LogLevels[level];
   const clear =


### PR DESCRIPTION
Closes #3497

State is no longer shared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Logger deduplication now operates independently per logger instance, ensuring repeated messages are properly tracked within each logger rather than globally.

* **Tests**
  * Added test coverage for per-instance logger deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->