### PR TITLE
feat(mcp): add outputSchema, annotations, title, and description to registerTool

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,6 +20,7 @@ import {
   type OpenApiInfoObject,
   pascal,
   upath,
+  type Verbs,
 } from '@orval/core';
 import { generateClient, generateFetchHeader } from '@orval/fetch';
 import { generateZod } from '@orval/zod';
@@ -35,6 +36,30 @@ const getHeader = (
   const header = option(info);
 
   return Array.isArray(header) ? jsDoc({ description: header }) : header;
+};
+
+const getAnnotations = (verb: Verbs): string => {
+  switch (verb) {
+    case 'get':
+    case 'head': {
+      return '{ readOnlyHint: true, destructiveHint: false }';
+    }
+    case 'post': {
+      return '{ destructiveHint: false }';
+    }
+    case 'put': {
+      return '{ destructiveHint: false, idempotentHint: true }';
+    }
+    case 'patch': {
+      return '{ destructiveHint: false }';
+    }
+    case 'delete': {
+      return '{ idempotentHint: true }';
+    }
+    default: {
+      return '';
+    }
+  }
 };
 
 const getSpecInfo = (context: ContextSpec): OpenApiInfoObject =>
@@ -189,6 +214,9 @@ export const generateServer = (
   const header = getHeader(output.override.header, info);
 
   const mcpServerOptions = output.override.mcp.server;
+  const hasResponseSchema =
+    output.override.zod.generate.response &&
+    !output.override.zod.generateEachHttpStatus;
 
   const toolImplementations = Object.values(verbOptions)
     .map((verbOption) => {
@@ -206,6 +234,29 @@ export const generateServer = (
           ? `\n    inputSchema: {\n      ${inputSchemaTypes.join(',\n      ')}\n    },`
           : '';
 
+      const outputSchemaImplementation = hasResponseSchema
+        ? `\n    outputSchema: ${pascalOperationName}Response,`
+        : '';
+
+      const annotationsValue = getAnnotations(verbOption.verb);
+      const annotationsImplementation = annotationsValue
+        ? `\n    annotations: ${annotationsValue},`
+        : '';
+
+      const titleImplementation = verbOption.summary
+        ? `\n    title: '${jsStringEscape(verbOption.summary)}',`
+        : '';
+      const operationDescription = verbOption.originalOperation.description as
+        | string
+        | undefined;
+      const descriptionValue =
+        (operationDescription && operationDescription.length > 0
+          ? operationDescription
+          : verbOption.summary) ?? '';
+      const descriptionImplementation = descriptionValue
+        ? `\n    description: '${jsStringEscape(descriptionValue)}',`
+        : '';
+
       const handlerCallImplementation =
         inputSchemaTypes.length > 0
           ? `(args) => ${verbOption.operationName}Handler(args, options)`
@@ -214,8 +265,7 @@ export const generateServer = (
       const toolImplementation = `
 tools.${verbOption.operationName} = server.registerTool(
   '${jsStringEscape(verbOption.operationName)}',
-  {
-    description: '${jsStringEscape(verbOption.summary ?? '')}',${inputSchemaImplementation}
+  {${titleImplementation}${descriptionImplementation}${inputSchemaImplementation}${outputSchemaImplementation}${annotationsImplementation}
   },
   ${handlerCallImplementation}
 );`;
@@ -237,6 +287,7 @@ tools.${verbOption.operationName} = server.registerTool(
         imports.push(`  ${pascalOperationName}QueryParams`);
       if (verbOption.body.definition)
         imports.push(`  ${pascalOperationName}Body`);
+      if (hasResponseSchema) imports.push(`  ${pascalOperationName}Response`);
 
       return imports;
     })

--- a/samples/mcp/custom-server/__snapshots__/server.ts
+++ b/samples/mcp/custom-server/__snapshots__/server.ts
@@ -36,16 +36,28 @@ import {
 } from './handlers';
 import {
   FindPetsByStatusQueryParams,
+  FindPetsByStatusResponse,
   FindPetsByTagsQueryParams,
+  FindPetsByTagsResponse,
   GetPetByIdParams,
+  GetPetByIdResponse,
   UpdatePetWithFormParams,
   UpdatePetWithFormQueryParams,
+  UpdatePetWithFormResponse,
   DeletePetParams,
+  DeletePetResponse,
+  GetInventoryResponse,
   GetOrderByIdParams,
+  GetOrderByIdResponse,
   DeleteOrderParams,
+  DeleteOrderResponse,
   LoginUserQueryParams,
+  LoginUserResponse,
+  LogoutUserResponse,
   GetUserByNameParams,
+  GetUserByNameResponse,
   DeleteUserParams,
+  DeleteUserResponse,
 } from './tool-schemas.zod';
 
 const createMcpServer = (
@@ -60,10 +72,14 @@ const createMcpServer = (
   tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',
     {
-      description: 'Finds Pets by status.',
+      title: 'Finds Pets by status.',
+      description:
+        'Multiple status values can be provided with comma separated strings.',
       inputSchema: {
         queryParams: FindPetsByStatusQueryParams,
       },
+      outputSchema: FindPetsByStatusResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => findPetsByStatusHandler(args, options),
   );
@@ -71,10 +87,14 @@ const createMcpServer = (
   tools.findPetsByTags = server.registerTool(
     'findPetsByTags',
     {
-      description: 'Finds Pets by tags.',
+      title: 'Finds Pets by tags.',
+      description:
+        'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.',
       inputSchema: {
         queryParams: FindPetsByTagsQueryParams,
       },
+      outputSchema: FindPetsByTagsResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => findPetsByTagsHandler(args, options),
   );
@@ -82,10 +102,13 @@ const createMcpServer = (
   tools.getPetById = server.registerTool(
     'getPetById',
     {
-      description: 'Find pet by ID.',
+      title: 'Find pet by ID.',
+      description: 'Returns a single pet.',
       inputSchema: {
         pathParams: GetPetByIdParams,
       },
+      outputSchema: GetPetByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getPetByIdHandler(args, options),
   );
@@ -93,11 +116,14 @@ const createMcpServer = (
   tools.updatePetWithForm = server.registerTool(
     'updatePetWithForm',
     {
-      description: 'Updates a pet in the store with form data.',
+      title: 'Updates a pet in the store with form data.',
+      description: 'Updates a pet resource based on the form data.',
       inputSchema: {
         pathParams: UpdatePetWithFormParams,
         queryParams: UpdatePetWithFormQueryParams,
       },
+      outputSchema: UpdatePetWithFormResponse,
+      annotations: { destructiveHint: false },
     },
     (args) => updatePetWithFormHandler(args, options),
   );
@@ -105,10 +131,13 @@ const createMcpServer = (
   tools.deletePet = server.registerTool(
     'deletePet',
     {
-      description: 'Deletes a pet.',
+      title: 'Deletes a pet.',
+      description: 'Delete a pet.',
       inputSchema: {
         pathParams: DeletePetParams,
       },
+      outputSchema: DeletePetResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deletePetHandler(args, options),
   );
@@ -116,7 +145,10 @@ const createMcpServer = (
   tools.getInventory = server.registerTool(
     'getInventory',
     {
-      description: 'Returns pet inventories by status.',
+      title: 'Returns pet inventories by status.',
+      description: 'Returns a map of status codes to quantities.',
+      outputSchema: GetInventoryResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => getInventoryHandler(options),
   );
@@ -124,10 +156,14 @@ const createMcpServer = (
   tools.getOrderById = server.registerTool(
     'getOrderById',
     {
-      description: 'Find purchase order by ID.',
+      title: 'Find purchase order by ID.',
+      description:
+        'For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.',
       inputSchema: {
         pathParams: GetOrderByIdParams,
       },
+      outputSchema: GetOrderByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getOrderByIdHandler(args, options),
   );
@@ -135,10 +171,14 @@ const createMcpServer = (
   tools.deleteOrder = server.registerTool(
     'deleteOrder',
     {
-      description: 'Delete purchase order by identifier.',
+      title: 'Delete purchase order by identifier.',
+      description:
+        'For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.',
       inputSchema: {
         pathParams: DeleteOrderParams,
       },
+      outputSchema: DeleteOrderResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deleteOrderHandler(args, options),
   );
@@ -146,10 +186,13 @@ const createMcpServer = (
   tools.loginUser = server.registerTool(
     'loginUser',
     {
-      description: 'Logs user into the system.',
+      title: 'Logs user into the system.',
+      description: 'Log into the system.',
       inputSchema: {
         queryParams: LoginUserQueryParams,
       },
+      outputSchema: LoginUserResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => loginUserHandler(args, options),
   );
@@ -157,7 +200,10 @@ const createMcpServer = (
   tools.logoutUser = server.registerTool(
     'logoutUser',
     {
-      description: 'Logs out current logged in user session.',
+      title: 'Logs out current logged in user session.',
+      description: 'Log user out of the system.',
+      outputSchema: LogoutUserResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => logoutUserHandler(options),
   );
@@ -165,10 +211,13 @@ const createMcpServer = (
   tools.getUserByName = server.registerTool(
     'getUserByName',
     {
-      description: 'Get user by user name.',
+      title: 'Get user by user name.',
+      description: 'Get user detail based on username.',
       inputSchema: {
         pathParams: GetUserByNameParams,
       },
+      outputSchema: GetUserByNameResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getUserByNameHandler(args, options),
   );
@@ -176,10 +225,13 @@ const createMcpServer = (
   tools.deleteUser = server.registerTool(
     'deleteUser',
     {
-      description: 'Delete user resource.',
+      title: 'Delete user resource.',
+      description: 'This can only be done by the logged in user.',
       inputSchema: {
         pathParams: DeleteUserParams,
       },
+      outputSchema: DeleteUserResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deleteUserHandler(args, options),
   );

--- a/samples/mcp/custom-server/src/server.ts
+++ b/samples/mcp/custom-server/src/server.ts
@@ -36,16 +36,28 @@ import {
 } from './handlers';
 import {
   FindPetsByStatusQueryParams,
+  FindPetsByStatusResponse,
   FindPetsByTagsQueryParams,
+  FindPetsByTagsResponse,
   GetPetByIdParams,
+  GetPetByIdResponse,
   UpdatePetWithFormParams,
   UpdatePetWithFormQueryParams,
+  UpdatePetWithFormResponse,
   DeletePetParams,
+  DeletePetResponse,
+  GetInventoryResponse,
   GetOrderByIdParams,
+  GetOrderByIdResponse,
   DeleteOrderParams,
+  DeleteOrderResponse,
   LoginUserQueryParams,
+  LoginUserResponse,
+  LogoutUserResponse,
   GetUserByNameParams,
+  GetUserByNameResponse,
   DeleteUserParams,
+  DeleteUserResponse,
 } from './tool-schemas.zod';
 
 const createMcpServer = (
@@ -60,10 +72,14 @@ const createMcpServer = (
   tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',
     {
-      description: 'Finds Pets by status.',
+      title: 'Finds Pets by status.',
+      description:
+        'Multiple status values can be provided with comma separated strings.',
       inputSchema: {
         queryParams: FindPetsByStatusQueryParams,
       },
+      outputSchema: FindPetsByStatusResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => findPetsByStatusHandler(args, options),
   );
@@ -71,10 +87,14 @@ const createMcpServer = (
   tools.findPetsByTags = server.registerTool(
     'findPetsByTags',
     {
-      description: 'Finds Pets by tags.',
+      title: 'Finds Pets by tags.',
+      description:
+        'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.',
       inputSchema: {
         queryParams: FindPetsByTagsQueryParams,
       },
+      outputSchema: FindPetsByTagsResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => findPetsByTagsHandler(args, options),
   );
@@ -82,10 +102,13 @@ const createMcpServer = (
   tools.getPetById = server.registerTool(
     'getPetById',
     {
-      description: 'Find pet by ID.',
+      title: 'Find pet by ID.',
+      description: 'Returns a single pet.',
       inputSchema: {
         pathParams: GetPetByIdParams,
       },
+      outputSchema: GetPetByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getPetByIdHandler(args, options),
   );
@@ -93,11 +116,14 @@ const createMcpServer = (
   tools.updatePetWithForm = server.registerTool(
     'updatePetWithForm',
     {
-      description: 'Updates a pet in the store with form data.',
+      title: 'Updates a pet in the store with form data.',
+      description: 'Updates a pet resource based on the form data.',
       inputSchema: {
         pathParams: UpdatePetWithFormParams,
         queryParams: UpdatePetWithFormQueryParams,
       },
+      outputSchema: UpdatePetWithFormResponse,
+      annotations: { destructiveHint: false },
     },
     (args) => updatePetWithFormHandler(args, options),
   );
@@ -105,10 +131,13 @@ const createMcpServer = (
   tools.deletePet = server.registerTool(
     'deletePet',
     {
-      description: 'Deletes a pet.',
+      title: 'Deletes a pet.',
+      description: 'Delete a pet.',
       inputSchema: {
         pathParams: DeletePetParams,
       },
+      outputSchema: DeletePetResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deletePetHandler(args, options),
   );
@@ -116,7 +145,10 @@ const createMcpServer = (
   tools.getInventory = server.registerTool(
     'getInventory',
     {
-      description: 'Returns pet inventories by status.',
+      title: 'Returns pet inventories by status.',
+      description: 'Returns a map of status codes to quantities.',
+      outputSchema: GetInventoryResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => getInventoryHandler(options),
   );
@@ -124,10 +156,14 @@ const createMcpServer = (
   tools.getOrderById = server.registerTool(
     'getOrderById',
     {
-      description: 'Find purchase order by ID.',
+      title: 'Find purchase order by ID.',
+      description:
+        'For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.',
       inputSchema: {
         pathParams: GetOrderByIdParams,
       },
+      outputSchema: GetOrderByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getOrderByIdHandler(args, options),
   );
@@ -135,10 +171,14 @@ const createMcpServer = (
   tools.deleteOrder = server.registerTool(
     'deleteOrder',
     {
-      description: 'Delete purchase order by identifier.',
+      title: 'Delete purchase order by identifier.',
+      description:
+        'For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.',
       inputSchema: {
         pathParams: DeleteOrderParams,
       },
+      outputSchema: DeleteOrderResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deleteOrderHandler(args, options),
   );
@@ -146,10 +186,13 @@ const createMcpServer = (
   tools.loginUser = server.registerTool(
     'loginUser',
     {
-      description: 'Logs user into the system.',
+      title: 'Logs user into the system.',
+      description: 'Log into the system.',
       inputSchema: {
         queryParams: LoginUserQueryParams,
       },
+      outputSchema: LoginUserResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => loginUserHandler(args, options),
   );
@@ -157,7 +200,10 @@ const createMcpServer = (
   tools.logoutUser = server.registerTool(
     'logoutUser',
     {
-      description: 'Logs out current logged in user session.',
+      title: 'Logs out current logged in user session.',
+      description: 'Log user out of the system.',
+      outputSchema: LogoutUserResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => logoutUserHandler(options),
   );
@@ -165,10 +211,13 @@ const createMcpServer = (
   tools.getUserByName = server.registerTool(
     'getUserByName',
     {
-      description: 'Get user by user name.',
+      title: 'Get user by user name.',
+      description: 'Get user detail based on username.',
       inputSchema: {
         pathParams: GetUserByNameParams,
       },
+      outputSchema: GetUserByNameResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getUserByNameHandler(args, options),
   );
@@ -176,10 +225,13 @@ const createMcpServer = (
   tools.deleteUser = server.registerTool(
     'deleteUser',
     {
-      description: 'Delete user resource.',
+      title: 'Delete user resource.',
+      description: 'This can only be done by the logged in user.',
       inputSchema: {
         pathParams: DeleteUserParams,
       },
+      outputSchema: DeleteUserResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deleteUserHandler(args, options),
   );

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -36,16 +36,28 @@ import {
 } from './handlers';
 import {
   FindPetsByStatusQueryParams,
+  FindPetsByStatusResponse,
   FindPetsByTagsQueryParams,
+  FindPetsByTagsResponse,
   GetPetByIdParams,
+  GetPetByIdResponse,
   UpdatePetWithFormParams,
   UpdatePetWithFormQueryParams,
+  UpdatePetWithFormResponse,
   DeletePetParams,
+  DeletePetResponse,
+  GetInventoryResponse,
   GetOrderByIdParams,
+  GetOrderByIdResponse,
   DeleteOrderParams,
+  DeleteOrderResponse,
   LoginUserQueryParams,
+  LoginUserResponse,
+  LogoutUserResponse,
   GetUserByNameParams,
+  GetUserByNameResponse,
   DeleteUserParams,
+  DeleteUserResponse,
 } from './tool-schemas.zod';
 
 const createMcpServer = (
@@ -60,10 +72,14 @@ const createMcpServer = (
   tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',
     {
-      description: 'Finds Pets by status.',
+      title: 'Finds Pets by status.',
+      description:
+        'Multiple status values can be provided with comma separated strings.',
       inputSchema: {
         queryParams: FindPetsByStatusQueryParams,
       },
+      outputSchema: FindPetsByStatusResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => findPetsByStatusHandler(args, options),
   );
@@ -71,10 +87,14 @@ const createMcpServer = (
   tools.findPetsByTags = server.registerTool(
     'findPetsByTags',
     {
-      description: 'Finds Pets by tags.',
+      title: 'Finds Pets by tags.',
+      description:
+        'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.',
       inputSchema: {
         queryParams: FindPetsByTagsQueryParams,
       },
+      outputSchema: FindPetsByTagsResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => findPetsByTagsHandler(args, options),
   );
@@ -82,10 +102,13 @@ const createMcpServer = (
   tools.getPetById = server.registerTool(
     'getPetById',
     {
-      description: 'Find pet by ID.',
+      title: 'Find pet by ID.',
+      description: 'Returns a single pet.',
       inputSchema: {
         pathParams: GetPetByIdParams,
       },
+      outputSchema: GetPetByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getPetByIdHandler(args, options),
   );
@@ -93,11 +116,14 @@ const createMcpServer = (
   tools.updatePetWithForm = server.registerTool(
     'updatePetWithForm',
     {
-      description: 'Updates a pet in the store with form data.',
+      title: 'Updates a pet in the store with form data.',
+      description: 'Updates a pet resource based on the form data.',
       inputSchema: {
         pathParams: UpdatePetWithFormParams,
         queryParams: UpdatePetWithFormQueryParams,
       },
+      outputSchema: UpdatePetWithFormResponse,
+      annotations: { destructiveHint: false },
     },
     (args) => updatePetWithFormHandler(args, options),
   );
@@ -105,10 +131,13 @@ const createMcpServer = (
   tools.deletePet = server.registerTool(
     'deletePet',
     {
-      description: 'Deletes a pet.',
+      title: 'Deletes a pet.',
+      description: 'Delete a pet.',
       inputSchema: {
         pathParams: DeletePetParams,
       },
+      outputSchema: DeletePetResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deletePetHandler(args, options),
   );
@@ -116,7 +145,10 @@ const createMcpServer = (
   tools.getInventory = server.registerTool(
     'getInventory',
     {
-      description: 'Returns pet inventories by status.',
+      title: 'Returns pet inventories by status.',
+      description: 'Returns a map of status codes to quantities.',
+      outputSchema: GetInventoryResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => getInventoryHandler(options),
   );
@@ -124,10 +156,14 @@ const createMcpServer = (
   tools.getOrderById = server.registerTool(
     'getOrderById',
     {
-      description: 'Find purchase order by ID.',
+      title: 'Find purchase order by ID.',
+      description:
+        'For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.',
       inputSchema: {
         pathParams: GetOrderByIdParams,
       },
+      outputSchema: GetOrderByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getOrderByIdHandler(args, options),
   );
@@ -135,10 +171,14 @@ const createMcpServer = (
   tools.deleteOrder = server.registerTool(
     'deleteOrder',
     {
-      description: 'Delete purchase order by identifier.',
+      title: 'Delete purchase order by identifier.',
+      description:
+        'For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.',
       inputSchema: {
         pathParams: DeleteOrderParams,
       },
+      outputSchema: DeleteOrderResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deleteOrderHandler(args, options),
   );
@@ -146,10 +186,13 @@ const createMcpServer = (
   tools.loginUser = server.registerTool(
     'loginUser',
     {
-      description: 'Logs user into the system.',
+      title: 'Logs user into the system.',
+      description: 'Log into the system.',
       inputSchema: {
         queryParams: LoginUserQueryParams,
       },
+      outputSchema: LoginUserResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => loginUserHandler(args, options),
   );
@@ -157,7 +200,10 @@ const createMcpServer = (
   tools.logoutUser = server.registerTool(
     'logoutUser',
     {
-      description: 'Logs out current logged in user session.',
+      title: 'Logs out current logged in user session.',
+      description: 'Log user out of the system.',
+      outputSchema: LogoutUserResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => logoutUserHandler(options),
   );
@@ -165,10 +211,13 @@ const createMcpServer = (
   tools.getUserByName = server.registerTool(
     'getUserByName',
     {
-      description: 'Get user by user name.',
+      title: 'Get user by user name.',
+      description: 'Get user detail based on username.',
       inputSchema: {
         pathParams: GetUserByNameParams,
       },
+      outputSchema: GetUserByNameResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => getUserByNameHandler(args, options),
   );
@@ -176,10 +225,13 @@ const createMcpServer = (
   tools.deleteUser = server.registerTool(
     'deleteUser',
     {
-      description: 'Delete user resource.',
+      title: 'Delete user resource.',
+      description: 'This can only be done by the logged in user.',
       inputSchema: {
         pathParams: DeleteUserParams,
       },
+      outputSchema: DeleteUserResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deleteUserHandler(args, options),
   );

--- a/tests/__snapshots__/mcp/custom-server/server.ts
+++ b/tests/__snapshots__/mcp/custom-server/server.ts
@@ -22,11 +22,17 @@ import {
 } from './handlers';
 import {
   ListPetsQueryParams,
+  ListPetsResponse,
   CreatePetsQueryParams,
   CreatePetsBody,
+  CreatePetsResponse,
   ShowPetByIdParams,
+  ShowPetByIdResponse,
   DeletePetByIdParams,
+  DeletePetByIdResponse,
+  HealthCheckResponse,
   ShowPetWithOwnerParams,
+  ShowPetWithOwnerResponse,
 } from './tool-schemas.zod';
 
 const createMcpServer = (
@@ -41,10 +47,13 @@ const createMcpServer = (
   tools.listPets = server.registerTool(
     'listPets',
     {
+      title: 'List all pets',
       description: 'List all pets',
       inputSchema: {
         queryParams: ListPetsQueryParams,
       },
+      outputSchema: ListPetsResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => listPetsHandler(args, options),
   );
@@ -52,11 +61,14 @@ const createMcpServer = (
   tools.createPets = server.registerTool(
     'createPets',
     {
+      title: 'Create a pet',
       description: 'Create a pet',
       inputSchema: {
         queryParams: CreatePetsQueryParams,
         bodyParams: CreatePetsBody,
       },
+      outputSchema: CreatePetsResponse,
+      annotations: { destructiveHint: false },
     },
     (args) => createPetsHandler(args, options),
   );
@@ -64,10 +76,13 @@ const createMcpServer = (
   tools.showPetById = server.registerTool(
     'showPetById',
     {
+      title: 'Info for a specific pet',
       description: 'Info for a specific pet',
       inputSchema: {
         pathParams: ShowPetByIdParams,
       },
+      outputSchema: ShowPetByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => showPetByIdHandler(args, options),
   );
@@ -75,10 +90,13 @@ const createMcpServer = (
   tools.deletePetById = server.registerTool(
     'deletePetById',
     {
+      title: 'Deletes a specific pet',
       description: 'Deletes a specific pet',
       inputSchema: {
         pathParams: DeletePetByIdParams,
       },
+      outputSchema: DeletePetByIdResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deletePetByIdHandler(args, options),
   );
@@ -86,7 +104,10 @@ const createMcpServer = (
   tools.healthCheck = server.registerTool(
     'healthCheck',
     {
+      title: 'health check',
       description: 'health check',
+      outputSchema: HealthCheckResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => healthCheckHandler(options),
   );
@@ -94,10 +115,13 @@ const createMcpServer = (
   tools.showPetWithOwner = server.registerTool(
     'showPetWithOwner',
     {
+      title: 'combinate nullable and $ref',
       description: 'combinate nullable and $ref',
       inputSchema: {
         pathParams: ShowPetWithOwnerParams,
       },
+      outputSchema: ShowPetWithOwnerResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => showPetWithOwnerHandler(args, options),
   );

--- a/tests/__snapshots__/mcp/single/server.ts
+++ b/tests/__snapshots__/mcp/single/server.ts
@@ -22,11 +22,17 @@ import {
 } from './handlers';
 import {
   ListPetsQueryParams,
+  ListPetsResponse,
   CreatePetsQueryParams,
   CreatePetsBody,
+  CreatePetsResponse,
   ShowPetByIdParams,
+  ShowPetByIdResponse,
   DeletePetByIdParams,
+  DeletePetByIdResponse,
+  HealthCheckResponse,
   ShowPetWithOwnerParams,
+  ShowPetWithOwnerResponse,
 } from './tool-schemas.zod';
 
 const createMcpServer = (
@@ -41,10 +47,13 @@ const createMcpServer = (
   tools.listPets = server.registerTool(
     'listPets',
     {
+      title: 'List all pets',
       description: 'List all pets',
       inputSchema: {
         queryParams: ListPetsQueryParams,
       },
+      outputSchema: ListPetsResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => listPetsHandler(args, options),
   );
@@ -52,11 +61,14 @@ const createMcpServer = (
   tools.createPets = server.registerTool(
     'createPets',
     {
+      title: 'Create a pet',
       description: 'Create a pet',
       inputSchema: {
         queryParams: CreatePetsQueryParams,
         bodyParams: CreatePetsBody,
       },
+      outputSchema: CreatePetsResponse,
+      annotations: { destructiveHint: false },
     },
     (args) => createPetsHandler(args, options),
   );
@@ -64,10 +76,13 @@ const createMcpServer = (
   tools.showPetById = server.registerTool(
     'showPetById',
     {
+      title: 'Info for a specific pet',
       description: 'Info for a specific pet',
       inputSchema: {
         pathParams: ShowPetByIdParams,
       },
+      outputSchema: ShowPetByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => showPetByIdHandler(args, options),
   );
@@ -75,10 +90,13 @@ const createMcpServer = (
   tools.deletePetById = server.registerTool(
     'deletePetById',
     {
+      title: 'Deletes a specific pet',
       description: 'Deletes a specific pet',
       inputSchema: {
         pathParams: DeletePetByIdParams,
       },
+      outputSchema: DeletePetByIdResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deletePetByIdHandler(args, options),
   );
@@ -86,7 +104,10 @@ const createMcpServer = (
   tools.healthCheck = server.registerTool(
     'healthCheck',
     {
+      title: 'health check',
       description: 'health check',
+      outputSchema: HealthCheckResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => healthCheckHandler(options),
   );
@@ -94,10 +115,13 @@ const createMcpServer = (
   tools.showPetWithOwner = server.registerTool(
     'showPetWithOwner',
     {
+      title: 'combinate nullable and $ref',
       description: 'combinate nullable and $ref',
       inputSchema: {
         pathParams: ShowPetWithOwnerParams,
       },
+      outputSchema: ShowPetWithOwnerResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => showPetWithOwnerHandler(args, options),
   );

--- a/tests/__snapshots__/mcp/zod-schema-response/server.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/server.ts
@@ -22,11 +22,17 @@ import {
 } from './handlers';
 import {
   ListPetsQueryParams,
+  ListPetsResponse,
   CreatePetsQueryParams,
   CreatePetsBody,
+  CreatePetsResponse,
   ShowPetByIdParams,
+  ShowPetByIdResponse,
   DeletePetByIdParams,
+  DeletePetByIdResponse,
+  HealthCheckResponse,
   ShowPetWithOwnerParams,
+  ShowPetWithOwnerResponse,
 } from './tool-schemas.zod';
 
 const createMcpServer = (
@@ -41,10 +47,13 @@ const createMcpServer = (
   tools.listPets = server.registerTool(
     'listPets',
     {
+      title: 'List all pets',
       description: 'List all pets',
       inputSchema: {
         queryParams: ListPetsQueryParams,
       },
+      outputSchema: ListPetsResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => listPetsHandler(args, options),
   );
@@ -52,11 +61,14 @@ const createMcpServer = (
   tools.createPets = server.registerTool(
     'createPets',
     {
+      title: 'Create a pet',
       description: 'Create a pet',
       inputSchema: {
         queryParams: CreatePetsQueryParams,
         bodyParams: CreatePetsBody,
       },
+      outputSchema: CreatePetsResponse,
+      annotations: { destructiveHint: false },
     },
     (args) => createPetsHandler(args, options),
   );
@@ -64,10 +76,13 @@ const createMcpServer = (
   tools.showPetById = server.registerTool(
     'showPetById',
     {
+      title: 'Info for a specific pet',
       description: 'Info for a specific pet',
       inputSchema: {
         pathParams: ShowPetByIdParams,
       },
+      outputSchema: ShowPetByIdResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => showPetByIdHandler(args, options),
   );
@@ -75,10 +90,13 @@ const createMcpServer = (
   tools.deletePetById = server.registerTool(
     'deletePetById',
     {
+      title: 'Deletes a specific pet',
       description: 'Deletes a specific pet',
       inputSchema: {
         pathParams: DeletePetByIdParams,
       },
+      outputSchema: DeletePetByIdResponse,
+      annotations: { idempotentHint: true },
     },
     (args) => deletePetByIdHandler(args, options),
   );
@@ -86,7 +104,10 @@ const createMcpServer = (
   tools.healthCheck = server.registerTool(
     'healthCheck',
     {
+      title: 'health check',
       description: 'health check',
+      outputSchema: HealthCheckResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     () => healthCheckHandler(options),
   );
@@ -94,10 +115,13 @@ const createMcpServer = (
   tools.showPetWithOwner = server.registerTool(
     'showPetWithOwner',
     {
+      title: 'combinate nullable and $ref',
       description: 'combinate nullable and $ref',
       inputSchema: {
         pathParams: ShowPetWithOwnerParams,
       },
+      outputSchema: ShowPetWithOwnerResponse,
+      annotations: { readOnlyHint: true, destructiveHint: false },
     },
     (args) => showPetWithOwnerHandler(args, options),
   );


### PR DESCRIPTION
## Summary

Add `outputSchema`, `annotations`, `title`, and `description` to MCP `registerTool` calls.

- `title`: OpenAPI summary
- `description`: OpenAPI operation description (falls back to summary)
- `outputSchema`: response Zod schema
- `annotations`: HTTP method-based hints (readOnlyHint, destructiveHint, idempotentHint)

### Before

```typescript
tools.listPets = server.registerTool(
  'listPets',
  {
    description: 'List all pets',
    inputSchema: { queryParams: ListPetsQueryParams },
  },
  (args) => listPetsHandler(args, options),
);
```

### After

```ts
tools.listPets = server.registerTool(
  'listPets',
  {
    title: 'List all pets',
    description: 'List all pets',
    inputSchema: { queryParams: ListPetsQueryParams },
    outputSchema: ListPetsResponse,
    annotations: { readOnlyHint: true, destructiveHint: false },
  },
  (args) => listPetsHandler(args, options),
);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server tools now include titles, richer descriptions, and explicit output schemas for every operation.
  * Added behavioral annotations (read-only, destructive, idempotent hints) per tool to clarify operation semantics and safety.

* **Tests**
  * Updated generated snapshots and sample outputs to reflect expanded tool metadata and new response schema imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->