### PR TITLE
feat(mcp): add error handling with isError and structuredContent to handlers

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -182,13 +182,26 @@ ${handlerArgsTypes.join('\n')}
 export const ${handlerName} = async (${handlerArgsTypes.length > 0 ? `args: ${handlerArgsName}, ` : ''}options?: RequestInit) => {
   const res = await ${verbOptions.operationName}(${fetchParams.length > 0 ? `${fetchParams.join(', ')}, ` : ''}options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };`;
 

--- a/samples/mcp/custom-server/__snapshots__/handlers.ts
+++ b/samples/mcp/custom-server/__snapshots__/handlers.ts
@@ -49,13 +49,26 @@ export const findPetsByStatusHandler = async (
 ) => {
   const res = await findPetsByStatus(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -74,13 +87,26 @@ export const findPetsByTagsHandler = async (
 ) => {
   const res = await findPetsByTags(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -101,13 +127,26 @@ export const getPetByIdHandler = async (
 ) => {
   const res = await getPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -133,13 +172,26 @@ export const updatePetWithFormHandler = async (
     options,
   );
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -160,13 +212,26 @@ export const deletePetHandler = async (
 ) => {
   const res = await deletePet(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -178,13 +243,26 @@ export const deletePetHandler = async (
 export const getInventoryHandler = async (options?: RequestInit) => {
   const res = await getInventory(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -205,13 +283,26 @@ export const getOrderByIdHandler = async (
 ) => {
   const res = await getOrderById(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -232,13 +323,26 @@ export const deleteOrderHandler = async (
 ) => {
   const res = await deleteOrder(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -257,13 +361,26 @@ export const loginUserHandler = async (
 ) => {
   const res = await loginUser(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -275,13 +392,26 @@ export const loginUserHandler = async (
 export const logoutUserHandler = async (options?: RequestInit) => {
   const res = await logoutUser(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -302,13 +432,26 @@ export const getUserByNameHandler = async (
 ) => {
   const res = await getUserByName(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -329,12 +472,25 @@ export const deleteUserHandler = async (
 ) => {
   const res = await deleteUser(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };

--- a/samples/mcp/custom-server/src/handlers.ts
+++ b/samples/mcp/custom-server/src/handlers.ts
@@ -49,13 +49,26 @@ export const findPetsByStatusHandler = async (
 ) => {
   const res = await findPetsByStatus(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -74,13 +87,26 @@ export const findPetsByTagsHandler = async (
 ) => {
   const res = await findPetsByTags(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -101,13 +127,26 @@ export const getPetByIdHandler = async (
 ) => {
   const res = await getPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -133,13 +172,26 @@ export const updatePetWithFormHandler = async (
     options,
   );
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -160,13 +212,26 @@ export const deletePetHandler = async (
 ) => {
   const res = await deletePet(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -178,13 +243,26 @@ export const deletePetHandler = async (
 export const getInventoryHandler = async (options?: RequestInit) => {
   const res = await getInventory(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -205,13 +283,26 @@ export const getOrderByIdHandler = async (
 ) => {
   const res = await getOrderById(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -232,13 +323,26 @@ export const deleteOrderHandler = async (
 ) => {
   const res = await deleteOrder(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -257,13 +361,26 @@ export const loginUserHandler = async (
 ) => {
   const res = await loginUser(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -275,13 +392,26 @@ export const loginUserHandler = async (
 export const logoutUserHandler = async (options?: RequestInit) => {
   const res = await logoutUser(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -302,13 +432,26 @@ export const getUserByNameHandler = async (
 ) => {
   const res = await getUserByName(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -329,12 +472,25 @@ export const deleteUserHandler = async (
 ) => {
   const res = await deleteUser(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };

--- a/samples/mcp/petstore/__snapshots__/handlers.ts
+++ b/samples/mcp/petstore/__snapshots__/handlers.ts
@@ -49,13 +49,26 @@ export const findPetsByStatusHandler = async (
 ) => {
   const res = await findPetsByStatus(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -74,13 +87,26 @@ export const findPetsByTagsHandler = async (
 ) => {
   const res = await findPetsByTags(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -101,13 +127,26 @@ export const getPetByIdHandler = async (
 ) => {
   const res = await getPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -133,13 +172,26 @@ export const updatePetWithFormHandler = async (
     options,
   );
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -160,13 +212,26 @@ export const deletePetHandler = async (
 ) => {
   const res = await deletePet(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -178,13 +243,26 @@ export const deletePetHandler = async (
 export const getInventoryHandler = async (options?: RequestInit) => {
   const res = await getInventory(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -205,13 +283,26 @@ export const getOrderByIdHandler = async (
 ) => {
   const res = await getOrderById(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -232,13 +323,26 @@ export const deleteOrderHandler = async (
 ) => {
   const res = await deleteOrder(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -257,13 +361,26 @@ export const loginUserHandler = async (
 ) => {
   const res = await loginUser(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -275,13 +392,26 @@ export const loginUserHandler = async (
 export const logoutUserHandler = async (options?: RequestInit) => {
   const res = await logoutUser(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -302,13 +432,26 @@ export const getUserByNameHandler = async (
 ) => {
   const res = await getUserByName(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -329,12 +472,25 @@ export const deleteUserHandler = async (
 ) => {
   const res = await deleteUser(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };

--- a/samples/mcp/petstore/src/handlers.ts
+++ b/samples/mcp/petstore/src/handlers.ts
@@ -49,13 +49,26 @@ export const findPetsByStatusHandler = async (
 ) => {
   const res = await findPetsByStatus(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -74,13 +87,26 @@ export const findPetsByTagsHandler = async (
 ) => {
   const res = await findPetsByTags(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -101,13 +127,26 @@ export const getPetByIdHandler = async (
 ) => {
   const res = await getPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -133,13 +172,26 @@ export const updatePetWithFormHandler = async (
     options,
   );
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -160,13 +212,26 @@ export const deletePetHandler = async (
 ) => {
   const res = await deletePet(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -178,13 +243,26 @@ export const deletePetHandler = async (
 export const getInventoryHandler = async (options?: RequestInit) => {
   const res = await getInventory(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -205,13 +283,26 @@ export const getOrderByIdHandler = async (
 ) => {
   const res = await getOrderById(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -232,13 +323,26 @@ export const deleteOrderHandler = async (
 ) => {
   const res = await deleteOrder(args.pathParams.orderId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -257,13 +361,26 @@ export const loginUserHandler = async (
 ) => {
   const res = await loginUser(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -275,13 +392,26 @@ export const loginUserHandler = async (
 export const logoutUserHandler = async (options?: RequestInit) => {
   const res = await logoutUser(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -302,13 +432,26 @@ export const getUserByNameHandler = async (
 ) => {
   const res = await getUserByName(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -329,12 +472,25 @@ export const deleteUserHandler = async (
 ) => {
   const res = await deleteUser(args.pathParams.username, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };

--- a/tests/__snapshots__/mcp/custom-server/handlers.ts
+++ b/tests/__snapshots__/mcp/custom-server/handlers.ts
@@ -33,13 +33,26 @@ export const listPetsHandler = async (
 ) => {
   const res = await listPets(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -58,13 +71,26 @@ export const createPetsHandler = async (
 ) => {
   const res = await createPets(args.bodyParams, args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -84,13 +110,26 @@ export const showPetByIdHandler = async (
 ) => {
   const res = await showPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -110,13 +149,26 @@ export const deletePetByIdHandler = async (
 ) => {
   const res = await deletePetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -127,13 +179,26 @@ export const deletePetByIdHandler = async (
 export const healthCheckHandler = async (options?: RequestInit) => {
   const res = await healthCheck(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -153,12 +218,25 @@ export const showPetWithOwnerHandler = async (
 ) => {
   const res = await showPetWithOwner(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };

--- a/tests/__snapshots__/mcp/single/handlers.ts
+++ b/tests/__snapshots__/mcp/single/handlers.ts
@@ -33,13 +33,26 @@ export const listPetsHandler = async (
 ) => {
   const res = await listPets(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -58,13 +71,26 @@ export const createPetsHandler = async (
 ) => {
   const res = await createPets(args.bodyParams, args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -84,13 +110,26 @@ export const showPetByIdHandler = async (
 ) => {
   const res = await showPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -110,13 +149,26 @@ export const deletePetByIdHandler = async (
 ) => {
   const res = await deletePetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -127,13 +179,26 @@ export const deletePetByIdHandler = async (
 export const healthCheckHandler = async (options?: RequestInit) => {
   const res = await healthCheck(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -153,12 +218,25 @@ export const showPetWithOwnerHandler = async (
 ) => {
   const res = await showPetWithOwner(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };

--- a/tests/__snapshots__/mcp/zod-schema-response/handlers.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/handlers.ts
@@ -33,13 +33,26 @@ export const listPetsHandler = async (
 ) => {
   const res = await listPets(args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -58,13 +71,26 @@ export const createPetsHandler = async (
 ) => {
   const res = await createPets(args.bodyParams, args.queryParams, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -84,13 +110,26 @@ export const showPetByIdHandler = async (
 ) => {
   const res = await showPetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -110,13 +149,26 @@ export const deletePetByIdHandler = async (
 ) => {
   const res = await deletePetById(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -127,13 +179,26 @@ export const deletePetByIdHandler = async (
 export const healthCheckHandler = async (options?: RequestInit) => {
   const res = await healthCheck(options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };
 
@@ -153,12 +218,25 @@ export const showPetWithOwnerHandler = async (
 ) => {
   const res = await showPetWithOwner(args.pathParams.petId, options);
 
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(res),
+        text: JSON.stringify(res.data ?? null),
       },
     ],
+    structuredContent: res.data,
   };
 };


### PR DESCRIPTION
## Summary

Add error handling and structured content to MCP handlers.

- Error responses (4xx/5xx): return `isError: true`, skipping `outputSchema` validation
- Success responses (2xx/3xx): return `structuredContent: res.data`, validated against `outputSchema`
- Return `res.data` instead of `res` to pass only the response body

### Before

```typescript
const res = await listPets(args.queryParams, options);
return {
  content: [{ type: 'text', text: JSON.stringify(res) }],
};
```

### After

```ts
const res = await listPets(args.queryParams, options);

if (res.status >= 400) {
  return {
    content: [{ type: 'text', text: JSON.stringify(res.data) }],
    isError: true,
  };
}

return {
  content: [{ type: 'text', text: JSON.stringify(res.data) }],
  structuredContent: res.data,
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now include structured response content alongside text payloads for easier consumption.

* **Bug Fixes**
  * Responses with HTTP status >= 400 are detected and flagged as errors.
  * Text serialization now uses the actual response body data (res.data) instead of the full response, removing extraneous metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->