### PR TITLE
fix(core): test that resolveDynamicRef preserves pre-existing imports

### DIFF
--- a/packages/core/src/resolvers/dynamic-ref.test.ts
+++ b/packages/core/src/resolvers/dynamic-ref.test.ts
@@ -617,8 +617,10 @@ describe('resolveDynamicRef', () => {
       },
     };
 
-    const result = resolveDynamicRef('itemType', context);
+    const existingImport = { name: 'Existing', schemaName: 'Existing' };
+    const result = resolveDynamicRef('itemType', context, [existingImport]);
 
+    expect(result.imports).toContainEqual(existingImport);
     expect(result.imports).toContainEqual({
       name: 'User',
       schemaName: 'User',


### PR DESCRIPTION
## Summary

Updates the `'merges resolved imports with pre-existing imports'` test in `dynamic-ref.test.ts` to actually pass pre-existing imports to `resolveDynamicRef` and verify they are preserved in the result.

This test improvement was suggested during review of #3490 but was not pushed before merge.

### Changes
- Pass an `existingImport` as the 3rd argument to `resolveDynamicRef`
- Assert the returned `imports` array `toContainEqual(existingImport)` alongside the resolved User import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage to verify proper handling of pre-existing imports during import resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->