### PR TITLE
factory methods: discriminator aliases and missing parent properties - fix

### DIFF
--- a/packages/core/src/generators/factory.test.ts
+++ b/packages/core/src/generators/factory.test.ts
@@ -584,4 +584,30 @@ describe('generateFactory', () => {
     expect(result?.model).not.toContain('user: createRefTarget()');
     expect(result?.model).toContain('token: createRefTarget()');
   });
+
+  it('combines combiner payloads with parent properties using Object.assign', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      oneOf: [
+        {
+          type: 'object',
+          required: ['variantProp'],
+          properties: { variantProp: { type: 'string' } },
+        },
+      ],
+      required: ['parentProp'],
+      properties: {
+        parentProp: { type: 'string' },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'CombinedWithProps',
+      createMockContext(),
+    );
+    expect(result?.model).toContain(
+      "Object.assign({}, {\n    variantProp: ''\n  }, {\n    parentProp: ''\n  })",
+    );
+  });
 });

--- a/packages/core/src/generators/factory.ts
+++ b/packages/core/src/generators/factory.ts
@@ -226,28 +226,46 @@ function buildPayload(
   }
 
   const schema = target;
+  const payloads: string[] = [];
 
-  if (schema.allOf)
-    return buildAllOfPayload(
-      getSchemas(schema.allOf) ?? [],
-      context,
-      parents,
-      imports,
+  if (schema.allOf) {
+    payloads.push(
+      buildAllOfPayload(
+        getSchemas(schema.allOf) ?? [],
+        context,
+        parents,
+        imports,
+      ),
     );
-  if (schema.oneOf)
-    return buildFirstOfPayload(
-      getSchemas(schema.oneOf) ?? [],
-      context,
-      parents,
-      imports,
+  } else if (schema.oneOf) {
+    payloads.push(
+      buildFirstOfPayload(
+        getSchemas(schema.oneOf) ?? [],
+        context,
+        parents,
+        imports,
+      ),
     );
-  if (schema.anyOf)
-    return buildFirstOfPayload(
-      getSchemas(schema.anyOf) ?? [],
-      context,
-      parents,
-      imports,
+  } else if (schema.anyOf) {
+    payloads.push(
+      buildFirstOfPayload(
+        getSchemas(schema.anyOf) ?? [],
+        context,
+        parents,
+        imports,
+      ),
     );
+  }
+
+  if (Object.keys(getProperties(schema)).length > 0) {
+    payloads.push(buildObjectPayload(schema, context, parents, imports));
+  }
+
+  if (payloads.length > 0) {
+    return payloads.length === 1
+      ? payloads[0]
+      : `Object.assign({}, ${payloads.join(', ')})`;
+  }
 
   const { constValue } = getExtendedProps(schema);
   if (constValue !== undefined) return formatValue(constValue);
@@ -255,8 +273,7 @@ function buildPayload(
 
   const schemaType = inferSchemaType(schema);
 
-  if (schemaType === 'object' || schema.properties)
-    return buildObjectPayload(schema, context, parents, imports);
+  if (schemaType === 'object') return '{}';
   if (schemaType === 'array')
     return buildArrayPayload(schema, context, parents, imports);
 


### PR DESCRIPTION
### Problem
OpenAPI specifications defining polymorphic interfaces often use a combiner (`oneOf`/`anyOf`/`allOf`) alongside the parent schema's own `properties`.
However, Orval's factory generator treated combiners and `properties` as mutually exclusive.
When a combiner was found, the generator returned early and completely ignored the parent's own properties.

Relates to: https://github.com/orval-labs/orval/pull/3523

### Result of the bad code
The generated parent factory simply returned the variant's factory output, which lacked the parent's required properties.
This caused TypeScript compiler errors (e.g., **TS2322: Type 'Variant' is not assignable to type 'Variant & { parentProp: string }'**) when trying to assign the factory output to the generated intersection type.

### Example OpenAPI Spec causing the issue
```yaml
openapi: 3.1.0
components:
  schemas:
    General:
      type: object
      oneOf:
        - $ref: '#/components/schemas/Specific'
      properties:
        responseType:
          type: string
      required:
        - responseType
    Specific:
      type: object
      properties:
        question:
          type: string
```

### How we fixed it
Refactored `buildPayload` in `packages/core/src/generators/factory.ts` to no longer treat combiners and `properties` as mutually exclusive.
The logic now collects payloads from both the combiner and the parent properties into an array, and combines them using `Object.assign({}, ...payloads)`.
This ensures the generated factory correctly outputs an object satisfying the full intersection type, including all required parent and variant properties.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for handling combined schema payloads.

* **Refactor**
  * Improved payload generation logic for composed schemas to better support merging multiple property sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->