### PR TITLE
fix(query): match TError to thrown error for fetch forceSuccessResponse

### DIFF
--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -661,6 +661,7 @@ export const getQueryErrorType = (
   response: GetterResponse,
   httpClient: OutputHttpClient,
   mutator?: GeneratorMutator,
+  forceSuccessResponse?: boolean,
 ) => {
   const errorsType = dedupeUnionTypes(response.definition.errors || 'unknown');
 
@@ -668,11 +669,21 @@ export const getQueryErrorType = (
     return mutator.hasErrorType
       ? `${mutator.default ? pascal(operationName) : ''}ErrorType<${errorsType}>`
       : errorsType;
-  } else {
-    return httpClient === OutputHttpClient.AXIOS
-      ? `AxiosError<${errorsType}>`
-      : errorsType;
   }
+
+  if (httpClient === OutputHttpClient.AXIOS) {
+    return `AxiosError<${errorsType}>`;
+  }
+
+  // With `forceSuccessResponse`, the fetch client narrows its return type to
+  // the success body and throws `globalThis.Error & { info?, status? }` on
+  // non-2xx responses instead of returning the error body. TError must match
+  // that thrown shape rather than the raw OpenAPI error type. See #3300.
+  if (forceSuccessResponse) {
+    return `globalThis.Error & { info?: ${errorsType}; status?: number }`;
+  }
+
+  return errorsType;
 };
 
 export const getHooksOptionImplementation = (

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -342,6 +342,7 @@ export const generateMutationHook = async ({
     response,
     httpClient,
     mutator,
+    override.fetch.forceSuccessResponse,
   );
 
   const dataType = mutator?.isHook

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -376,6 +376,7 @@ const generateQueryImplementation = ({
   isExactOptionalPropertyTypes,
   hasSignal,
   useRuntimeFetcher,
+  forceSuccessResponse,
   route,
   doc,
   usePrefetch,
@@ -410,6 +411,7 @@ const generateQueryImplementation = ({
   isExactOptionalPropertyTypes: boolean;
   hasSignal: boolean;
   useRuntimeFetcher?: boolean;
+  forceSuccessResponse?: boolean;
   route: string;
   doc?: string;
   usePrefetch?: boolean;
@@ -502,6 +504,7 @@ const generateQueryImplementation = ({
     response,
     httpClient,
     mutator,
+    forceSuccessResponse,
   );
 
   const dataType = mutator?.isHook
@@ -1192,6 +1195,7 @@ ${queryKeyFns}`;
           overrideQuerySignal: override.query.signal,
         }),
         useRuntimeFetcher: override.fetch.useRuntimeFetcher,
+        forceSuccessResponse: override.fetch.forceSuccessResponse,
         queryOptionsMutator,
         queryKeyMutator,
         route,

--- a/tests/__snapshots__/react-query/http-client-fetch/health/health.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/health/health.ts
@@ -118,7 +118,7 @@ export const getHealthCheckQueryKey = () => {
 
 export const getHealthCheckQueryOptions = <
   TData = Awaited<ReturnType<typeof healthCheck>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(options?: {
   query?: Partial<
     UseQueryOptions<Awaited<ReturnType<typeof healthCheck>>, TError, TData>
@@ -143,11 +143,14 @@ export const getHealthCheckQueryOptions = <
 export type HealthCheckQueryResult = NonNullable<
   Awaited<ReturnType<typeof healthCheck>>
 >;
-export type HealthCheckQueryError = Error;
+export type HealthCheckQueryError = globalThis.Error & {
+  info?: Error;
+  status?: number;
+};
 
 export function useHealthCheck<
   TData = Awaited<ReturnType<typeof healthCheck>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   options: {
     query: Partial<
@@ -169,7 +172,7 @@ export function useHealthCheck<
 };
 export function useHealthCheck<
   TData = Awaited<ReturnType<typeof healthCheck>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   options?: {
     query?: Partial<
@@ -191,7 +194,7 @@ export function useHealthCheck<
 };
 export function useHealthCheck<
   TData = Awaited<ReturnType<typeof healthCheck>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   options?: {
     query?: Partial<
@@ -209,7 +212,7 @@ export function useHealthCheck<
 
 export function useHealthCheck<
   TData = Awaited<ReturnType<typeof healthCheck>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   options?: {
     query?: Partial<

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -140,7 +140,7 @@ export const getListPetsQueryKey = (params?: ListPetsParams) => {
 
 export const getListPetsQueryOptions = <
   TData = Awaited<ReturnType<typeof listPets>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   params: ListPetsParams,
   options?: {
@@ -168,11 +168,14 @@ export const getListPetsQueryOptions = <
 export type ListPetsQueryResult = NonNullable<
   Awaited<ReturnType<typeof listPets>>
 >;
-export type ListPetsQueryError = Error;
+export type ListPetsQueryError = globalThis.Error & {
+  info?: Error;
+  status?: number;
+};
 
 export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   params: ListPetsParams,
   options: {
@@ -195,7 +198,7 @@ export function useListPets<
 };
 export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   params: ListPetsParams,
   options?: {
@@ -218,7 +221,7 @@ export function useListPets<
 };
 export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   params: ListPetsParams,
   options?: {
@@ -237,7 +240,7 @@ export function useListPets<
 
 export function useListPets<
   TData = Awaited<ReturnType<typeof listPets>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   params: ListPetsParams,
   options?: {
@@ -326,7 +329,7 @@ export const createPets = async (
 };
 
 export const getCreatePetsMutationOptions = <
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -367,12 +370,18 @@ export type CreatePetsMutationResult = NonNullable<
   Awaited<ReturnType<typeof createPets>>
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
-export type CreatePetsMutationError = Error;
+export type CreatePetsMutationError = globalThis.Error & {
+  info?: Error;
+  status?: number;
+};
 
 /**
  * @summary Create a pet
  */
-export const useCreatePets = <TError = Error, TContext = unknown>(
+export const useCreatePets = <
+  TError = globalThis.Error & { info?: Error; status?: number },
+  TContext = unknown,
+>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
@@ -449,7 +458,7 @@ export const getShowPetByIdQueryKey = (petId: string) => {
 
 export const getShowPetByIdQueryOptions = <
   TData = Awaited<ReturnType<typeof showPetById>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -482,11 +491,14 @@ export const getShowPetByIdQueryOptions = <
 export type ShowPetByIdQueryResult = NonNullable<
   Awaited<ReturnType<typeof showPetById>>
 >;
-export type ShowPetByIdQueryError = Error;
+export type ShowPetByIdQueryError = globalThis.Error & {
+  info?: Error;
+  status?: number;
+};
 
 export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options: {
@@ -509,7 +521,7 @@ export function useShowPetById<
 };
 export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -532,7 +544,7 @@ export function useShowPetById<
 };
 export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -551,7 +563,7 @@ export function useShowPetById<
 
 export function useShowPetById<
   TData = Awaited<ReturnType<typeof showPetById>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -631,7 +643,7 @@ export const deletePetById = async (
 };
 
 export const getDeletePetByIdMutationOptions = <
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -672,12 +684,18 @@ export type DeletePetByIdMutationResult = NonNullable<
   Awaited<ReturnType<typeof deletePetById>>
 >;
 
-export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationError = globalThis.Error & {
+  info?: Error;
+  status?: number;
+};
 
 /**
  * @summary Deletes a specific pet
  */
-export const useDeletePetById = <TError = Error, TContext = unknown>(
+export const useDeletePetById = <
+  TError = globalThis.Error & { info?: Error; status?: number },
+  TContext = unknown,
+>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
@@ -758,7 +776,7 @@ export const getShowPetWithOwnerQueryKey = (petId: string) => {
 
 export const getShowPetWithOwnerQueryOptions = <
   TData = Awaited<ReturnType<typeof showPetWithOwner>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -795,11 +813,14 @@ export const getShowPetWithOwnerQueryOptions = <
 export type ShowPetWithOwnerQueryResult = NonNullable<
   Awaited<ReturnType<typeof showPetWithOwner>>
 >;
-export type ShowPetWithOwnerQueryError = Error;
+export type ShowPetWithOwnerQueryError = globalThis.Error & {
+  info?: Error;
+  status?: number;
+};
 
 export function useShowPetWithOwner<
   TData = Awaited<ReturnType<typeof showPetWithOwner>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options: {
@@ -826,7 +847,7 @@ export function useShowPetWithOwner<
 };
 export function useShowPetWithOwner<
   TData = Awaited<ReturnType<typeof showPetWithOwner>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -853,7 +874,7 @@ export function useShowPetWithOwner<
 };
 export function useShowPetWithOwner<
   TData = Awaited<ReturnType<typeof showPetWithOwner>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {
@@ -876,7 +897,7 @@ export function useShowPetWithOwner<
 
 export function useShowPetWithOwner<
   TData = Awaited<ReturnType<typeof showPetWithOwner>>,
-  TError = Error,
+  TError = globalThis.Error & { info?: Error; status?: number },
 >(
   petId: string,
   options?: {

--- a/tests/api-generation.spec.ts
+++ b/tests/api-generation.spec.ts
@@ -888,3 +888,24 @@ test('hono issue-3512 zod mutator import path is prefixed with an extra `../` in
     "import { stripNill } from '../../../../mutators/zod-preprocess';",
   );
 });
+
+test('react-query issue-3300 TError matches the thrown error for fetch forceSuccessResponse', async () => {
+  // With `override.fetch.forceSuccessResponse`, the fetch request function
+  // narrows its return type to the success body and throws
+  // `globalThis.Error & { info?, status? }` on non-2xx responses. The generated
+  // query/mutation hooks must therefore default `TError` to that thrown shape,
+  // not to the raw OpenAPI error model (`Error`) that is never actually
+  // returned. Keep this focused assertion alongside the snapshot so #3300 fails
+  // with a targeted message instead of a full-file snapshot diff. pets.ts
+  // covers both queries (listPets/showPetById) and a mutation (createPets).
+  const petsFile = generated(
+    'react-query',
+    'http-client-fetch',
+    'pets',
+    'pets.ts',
+  );
+  const content = await readFile(petsFile, 'utf8');
+
+  expect(content).toContain('TError = globalThis.Error');
+  expect(content).not.toContain('TError = Error');
+});

--- a/tests/api-generation.spec.ts
+++ b/tests/api-generation.spec.ts
@@ -906,6 +906,19 @@ test('react-query issue-3300 TError matches the thrown error for fetch forceSucc
   );
   const content = await readFile(petsFile, 'utf8');
 
-  expect(content).toContain('TError = globalThis.Error');
-  expect(content).not.toContain('TError = Error');
+  // The hook generics default TError to the full thrown shape (shared by every
+  // query and mutation in the file).
+  expect(content).toContain(
+    'TError = globalThis.Error & { info?: Error; status?: number }',
+  );
+  // And assert the corrected envelope explicitly on both a query error alias
+  // and a mutation error alias so a regression on either path is caught.
+  expect(content).toContain(
+    'export type ListPetsQueryError = globalThis.Error & {',
+  );
+  expect(content).toContain(
+    'export type CreatePetsMutationError = globalThis.Error & {',
+  );
+  // The bare OpenAPI error model must no longer be used as the default TError.
+  expect(content).not.toContain('TError = Error,');
 });


### PR DESCRIPTION
## What & why

Fixes the `TError` mismatch reported in #3300.

When generating a TanStack Query client with the fetch HTTP client and `override.fetch.forceSuccessResponse: true`, the generated request function narrows its return type to the **success** body and, on a non-2xx response, throws `globalThis.Error & { info?: <errorBody>; status?: number }` instead of returning the error body.

The generated hooks, however, still defaulted `TError` to the raw OpenAPI error model. So a consumer of `useCreateAccount().error` was told the error was e.g. `Error` (`{ code, message }`), while at runtime it is the wrapped thrown object — `error.info` / `error.status` were missing from the type, and the declared fields were absent at runtime.

## Fix

`getQueryErrorType` now takes `forceSuccessResponse` and, for the fetch client, returns:

```ts
globalThis.Error & { info?: <errors>; status?: number }
```

so `TError` matches the thrown shape. This mirrors how axios is already handled (`AxiosError<…>`); the fetch path simply had no envelope. The flag is threaded through both the query and mutation generators, so the hook generics, `getX{Query,Mutation}Options`, prefetch helpers and the exported `…QueryError` / `…MutationError` aliases are all corrected from a single place. `errorsType` (the spec error model already imported for the previous default) is reused, so no new imports are generated.

The `mutator` and `axios` branches are unchanged — `forceSuccessResponse` only affects the built-in fetch client.

## Tests

- Updated the existing `react-query` `http-client-fetch` snapshots (the only fixtures using `forceSuccessResponse`) to the corrected `TError`.
- Added a focused regression test in `tests/api-generation.spec.ts` (`react-query issue-3300 …`) covering both queries and a mutation, so #3300 fails with a targeted message rather than a raw snapshot diff.
- Full CI parity locally: `format:check`, `typecheck`, `lint`, `test`, `test:snapshots`, and `orval-tests build` (which type-checks the generated clients) all pass.

## Out of scope

- SWR has an analogous, separate helper (`getSwrErrorType`) that also ignores `forceSuccessResponse`; left for a follow-up to keep this PR to one logical change.

Closes #3300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error typing for React Query hooks: default errors now include richer info and HTTP status where available; an option can adjust how success/error responses are modeled for generated hooks.

* **Tests**
  * Added tests verifying the generated hooks and error aliases use the new richer error shape and the adjustable response-modeling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->