### PR TITLE
feat(hono): setup new propery handler generation strategy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -140,6 +140,12 @@
         "vitest": "catalog:",
         "zod": "catalog:zod3",
       },
+      "peerDependencies": {
+        "typescript": ">=5",
+      },
+      "optionalPeers": [
+        "typescript",
+      ],
     },
     "packages/mcp": {
       "name": "@orval/mcp",

--- a/docs/content/docs/guides/hono.mdx
+++ b/docs/content/docs/guides/hono.mdx
@@ -78,10 +78,13 @@ export const listPetsHandlers = factory.createHandlers(
 
 Add your business logic to the generated handlers:
 
-> Re-running orval refreshes the file header, imports, and `factory` line so
-> changes to your config (paths, validators, etc.) take effect — but the body
-> of each `factory.createHandlers(...)` call is preserved verbatim, so your
-> business logic is safe across regeneration.
+> Re-running orval reconciles your handler files according to
+> [`override.hono.handlerGenerationStrategy`](/docs/reference/configuration/output#handlergenerationstrategy)
+> (default `smart`). With `smart`, orval only updates the parts it owns — its own
+> imports (names, paths, casing) and the `zValidator(...)` arguments, and appends
+> handlers for new operations — while preserving your custom imports, middleware,
+> handler bodies, and top-level helpers. Use `skip` to freeze a file, or `full`
+> for the legacy behavior that rebuilds the wrapper and keeps only the body.
 
 ```ts title="src/handlers/listPets.ts"
 export const listPetsHandlers = factory.createHandlers(

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1400,6 +1400,7 @@ export default defineConfig({
       override: {
         hono: {
           handlers: 'src/handlers',
+          handlerGenerationStrategy: 'smart',
           validatorOutputPath: 'src/validator.ts',
           compositeRoute: 'src/routes.ts',
         },
@@ -1414,6 +1415,41 @@ export default defineConfig({
 **Type:** `String`
 
 Changes output path for Hono handlers.
+
+### handlerGenerationStrategy
+
+**Type:** `'smart' | 'skip' | 'full'`
+
+**Default:** `'smart'`
+
+Controls how an **existing** handler file is treated when you re-run orval. A
+file that does not exist yet is always generated fresh.
+
+- `smart` (default) — non-destructively reconcile only the parts orval owns: its
+  own imports (names, module paths, casing) and the `zValidator(...)` arguments,
+  and append handlers for new operations. Your custom imports, middleware,
+  handler bodies, and top-level helpers are preserved. Requires the optional
+  `typescript` peer dependency (see note below); if it is absent, smart falls
+  back to `skip` with a warning.
+- `skip` — leave an existing handler file byte-for-byte unchanged. New operations
+  still get fresh files (in `split` mode).
+- `full` — rebuild the file header, imports, and validator chain from the spec,
+  splicing back only each handler body. **Destructive:** custom imports,
+  middleware, and top-level helpers are dropped. Use only if you keep handlers
+  minimal and want maximal sync with the spec.
+
+<Callout type="info">
+  `smart` and `full` use the TypeScript compiler API to parse existing handler
+  files. `typescript` is an optional peer dependency — virtually every orval
+  project already has it, so nothing extra is installed.
+</Callout>
+
+<Callout type="warn">
+  If `output.clean` is enabled and the handlers directory lives under the output
+  target directory, handler files are deleted before generation runs, which
+  defeats `smart`/`skip` preservation. Disable `clean` (or scope it) when
+  relying on handler preservation.
+</Callout>
 
 ### validatorOutputPath
 

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -55,6 +55,7 @@ const createOutput = (
       jsDoc: {},
       header: false,
       hono: {
+        handlerGenerationStrategy: 'smart',
         compositeRoute: '',
         validator: true,
         validatorOutputPath: '',

--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -63,6 +63,7 @@ const createOutput = (
       jsDoc: {},
       header: false,
       hono: {
+        handlerGenerationStrategy: 'smart',
         compositeRoute: '',
         validator: true,
         validatorOutputPath: '',

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -70,7 +70,12 @@ export function createTestContextSpec({
         parameters: { suffix: '' },
         requestBodies: { suffix: '' },
       },
-      hono: { compositeRoute: '', validator: false, validatorOutputPath: '' },
+      hono: {
+        handlerGenerationStrategy: 'smart',
+        compositeRoute: '',
+        validator: false,
+        validatorOutputPath: '',
+      },
       query: {
         useQuery: false,
         useSuspenseQuery: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -698,8 +698,22 @@ export interface OverrideOutputContentType {
   exclude?: string[];
 }
 
+/**
+ * Strategy controlling how an existing hono handler file is treated on
+ * regeneration.
+ *
+ * - `smart` (default): non-destructively reconcile orval-owned imports and
+ *   `zValidator` arguments and append handlers for new operations, preserving
+ *   all user-authored imports, middleware, bodies, and top-level code.
+ * - `skip`: leave an existing handler file byte-for-byte unchanged.
+ * - `full`: rebuild the preamble and validator chain from the spec, splicing
+ *   back only the handler body. Drops custom imports/middleware/helpers.
+ */
+export type HonoHandlerStrategy = 'smart' | 'skip' | 'full';
+
 export interface NormalizedHonoOptions {
   handlers?: string;
+  handlerGenerationStrategy: HonoHandlerStrategy;
   compositeRoute: string;
   validator: boolean | 'hono';
   validatorOutputPath: string;
@@ -856,6 +870,7 @@ export type MutationInvalidatesConfig = MutationInvalidatesRule[];
 
 export interface HonoOptions {
   handlers?: string;
+  handlerGenerationStrategy?: HonoHandlerStrategy;
   compositeRoute?: string;
   validator?: boolean | 'hono';
   validatorOutputPath?: string;

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -40,6 +40,14 @@
     "fs-extra": "^11.3.2",
     "remeda": "^2.33.6"
   },
+  "peerDependencies": {
+    "typescript": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@hono/zod-validator": "catalog:hono",
     "@types/fs-extra": "^11.0.4",

--- a/packages/hono/src/handler-merge.test.ts
+++ b/packages/hono/src/handler-merge.test.ts
@@ -910,18 +910,23 @@ export const listPetsHandlers = factory.createHandlers(
     );
   });
 
-  it('imports the renamed schema when migrating a mixed zod import', async () => {
-    const source = `import { createFactory } from 'hono/factory';
+  it('migrates ALL references to a renamed schema, including z.infer in the body', async () => {
+    // Regression: a schema migration must update the import binding, the
+    // validator arg, AND any other reference (e.g. `z.infer<typeof schema>` in
+    // the handler body) — otherwise the body keeps a dangling old identifier.
+    const source = `import { z } from 'zod';
+import { createFactory } from 'hono/factory';
 import { zValidator } from '../endpoints.validator';
-import { ListPetsContext } from '../endpoints.context';
-import { listPetsResponse, customHelper } from '../endpoints.zod';
+import { GetStatsContext } from '../endpoints.context';
+import { getStatsResponse } from '../endpoints.zod';
 
 const factory = createFactory();
 
-export const listPetsHandlers = factory.createHandlers(
-  zValidator('response', listPetsResponse),
-  async (c: ListPetsContext) => {
-    return c.json(customHelper());
+export const getStatsHandlers = factory.createHandlers(
+  zValidator('response', getStatsResponse),
+  async (c: GetStatsContext) => {
+    const stats: z.infer<typeof getStatsResponse> = await load();
+    return c.json(stats);
   },
 );
 `;
@@ -929,23 +934,23 @@ export const listPetsHandlers = factory.createHandlers(
       imports: {
         factory: factoryImport,
         validator: { names: ['zValidator'], module: '../endpoints.validator' },
-        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
-        zod: { names: ['ListPetsResponse'], module: '../endpoints.zod' },
+        context: { names: ['GetStatsContext'], module: '../endpoints.context' },
+        zod: { names: ['GetStatsResponse'], module: '../endpoints.zod' },
       },
       handlers: [
         {
-          handlerName: 'listPetsHandlers',
-          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          handlerName: 'getStatsHandlers',
+          validators: [{ target: 'response', schema: 'GetStatsResponse' }],
           stub: '',
         },
       ],
     });
 
-    expect(result).toContain('customHelper'); // user import preserved
-    expect(result).toContain("zValidator('response', ListPetsResponse)"); // migrated
-    // the migrated PascalCase schema is imported — no unimported reference
     expect(result).toContain(
-      "import { ListPetsResponse } from '../endpoints.zod';",
+      "import { GetStatsResponse } from '../endpoints.zod';",
     );
+    expect(result).toContain("zValidator('response', GetStatsResponse)");
+    expect(result).toContain('z.infer<typeof GetStatsResponse>'); // body migrated
+    expect(result).not.toContain('getStatsResponse'); // no dangling old name
   });
 });

--- a/packages/hono/src/handler-merge.test.ts
+++ b/packages/hono/src/handler-merge.test.ts
@@ -258,19 +258,19 @@ export const createPetsHandlers = factory.createHandlers(
 `;
 
     const bodies = await extractHandlerBodies(source);
-    expect([...bodies.keys()]).toEqual([
+    expect([...(bodies?.keys() ?? [])]).toEqual([
       'listPetsHandlers',
       'createPetsHandlers',
     ]);
-    expect(bodies.get('listPetsHandlers')).toContain(
+    expect(bodies?.get('listPetsHandlers')).toContain(
       'return c.json(pets.slice(0, 10));',
     );
-    expect(bodies.get('createPetsHandlers')).toBe('');
+    expect(bodies?.get('createPetsHandlers')).toBe('');
   });
 
-  it('returns an empty map on parse failure', async () => {
+  it('returns undefined on parse failure (so full mode can preserve the file)', async () => {
     const bodies = await extractHandlerBodies('const x = (');
-    expect(bodies.size).toBe(0);
+    expect(bodies).toBeUndefined();
   });
 });
 
@@ -785,7 +785,7 @@ export const listPetsHandlers = factory.createHandlers(
 );
 `;
     const bodies = await extractHandlerBodies(source);
-    const body = bodies.get('listPetsHandlers');
+    const body = bodies?.get('listPetsHandlers');
     expect(body).toContain('HANDLER_BODY');
     expect(body).not.toContain('MIDDLEWARE_BODY');
   });

--- a/packages/hono/src/handler-merge.test.ts
+++ b/packages/hono/src/handler-merge.test.ts
@@ -953,4 +953,73 @@ export const getStatsHandlers = factory.createHandlers(
     expect(result).toContain('z.infer<typeof GetStatsResponse>'); // body migrated
     expect(result).not.toContain('getStatsResponse'); // no dangling old name
   });
+
+  it('inserts a validator into a single-line createHandlers without breaking it', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsQueryParams } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(async (c: ListPetsContext) => c.json([]));
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsQueryParams'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'query', schema: 'ListPetsQueryParams' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain("zValidator('query', ListPetsQueryParams)");
+    // the validator is inserted INSIDE the call, not prepended before the export
+    expect(result.indexOf('export const listPetsHandlers')).toBeLessThan(
+      result.indexOf("zValidator('query'"),
+    );
+  });
+
+  it('does not insert a duplicate binding when the name is already imported elsewhere', async () => {
+    const source = `import GetStatsResponse from '../legacy';
+import { createFactory } from 'hono/factory';
+import { GetStatsContext } from '../endpoints.context';
+
+const factory = createFactory();
+
+export const getStatsHandlers = factory.createHandlers(
+  async (c: GetStatsContext) => {
+    return c.json(GetStatsResponse);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['GetStatsContext'], module: '../endpoints.context' },
+        zod: { names: ['GetStatsResponse'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'getStatsHandlers',
+          validators: [{ target: 'response', schema: 'GetStatsResponse' }],
+          stub: '',
+        },
+      ],
+    });
+
+    // the existing default import is kept; no duplicate named import is added
+    expect(result).toContain("import GetStatsResponse from '../legacy';");
+    expect(result).not.toContain(
+      "import { GetStatsResponse } from '../endpoints.zod';",
+    );
+  });
 });

--- a/packages/hono/src/handler-merge.test.ts
+++ b/packages/hono/src/handler-merge.test.ts
@@ -75,6 +75,40 @@ async function helper() {
     expect(result).toContain('async function helper() {');
   });
 
+  it('detects a bare reference whose name contains a regex metachar ($) and adds the missing import', async () => {
+    // The handler references `Get$FooContext` but its context import is missing.
+    // `referencedBare` must escape `$` before building its RegExp — otherwise `$`
+    // acts as an end-of-input anchor, the reference goes undetected, and the
+    // import is never re-added (a TS "cannot find name" error).
+    const source = `import { createFactory } from 'hono/factory';
+
+const factory = createFactory();
+
+export const getFooHandlers = factory.createHandlers(
+  async (c: Get$FooContext) => {
+    return c.json(null);
+  },
+);
+`;
+
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: {
+          names: ['Get$FooContext'],
+          module: '../endpoints.context',
+        },
+      },
+      handlers: [{ handlerName: 'getFooHandlers', validators: [], stub: '' }],
+    });
+
+    expect(result).toContain(
+      "import { Get$FooContext } from '../endpoints.context';",
+    );
+    // user body untouched
+    expect(result).toContain('async (c: Get$FooContext) =>');
+  });
+
   it('fixes a moved module specifier, matching the import by name', async () => {
     const source = `import { createFactory } from 'hono/factory';
 import { zValidator } from '../old/users.validator';

--- a/packages/hono/src/handler-merge.test.ts
+++ b/packages/hono/src/handler-merge.test.ts
@@ -1,0 +1,951 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DesiredHandler,
+  type DesiredImports,
+  extractHandlerBodies,
+  reconcileHandlerFile,
+} from './handler-merge';
+
+const factoryImport = { names: ['createFactory'], module: 'hono/factory' };
+
+describe('reconcileHandlerFile', () => {
+  it('renames the zod import and validator schema while preserving all user code', async () => {
+    const source = `/* eslint-disable */
+import { getDBClient } from '@altissia/database';
+import { authenticate, getDecodedToken } from '@altissia/workers/middlewares/auth';
+import { rateLimit } from '@altissia/workers/middlewares/ratelimit';
+import { createFactory } from 'hono/factory';
+import { zValidator } from '../users/users.validator';
+import { VerifyAccountContext } from '../users/users.context';
+import { verifyAccountResponse } from '../users/users.zod';
+
+const logger = getLogger();
+const factory = createFactory();
+
+export const verifyAccountHandlers = factory.createHandlers(
+  authenticate(),
+  rateLimit(),
+  zValidator('response', verifyAccountResponse),
+  async (c: VerifyAccountContext) => {
+    const token = getDecodedToken(c);
+    return c.json({ ok: !!token });
+  },
+);
+
+async function helper() {
+  return getDBClient();
+}
+`;
+
+    const imports: DesiredImports = {
+      factory: factoryImport,
+      validator: { names: ['zValidator'], module: '../users/users.validator' },
+      context: {
+        names: ['VerifyAccountContext'],
+        module: '../users/users.context',
+      },
+      zod: { names: ['VerifyAccountResponse'], module: '../users/users.zod' },
+    };
+    const handlers: DesiredHandler[] = [
+      {
+        handlerName: 'verifyAccountHandlers',
+        validators: [{ target: 'response', schema: 'VerifyAccountResponse' }],
+        stub: '/* unused */',
+      },
+    ];
+
+    const result = await reconcileHandlerFile(source, { imports, handlers });
+
+    // orval-owned bits reconciled
+    expect(result).toContain(
+      "import { VerifyAccountResponse } from '../users/users.zod';",
+    );
+    expect(result).toContain("zValidator('response', VerifyAccountResponse)");
+    expect(result).not.toContain('verifyAccountResponse');
+
+    // user-owned code untouched
+    expect(result).toContain(
+      "import { getDBClient } from '@altissia/database';",
+    );
+    expect(result).toContain('authenticate(),');
+    expect(result).toContain('rateLimit(),');
+    expect(result).toContain('const logger = getLogger();');
+    expect(result).toContain('const token = getDecodedToken(c);');
+    expect(result).toContain('async function helper() {');
+  });
+
+  it('fixes a moved module specifier, matching the import by name', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../old/users.validator';
+import { ListPetsContext } from '../old/users.context';
+import {
+  ListPetsResponse
+} from '../old/users.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', ListPetsResponse),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: {
+          names: ['zValidator'],
+          module: '../new/endpoints.validator',
+        },
+        context: {
+          names: ['ListPetsContext'],
+          module: '../new/endpoints.context',
+        },
+        zod: { names: ['ListPetsResponse'], module: '../new/endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain("from '../new/endpoints.zod'");
+    expect(result).toContain("from '../new/endpoints.context'");
+    expect(result).toContain("from '../new/endpoints.validator'");
+    expect(result).not.toContain('../old/');
+  });
+
+  it('inserts a newly-required validator before the handler, keeping middleware', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { authenticate } from './mw';
+import { ListPetsContext } from './endpoints.context';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  authenticate(),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: './endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: './endpoints.context' },
+        zod: { names: ['ListPetsQueryParams'], module: './endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'query', schema: 'ListPetsQueryParams' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain("zValidator('query', ListPetsQueryParams),");
+    expect(result).toContain('authenticate(),');
+    expect(result).toContain(
+      "import { zValidator } from './endpoints.validator';",
+    );
+    expect(result).toContain('ListPetsQueryParams');
+    // validator sits after the middleware and before the handler
+    const authIdx = result.indexOf('authenticate(),');
+    const valIdx = result.indexOf("zValidator('query'");
+    const handlerIdx = result.indexOf('async (c: ListPetsContext)');
+    expect(authIdx).toBeLessThan(valIdx);
+    expect(valIdx).toBeLessThan(handlerIdx);
+  });
+
+  it('removes a stale validator that the spec no longer requires', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from './endpoints.validator';
+import { CreatePetContext } from './endpoints.context';
+import { CreatePetBody } from './endpoints.zod';
+
+const factory = createFactory();
+
+export const createPetHandlers = factory.createHandlers(
+  zValidator('json', CreatePetBody),
+  async (c: CreatePetContext) => {
+    return c.json({});
+  },
+);
+`;
+
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: { names: ['CreatePetContext'], module: './endpoints.context' },
+      },
+      handlers: [
+        { handlerName: 'createPetHandlers', validators: [], stub: '' },
+      ],
+    });
+
+    expect(result).not.toContain("zValidator('json'");
+    expect(result).toContain('async (c: CreatePetContext)');
+    // the now-unused zValidator import is removed
+    expect(result).not.toContain('import { zValidator }');
+  });
+
+  it('appends a stub for an operation missing from the file', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { ListPetsContext } from './endpoints.context';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+
+    const stub = `\nexport const createPetsHandlers = factory.createHandlers(\nasync (c: CreatePetsContext) => {\n\n  },\n);`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: {
+          names: ['ListPetsContext', 'CreatePetsContext'],
+          module: './endpoints.context',
+        },
+      },
+      handlers: [
+        { handlerName: 'listPetsHandlers', validators: [], stub: '' },
+        { handlerName: 'createPetsHandlers', validators: [], stub },
+      ],
+    });
+
+    expect(result).toContain('export const createPetsHandlers');
+    expect(result.match(/listPetsHandlers/g)?.length).toBe(1);
+    // context import grows to include the new operation
+    expect(result).toContain('CreatePetsContext');
+  });
+
+  it('returns the source unchanged when it cannot be parsed', async () => {
+    const broken = 'export const x = factory.createHandlers(  // unterminated';
+    const result = await reconcileHandlerFile(broken, {
+      imports: { factory: factoryImport, context: { names: [], module: 'x' } },
+      handlers: [],
+    });
+    expect(result).toBe(broken);
+  });
+});
+
+describe('extractHandlerBodies', () => {
+  it('returns the inner body of each handler keyed by name', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+const factory = createFactory();
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('query', ListPetsQueryParams),
+  async (c: ListPetsContext) => {
+    return c.json(pets.slice(0, 10));
+  },
+);
+export const createPetsHandlers = factory.createHandlers(
+  async (c: CreatePetsContext) => {},
+);
+`;
+
+    const bodies = await extractHandlerBodies(source);
+    expect([...bodies.keys()]).toEqual([
+      'listPetsHandlers',
+      'createPetsHandlers',
+    ]);
+    expect(bodies.get('listPetsHandlers')).toContain(
+      'return c.json(pets.slice(0, 10));',
+    );
+    expect(bodies.get('createPetsHandlers')).toBe('');
+  });
+
+  it('returns an empty map on parse failure', async () => {
+    const bodies = await extractHandlerBodies('const x = (');
+    expect(bodies.size).toBe(0);
+  });
+});
+
+describe('reconcileHandlerFile — preserves non-standard and user imports', () => {
+  it('does NOT delete a user import whose name ends in "Context" (regression)', async () => {
+    const source = `import { getCommunityFilterContext } from '../services/community-filters';
+import { createFactory } from 'hono/factory';
+
+const factory = createFactory();
+
+export const getCommunityHandlers = factory.createHandlers(
+  async (c) => {
+    return c.json(getCommunityFilterContext());
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: {
+          names: ['GetCommunityContext'],
+          module: '../endpoints.context',
+        },
+      },
+      handlers: [
+        { handlerName: 'getCommunityHandlers', validators: [], stub: '' },
+      ],
+    });
+
+    expect(result).toContain(
+      "import { getCommunityFilterContext } from '../services/community-filters';",
+    );
+    // untyped handler → no context import is added
+    expect(result).not.toContain('GetCommunityContext');
+  });
+
+  it('leaves a namespace import untouched', async () => {
+    const source = `import * as Ctx from '../endpoints.context';
+import { createFactory } from 'hono/factory';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: Ctx.ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+      },
+      handlers: [{ handlerName: 'listPetsHandlers', validators: [], stub: '' }],
+    });
+
+    expect(result).toContain("import * as Ctx from '../endpoints.context';");
+    expect(result).not.toContain('import { ListPetsContext }');
+  });
+
+  it('leaves a default import untouched', async () => {
+    const source = `import createFactory from 'hono/factory';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: { names: ['createFactory'], module: 'hono/factory' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+      },
+      handlers: [{ handlerName: 'listPetsHandlers', validators: [], stub: '' }],
+    });
+
+    expect(result).toContain("import createFactory from 'hono/factory';");
+    expect(result).not.toContain('import { createFactory }');
+  });
+
+  it('does not duplicate an aliased zValidator import', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator as zv } from '@hono/zod-validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsQueryParams } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zv('query', ListPetsQueryParams),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '@hono/zod-validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsQueryParams'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'query', schema: 'ListPetsQueryParams' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain('import { zValidator as zv }');
+    expect(result.match(/from '@hono\/zod-validator'/g)?.length).toBe(1);
+  });
+
+  it('does not duplicate or rename an aliased zod schema import', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsResponse as Resp } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', Resp),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsResponse'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain('import { ListPetsResponse as Resp }');
+    expect(result).toContain("zValidator('response', Resp)");
+    expect(result).not.toContain(
+      "import { ListPetsResponse } from '../endpoints.zod';",
+    );
+  });
+
+  it('preserves user names sharing an orval module import', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { ListPetsContext, somethingCustom } from '../endpoints.context';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: ListPetsContext) => {
+    return c.json(somethingCustom);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+      },
+      handlers: [{ handlerName: 'listPetsHandlers', validators: [], stub: '' }],
+    });
+
+    expect(result).toContain('somethingCustom');
+    expect(result).toContain('ListPetsContext');
+  });
+
+  it('does NOT clobber a user import whose name only case-folds to a zod schema', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { listPetsResponse } from '../helpers';
+import { ListPetsContext } from '../endpoints.context';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: ListPetsContext) => {
+    return c.json(listPetsResponse());
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsResponse'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          stub: '',
+        },
+      ],
+    });
+
+    // user's lowercase import is untouched; orval's PascalCase import is added
+    expect(result).toContain("import { listPetsResponse } from '../helpers';");
+    expect(result).toContain(
+      "import { ListPetsResponse } from '../endpoints.zod';",
+    );
+  });
+
+  it('only renames a validator schema on a pure case migration', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { MyCustomSchema } from '../schemas';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', MyCustomSchema),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsResponse'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          stub: '',
+        },
+      ],
+    });
+
+    // a user-chosen, non-case-equal schema identifier is left alone
+    expect(result).toContain("zValidator('response', MyCustomSchema)");
+    expect(result).not.toContain('ListPetsResponse)');
+  });
+
+  it('consumes CRLF line endings when removing a validator', async () => {
+    const source =
+      "import { createFactory } from 'hono/factory';\r\n" +
+      "import { zValidator } from '../endpoints.validator';\r\n" +
+      "import { ListPetsContext } from '../endpoints.context';\r\n" +
+      "import { ListPetsQueryParams } from '../endpoints.zod';\r\n" +
+      '\r\n' +
+      'const factory = createFactory();\r\n' +
+      '\r\n' +
+      'export const listPetsHandlers = factory.createHandlers(\r\n' +
+      "  zValidator('query', ListPetsQueryParams),\r\n" +
+      '  async (c: ListPetsContext) => {\r\n' +
+      '    return c.json([]);\r\n' +
+      '  },\r\n' +
+      ');\r\n';
+
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+      },
+      handlers: [{ handlerName: 'listPetsHandlers', validators: [], stub: '' }],
+    });
+
+    expect(result).not.toContain("zValidator('query'");
+    // no dangling carriage return left where the validator line was
+    expect(result).not.toContain('\r\n\r\n  async');
+  });
+
+  it('reconciles multiple handlers in one file independently', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext, CreatePetsContext } from '../endpoints.context';
+import { listPetsResponse, createPetsBody } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', listPetsResponse),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+
+export const createPetsHandlers = factory.createHandlers(
+  zValidator('json', createPetsBody),
+  async (c: CreatePetsContext) => {
+    return c.json({});
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: {
+          names: ['ListPetsContext', 'CreatePetsContext'],
+          module: '../endpoints.context',
+        },
+        zod: {
+          names: ['ListPetsResponse', 'CreatePetsBody'],
+          module: '../endpoints.zod',
+        },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          stub: '',
+        },
+        {
+          handlerName: 'createPetsHandlers',
+          validators: [{ target: 'json', schema: 'CreatePetsBody' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain("zValidator('response', ListPetsResponse)");
+    expect(result).toContain("zValidator('json', CreatePetsBody)");
+    expect(result).not.toContain('listPetsResponse');
+    expect(result).not.toContain('createPetsBody');
+  });
+
+  it('detects an aliased zValidator and inserts new validators under the alias', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator as zv } from '@hono/zod-validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsQueryParams } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zv('query', ListPetsQueryParams),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '@hono/zod-validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: {
+          names: ['ListPetsQueryParams', 'ListPetsResponse'],
+          module: '../endpoints.zod',
+        },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [
+            { target: 'query', schema: 'ListPetsQueryParams' },
+            { target: 'response', schema: 'ListPetsResponse' },
+          ],
+          stub: '',
+        },
+      ],
+    });
+
+    // existing aliased validator detected → not duplicated under the bare name
+    expect(result.match(/zv\('query'/g)?.length).toBe(1);
+    expect(result).not.toContain("zValidator('query'");
+    // new validator inserted under the SAME alias, never an unimported name
+    expect(result).toContain("zv('response', ListPetsResponse)");
+    expect(result).not.toContain("zValidator('response'");
+    // alias import preserved, no duplicate
+    expect(result).toContain('import { zValidator as zv }');
+    expect(result.match(/from '@hono\/zod-validator'/g)?.length).toBe(1);
+  });
+
+  it('augments a mixed import with a new operation context, preserving user names', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { ListPetsContext, somethingCustom } from '../endpoints.context';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: ListPetsContext) => {
+    return c.json(somethingCustom);
+  },
+);
+`;
+    const stub = `\nexport const createPetsHandlers = factory.createHandlers(\nasync (c: CreatePetsContext) => {\n\n  },\n);`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: {
+          names: ['ListPetsContext', 'CreatePetsContext'],
+          module: '../endpoints.context',
+        },
+      },
+      handlers: [
+        { handlerName: 'listPetsHandlers', validators: [], stub: '' },
+        { handlerName: 'createPetsHandlers', validators: [], stub },
+      ],
+    });
+
+    expect(result).toContain('somethingCustom'); // user name preserved
+    expect(result).toContain('export const createPetsHandlers'); // new op appended
+    expect(result).toContain(
+      "import { CreatePetsContext } from '../endpoints.context';",
+    ); // new op's context added via a separate import
+  });
+
+  it('augments a mixed zod import with a newly-required schema', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsResponse, myZodHelper } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', ListPetsResponse),
+  async (c: ListPetsContext) => {
+    return c.json(myZodHelper());
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: {
+          names: ['ListPetsResponse', 'ListPetsQueryParams'],
+          module: '../endpoints.zod',
+        },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [
+            { target: 'response', schema: 'ListPetsResponse' },
+            { target: 'query', schema: 'ListPetsQueryParams' },
+          ],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain('myZodHelper'); // user name preserved
+    expect(result).toContain("zValidator('query', ListPetsQueryParams)"); // new validator
+    expect(result).toContain(
+      "import { ListPetsQueryParams } from '../endpoints.zod';",
+    ); // new schema added via a separate import
+  });
+
+  it('inserts a validator after inline middleware, before the handler', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsQueryParams } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  (c, next) => next(),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsQueryParams'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'query', schema: 'ListPetsQueryParams' }],
+          stub: '',
+        },
+      ],
+    });
+
+    const mwIdx = result.indexOf('(c, next) => next()');
+    const valIdx = result.indexOf("zValidator('query'");
+    const handlerIdx = result.indexOf('async (c: ListPetsContext)');
+    // the inline middleware arrow is NOT mistaken for the handler
+    expect(mwIdx).toBeLessThan(valIdx);
+    expect(valIdx).toBeLessThan(handlerIdx);
+  });
+
+  it('extractHandlerBodies returns the handler body, not an inline middleware body', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+const factory = createFactory();
+export const listPetsHandlers = factory.createHandlers(
+  (c, next) => {
+    /* MIDDLEWARE_BODY */ return next();
+  },
+  async (c: ListPetsContext) => {
+    return c.json([]); /* HANDLER_BODY */
+  },
+);
+`;
+    const bodies = await extractHandlerBodies(source);
+    const body = bodies.get('listPetsHandlers');
+    expect(body).toContain('HANDLER_BODY');
+    expect(body).not.toContain('MIDDLEWARE_BODY');
+  });
+
+  it('imports a new operation context even when the existing import is a namespace', async () => {
+    const source = `import * as Ctx from '../endpoints.context';
+import { createFactory } from 'hono/factory';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: Ctx.ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const stub = `\nexport const createPetsHandlers = factory.createHandlers(\nasync (c: CreatePetsContext) => {\n\n  },\n);`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        context: {
+          names: ['ListPetsContext', 'CreatePetsContext'],
+          module: '../endpoints.context',
+        },
+      },
+      handlers: [
+        { handlerName: 'listPetsHandlers', validators: [], stub: '' },
+        { handlerName: 'createPetsHandlers', validators: [], stub },
+      ],
+    });
+
+    expect(result).toContain("import * as Ctx from '../endpoints.context';"); // namespace kept
+    expect(result).toContain('export const createPetsHandlers'); // new op appended
+    expect(result).toContain(
+      "import { CreatePetsContext } from '../endpoints.context';",
+    ); // new op's bare context imported
+    // the namespace-qualified existing context is not duplicated bare
+    expect(result).not.toContain('import { ListPetsContext }');
+  });
+
+  it('imports a newly-required schema even when the existing zod import is aliased', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsResponse as Resp } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', Resp),
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: {
+          names: ['ListPetsResponse', 'ListPetsQueryParams'],
+          module: '../endpoints.zod',
+        },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [
+            { target: 'response', schema: 'ListPetsResponse' },
+            { target: 'query', schema: 'ListPetsQueryParams' },
+          ],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain('import { ListPetsResponse as Resp }'); // alias kept
+    expect(result).toContain("zValidator('response', Resp)"); // existing kept on alias
+    expect(result).toContain("zValidator('query', ListPetsQueryParams)"); // new validator
+    expect(result).toContain(
+      "import { ListPetsQueryParams } from '../endpoints.zod';",
+    ); // its schema imported
+  });
+
+  it('routes new validators through the desired validator module, ignoring an unrelated zValidator alias', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator as zv } from '@hono/zod-validator';
+import { ListPetsContext } from '../endpoints.context';
+import { ListPetsQueryParams } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  async (c: ListPetsContext) => {
+    return c.json([]);
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsQueryParams'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'query', schema: 'ListPetsQueryParams' }],
+          stub: '',
+        },
+      ],
+    });
+
+    // the unrelated alias (from @hono/zod-validator) is NOT used for new validators
+    expect(result).toContain("zValidator('query', ListPetsQueryParams)");
+    expect(result).not.toContain("zv('query'");
+    // orval's validator comes from the DESIRED module
+    expect(result).toContain(
+      "import { zValidator } from '../endpoints.validator';",
+    );
+  });
+
+  it('imports the renamed schema when migrating a mixed zod import', async () => {
+    const source = `import { createFactory } from 'hono/factory';
+import { zValidator } from '../endpoints.validator';
+import { ListPetsContext } from '../endpoints.context';
+import { listPetsResponse, customHelper } from '../endpoints.zod';
+
+const factory = createFactory();
+
+export const listPetsHandlers = factory.createHandlers(
+  zValidator('response', listPetsResponse),
+  async (c: ListPetsContext) => {
+    return c.json(customHelper());
+  },
+);
+`;
+    const result = await reconcileHandlerFile(source, {
+      imports: {
+        factory: factoryImport,
+        validator: { names: ['zValidator'], module: '../endpoints.validator' },
+        context: { names: ['ListPetsContext'], module: '../endpoints.context' },
+        zod: { names: ['ListPetsResponse'], module: '../endpoints.zod' },
+      },
+      handlers: [
+        {
+          handlerName: 'listPetsHandlers',
+          validators: [{ target: 'response', schema: 'ListPetsResponse' }],
+          stub: '',
+        },
+      ],
+    });
+
+    expect(result).toContain('customHelper'); // user import preserved
+    expect(result).toContain("zValidator('response', ListPetsResponse)"); // migrated
+    // the migrated PascalCase schema is imported — no unimported reference
+    expect(result).toContain(
+      "import { ListPetsResponse } from '../endpoints.zod';",
+    );
+  });
+});

--- a/packages/hono/src/handler-merge.ts
+++ b/packages/hono/src/handler-merge.ts
@@ -1,0 +1,590 @@
+import type * as TS from 'typescript';
+
+/**
+ * AST-based reconciliation of an existing hono handler file.
+ *
+ * The `smart` handler strategy regenerates only the regions orval owns — its own
+ * imports (names + module specifier) and the `zValidator(...)` arguments of each
+ * handler — while leaving every user-authored construct untouched: custom imports,
+ * middleware passed to `factory.createHandlers(...)`, the `async (c) => { ... }`
+ * body, and any top-level helpers, constants, types, or comments.
+ *
+ * We edit the original source text in place using node offsets from the
+ * TypeScript compiler API, so formatting and comments of untouched regions are
+ * preserved. On any parse failure we return the source unchanged — user code is
+ * never destroyed by a parser hiccup.
+ */
+
+/**
+ * `typescript` is an optional peer dependency, imported lazily. Consumers who do
+ * not have it installed — and every non-hono or `skip` code path — never trigger
+ * the import; `smart`/`full` fall back to `skip` when it is unavailable. Loading
+ * the consumer's own typescript also avoids shipping a second copy of it.
+ */
+let ts!: typeof TS;
+let typeScriptAvailable: boolean | undefined;
+
+export const ensureTypeScript = async (): Promise<boolean> => {
+  if (typeScriptAvailable === undefined) {
+    try {
+      const mod = await import('typescript');
+      ts = (mod as unknown as { default?: typeof TS }).default ?? mod;
+      typeScriptAvailable = true;
+    } catch {
+      typeScriptAvailable = false;
+    }
+  }
+  return typeScriptAvailable;
+};
+
+export type ValidatorTarget =
+  | 'header'
+  | 'param'
+  | 'query'
+  | 'json'
+  | 'form'
+  | 'response';
+
+export interface DesiredValidator {
+  target: ValidatorTarget;
+  /** PascalCase zod schema identifier, e.g. `VerifyAccountResponse`. */
+  schema: string;
+}
+
+export interface DesiredHandler {
+  /** e.g. `verifyAccountHandlers`. */
+  handlerName: string;
+  /** Validators required by the spec, in canonical order. */
+  validators: DesiredValidator[];
+  /** Full handler block, used only when the handler is missing and appended. */
+  stub: string;
+}
+
+export interface OrvalImport {
+  names: string[];
+  /** Module specifier as orval would emit it (relative, extensionless). */
+  module: string;
+}
+
+export interface DesiredImports {
+  /** `createFactory` from `hono/factory`. */
+  factory: OrvalImport;
+  /** `zValidator` from the validator module; omitted when no validators exist. */
+  validator?: OrvalImport;
+  /** `<Op>Context` identifiers from the context module. */
+  context: OrvalImport;
+  /** zod schema identifiers from the zod module; omitted when none are needed. */
+  zod?: OrvalImport;
+}
+
+const VALIDATOR_TARGETS = new Set<string>([
+  'header',
+  'param',
+  'query',
+  'json',
+  'form',
+  'response',
+]);
+
+interface Edit {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const parse = (source: string): TS.SourceFile | undefined => {
+  const sourceFile = ts.createSourceFile(
+    'handler.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  const diagnostics = (
+    sourceFile as unknown as { parseDiagnostics?: TS.Diagnostic[] }
+  ).parseDiagnostics;
+  if (diagnostics && diagnostics.length > 0) return undefined;
+  return sourceFile;
+};
+
+interface ParsedHandler {
+  name: string;
+  call: TS.CallExpression;
+}
+
+const findHandlers = (sourceFile: TS.SourceFile): ParsedHandler[] => {
+  const handlers: ParsedHandler[] = [];
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name)) continue;
+      const name = declaration.name.text;
+      if (!name.endsWith('Handlers')) continue;
+      const init = declaration.initializer;
+      if (
+        init &&
+        ts.isCallExpression(init) &&
+        ts.isPropertyAccessExpression(init.expression) &&
+        init.expression.name.text === 'createHandlers'
+      ) {
+        handlers.push({ name, call: init });
+      }
+    }
+  }
+  return handlers;
+};
+
+const importedNames = (declaration: TS.ImportDeclaration): string[] => {
+  const bindings = declaration.importClause?.namedBindings;
+  if (!bindings || !ts.isNamedImports(bindings)) return [];
+  return bindings.elements.map((element) => element.name.text);
+};
+
+const moduleText = (declaration: TS.ImportDeclaration): string =>
+  ts.isStringLiteral(declaration.moduleSpecifier)
+    ? declaration.moduleSpecifier.text
+    : '';
+
+/**
+ * A "plain" named import — no default binding, no namespace (`* as x`), and no
+ * aliases (`x as y`). Only plain named imports are safe for orval to rewrite;
+ * default / namespace / aliased / mixed imports are user-authored and must be
+ * left untouched.
+ */
+const isPlainNamedImport = (declaration: TS.ImportDeclaration): boolean => {
+  const clause = declaration.importClause;
+  if (!clause || clause.name) return false;
+  const bindings = clause.namedBindings;
+  if (!bindings || !ts.isNamedImports(bindings)) return false;
+  return bindings.elements.every(
+    (element) => element.propertyName === undefined,
+  );
+};
+
+const setEquals = (a: string[], b: string[]): boolean =>
+  a.length === b.length && a.every((value) => b.includes(value));
+
+/**
+ * The local binding name an imported symbol is bound to, honouring aliases —
+ * e.g. `import { zValidator as zv }` → `'zv'`. Returns undefined when the symbol
+ * is not imported. Used so a handler that aliases `zValidator` is detected and
+ * its new validators are inserted under the same alias (never an unimported name).
+ */
+const localNameFor = (
+  importDeclarations: TS.ImportDeclaration[],
+  importedName: string,
+  module: string,
+): string | undefined => {
+  for (const declaration of importDeclarations) {
+    if (moduleText(declaration) !== module) continue;
+    const bindings = declaration.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      if ((element.propertyName?.text ?? element.name.text) === importedName) {
+        return element.name.text;
+      }
+    }
+  }
+  return undefined;
+};
+
+const renderImport = ({ names, module }: OrvalImport): string =>
+  names.length <= 1
+    ? `import { ${names.join('')} } from '${module}';`
+    : `import {\n  ${names.join(',\n  ')}\n} from '${module}';`;
+
+const lineStart = (source: string, position: number): number =>
+  source.lastIndexOf('\n', position - 1) + 1;
+
+/** Whether only whitespace sits between the line start and `position`. */
+const startsLine = (source: string, position: number): boolean =>
+  /^\s*$/.test(source.slice(lineStart(source, position), position));
+
+export const reconcileHandlerFile = async (
+  source: string,
+  desired: { imports: DesiredImports; handlers: DesiredHandler[] },
+): Promise<string> => {
+  if (!(await ensureTypeScript())) return source;
+
+  const sourceFile = parse(source);
+  if (!sourceFile) return source;
+
+  const edits: Edit[] = [];
+  const importDeclarations = sourceFile.statements.filter(
+    (statement): statement is TS.ImportDeclaration =>
+      ts.isImportDeclaration(statement),
+  );
+  const handlers = findHandlers(sourceFile);
+  const existingNames = new Set(handlers.map((handler) => handler.name));
+  const pendingInsertions: string[] = [];
+
+  // Locate an orval-owned import by its module specifier (authoritative).
+  const byModule = (module: string): TS.ImportDeclaration | undefined =>
+    module
+      ? importDeclarations.find(
+          (declaration) => moduleText(declaration) === module,
+        )
+      : undefined;
+
+  // Fallback used only when the module specifier has moved: a PLAIN named import
+  // whose names are EXACTLY `signature` (case-sensitive). This relocates an
+  // orval import without the case-folding hazard of fuzzy name matching, which
+  // could otherwise clobber an unrelated user import (e.g. `listPetsResponse`).
+  const plainExact = (signature: string[]): TS.ImportDeclaration | undefined =>
+    signature.length === 0
+      ? undefined
+      : importDeclarations.find(
+          (declaration) =>
+            isPlainNamedImport(declaration) &&
+            setEquals(importedNames(declaration), signature),
+        );
+
+  const removeImportEdit = (declaration: TS.ImportDeclaration) => {
+    let end = declaration.getEnd();
+    if (source.slice(end, end + 2) === '\r\n') end += 2;
+    else if (source[end] === '\n') end += 1;
+    edits.push({ start: declaration.getStart(sourceFile), end, text: '' });
+  };
+
+  // Whether `name` is already bound as a bare identifier by some import (a named
+  // import's local name, or a default import). Namespace imports do NOT bind
+  // their members bare. Used to avoid duplicate imports when augmenting.
+  const isImportedBare = (name: string): boolean =>
+    importDeclarations.some((declaration) => {
+      const clause = declaration.importClause;
+      if (!clause) return false;
+      if (clause.name?.text === name) return true;
+      return importedNames(declaration).includes(name);
+    });
+
+  /**
+   * Reconcile an orval-owned import to `names`. We only rewrite/remove a PLAIN
+   * named import whose names are ALL orval-owned (per `isOrvalName`). A
+   * user-authored import (aliased / namespace / default / mixed) is never
+   * rewritten; instead, when `augment` is provided, we add any orval name that
+   * is genuinely needed as a bare reference but isn't yet importable bare — e.g.
+   * a newly appended handler's context, or a newly-inserted validator's schema.
+   */
+  const reconcileImport = (
+    existing: TS.ImportDeclaration | undefined,
+    names: string[],
+    module: string,
+    isOrvalName: (name: string) => boolean,
+    augment?: (name: string) => boolean,
+  ) => {
+    if (!existing) {
+      const toInsert = augment ? names.filter((name) => augment(name)) : names;
+      if (toInsert.length > 0) {
+        pendingInsertions.push(renderImport({ names: toInsert, module }));
+      }
+      return;
+    }
+
+    const isOurs =
+      isPlainNamedImport(existing) &&
+      importedNames(existing).every((name) => isOrvalName(name));
+    if (!isOurs) {
+      if (augment) {
+        const missing = names.filter(
+          (name) => augment(name) && !isImportedBare(name),
+        );
+        if (missing.length > 0) {
+          pendingInsertions.push(renderImport({ names: missing, module }));
+        }
+      }
+      return;
+    }
+
+    if (names.length === 0) {
+      removeImportEdit(existing);
+      return;
+    }
+
+    if (
+      setEquals(importedNames(existing), names) &&
+      moduleText(existing) === module
+    ) {
+      return;
+    }
+
+    edits.push({
+      start: existing.getStart(sourceFile),
+      end: existing.getEnd(),
+      text: renderImport({ names, module }),
+    });
+  };
+
+  // --- validators first, so schema names referenced by reconciled validators
+  // (newly inserted, or renamed camelCase → PascalCase) are known to the import
+  // step below. The local name `zValidator` is bound to in the DESIRED validator
+  // module (honours `import { zValidator as zv } from '<validatorModule>'`); a
+  // zValidator imported from a different module is the user's own and ignored,
+  // so new validators always route through orval's validator. ---
+  const validatorModule = desired.imports.validator?.module ?? '';
+  const zValidatorName = validatorModule
+    ? (localNameFor(importDeclarations, 'zValidator', validatorModule) ??
+      'zValidator')
+    : 'zValidator';
+
+  const requiredSchemas = new Set<string>();
+  for (const desiredHandler of desired.handlers) {
+    const parsed = handlers.find(
+      (handler) => handler.name === desiredHandler.handlerName,
+    );
+    if (parsed) {
+      reconcileValidators(
+        sourceFile,
+        source,
+        parsed.call,
+        desiredHandler.validators,
+        edits,
+        zValidatorName,
+        requiredSchemas,
+      );
+    }
+  }
+
+  const toAppend = desired.handlers.filter(
+    (handler) => !existingNames.has(handler.handlerName),
+  );
+
+  // --- imports ---
+  // Source with import declarations blanked out, so an import's own text (e.g.
+  // `import { ListPetsResponse as Resp }`) is never counted as a usage.
+  let bodySource = source;
+  for (const declaration of importDeclarations) {
+    const start = declaration.getStart(sourceFile);
+    const end = declaration.getEnd();
+    bodySource =
+      bodySource.slice(0, start) +
+      ' '.repeat(end - start) +
+      bodySource.slice(end);
+  }
+
+  // A name needs a bare import when it is referenced unqualified in the body
+  // (not as `Ns.Name`), is a schema a reconciled validator now references
+  // (inserted or renamed), or is used by an appended handler stub.
+  const referencedBare = (name: string): boolean =>
+    new RegExp(String.raw`(?<!\.)\b${name}\b`).test(bodySource);
+  const inAppendedStub = (name: string): boolean =>
+    toAppend.some((handler) => handler.stub.includes(name));
+  const needsBareContext = (name: string): boolean =>
+    referencedBare(name) || inAppendedStub(name);
+  const needsBareZod = (name: string): boolean =>
+    referencedBare(name) || requiredSchemas.has(name) || inAppendedStub(name);
+
+  // Context types are orval-owned only where a handler references one bare (a
+  // typed `async (c: XContext)`) or an appended stub uses it. Match by EXACT
+  // orval name — never `endsWith('Context')`, which would clobber a user import
+  // such as `getCommunityFilterContext`.
+  const contextNames = desired.imports.context.names.filter((name) =>
+    needsBareContext(name),
+  );
+  const zodLower = new Set(
+    (desired.imports.zod?.names ?? []).map((name) => name.toLowerCase()),
+  );
+
+  const factoryModule = desired.imports.factory.module;
+  reconcileImport(
+    byModule(factoryModule) ?? plainExact(['createFactory']),
+    desired.imports.factory.names,
+    factoryModule,
+    (name) => name === 'createFactory',
+  );
+
+  reconcileImport(
+    byModule(validatorModule) ?? plainExact(['zValidator']),
+    desired.imports.validator ? ['zValidator'] : [],
+    validatorModule,
+    (name) => name === 'zValidator',
+  );
+
+  reconcileImport(
+    byModule(desired.imports.context.module) ?? plainExact(contextNames),
+    contextNames,
+    desired.imports.context.module,
+    (name) => desired.imports.context.names.includes(name),
+    needsBareContext,
+  );
+
+  const zodModule = desired.imports.zod?.module ?? '';
+  const zodNames = desired.imports.zod?.names ?? [];
+  reconcileImport(
+    byModule(zodModule) ?? plainExact(zodNames),
+    zodNames,
+    zodModule,
+    (name) => zodLower.has(name.toLowerCase()),
+    needsBareZod,
+  );
+
+  if (pendingInsertions.length > 0) {
+    const lastImport = importDeclarations.at(-1);
+    const insertPos = lastImport
+      ? source.indexOf('\n', lastImport.getEnd()) + 1
+      : 0;
+    edits.push({
+      start: insertPos,
+      end: insertPos,
+      text: pendingInsertions.map((line) => `${line}\n`).join(''),
+    });
+  }
+
+  if (toAppend.length > 0) {
+    edits.push({
+      start: source.length,
+      end: source.length,
+      text: toAppend.map((handler) => handler.stub).join(''),
+    });
+  }
+
+  return applyEdits(source, edits);
+};
+
+const reconcileValidators = (
+  sourceFile: TS.SourceFile,
+  source: string,
+  call: TS.CallExpression,
+  desiredValidators: DesiredValidator[],
+  edits: Edit[],
+  zValidatorName: string,
+  requiredSchemas: Set<string>,
+) => {
+  const existing: {
+    target: string;
+    arg: TS.CallExpression;
+    schema?: TS.Node;
+  }[] = [];
+
+  for (const arg of call.arguments) {
+    if (
+      ts.isCallExpression(arg) &&
+      ts.isIdentifier(arg.expression) &&
+      arg.expression.text === zValidatorName
+    ) {
+      const target = arg.arguments[0];
+      if (
+        arg.arguments.length > 0 &&
+        ts.isStringLiteralLike(target) &&
+        VALIDATOR_TARGETS.has(target.text)
+      ) {
+        existing.push({ target: target.text, arg, schema: arg.arguments[1] });
+      }
+    }
+  }
+
+  const desiredByTarget = new Map(
+    desiredValidators.map((validator) => [validator.target, validator]),
+  );
+  const existingByTarget = new Set(existing.map((item) => item.target));
+
+  for (const item of existing) {
+    const want = desiredByTarget.get(item.target as ValidatorTarget);
+    if (!want) {
+      edits.push(removeArgumentEdit(sourceFile, source, item.arg));
+    } else if (
+      item.schema &&
+      ts.isIdentifier(item.schema) &&
+      item.schema.text !== want.schema &&
+      // Only migrate a pure case change of the SAME schema (camelCase →
+      // PascalCase). Never rewrite a user-chosen alias or a different identifier.
+      item.schema.text.toLowerCase() === want.schema.toLowerCase()
+    ) {
+      edits.push({
+        start: item.schema.getStart(sourceFile),
+        end: item.schema.getEnd(),
+        text: want.schema,
+      });
+      // The validator now references the PascalCase name, so it must be
+      // importable bare even if the old import can't be safely rewritten.
+      requiredSchemas.add(want.schema);
+    }
+  }
+
+  const missing = desiredValidators.filter(
+    (validator) => !existingByTarget.has(validator.target),
+  );
+  if (missing.length > 0) {
+    const insertPos = validatorInsertPos(sourceFile, source, call);
+    const text = missing
+      .map((validator) => {
+        requiredSchemas.add(validator.schema);
+        return `  ${zValidatorName}('${validator.target}', ${validator.schema}),\n`;
+      })
+      .join('');
+    edits.push({ start: insertPos, end: insertPos, text });
+  }
+};
+
+/** Position to insert new validators: the line start of the trailing handler. */
+const validatorInsertPos = (
+  sourceFile: TS.SourceFile,
+  source: string,
+  call: TS.CallExpression,
+): number => {
+  // The handler is the LAST function argument; earlier function args may be
+  // inline middleware, so search from the end.
+  const handler = call.arguments.findLast(
+    (arg) => ts.isArrowFunction(arg) || ts.isFunctionExpression(arg),
+  );
+  if (handler) return lineStart(source, handler.getStart(sourceFile));
+  // No trailing handler found — insert just before the closing paren.
+  return call.getEnd() - 1;
+};
+
+const removeArgumentEdit = (
+  sourceFile: TS.SourceFile,
+  source: string,
+  arg: TS.Node,
+): Edit => {
+  const argStart = arg.getStart(sourceFile);
+  const start = startsLine(source, argStart)
+    ? lineStart(source, argStart)
+    : argStart;
+
+  const commaIdx = source.indexOf(',', arg.getEnd());
+  let end = commaIdx === -1 ? arg.getEnd() : commaIdx + 1;
+  while (source[end] === ' ' || source[end] === '\t') end += 1;
+  if (source.slice(end, end + 2) === '\r\n') end += 2;
+  else if (source[end] === '\n') end += 1;
+
+  return { start, end, text: '' };
+};
+
+const applyEdits = (source: string, edits: Edit[]): string => {
+  let result = source;
+  for (const edit of edits.toSorted((a, b) => b.start - a.start)) {
+    result = result.slice(0, edit.start) + edit.text + result.slice(edit.end);
+  }
+  return result;
+};
+
+/**
+ * Extracts the inner body of each handler's `async (c) => { ... }` block, keyed
+ * by handler name. Used by the `full` strategy to splice user bodies back into a
+ * freshly-regenerated wrapper. Returns an empty map on parse failure or when
+ * typescript is unavailable.
+ */
+export const extractHandlerBodies = async (
+  source: string,
+): Promise<Map<string, string>> => {
+  const bodies = new Map<string, string>();
+  if (!(await ensureTypeScript())) return bodies;
+
+  const sourceFile = parse(source);
+  if (!sourceFile) return bodies;
+
+  for (const { name, call } of findHandlers(sourceFile)) {
+    // The handler is the LAST function argument (earlier ones may be inline
+    // middleware), so its body — not a middleware's — is what `full` splices.
+    const handler = call.arguments.findLast(
+      (arg) => ts.isArrowFunction(arg) || ts.isFunctionExpression(arg),
+    );
+    if (handler?.body && ts.isBlock(handler.body)) {
+      const bodyStart = handler.body.getStart(sourceFile) + 1;
+      const bodyEnd = handler.body.getEnd() - 1;
+      bodies.set(name, source.slice(bodyStart, bodyEnd));
+    }
+  }
+
+  return bodies;
+};

--- a/packages/hono/src/handler-merge.ts
+++ b/packages/hono/src/handler-merge.ts
@@ -617,18 +617,19 @@ const applyEdits = (source: string, edits: Edit[]): string => {
 /**
  * Extracts the inner body of each handler's `async (c) => { ... }` block, keyed
  * by handler name. Used by the `full` strategy to splice user bodies back into a
- * freshly-regenerated wrapper. Returns an empty map on parse failure or when
- * typescript is unavailable.
+ * freshly-regenerated wrapper. Returns `undefined` when the source can't be
+ * parsed (or typescript is unavailable) — distinct from an empty map (parsed, no
+ * handlers) — so callers can preserve the file instead of dropping its bodies.
  */
 export const extractHandlerBodies = async (
   source: string,
-): Promise<Map<string, string>> => {
-  const bodies = new Map<string, string>();
-  if (!(await ensureTypeScript())) return bodies;
+): Promise<Map<string, string> | undefined> => {
+  if (!(await ensureTypeScript())) return undefined;
 
   const sourceFile = parse(source);
-  if (!sourceFile) return bodies;
+  if (!sourceFile) return undefined;
 
+  const bodies = new Map<string, string>();
   for (const { name, call } of findHandlers(sourceFile)) {
     // The handler is the LAST function argument (earlier ones may be inline
     // middleware), so its body — not a middleware's — is what `full` splices.

--- a/packages/hono/src/handler-merge.ts
+++ b/packages/hono/src/handler-merge.ts
@@ -164,6 +164,11 @@ const isPlainNamedImport = (declaration: TS.ImportDeclaration): boolean => {
 const setEquals = (a: string[], b: string[]): boolean =>
   a.length === b.length && a.every((value) => b.includes(value));
 
+// Escape regex metacharacters so an identifier can be interpolated literally.
+// JS identifiers may contain `$`, which would otherwise act as an anchor.
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
 /**
  * The local binding name an imported symbol is bound to, honouring aliases —
  * e.g. `import { zValidator as zv }` → `'zv'`. Returns undefined when the symbol
@@ -389,7 +394,7 @@ export const reconcileHandlerFile = async (
   // (not as `Ns.Name`), is a schema a reconciled validator now references
   // (inserted or renamed), or is used by an appended handler stub.
   const referencedBare = (name: string): boolean =>
-    new RegExp(String.raw`(?<!\.)\b${name}\b`).test(bodySource);
+    new RegExp(String.raw`(?<!\.)\b${escapeRegExp(name)}\b`).test(bodySource);
   const inAppendedStub = (name: string): boolean =>
     toAppend.some((handler) => handler.stub.includes(name));
   const needsBareContext = (name: string): boolean =>

--- a/packages/hono/src/handler-merge.ts
+++ b/packages/hono/src/handler-merge.ts
@@ -274,7 +274,12 @@ export const reconcileHandlerFile = async (
     collectRenames?: Map<string, string>,
   ) => {
     if (!existing) {
-      const toInsert = augment ? names.filter((name) => augment(name)) : names;
+      // Never insert a name that is already bound bare elsewhere (e.g. a default
+      // or namespace import from another module) — that would create a duplicate
+      // binding.
+      const toInsert = (
+        augment ? names.filter((name) => augment(name)) : names
+      ).filter((name) => !isImportedBare(name));
       if (toInsert.length > 0) {
         pendingInsertions.push(renderImport({ names: toInsert, module }));
       }
@@ -475,9 +480,13 @@ export const reconcileHandlerFile = async (
 
   if (pendingInsertions.length > 0) {
     const lastImport = importDeclarations.at(-1);
-    const insertPos = lastImport
-      ? source.indexOf('\n', lastImport.getEnd()) + 1
-      : 0;
+    let insertPos = 0;
+    if (lastImport) {
+      // Guard the EOF case: when the last import has no trailing newline,
+      // indexOf returns -1 and `+ 1` would prepend to the top of the file.
+      const newline = source.indexOf('\n', lastImport.getEnd());
+      insertPos = newline === -1 ? source.length : newline + 1;
+    }
     edits.push({
       start: insertPos,
       end: insertPos,
@@ -567,7 +576,13 @@ const validatorInsertPos = (
   const handler = call.arguments.findLast(
     (arg) => ts.isArrowFunction(arg) || ts.isFunctionExpression(arg),
   );
-  if (handler) return lineStart(source, handler.getStart(sourceFile));
+  if (handler) {
+    // Insert at the handler's line start when it's on its own line; otherwise
+    // (single-line `createHandlers(async (c) => {})`) insert right before it so
+    // the validator isn't pushed to the start of the statement.
+    const start = handler.getStart(sourceFile);
+    return startsLine(source, start) ? lineStart(source, start) : start;
+  }
   // No trailing handler found — insert just before the closing paren.
   return call.getEnd() - 1;
 };

--- a/packages/hono/src/handler-merge.ts
+++ b/packages/hono/src/handler-merge.ts
@@ -271,6 +271,7 @@ export const reconcileHandlerFile = async (
     module: string,
     isOrvalName: (name: string) => boolean,
     augment?: (name: string) => boolean,
+    collectRenames?: Map<string, string>,
   ) => {
     if (!existing) {
       const toInsert = augment ? names.filter((name) => augment(name)) : names;
@@ -307,6 +308,18 @@ export const reconcileHandlerFile = async (
       return;
     }
 
+    // Record the camelCase→PascalCase migrations this rewrite implies, so every
+    // OTHER reference to the old binding (validator args, `z.infer<typeof X>` in
+    // bodies, etc.) can be renamed too — not just the import itself.
+    if (collectRenames) {
+      for (const old of importedNames(existing)) {
+        const next = names.find(
+          (name) => name !== old && name.toLowerCase() === old.toLowerCase(),
+        );
+        if (next) collectRenames.set(old, next);
+      }
+    }
+
     edits.push({
       start: existing.getStart(sourceFile),
       end: existing.getEnd(),
@@ -327,6 +340,7 @@ export const reconcileHandlerFile = async (
     : 'zValidator';
 
   const requiredSchemas = new Set<string>();
+  const removedValidatorRanges: [number, number][] = [];
   for (const desiredHandler of desired.handlers) {
     const parsed = handlers.find(
       (handler) => handler.name === desiredHandler.handlerName,
@@ -340,9 +354,14 @@ export const reconcileHandlerFile = async (
         edits,
         zValidatorName,
         requiredSchemas,
+        removedValidatorRanges,
       );
     }
   }
+
+  // Schema migrations (old camelCase → new PascalCase) implied by rewriting the
+  // zod import; applied file-wide below so every reference is migrated.
+  const schemaRenames = new Map<string, string>();
 
   const toAppend = desired.handlers.filter(
     (handler) => !existingNames.has(handler.handlerName),
@@ -415,7 +434,44 @@ export const reconcileHandlerFile = async (
     zodModule,
     (name) => zodLower.has(name.toLowerCase()),
     needsBareZod,
+    schemaRenames,
   );
+
+  // Apply the schema migrations file-wide: rename every remaining reference to a
+  // migrated schema (validator args, `z.infer<typeof X>` in bodies, helper code).
+  // The import is rewritten above (its decl range is skipped here); ranges of
+  // removed validators are skipped too (their args are already deleted).
+  if (schemaRenames.size > 0) {
+    const inSkippedRange = (pos: number): boolean =>
+      importDeclarations.some(
+        (declaration) =>
+          pos >= declaration.getStart(sourceFile) && pos < declaration.getEnd(),
+      ) ||
+      removedValidatorRanges.some(([start, end]) => pos >= start && pos < end);
+
+    const renameReferences = (node: TS.Node): void => {
+      if (ts.isIdentifier(node)) {
+        const replacement = schemaRenames.get(node.text);
+        if (replacement) {
+          const parent = node.parent;
+          const isMemberName =
+            ts.isPropertyAccessExpression(parent) && parent.name === node;
+          const isDeclarationName =
+            (ts.isVariableDeclaration(parent) && parent.name === node) ||
+            (ts.isParameter(parent) && parent.name === node) ||
+            (ts.isBindingElement(parent) && parent.name === node) ||
+            (ts.isPropertyAssignment(parent) && parent.name === node) ||
+            (ts.isPropertySignature(parent) && parent.name === node);
+          const start = node.getStart(sourceFile);
+          if (!isMemberName && !isDeclarationName && !inSkippedRange(start)) {
+            edits.push({ start, end: node.getEnd(), text: replacement });
+          }
+        }
+      }
+      ts.forEachChild(node, renameReferences);
+    };
+    renameReferences(sourceFile);
+  }
 
   if (pendingInsertions.length > 0) {
     const lastImport = importDeclarations.at(-1);
@@ -448,12 +504,9 @@ const reconcileValidators = (
   edits: Edit[],
   zValidatorName: string,
   requiredSchemas: Set<string>,
+  removedRanges: [number, number][],
 ) => {
-  const existing: {
-    target: string;
-    arg: TS.CallExpression;
-    schema?: TS.Node;
-  }[] = [];
+  const existing: { target: string; arg: TS.CallExpression }[] = [];
 
   for (const arg of call.arguments) {
     if (
@@ -467,7 +520,7 @@ const reconcileValidators = (
         ts.isStringLiteralLike(target) &&
         VALIDATOR_TARGETS.has(target.text)
       ) {
-        existing.push({ target: target.text, arg, schema: arg.arguments[1] });
+        existing.push({ target: target.text, arg });
       }
     }
   }
@@ -477,26 +530,14 @@ const reconcileValidators = (
   );
   const existingByTarget = new Set(existing.map((item) => item.target));
 
+  // Remove validators the spec no longer requires. (Schema RENAMES — e.g.
+  // camelCase→PascalCase — are handled by the file-wide rename pass driven by the
+  // zod-import rewrite, so every reference is migrated, not just the arg here.)
   for (const item of existing) {
-    const want = desiredByTarget.get(item.target as ValidatorTarget);
-    if (!want) {
-      edits.push(removeArgumentEdit(sourceFile, source, item.arg));
-    } else if (
-      item.schema &&
-      ts.isIdentifier(item.schema) &&
-      item.schema.text !== want.schema &&
-      // Only migrate a pure case change of the SAME schema (camelCase →
-      // PascalCase). Never rewrite a user-chosen alias or a different identifier.
-      item.schema.text.toLowerCase() === want.schema.toLowerCase()
-    ) {
-      edits.push({
-        start: item.schema.getStart(sourceFile),
-        end: item.schema.getEnd(),
-        text: want.schema,
-      });
-      // The validator now references the PascalCase name, so it must be
-      // importable bare even if the old import can't be safely rewritten.
-      requiredSchemas.add(want.schema);
+    if (!desiredByTarget.has(item.target as ValidatorTarget)) {
+      const edit = removeArgumentEdit(sourceFile, source, item.arg);
+      edits.push(edit);
+      removedRanges.push([edit.start, edit.end]);
     }
   }
 

--- a/packages/hono/src/index.no-typescript.test.ts
+++ b/packages/hono/src/index.no-typescript.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { GeneratorVerbOptions } from '@orval/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { logWarningSpy } = vi.hoisted(() => ({ logWarningSpy: vi.fn() }));
+
+vi.mock('@orval/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@orval/core')>();
+  return { ...actual, logWarning: logWarningSpy };
+});
+
+// Simulate the optional `typescript` peer dependency being absent.
+vi.mock('./handler-merge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./handler-merge')>();
+  return { ...actual, ensureTypeScript: vi.fn().mockResolvedValue(false) };
+});
+
+import { generateHandlerFile } from './index';
+
+const verb = (operationName: string): GeneratorVerbOptions =>
+  ({
+    operationName,
+    params: [],
+    body: { definition: '' },
+    response: { originalSchema: {} },
+  }) as unknown as GeneratorVerbOptions;
+
+const existing = `import { custom } from './x';
+const factory = createFactory();
+export const listPetsHandlers = factory.createHandlers(
+  async (c) => {
+    return c.json(custom());
+  },
+);
+`;
+
+describe('generateHandlerFile when typescript is unavailable', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'orval-hono-nots-'));
+    logWarningSpy.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const run = async (strategy: 'smart' | 'full') => {
+    const file = path.join(dir, 'listPets.ts');
+    await writeFile(file, existing, 'utf8');
+    return generateHandlerFile({
+      verbs: [verb('listPets')],
+      path: file,
+      header: '/* eslint-disable */\n',
+      zodModule: path.join(dir, 'endpoints.zod'),
+      contextModule: path.join(dir, 'endpoints.context'),
+      strategy,
+    });
+  };
+
+  it('smart falls back to leaving the file unchanged and warns', async () => {
+    const result = await run('smart');
+    expect(result).toBe(existing);
+    expect(logWarningSpy).toHaveBeenCalled();
+  });
+
+  it('full also falls back to leaving the file unchanged', async () => {
+    const result = await run('full');
+    expect(result).toBe(existing);
+  });
+});

--- a/packages/hono/src/index.no-typescript.test.ts
+++ b/packages/hono/src/index.no-typescript.test.ts
@@ -18,8 +18,6 @@ vi.mock('./handler-merge', async (importOriginal) => {
   return { ...actual, ensureTypeScript: vi.fn().mockResolvedValue(false) };
 });
 
-import { generateHandlerFile } from './index';
-
 const verb = (operationName: string): GeneratorVerbOptions =>
   ({
     operationName,
@@ -43,6 +41,10 @@ describe('generateHandlerFile when typescript is unavailable', () => {
   beforeEach(async () => {
     dir = await mkdtemp(path.join(tmpdir(), 'orval-hono-nots-'));
     logWarningSpy.mockClear();
+    // The "warn once" guard is module-scoped state in ./index. Reset the module
+    // registry so each test gets a fresh guard and the warning assertion below
+    // doesn't depend on test order.
+    vi.resetModules();
   });
 
   afterEach(async () => {
@@ -50,6 +52,7 @@ describe('generateHandlerFile when typescript is unavailable', () => {
   });
 
   const run = async (strategy: 'smart' | 'full') => {
+    const { generateHandlerFile } = await import('./index');
     const file = path.join(dir, 'listPets.ts');
     await writeFile(file, existing, 'utf8');
     return generateHandlerFile({

--- a/packages/hono/src/index.test.ts
+++ b/packages/hono/src/index.test.ts
@@ -1,91 +1,129 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
-import { extractExistingHandlerBodies } from './index';
+import type { GeneratorVerbOptions } from '@orval/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-describe('extractExistingHandlerBodies', () => {
-  it('returns the body of each handler keyed by name', () => {
-    const source = `
+import { generateHandlerFile } from './index';
+
+const verb = (operationName: string): GeneratorVerbOptions =>
+  ({
+    operationName,
+    params: [],
+    body: { definition: '' },
+    response: { originalSchema: {} },
+  }) as unknown as GeneratorVerbOptions;
+
+// A handler the user has filled in: a custom import, middleware in the chain, a
+// distinctive body marker, and a top-level helper — none of which orval owns.
+const userHandler = `import { getPets } from './db';
 import { createFactory } from 'hono/factory';
+import { ListPetsContext } from './endpoints.context';
 
 const factory = createFactory();
+
 export const listPetsHandlers = factory.createHandlers(
+  authenticate(),
   async (c: ListPetsContext) => {
-    return c.json([]);
+    return c.json(await loadPets()); // BODY_MARKER
   },
 );
-export const createPetsHandlers = factory.createHandlers(
-  zValidator('json', CreatePetsBody),
-  async (c: CreatePetsContext) => {},
-);
+
+async function loadPets() {
+  return getPets(); // HELPER_BODY
+}
 `;
 
-    const bodies = extractExistingHandlerBodies(source);
+describe('generateHandlerFile strategies', () => {
+  let dir: string;
 
-    expect([...bodies.keys()]).toEqual([
-      'listPetsHandlers',
-      'createPetsHandlers',
-    ]);
-    expect(bodies.get('listPetsHandlers')).toContain('return c.json([]);');
-    expect(bodies.get('createPetsHandlers')).toBe('');
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'orval-hono-'));
   });
 
-  it('preserves nested syntax inside the handler body', () => {
-    const source = `export const listPetsHandlers = factory.createHandlers(
-  async (c: ListPetsContext) => {
-    const limit = Number(c.req.query('limit') ?? 10);
-    if (limit > 0) { return c.json({ items: pets.slice(0, limit) }); }
-  },
-);`;
-
-    const body = extractExistingHandlerBodies(source).get('listPetsHandlers');
-    expect(body).toContain("Number(c.req.query('limit') ?? 10)");
-    expect(body).toContain('{ items: pets.slice(0, limit) }');
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
   });
 
-  it('is not confused by parentheses or braces inside strings, templates, comments, and regex', () => {
-    const source = `export const trickyHandlers = factory.createHandlers(
-  async (c: TrickyContext) => {
-    const a = ")"; // a paren in a string — must not close the call
-    const b = '}';
-    const c1 = \`tpl ) { } \${'} )'} end\`;
-    const re = /\\)\\}\\(/g;
-    /* block comment with ) and } and ( */
-    // line comment with ) }
-    return c.text(a + b + c1);
-  },
-);`;
-
-    const body = extractExistingHandlerBodies(source).get('trickyHandlers');
-    expect(body).toBeDefined();
-    expect(body).toContain('return c.text(a + b + c1);');
-    expect(body).toContain('/* block comment with ) and } and ( */');
+  const args = (file: string, strategy: 'smart' | 'skip' | 'full') => ({
+    verbs: [verb('listPets')],
+    path: file,
+    header: '/* eslint-disable */\n',
+    zodModule: path.join(dir, 'endpoints.zod'),
+    contextModule: path.join(dir, 'endpoints.context'),
+    strategy,
   });
 
-  it('preserves bodies containing nested arrow functions', () => {
-    const source = `export const listPetsHandlers = factory.createHandlers(
-  async (c: ListPetsContext) => {
-    const ids = pets.map((p) => p.id);
-    return c.json(ids);
-  },
-);`;
+  const writeHandler = async (content = userHandler) => {
+    const file = path.join(dir, 'listPets.ts');
+    await writeFile(file, content, 'utf8');
+    return file;
+  };
 
-    const body = extractExistingHandlerBodies(source).get('listPetsHandlers');
-    expect(body).toContain('pets.map((p) => p.id)');
-    expect(body).toContain('return c.json(ids);');
+  it('generates a fresh file when none exists (any strategy)', async () => {
+    const file = path.join(dir, 'listPets.ts');
+    const result = await generateHandlerFile(args(file, 'smart'));
+
+    expect(result).toContain("import { createFactory } from 'hono/factory';");
+    expect(result).toContain('const factory = createFactory();');
+    expect(result).toContain(
+      'export const listPetsHandlers = factory.createHandlers(',
+    );
   });
 
-  it('preserves bodies containing regex literals after keywords', () => {
-    const source = `export const listPetsHandlers = factory.createHandlers(
-  async (c: ListPetsContext) => {
-    return /[)]/.test(c.req.query('q') ?? '');
-  },
-);`;
-
-    const body = extractExistingHandlerBodies(source).get('listPetsHandlers');
-    expect(body).toContain('/[)]/.test');
+  it('skip: returns an existing file byte-for-byte', async () => {
+    const file = await writeHandler();
+    const result = await generateHandlerFile(args(file, 'skip'));
+    expect(result).toBe(userHandler);
   });
 
-  it('returns an empty map when no handlers are present', () => {
-    expect(extractExistingHandlerBodies('// nothing here').size).toBe(0);
+  it('smart (regenerate, no clean): preserves custom imports, middleware, helpers, and body', async () => {
+    const file = await writeHandler();
+    const result = await generateHandlerFile(args(file, 'smart'));
+
+    expect(result).toContain("import { getPets } from './db';"); // custom import
+    expect(result).toContain('authenticate(),'); // middleware
+    expect(result).toContain('async function loadPets() {'); // top-level helper
+    expect(result).toContain('HELPER_BODY');
+    expect(result).toContain('BODY_MARKER'); // handler body
+  });
+
+  it('full: keeps the body but drops custom imports, middleware, and helpers', async () => {
+    const file = await writeHandler();
+    const result = await generateHandlerFile(args(file, 'full'));
+
+    expect(result).toContain('BODY_MARKER'); // body spliced back
+    expect(result).not.toContain("import { getPets } from './db';");
+    expect(result).not.toContain('authenticate(),');
+    expect(result).not.toContain('async function loadPets()');
+  });
+
+  it('uses zValidator("form") for multipart/form-data bodies', async () => {
+    const file = path.join(dir, 'uploadPhoto.ts');
+    const formVerb = {
+      operationName: 'uploadPhoto',
+      params: [],
+      body: {
+        definition: 'UploadPhotoBody',
+        contentType: 'multipart/form-data',
+      },
+      response: { originalSchema: {} },
+      pathRoute: '/photo',
+      tags: ['default'],
+    } as unknown as GeneratorVerbOptions;
+
+    const result = await generateHandlerFile({
+      verbs: [formVerb],
+      path: file,
+      header: '/* eslint-disable */\n',
+      validatorModule: path.join(dir, 'endpoints.validator'),
+      zodModule: path.join(dir, 'endpoints.zod'),
+      contextModule: path.join(dir, 'endpoints.context'),
+      strategy: 'smart',
+    });
+
+    expect(result).toContain("zValidator('form', UploadPhotoBody)");
+    expect(result).not.toContain("zValidator('json'");
   });
 });

--- a/packages/hono/src/index.test.ts
+++ b/packages/hono/src/index.test.ts
@@ -99,6 +99,16 @@ describe('generateHandlerFile strategies', () => {
     expect(result).not.toContain('async function loadPets()');
   });
 
+  it('full: preserves an unparseable file instead of regenerating with empty bodies', async () => {
+    // Body extraction returns `undefined` (not an empty map) when the file
+    // can't be parsed. Full mode must fall back to leaving the file untouched
+    // rather than rebuilding the wrapper and dropping the user's logic.
+    const broken = `${userHandler}\nexport const oops = factory.createHandlers(`;
+    const file = await writeHandler(broken);
+    const result = await generateHandlerFile(args(file, 'full'));
+    expect(result).toBe(broken);
+  });
+
   it('uses zValidator("form") for multipart/form-data bodies', async () => {
     const file = path.join(dir, 'uploadPhoto.ts');
     const formVerb = {

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -15,9 +15,11 @@ import {
   getFileInfo,
   getOrvalGeneratedTypes,
   getParamsInPath,
+  type HonoHandlerStrategy,
   isObject,
   jsDoc,
   kebab,
+  logWarning,
   type NormalizedMutator,
   type NormalizedOutputOptions,
   type OpenApiInfoObject,
@@ -28,6 +30,17 @@ import {
 import { generateZod } from '@orval/zod';
 import fs from 'fs-extra';
 
+import {
+  type DesiredImports,
+  type DesiredValidator,
+  ensureTypeScript,
+  extractHandlerBodies,
+  reconcileHandlerFile,
+} from './handler-merge';
+
+// Warn at most once per run when the optional `typescript` peer is missing and a
+// non-`skip` strategy was requested, so the degraded behavior is never silent.
+let warnedMissingTypeScript = false;
 import { getRoute } from './route';
 
 const ZVALIDATOR_SOURCE = fs
@@ -169,6 +182,72 @@ export const generateHono: ClientBuilder = (verbOptions, options) => {
  */
 const DEFAULT_HANDLER_BODY = '\n\n  ';
 
+const FORM_CONTENT_TYPES = new Set([
+  'multipart/form-data',
+  'application/x-www-form-urlencoded',
+]);
+
+/**
+ * Whether a request body uses a form encoding. Hono validates these with
+ * `zValidator('form', …)` against `c.req.parseBody()`, not `'json'`.
+ */
+const isFormBody = (body: GeneratorVerbOptions['body']): boolean =>
+  FORM_CONTENT_TYPES.has(body.contentType);
+
+/**
+ * getDesiredValidators returns the `zValidator` targets (and their PascalCase zod
+ * schema identifiers) required by a verb, in canonical order. This is the single
+ * source of truth shared by fresh generation and the `smart` reconcile.
+ */
+const getDesiredValidators = (
+  verbOption: GeneratorVerbOptions,
+  validator: boolean | 'hono' | NormalizedMutator,
+): DesiredValidator[] => {
+  if (!validator) return [];
+
+  const pascalOperationName = pascal(verbOption.operationName);
+  const validators: DesiredValidator[] = [];
+
+  if (verbOption.headers) {
+    validators.push({
+      target: 'header',
+      schema: `${pascalOperationName}Header`,
+    });
+  }
+  if (verbOption.params.length > 0) {
+    validators.push({
+      target: 'param',
+      schema: `${pascalOperationName}Params`,
+    });
+  }
+  if (verbOption.queryParams) {
+    validators.push({
+      target: 'query',
+      schema: `${pascalOperationName}QueryParams`,
+    });
+  }
+  if (verbOption.body.definition) {
+    validators.push({
+      target: isFormBody(verbOption.body) ? 'form' : 'json',
+      schema: `${pascalOperationName}Body`,
+    });
+  }
+  if (
+    validator !== 'hono' &&
+    verbOption.response.originalSchema?.['200']?.content?.[
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      'application/json'
+    ]
+  ) {
+    validators.push({
+      target: 'response',
+      schema: `${pascalOperationName}Response`,
+    });
+  }
+
+  return validators;
+};
+
 const getHonoHandlers = (
   ...opts: {
     handlerName: string;
@@ -176,10 +255,8 @@ const getHonoHandlers = (
     verbOption: GeneratorVerbOptions;
     validator: boolean | 'hono' | NormalizedMutator;
     /**
-     * Optional async-handler body to splice into the generated wrapper. When
-     * supplied the validator chain is still rebuilt from the current verb
-     * options, but the body inside `async (c) => { ... }` is taken verbatim
-     * from the existing file so user logic survives regeneration.
+     * Optional async-handler body to splice into the generated wrapper. Used by
+     * the `full` strategy to preserve user logic across regeneration.
      */
     bodyOverride?: string;
   }[]
@@ -199,33 +276,9 @@ const getHonoHandlers = (
     validator,
     bodyOverride,
   } of opts) {
-    let currentValidator = '';
-
-    if (validator) {
-      const pascalOperationName = pascal(verbOption.operationName);
-
-      if (verbOption.headers) {
-        currentValidator += `zValidator('header', ${pascalOperationName}Header),\n`;
-      }
-      if (verbOption.params.length > 0) {
-        currentValidator += `zValidator('param', ${pascalOperationName}Params),\n`;
-      }
-      if (verbOption.queryParams) {
-        currentValidator += `zValidator('query', ${pascalOperationName}QueryParams),\n`;
-      }
-      if (verbOption.body.definition) {
-        currentValidator += `zValidator('json', ${pascalOperationName}Body),\n`;
-      }
-      if (
-        validator !== 'hono' &&
-        verbOption.response.originalSchema?.['200']?.content?.[
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          'application/json'
-        ]
-      ) {
-        currentValidator += `zValidator('response', ${pascalOperationName}Response),\n`;
-      }
-    }
+    const currentValidator = getDesiredValidators(verbOption, validator)
+      .map((v) => `zValidator('${v.target}', ${v.schema}),\n`)
+      .join('');
 
     const body = bodyOverride ?? DEFAULT_HANDLER_BODY;
 
@@ -307,34 +360,76 @@ const getVerbOptionGroupByTag = (
   return grouped;
 };
 
-const generateHandlerFile = async ({
-  verbs,
+/** Computes the orval-owned imports a handler file should contain. */
+const buildDesiredImports = ({
+  verbList,
+  path,
+  validatorModule,
+  zodModule,
+  contextModule,
+  validator,
+}: {
+  verbList: GeneratorVerbOptions[];
+  path: string;
+  validatorModule?: string;
+  zodModule: string;
+  contextModule: string;
+  validator: boolean | 'hono';
+}): DesiredImports => {
+  const contextNames = verbList.map(
+    (verb) => `${pascal(verb.operationName)}Context`,
+  );
+  const zodNames = verbList.flatMap((verb) =>
+    getDesiredValidators(verb, validator).map((v) => v.schema),
+  );
+  const hasValidators = zodNames.length > 0;
+
+  return {
+    factory: { names: ['createFactory'], module: 'hono/factory' },
+    validator:
+      hasValidators && validatorModule != undefined
+        ? {
+            names: ['zValidator'],
+            module: generateModuleSpecifier(path, validatorModule),
+          }
+        : undefined,
+    context: {
+      names: contextNames,
+      module: generateModuleSpecifier(path, contextModule),
+    },
+    zod: hasValidators
+      ? { names: zodNames, module: generateModuleSpecifier(path, zodModule) }
+      : undefined,
+  };
+};
+
+/** Generates a complete handler file from scratch (no existing file to merge). */
+const generateFreshHandlerFile = ({
+  verbList,
   path,
   header,
   validatorModule,
   zodModule,
   contextModule,
+  validator,
+  bodyFor,
 }: {
-  verbs: GeneratorVerbOptions[];
+  verbList: GeneratorVerbOptions[];
   path: string;
   header: string;
   validatorModule?: string;
   zodModule: string;
   contextModule: string;
-}) => {
-  const validator =
-    validatorModule === '@hono/zod-validator'
-      ? ('hono' as const)
-      : validatorModule != undefined;
-
-  const verbList = Object.values(verbs);
-
-  const [, hasZValidator] = getHonoHandlers(
+  validator: boolean | 'hono';
+  bodyFor?: (operationName: string) => string | undefined;
+}): string => {
+  const [handlerCode, hasZValidator] = getHonoHandlers(
     ...verbList.map((verbOption) => ({
       handlerName: `${verbOption.operationName}Handlers`,
       contextTypeName: `${pascal(verbOption.operationName)}Context`,
       verbOption,
       validator,
+      bodyOverride: bodyFor?.(verbOption.operationName),
     })),
   );
 
@@ -362,269 +457,108 @@ const generateHandlerFile = async ({
     );
   }
 
-  const preamble = `${header}${imports.filter((imp) => imp !== '').join('\n')}\n\nconst factory = createFactory();`;
-
-  const existingBodies = fs.existsSync(path)
-    ? extractExistingHandlerBodies(await fs.readFile(path, 'utf8'))
-    : new Map<string, string>();
-
-  // Always rebuild the preamble (header + imports + factory) and the validator
-  // chain from current metadata so import paths, casing, and middleware match
-  // the latest configuration. We only splice the user-authored async body
-  // back in — preserving the wrapper would risk keeping stale `zValidator`
-  // calls whose imports we just rewrote.
-  const [handlerCode] = getHonoHandlers(
-    ...verbList.map((verbOption) => ({
-      handlerName: `${verbOption.operationName}Handlers`,
-      contextTypeName: `${pascal(verbOption.operationName)}Context`,
-      verbOption,
-      validator,
-      bodyOverride: existingBodies.get(`${verbOption.operationName}Handlers`),
-    })),
-  );
-
-  return `${preamble}${handlerCode}`;
+  return `${header}${imports.filter((imp) => imp !== '').join('\n')}\n\nconst factory = createFactory();${handlerCode}`;
 };
 
 /**
- * extractExistingHandlerBodies scans a previously generated handler file and
- * returns the user-authored body of each
- * `async (c: ...) => { /* body *\/ }` block keyed by handler name.
+ * Generates or updates a handler file according to `strategy`:
  *
- * We deliberately preserve only the inner body — not the surrounding
- * `factory.createHandlers(...)` call — so the regenerated wrapper always
- * reflects the current validator chain and imports. The scanner is
- * lex-aware: it skips strings, template literals, regex literals, and
- * comments while counting parentheses/braces, so user code containing
- * `)` or `}` characters in those contexts does not confuse the matcher.
+ * - a non-existent file is always freshly generated;
+ * - `skip` leaves an existing file byte-for-byte unchanged;
+ * - `full` rebuilds the preamble + validator chain and splices back user bodies
+ *   (drops custom imports/middleware/helpers — the thin-handler model);
+ * - `smart` non-destructively reconciles orval-owned imports + validators and
+ *   appends handlers for new operations, preserving all user-authored code.
  */
-export const extractExistingHandlerBodies = (
-  source: string,
-): Map<string, string> => {
-  const bodies = new Map<string, string>();
-  const exportRegex =
-    /export\s+const\s+(\w+Handlers)\s*=\s*factory\.createHandlers\s*\(/g;
+export const generateHandlerFile = async ({
+  verbs,
+  path,
+  header,
+  validatorModule,
+  zodModule,
+  contextModule,
+  strategy,
+}: {
+  verbs: GeneratorVerbOptions[];
+  path: string;
+  header: string;
+  validatorModule?: string;
+  zodModule: string;
+  contextModule: string;
+  strategy: HonoHandlerStrategy;
+}) => {
+  const validator =
+    validatorModule === '@hono/zod-validator'
+      ? ('hono' as const)
+      : validatorModule != undefined;
 
-  let match: RegExpExecArray | null;
-  while ((match = exportRegex.exec(source)) !== null) {
-    const handlerName = match[1];
-    const callOpenIdx = match.index + match[0].length - 1; // points at '('
-    const callCloseIdx = findMatchingClose(source, callOpenIdx, '(', ')');
-    if (callCloseIdx === -1) continue;
+  const verbList = Object.values(verbs);
 
-    const callBody = source.slice(callOpenIdx + 1, callCloseIdx);
-    const body = extractAsyncArrowBody(callBody);
-    if (body !== undefined) {
-      bodies.set(handlerName, body);
-    }
+  if (!fs.existsSync(path)) {
+    return generateFreshHandlerFile({
+      verbList,
+      path,
+      header,
+      validatorModule,
+      zodModule,
+      contextModule,
+      validator,
+    });
   }
 
-  return bodies;
-};
+  const source = await fs.readFile(path, 'utf8');
 
-/**
- * findMatchingClose returns the index of the closing bracket that pairs with
- * the opening bracket at `openIdx`, or -1 if unbalanced. The scan skips
- * strings, template literals, regex literals, and comments so brackets in
- * those contexts do not affect depth.
- */
-const findMatchingClose = (
-  source: string,
-  openIdx: number,
-  open: '(' | '{',
-  close: ')' | '}',
-): number => {
-  let depth = 0;
-  let i = openIdx;
-  while (i < source.length) {
-    const ch = source[i];
-    const next = source[i + 1];
-
-    // Line comment
-    if (ch === '/' && next === '/') {
-      const nl = source.indexOf('\n', i + 2);
-      i = nl === -1 ? source.length : nl + 1;
-      continue;
-    }
-    // Block comment
-    if (ch === '/' && next === '*') {
-      const end = source.indexOf('*/', i + 2);
-      i = end === -1 ? source.length : end + 2;
-      continue;
-    }
-    // String / template literal
-    if (ch === "'" || ch === '"' || ch === '`') {
-      i = skipString(source, i, ch);
-      continue;
-    }
-    // Regex literal — only when a regex is syntactically possible. A `/`
-    // following an identifier or closing bracket is division, not a regex.
-    if (ch === '/' && isRegexContext(source, i)) {
-      i = skipRegex(source, i);
-      continue;
-    }
-
-    if (ch === open) depth++;
-    else if (ch === close) {
-      depth--;
-      if (depth === 0) return i;
-    }
-    i++;
-  }
-  return -1;
-};
-
-const skipString = (
-  source: string,
-  start: number,
-  quote: "'" | '"' | '`',
-): number => {
-  let i = start + 1;
-  while (i < source.length) {
-    const ch = source[i];
-    if (ch === '\\') {
-      i += 2;
-      continue;
-    }
-    if (quote === '`' && ch === '$' && source[i + 1] === '{') {
-      const end = findMatchingClose(source, i + 1, '{', '}');
-      i = end === -1 ? source.length : end + 1;
-      continue;
-    }
-    if (ch === quote) return i + 1;
-    i++;
-  }
-  return source.length;
-};
-
-const skipRegex = (source: string, start: number): number => {
-  let i = start + 1;
-  let inClass = false;
-  while (i < source.length) {
-    const ch = source[i];
-    if (ch === '\\') {
-      i += 2;
-      continue;
-    }
-    if (ch === '[') inClass = true;
-    else if (ch === ']') inClass = false;
-    else if (ch === '/' && !inClass) {
-      i++;
-      while (i < source.length && /[gimsuy]/.test(source[i])) i++;
-      return i;
-    }
-    if (ch === '\n') return start + 1; // not a regex after all; bail
-    i++;
-  }
-  return source.length;
-};
-
-const REGEX_PRECEDING_KEYWORDS = new Set([
-  'return',
-  'throw',
-  'yield',
-  'await',
-  'case',
-  'new',
-  'typeof',
-  'void',
-  'delete',
-  'in',
-  'of',
-  'instanceof',
-]);
-
-const isRegexContext = (source: string, slashIdx: number): boolean => {
-  let j = slashIdx - 1;
-  while (
-    j >= 0 &&
-    (source[j] === ' ' || source[j] === '\t' || source[j] === '\n')
-  ) {
-    j--;
-  }
-  if (j < 0) return true;
-
-  const c = source[j];
-
-  // Spread `...` allows a regex literal as the spread target.
-  if (c === '.') {
-    if (j >= 2 && source[j - 1] === '.' && source[j - 2] === '.') return true;
-    return false;
+  if (strategy === 'skip') {
+    return source;
   }
 
-  // Identifier char: scan backward to extract token, check keyword set.
-  if (/[A-Za-z0-9_$]/.test(c)) {
-    let k = j;
-    while (k >= 0 && /[A-Za-z0-9_$]/.test(source[k])) k--;
-    const token = source.slice(k + 1, j + 1);
-    return REGEX_PRECEDING_KEYWORDS.has(token);
+  // `smart` and `full` parse the existing file with the TypeScript compiler API.
+  // typescript is an optional peer dependency; without it we cannot safely
+  // reconcile or splice, so we preserve the existing file untouched and warn.
+  if (!(await ensureTypeScript())) {
+    if (!warnedMissingTypeScript) {
+      warnedMissingTypeScript = true;
+      logWarning(
+        `hono handlerGenerationStrategy '${strategy}' requires the optional peer dependency "typescript", which is not installed. Existing handler files are left unchanged (as with 'skip'). Install typescript to enable handler reconciliation.`,
+      );
+    }
+    return source;
   }
 
-  // Closing brackets imply a value precedes — division.
-  if (c === ')' || c === ']') return false;
-
-  return true;
-};
-
-/**
- * extractAsyncArrowBody finds the trailing `async (c: ...) => { ... }`
- * argument inside `factory.createHandlers(...)` and returns the inner body
- * (without the surrounding braces). Returns undefined when the call does not
- * end with the expected arrow function shape.
- */
-const extractAsyncArrowBody = (callBody: string): string | undefined => {
-  // Walk the argument list at depth 0 only, skipping strings, templates,
-  // regex literals, comments, and nested parens/braces, so arrows inside
-  // user-authored callbacks (e.g. `pets.map(p => p.id)`) are ignored.
-  let i = 0;
-  let lastTopLevelArrow = -1;
-  while (i < callBody.length) {
-    const ch = callBody[i];
-    const next = callBody[i + 1];
-
-    if (ch === '/' && next === '/') {
-      const nl = callBody.indexOf('\n', i + 2);
-      i = nl === -1 ? callBody.length : nl + 1;
-      continue;
-    }
-    if (ch === '/' && next === '*') {
-      const end = callBody.indexOf('*/', i + 2);
-      i = end === -1 ? callBody.length : end + 2;
-      continue;
-    }
-    if (ch === "'" || ch === '"' || ch === '`') {
-      i = skipString(callBody, i, ch);
-      continue;
-    }
-    if (ch === '/' && isRegexContext(callBody, i)) {
-      i = skipRegex(callBody, i);
-      continue;
-    }
-    if (ch === '(' || ch === '{') {
-      const open = ch;
-      const close = ch === '(' ? ')' : '}';
-      const end = findMatchingClose(callBody, i, open, close);
-      i = end === -1 ? callBody.length : end + 1;
-      continue;
-    }
-    if (ch === '=' && next === '>') {
-      lastTopLevelArrow = i;
-      i += 2;
-      continue;
-    }
-    i++;
+  if (strategy === 'full') {
+    const bodies = await extractHandlerBodies(source);
+    return generateFreshHandlerFile({
+      verbList,
+      path,
+      header,
+      validatorModule,
+      zodModule,
+      contextModule,
+      validator,
+      bodyFor: (operationName) => bodies.get(`${operationName}Handlers`),
+    });
   }
 
-  if (lastTopLevelArrow === -1) return undefined;
-
-  let j = lastTopLevelArrow + 2;
-  while (j < callBody.length && /\s/.test(callBody[j])) j++;
-  if (callBody[j] !== '{') return undefined;
-
-  const closeIdx = findMatchingClose(callBody, j, '{', '}');
-  if (closeIdx === -1) return undefined;
-
-  return callBody.slice(j + 1, closeIdx);
+  return reconcileHandlerFile(source, {
+    imports: buildDesiredImports({
+      verbList,
+      path,
+      validatorModule,
+      zodModule,
+      contextModule,
+      validator,
+    }),
+    handlers: verbList.map((verbOption) => ({
+      handlerName: `${verbOption.operationName}Handlers`,
+      validators: getDesiredValidators(verbOption, validator),
+      stub: getHonoHandlers({
+        handlerName: `${verbOption.operationName}Handlers`,
+        contextTypeName: `${pascal(verbOption.operationName)}Context`,
+        verbOption,
+        validator,
+      })[0],
+    })),
+  });
 };
 
 const generateHandlerFiles = async (
@@ -635,6 +569,7 @@ const generateHandlerFiles = async (
 ) => {
   const header = getHeader(output.override.header, getSpecInfo(context));
   const { extension, dirname, filename } = getFileInfo(output.target);
+  const strategy = output.override.hono.handlerGenerationStrategy;
 
   // This function _does not control_ where the .zod and .context modules land.
   // That determination is made elsewhere and this function must implement the
@@ -674,6 +609,7 @@ const generateHandlerFiles = async (
             validatorModule,
             zodModule,
             contextModule,
+            strategy,
           }),
           path,
         };
@@ -706,6 +642,7 @@ const generateHandlerFiles = async (
               output.mode === 'tags'
                 ? nodePath.join(dirname, `${kebab(tag)}.context`)
                 : nodePath.join(dirname, tag, tag + '.context'),
+            strategy,
           }),
           path: handlerPath,
         };
@@ -728,6 +665,7 @@ const generateHandlerFiles = async (
         validatorModule,
         zodModule: nodePath.join(dirname, `${filename}.zod`),
         contextModule: nodePath.join(dirname, `${filename}.context`),
+        strategy,
       }),
       path: handlerPath,
     },
@@ -756,7 +694,7 @@ const getContext = (verbOption: GeneratorVerbOptions) => {
     ? `query: ${verbOption.queryParams.schema.name},`
     : '';
   const bodyType = verbOption.body.definition
-    ? `json: ${verbOption.body.definition},`
+    ? `${isFormBody(verbOption.body) ? 'form' : 'json'}: ${verbOption.body.definition},`
     : '';
   const hasIn = !!paramType || !!queryType || !!bodyType;
 

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -527,6 +527,11 @@ export const generateHandlerFile = async ({
 
   if (strategy === 'full') {
     const bodies = await extractHandlerBodies(source);
+    // A parse failure yields `undefined` (not an empty map): preserve the file
+    // rather than regenerate with empty bodies and drop the user's logic.
+    if (!bodies) {
+      return source;
+    }
     return generateFreshHandlerFile({
       verbList,
       path,

--- a/packages/hono/vitest.config.ts
+++ b/packages/hono/vitest.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    // The smart/full strategies lazy-load the TypeScript compiler via
+    // `await import('typescript')`. The first test to trigger that pays the
+    // cold module-load cost, which can exceed vitest's 5s default on a cold
+    // cache / CI. Give these tests headroom.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });

--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -67,7 +67,12 @@ function createMockContext(): ContextSpec {
           parameters: { suffix: '' },
           requestBodies: { suffix: '' },
         },
-        hono: { compositeRoute: '', validator: false, validatorOutputPath: '' },
+        hono: {
+          handlerGenerationStrategy: 'smart',
+          compositeRoute: '',
+          validator: false,
+          validatorOutputPath: '',
+        },
         query: {
           useQuery: false,
           useSuspenseQuery: false,

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -479,6 +479,61 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('defaults hono handlerGenerationStrategy to "smart"', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: { target: './generated.ts' },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.hono.handlerGenerationStrategy).toBe(
+        'smart',
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an explicit hono handlerGenerationStrategy', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './generated.ts',
+            override: { hono: { handlerGenerationStrategy: 'skip' } },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.hono.handlerGenerationStrategy).toBe(
+        'skip',
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   describe('optionsParamRequired with fetch httpClient', () => {
     const fetchOptionsRequiredWarningPattern =
       /httpClient: 'fetch'.*optionsParamRequired.*cannot make.*options.*required/s;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -990,6 +990,7 @@ function normalizeHonoOptions(
     ...(hono.handlers
       ? { handlers: nodePath.resolve(workspace, hono.handlers) }
       : {}),
+    handlerGenerationStrategy: hono.handlerGenerationStrategy ?? 'smart',
     compositeRoute: hono.compositeRoute
       ? nodePath.resolve(workspace, hono.compositeRoute)
       : '',

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -72,7 +72,12 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         parameters: { suffix: '' },
         requestBodies: { suffix: '' },
       },
-      hono: { compositeRoute: '', validator: false, validatorOutputPath: '' },
+      hono: {
+        handlerGenerationStrategy: 'smart',
+        compositeRoute: '',
+        validator: false,
+        validatorOutputPath: '',
+      },
       query: {
         useQuery: false,
         useSuspenseQuery: false,

--- a/tests/handler-preservation.spec.ts
+++ b/tests/handler-preservation.spec.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { generate } from 'orval';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const spec = {
+  openapi: '3.1.0',
+  info: { title: 'Test', version: '1.0.0' },
+  paths: {
+    '/pets': {
+      post: {
+        operationId: 'createPet',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { id: { type: 'number' } },
+                  required: ['id'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// No `clean` — handler files must survive regeneration.
+const config = {
+  input: { target: spec },
+  output: {
+    target: 'src/endpoints.ts',
+    mode: 'split',
+    client: 'hono',
+    override: { hono: { handlers: 'src/handlers' } },
+  },
+} as unknown as Parameters<typeof generate>[0];
+
+describe('hono handler preservation (end-to-end, clean disabled)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), 'orval-hono-preserve-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('preserves custom imports, middleware, helpers, and bodies across regeneration', async () => {
+    // 1. first generation → fresh handler stub
+    await generate(config, dir);
+    const handlerPath = path.join(dir, 'src/handlers/createPet.ts');
+    const fresh = await readFile(handlerPath, 'utf8');
+    expect(fresh).toContain('createPetHandlers');
+    expect(fresh).toContain("zValidator('json'");
+    expect(fresh).toContain("zValidator('response'");
+
+    // 2. the user fills it in: custom imports, middleware, body, top-level helper
+    const edited =
+      fresh
+        .replace(
+          "import { createFactory } from 'hono/factory';",
+          "import { db } from '../db';\nimport { authenticate } from '../mw';\nimport { createFactory } from 'hono/factory';",
+        )
+        .replace(
+          'export const createPetHandlers = factory.createHandlers(',
+          'export const createPetHandlers = factory.createHandlers(\n  authenticate(),',
+        )
+        .replace(
+          '=> {',
+          '=> {\n    return c.json(await save()); // USER_BODY',
+        ) + '\nasync function save() {\n  return db.insert();\n}\n';
+    await writeFile(handlerPath, edited, 'utf8');
+
+    // 3. regenerate with the default `smart` strategy and no clean
+    await generate(config, dir);
+    const result = await readFile(handlerPath, 'utf8');
+
+    // user-authored code survives
+    expect(result).toContain("import { db } from '../db';");
+    expect(result).toContain("import { authenticate } from '../mw';");
+    expect(result).toContain('authenticate(),');
+    expect(result).toContain('async function save() {');
+    expect(result).toContain('USER_BODY');
+    // orval-owned validators remain in sync
+    expect(result).toContain("zValidator('json'");
+    expect(result).toContain("zValidator('response'");
+  });
+});

--- a/tests/handler-preservation.spec.ts
+++ b/tests/handler-preservation.spec.ts
@@ -84,8 +84,11 @@ describe('hono handler preservation (end-to-end, clean disabled)', () => {
           'export const createPetHandlers = factory.createHandlers(',
           'export const createPetHandlers = factory.createHandlers(\n  authenticate(),',
         )
+        // Inject a body into the handler arrow. Match the first `=> {` with a
+        // regex tolerant of arrow/brace spacing so this stays correct if the
+        // generated formatting shifts.
         .replace(
-          '=> {',
+          /=>\s*\{/,
           '=> {\n    return c.json(await save()); // USER_BODY',
         ) + '\nasync function save() {\n  return db.insert();\n}\n';
     await writeFile(handlerPath, edited, 'utf8');

--- a/tests/vitest.snapshots.ts
+++ b/tests/vitest.snapshots.ts
@@ -5,7 +5,7 @@ import pkg from './package.json' with { type: 'json' };
 export default defineConfig({
   test: {
     name: { label: pkg.name },
-    include: ['api-generation.spec.ts'],
+    include: ['api-generation.spec.ts', 'handler-preservation.spec.ts'],
     silent: 'passed-only',
   },
 });


### PR DESCRIPTION

### Summary
Handler files under `override.hono.handlers` are where users put business logic.
Since #3292 (shipped in 8.11.x), regeneration rebuilt the preamble + validator
chain from the spec and spliced back only the `async (c) => {…}` body — silently
deleting custom imports, middleware (`authenticate()`, `rateLimit()`), and
top-level helpers on every run. In one project a single regeneration stripped 66
handlers (~2,880 deletions), removing auth middleware from protected endpoints.

This PR replaces that with a configurable, non-destructive strategy.

### New option: `override.hono.handlerGenerationStrategy`
Controls how an **existing** handler file is treated on regeneration (a
non-existent file is always generated fresh):

- **`smart`** (default) — parse the file (TypeScript compiler API) and reconcile
  only orval-owned regions: its own imports (names, module paths,
  camelCase→PascalCase casing) and the `zValidator(...)` arguments, and append
  handlers for new operations. Custom imports, middleware, bodies, and top-level
  helpers are preserved.
- **`skip`** — leave an existing file byte-for-byte unchanged.
- **`full`** — previous behavior: rebuild header/imports/validators, splice back
  the body (drops custom imports/middleware/helpers).

`smart` is a general reconcile: adds missing imports/validators, removes stale
validators, migrates renamed schemas, appends new-operation stubs.

### Also fixed
- **multipart/form-data**: bodies with `multipart/form-data` or
  `application/x-www-form-urlencoded` now emit `zValidator('form', …)` + `form:`
  context instead of `'json'`.

### Implementation
- New module `packages/hono/src/handler-merge.ts` (AST reconcile). Only rewrites a
  plain named import whose names are all orval-owned; locates imports by module
  specifier (no fuzzy name matching); resolves an aliased `zValidator` scoped to
  the validator module; on parse failure falls back to `skip`.
- `typescript` is an **optional `peerDependency`**, loaded lazily via
  `import('typescript')`. If absent, `smart`/`full` degrade to `skip` with a
  warning. The compiler is not bundled.

### ⚠️ Breaking change
Default changes from the 8.11.x `full` (destructive) to `smart` (non-destructive).
Set `handlerGenerationStrategy: 'full'` for the old behavior.

> Note: if `output.clean` is enabled and the handlers dir is under the output
> target, handler files are deleted before generation, defeating preservation.

### Tests
- `handler-merge.test.ts` + `index.test.ts`: preservation of
  imports/middleware/helpers/bodies; camelCase→PascalCase migration (incl. mixed
  imports); add/remove/rename validators; new-operation append;
  namespace/default/aliased import safety; the `getCommunityFilterContext` clobber
  regression; inline-middleware handling; CRLF; typescript-unavailable fallback.
- `options.test.ts`: default + explicit strategy.
- `tests/handler-preservation.spec.ts`: end-to-end `generate()` ×2 with an edit
  between (clean disabled).
- All existing generation snapshots unchanged.

### Docs
- `output.mdx`: documents `handlerGenerationStrategy` (+ typescript-peer & `clean`
  callouts).
- `hono.mdx`: replaces the stale "refresh header/imports, preserve body" text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `handlerGenerationStrategy` for Hono handlers: `smart` (default, non-destructive), `skip` (freeze), and `full` (regenerate wrapper and splice back bodies). Request-body validator now uses `form` for multipart/form-data and x-www-form-urlencoded.

* **Documentation**
  * Expanded guides and configuration docs to describe regeneration strategies and the optional TypeScript peer dependency and its fallback behavior.

* **Tests**
  * Added extensive unit and end-to-end tests covering reconciliation, preservation, strategy variations, and TypeScript-absent fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->