### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-doc.yaml
+++ b/.github/workflows/deploy-doc.yaml
@@ -5,6 +5,8 @@ on:
       - master
     paths:
       - 'docs/**'
+permissions:
+  contents: read
 jobs:
   deploy-to-cloudflare:
     name: Deploy to Cloudflare


### PR DESCRIPTION
Potential fix for [https://github.com/orval-labs/orval/security/code-scanning/10](https://github.com/orval-labs/orval/security/code-scanning/10)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here: define workflow-level permissions immediately after `on` (or before `jobs`) with `contents: read`, since this workflow only needs to check out code and does not require GitHub writes.

**File to change**
- `.github/workflows/deploy-doc.yaml`

**Specific change**
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  at the root level of the workflow (same indentation as `on:` and `jobs:`), without altering job behavior.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow permissions for improved security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->