### PR TITLE
fix(zod): escape newlines in $ref description with generateReusableSchemas

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -281,7 +281,14 @@ export const generateZodValidationSchemaDefinition = (
     }
 
     if (typeof siblingSchema.description === 'string') {
-      functions.push(['describe', `"${escape(siblingSchema.description)}"`]);
+      // Use the same single-quoted, fully JS-escaped form as the primitive
+      // description path (see `pushDescriptionOrMeta`). `escape` only escapes
+      // quote chars, so a multi-line description would emit raw newlines and
+      // break the generated string literal (TS1002).
+      functions.push([
+        'describe',
+        `'${jsStringEscape(siblingSchema.description)}'`,
+      ]);
     }
   };
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4101,7 +4101,10 @@ describe('generateZodValidationSchemaDefinition`', () => {
       // newlines that would break the generated string literal (TS1002).
       expect(result.functions).toEqual([
         ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
-        ['describe', "'Subject identifier.\\n\\nMust be normalized first.'"],
+        [
+          'describe',
+          String.raw`'Subject identifier.\n\nMust be normalized first.'`,
+        ],
       ]);
     });
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4078,7 +4078,30 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
       expect(result.functions).toEqual([
         ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
-        ['describe', '"optional pet"'],
+        ['describe', "'optional pet'"],
+      ]);
+    });
+
+    it('escapes newlines in a multi-line description sibling on a $ref (#3517)', () => {
+      const context = makeContextSpec({
+        spec: { components: { schemas: { Pet: { type: 'object' } } } },
+      });
+      const result = generateZodValidationSchemaDefinition(
+        {
+          $ref: '#/components/schemas/Pet',
+          description: 'Subject identifier.\n\nMust be normalized first.',
+        } as never,
+        context,
+        'someField',
+        false,
+        false,
+        { required: true, useReusableSchemas: true },
+      );
+      // Same single-quoted, \n-escaped form as a primitive sibling — no raw
+      // newlines that would break the generated string literal (TS1002).
+      expect(result.functions).toEqual([
+        ['namedRef', { name: 'Pet', sourceRef: '#/components/schemas/Pet' }],
+        ['describe', "'Subject identifier.\\n\\nMust be normalized first.'"],
       ]);
     });
 


### PR DESCRIPTION
## Summary

Fixes #3517.

With `output.override.zod.generateReusableSchemas: true`, when an object property is a `$ref` to a reusable component **and** carries a multi-line `description`, orval emitted `ReferencedSchema.describe("…")` using double quotes around the **raw, unescaped** description. The literal newlines broke the string literal, producing invalid TypeScript:

```
x.zod.schemas.ts(15,46): error TS1002: Unterminated string literal.
```

Sibling primitive fields with the same multi-line description were emitted correctly (single-quoted, `\n`-escaped) — orval already had a working escaper; the `$ref` + `.describe()` path just wasn't using it.

## Root cause

`packages/zod/src/index.ts` — the chainable-sibling path for `$ref`s used:

```js
functions.push(['describe', `"${escape(siblingSchema.description)}"`]);
```

`escape()` only escapes quote characters, not newlines, and the result was wrapped in double quotes. This construct is only produced in `generateReusableSchemas` mode, which is why it didn't surface before.

## Fix

Use the same single-quoted, fully JS-escaped form as the primitive description path (`pushDescriptionOrMeta`):

```js
functions.push(['describe', `'${jsStringEscape(siblingSchema.description)}'`]);
```

Now `$ref` siblings and primitive fields are escaped identically:

```ts
"sub": UserId.describe('Subject identifier.\n\nMust be normalized first.'),
```

## Tests

- Updated the existing `$ref` description test to expect the single-quoted form.
- Added regression test `escapes newlines in a multi-line description sibling on a $ref (#3517)`, verified to fail before the fix and pass after.
- Full `@orval/zod` suite passes (204 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Zod validation schemas now emit description strings as single-quoted, fully JS-escaped literals, ensuring special characters and newlines are represented safely.

* **Tests**
  * Added a regression test verifying multi-line descriptions are emitted with escaped newline characters so generated code remains single-line and valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->