### PR TITLE
fix(zod): emit preprocess mutator imports for query/param/header/body, not just response

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -2552,6 +2552,15 @@ export const ${operationResponse} = zod.array(${operationResponse}Item)${
       }),
     ].join('\n\n'),
     mutators: [
+      // Gate each request-side preprocess mutator on its parsed `.zod`: it is
+      // computed for every operation once the target is configured, so without
+      // this an operation lacking the schema would emit an unused import.
+      ...(preprocessParams && inputParams.zod ? [preprocessParams] : []),
+      ...(preprocessQueryParams && inputQueryParams.zod
+        ? [preprocessQueryParams]
+        : []),
+      ...(preprocessHeader && inputHeaders.zod ? [preprocessHeader] : []),
+      ...(preprocessBody && inputBody.zod ? [preprocessBody] : []),
       ...(preprocessResponse ? [preprocessResponse] : []),
       // Unconditional even when this operation's parsed schemas don't
       // reference `paramsMutator.name`: in `single` mode, inline component

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4468,6 +4468,53 @@ const basicApiSchema = {
     },
   },
 } as unknown as GeneratorOptions;
+
+// An operation with a request body and a response but NO param/query/header,
+// to assert a preprocess mutator is collected only for the targets present.
+const bodyOnlyApiSchema = {
+  pathRoute: '/cats',
+  context: {
+    spec: {
+      paths: {
+        '/cats': {
+          post: {
+            operationId: 'createCat',
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { name: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+} as unknown as GeneratorOptions;
 describe('generatePartOfSchemaGenerateZod', () => {
   it('Default Config', async () => {
     const result = await generateZod(
@@ -4867,6 +4914,125 @@ describe('generatePartOfSchemaGenerateZod', () => {
     // The resolved paramsMutator is returned so the import writer can emit
     // the `import { zodParams } from './zod-params'` line in the operation file.
     expect(result.mutators?.some((m) => m.name === 'zodParams')).toBe(true);
+  });
+
+  it('collects a preprocess mutator for every configured target so its import is emitted, not just response', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationId: 'createCat',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            preprocess: {
+              param: { path: './pre-param', name: 'prependParam' },
+              query: { path: './pre-query', name: 'prependQuery' },
+              header: { path: './pre-header', name: 'prependHeader' },
+              body: { path: './pre-body', name: 'prependBody' },
+              response: { path: './pre-response', name: 'prependResponse' },
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      basicApiSchema,
+      testOutput,
+    );
+
+    // Each target schema is wrapped in preprocess(<mutator>, …).
+    expect(result.implementation).toContain('preprocess(prependParam,');
+    expect(result.implementation).toContain('preprocess(prependQuery,');
+    expect(result.implementation).toContain('preprocess(prependHeader,');
+    expect(result.implementation).toContain('preprocess(prependBody,');
+    expect(result.implementation).toContain('preprocess(prependResponse,');
+
+    // The regression: every resolved mutator is returned in `mutators` so its
+    // import is emitted. Before the fix only `response`/`params` were collected.
+    const names = (result.mutators ?? []).map((m) => m.name);
+    expect(names).toContain('prependParam');
+    expect(names).toContain('prependQuery');
+    expect(names).toContain('prependHeader');
+    expect(names).toContain('prependBody');
+    expect(names).toContain('prependResponse');
+  });
+
+  it('omits a request-side preprocess mutator when the operation has no such schema (no unused import / TS6133)', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationId: 'createCat',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            preprocess: {
+              param: { path: './pre-param', name: 'prependParam' },
+              query: { path: './pre-query', name: 'prependQuery' },
+              header: { path: './pre-header', name: 'prependHeader' },
+              body: { path: './pre-body', name: 'prependBody' },
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      bodyOnlyApiSchema,
+      testOutput,
+    );
+
+    const names = (result.mutators ?? []).map((m) => m.name);
+    // body schema present → collected; param/query/header absent → not collected
+    // (else the file would get an unused import).
+    expect(names).toContain('prependBody');
+    expect(names).not.toContain('prependParam');
+    expect(names).not.toContain('prependQuery');
+    expect(names).not.toContain('prependHeader');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #3531.

When `override.zod.preprocess.query` / `.param` / `.header` / `.body` is configured with a mutator, the generated zod schema is wrapped in `zod.preprocess(mutator, …)` but the mutator import is never emitted → `TS2304: Cannot find name`. Only `preprocess.response` worked, because it was the only branch added to the `mutators` array that drives `generateMutatorImports`.

This continues #3515 (wrap not applied) and #3516 (wrong import path in tags-split), which fixed the response/path sides but left import *emission* for the four non-response branches broken.

## Change

In `generateZodRoute` (`packages/zod/src/index.ts`), add the four request-side preprocess mutators to the returned `mutators` array, **gated on the parsed `.zod`**:

```ts
...(preprocessParams && inputParams.zod ? [preprocessParams] : []),
...(preprocessQueryParams && inputQueryParams.zod ? [preprocessQueryParams] : []),
...(preprocessHeader && inputHeaders.zod ? [preprocessHeader] : []),
...(preprocessBody && inputBody.zod ? [preprocessBody] : []),
...(preprocessResponse ? [preprocessResponse] : []), // unchanged
```

The gating matters: `preprocessQueryParams` etc. are resolved for every operation as soon as the target is configured, but the `zod.preprocess(…)` wrap is only emitted for operations that actually have that schema. Adding them unconditionally would emit an *unused* import (`TS6133`) in files whose operations lack the schema. `response` stays unconditional (every operation emits a response schema), matching the behaviour exercised by #3516.

## Tests

Adds two regression tests in `packages/zod/src/zod.test.ts`, asserting `generateZod(...).mutators` (the array that drives imports):

1. **collects a preprocess mutator for every configured target** — param/query/header/body/response each with a distinct mutator; asserts all five wraps are emitted *and* all five mutators are returned. Fails on master (only `prependResponse` is collected).
2. **omits a request-side preprocess mutator when the operation has no such schema** — a body-only operation with all four request targets configured: only the body mutator is collected, proving the gating prevents the unused import.

Both fail without the fix; the full `@orval/zod` suite (229) and all generation snapshots pass with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema generation to conditionally include request-side preprocessors only when their corresponding schemas are present, preventing unused import warnings and build errors.

* **Tests**
  * Enhanced test coverage for conditional preprocessor collection, validating correct behavior with body-only requests and multiple configured preprocess targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->