### PR TITLE
feat(core): `resolveDiscriminators` in cycle - fix

### DIFF
--- a/packages/core/src/getters/discriminators.test.ts
+++ b/packages/core/src/getters/discriminators.test.ts
@@ -574,6 +574,106 @@ describe('resolveDiscriminators getter', () => {
     expect(allOf?.[0]).toHaveProperty('$ref', '#/components/schemas/Base');
   });
 
+  it('rewrites variant allOf $ref to parent when parent has oneOf but no discriminator mapping', () => {
+    const schemas: OpenApiSchemasObject = {
+      Animal: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: { type: 'string' },
+        },
+        discriminator: { propertyName: 'type' },
+        oneOf: [
+          { $ref: '#/components/schemas/Dog' },
+          { $ref: '#/components/schemas/Cat' },
+        ],
+      },
+      Dog: {
+        allOf: [
+          { $ref: '#/components/schemas/Animal' },
+          {
+            type: 'object',
+            properties: { bark: { type: 'string' } },
+          },
+        ],
+      },
+      Cat: {
+        allOf: [
+          { $ref: '#/components/schemas/Animal' },
+          {
+            type: 'object',
+            properties: { meow: { type: 'string' } },
+          },
+        ],
+      },
+    };
+    const result = resolveDiscriminators(structuredClone(schemas), context);
+    const dog = result.Dog as NonNullable<OpenApiSchemasObject[string]>;
+    const cat = result.Cat as NonNullable<OpenApiSchemasObject[string]>;
+
+    const dogAllOf = dog.allOf as
+      | (OpenApiSchemaObject | OpenApiReferenceObject)[]
+      | undefined;
+    expect(dogAllOf).toHaveLength(1);
+    expect(dogAllOf?.[0]).not.toHaveProperty('$ref');
+
+    const catAllOf = cat.allOf as
+      | (OpenApiSchemaObject | OpenApiReferenceObject)[]
+      | undefined;
+    expect(catAllOf).toHaveLength(1);
+    expect(catAllOf?.[0]).not.toHaveProperty('$ref');
+  });
+
+  it('rewrites variant allOf $ref to parent when parent has anyOf but no discriminator mapping', () => {
+    const schemas: OpenApiSchemasObject = {
+      Animal: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: { type: 'string' },
+        },
+        discriminator: { propertyName: 'type' },
+        anyOf: [
+          { $ref: '#/components/schemas/Dog' },
+          { $ref: '#/components/schemas/Cat' },
+        ],
+      },
+      Dog: {
+        allOf: [
+          { $ref: '#/components/schemas/Animal' },
+          {
+            type: 'object',
+            properties: { bark: { type: 'string' } },
+          },
+        ],
+      },
+      Cat: {
+        allOf: [
+          { $ref: '#/components/schemas/Animal' },
+          {
+            type: 'object',
+            properties: { meow: { type: 'string' } },
+          },
+        ],
+      },
+    };
+    const result = resolveDiscriminators(structuredClone(schemas), context);
+    const dog = result.Dog as NonNullable<OpenApiSchemasObject[string]>;
+    const cat = result.Cat as NonNullable<OpenApiSchemasObject[string]>;
+
+    const dogAllOf = dog.allOf as
+      | (OpenApiSchemaObject | OpenApiReferenceObject)[]
+      | undefined;
+    expect(dogAllOf).toHaveLength(1);
+    expect(dogAllOf?.[0]).not.toHaveProperty('$ref');
+
+    const catAllOf = cat.allOf as
+      | (OpenApiSchemaObject | OpenApiReferenceObject)[]
+      | undefined;
+    expect(catAllOf).toHaveLength(1);
+    expect(catAllOf?.[0]).not.toHaveProperty('$ref');
+  });
+
   it('hoists oneOf from discriminator when nested incorrectly', () => {
     const schemas: OpenApiSchemasObject = {
       Animal: {

--- a/packages/core/src/getters/discriminators.ts
+++ b/packages/core/src/getters/discriminators.ts
@@ -114,13 +114,22 @@ export function resolveDiscriminators(
     if (isBoolean(parentSchema)) {
       continue;
     }
-    if (!parentSchema.oneOf || !parentSchema.discriminator?.mapping) {
+    const variants = parentSchema.oneOf ?? parentSchema.anyOf;
+    if (!variants || !parentSchema.discriminator) {
       continue;
     }
-    const { mapping, propertyName } = parentSchema.discriminator;
+    const { propertyName, mapping } = parentSchema.discriminator;
     if (!propertyName) {
       continue;
     }
+    const mappedRefs = mapping ? Object.values(mapping) : [];
+    const variantArrayRefs = variants
+      .filter(
+        (item): item is OpenApiReferenceObject & { $ref: string } =>
+          isReference(item) && typeof item.$ref === 'string',
+      )
+      .map((item) => item.$ref);
+    const variantRefs = [...new Set([...mappedRefs, ...variantArrayRefs])];
 
     const parentProperties = parentSchema.properties as
       | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
@@ -142,7 +151,7 @@ export function resolveDiscriminators(
     );
     const hasInheritableProps = Object.keys(inheritableProps).length > 0;
 
-    for (const mappingValue of Object.values(mapping)) {
+    for (const mappingValue of variantRefs) {
       let variantSchema;
       try {
         const { originalName } = getRefInfo(mappingValue, context);


### PR DESCRIPTION
### Problem
OpenAPI specifications defining polymorphic interfaces permits a `discriminator` with a `propertyName` and a `oneOf`/`anyOf` array, but omit the explicit `mapping` dictionary. 

### Result of the bad code
Orval's `resolveDiscriminators` cycle-breaking logic was strictly guarded by a check for `discriminator.mapping`. When the mapping was missing, Orval skipped inlining the parent schema's properties into the variants.
This resulted in the parent type being generated as a union of variants (`type Parent = VariantA | VariantB`), while variants were generated as intersections extending the parent (`type VariantA = Parent & { ... }`).
This circular dependency caused TypeScript compiler error **TS2456: Type alias circularly references itself**.

### Example OpenAPI Spec causing the issue
```yaml
openapi: 3.1.0
components:
  schemas:
    Animal:
      type: object
      discriminator:
        propertyName: type
      oneOf / anyOf:
        - $ref: '#/components/schemas/Dog'
        - $ref: '#/components/schemas/Cat'
      properties:
        type:
          type: string
      required:
        - type
    Dog:
      allOf:
        - $ref: '#/components/schemas/Animal'
        - type: object
          properties:
            bark:
              type: string
    Cat:
      allOf:
        - $ref: '#/components/schemas/Animal'
        - type: object
          properties:
            meow:
              type: string
```

### How we fixed it
Relaxed the guard condition in `packages/core/src/getters/discriminators.ts` to check for the presence of `discriminator` and `oneOf`/`anyOf`, rather than strictly requiring `discriminator.mapping`. When `mapping` is absent, the logic now dynamically extracts the variant `$ref` strings directly from the `oneOf`/`anyOf` array to identify which schemas need the parent's properties inlined.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discriminator handling to also resolve variant references when explicit mappings are absent, deriving them from schema composition (oneOf/anyOf) to ensure correct variant rewriting.

* **Tests**
  * Added test coverage validating discriminator resolution and correct transformation of variant schemas when explicit mappings are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->