### PR TITLE
fix(zod): preprocess mutator reads target key instead of always .response

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -2237,7 +2237,7 @@ const generateZodRoute = async (
   const preprocessParams = override.zod.preprocess?.param
     ? await generateMutator({
         output,
-        mutator: override.zod.preprocess.response,
+        mutator: override.zod.preprocess.param,
         name: `${operationName}PreprocessParams`,
         workspace: context.workspace,
         tsconfig: context.output.tsconfig,
@@ -2281,7 +2281,7 @@ const generateZodRoute = async (
   const preprocessQueryParams = override.zod.preprocess?.query
     ? await generateMutator({
         output,
-        mutator: override.zod.preprocess.response,
+        mutator: override.zod.preprocess.query,
         name: `${operationName}PreprocessQueryParams`,
         workspace: context.workspace,
         tsconfig: context.output.tsconfig,
@@ -2301,7 +2301,7 @@ const generateZodRoute = async (
   const preprocessHeader = override.zod.preprocess?.header
     ? await generateMutator({
         output,
-        mutator: override.zod.preprocess.response,
+        mutator: override.zod.preprocess.header,
         name: `${operationName}PreprocessHeader`,
         workspace: context.workspace,
         tsconfig: context.output.tsconfig,
@@ -2321,7 +2321,7 @@ const generateZodRoute = async (
   const preprocessBody = override.zod.preprocess?.body
     ? await generateMutator({
         output,
-        mutator: override.zod.preprocess.response,
+        mutator: override.zod.preprocess.body,
         name: `${operationName}PreprocessBody`,
         workspace: context.workspace,
         tsconfig: context.output.tsconfig,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -9678,3 +9678,129 @@ describe('$dynamicRef / $dynamicAnchor', () => {
     });
   });
 });
+
+// Regression: each preprocess target must read its own mutator config, not
+// `preprocess.response` (copy-paste bug fixed in #3511).
+describe('generateZod preprocess regression (#3511)', () => {
+  it('wraps the query schema using `preprocess.query` even when `preprocess.response` is not set', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            preprocess: {
+              query: { name: 'coerceQuery', path: './coerce-query' },
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      basicApiSchema,
+      testOutput,
+    );
+
+    expect(result.implementation).toContain(
+      'export const TestQueryParams = zod.preprocess(coerceQuery, zod.object({',
+    );
+    expect(result.implementation).toContain(
+      'export const TestParams = zod.object({',
+    );
+    expect(result.implementation).toContain(
+      'export const TestHeader = zod.object({',
+    );
+    expect(result.implementation).toContain(
+      'export const TestBody = zod.object({',
+    );
+    expect(result.implementation).toContain(
+      'export const TestResponse = zod.object({',
+    );
+  });
+
+  it('uses a distinct mutator per target when each preprocess key is configured separately', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            preprocess: {
+              param: { name: 'paramMutator', path: './param' },
+              query: { name: 'queryMutator', path: './query' },
+              header: { name: 'headerMutator', path: './header' },
+              body: { name: 'bodyMutator', path: './body' },
+              response: { name: 'responseMutator', path: './response' },
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      basicApiSchema,
+      testOutput,
+    );
+
+    expect(result.implementation).toContain(
+      'export const TestParams = zod.preprocess(paramMutator,',
+    );
+    expect(result.implementation).toContain(
+      'export const TestQueryParams = zod.preprocess(queryMutator,',
+    );
+    expect(result.implementation).toContain(
+      'export const TestHeader = zod.preprocess(headerMutator,',
+    );
+    expect(result.implementation).toContain(
+      'export const TestBody = zod.preprocess(bodyMutator,',
+    );
+    expect(result.implementation).toContain(
+      'export const TestResponse = zod.preprocess(responseMutator,',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3511.
Fixed #1575 

Each preprocess target (`param`, `query`, `header`, `body`) was guarded on its own key but called `generateMutator` with `mutator: override.zod.preprocess.response` — a copy-paste bug. When `preprocess.response` was not set (the common case when only configuring `preprocess.query` for example), the mutator argument was `undefined`, `generateMutator` returned nothing, and the schema was emitted without the `zod.preprocess(...)` wrap. Only the `response` branch worked because both guard and reference read `.response`.

## Change

Four-line fix in `packages/zod/src/index.ts`: each non-response branch now reads its own target key.

| Branch | Before | After |
|---|---|---|
| `preprocessParams` | `mutator: override.zod.preprocess.response` | `mutator: override.zod.preprocess.param` |
| `preprocessQueryParams` | `mutator: override.zod.preprocess.response` | `mutator: override.zod.preprocess.query` |
| `preprocessHeader` | `mutator: override.zod.preprocess.response` | `mutator: override.zod.preprocess.header` |
| `preprocessBody` | `mutator: override.zod.preprocess.response` | `mutator: override.zod.preprocess.body` |

The `preprocessResponse` branch is unchanged (already correct).

## Tests

Added two regression tests in `packages/zod/src/zod.test.ts`:

1. **`wraps the query schema using preprocess.query even when preprocess.response is not set`** — directly demonstrates the original bug: with only `.query` configured, the wrap is now correctly applied. This test would fail before the fix.
2. **`uses a distinct mutator per target when each preprocess key is configured separately`** — proves each target uses its own mutator and not another target's, by configuring all five targets with five different mutator names.

All existing tests still pass (227/227).

## Related

- #1575 — the feature request for preprocess on query params is implemented but was silently broken by this bug.
- #1601 — the body preprocess fix may have introduced this regression by adding the guards without updating the mutator references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a bug where request and response validators were using incorrect preprocessor configurations instead of their designated target-specific settings.

## Tests
- Added regression tests to ensure each validation schema type uses its corresponding preprocessor configuration correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->