### PR TITLE
refactor(mock): emit strict mock types once from structured names

### DIFF
--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -11,6 +11,7 @@ import { isFakerMock, isMswMock, OutputMockType } from '@orval/core';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { createTestContextSpec } from '../../../core/src/test-utils/context';
+import { dedupeStrictMockTypeDeclarations } from '../mock-types';
 import {
   generateFaker,
   generateFakerForSchemas,
@@ -203,5 +204,41 @@ describe('generateFakerForSchemas strict mock types (#3525)', () => {
       ') as MockWithNullableOverrides<Pet, O, PetMock>;',
     );
     expect(result.implementation).not.toContain(', null]');
+  });
+
+  it('includes non-overridable strict schemas in strictMockSchemaTypeNames', () => {
+    const result = generateFakerForSchemas(
+      [
+        {
+          name: 'Status',
+          model: 'Status',
+          imports: [],
+          schema: {
+            type: 'string',
+            enum: ['active', 'inactive'],
+          },
+        },
+      ],
+      context,
+      { type: OutputMockType.FAKER, schemas: true },
+    );
+
+    expect(result.strictMockSchemaTypeNames).toEqual(['Status']);
+    expect(result.implementation).not.toContain('overrideResponse');
+    expect(result.implementation).toContain(
+      'export const getStatusMock = (): StatusMock =>',
+    );
+    expect(result.implementation).not.toContain('export type StatusMock = {');
+
+    const finalized = dedupeStrictMockTypeDeclarations(result.implementation, {
+      mockOptions: { required: true, nonNullable: true },
+      strictSchemaTypeNames: result.strictMockSchemaTypeNames,
+    });
+
+    expect(finalized).toContain('export type StatusMock = {');
+    expect(finalized).toContain('export type KeysWithNull<O>');
+    expect(finalized.indexOf('export type StatusMock')).toBeLessThan(
+      finalized.indexOf('export const getStatusMock'),
+    );
   });
 });

--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -171,7 +171,7 @@ describe('generateFakerForSchemas strict mock types (#3525)', () => {
     },
   });
 
-  it('emits PetMock alias and return type for schema factories', () => {
+  it('exposes strict schema names and omits inline type declarations', () => {
     const result = generateFakerForSchemas(
       [
         {
@@ -193,8 +193,9 @@ describe('generateFakerForSchemas strict mock types (#3525)', () => {
       { type: OutputMockType.FAKER, schemas: true },
     );
 
-    expect(result.implementation).toContain('export type PetMock = {');
-    expect(result.implementation).toContain('export type KeysWithNull<O>');
+    expect(result.strictMockSchemaTypeNames).toEqual(['Pet']);
+    expect(result.implementation).not.toContain('export type PetMock = {');
+    expect(result.implementation).not.toContain('export type KeysWithNull<O>');
     expect(result.implementation).toContain(
       'export const getPetMock = <O extends Partial<Pet> = {}>(overrideResponse?: O): MockWithNullableOverrides<Pet, O, PetMock> =>',
     );

--- a/packages/mock/src/faker/index.ts
+++ b/packages/mock/src/faker/index.ts
@@ -165,7 +165,7 @@ export function generateFakerForSchemas(
       returnCast,
     );
 
-    if (isStrictMock(mockOptions) && isOverridable) {
+    if (isStrictMock(mockOptions)) {
       strictMockTypeNames.add(typeName);
     }
 

--- a/packages/mock/src/faker/index.ts
+++ b/packages/mock/src/faker/index.ts
@@ -15,8 +15,6 @@ import {
 import {
   formatMockFactoryDeclaration,
   getMockFactorySignatureParts,
-  getStrictMockHelperTypeDeclarations,
-  getStrictMockTypeDeclaration,
   isStrictMock,
 } from '../mock-types';
 import { generateMSW } from '../msw';
@@ -84,6 +82,7 @@ export function generateFaker(
 export interface GenerateFakerForSchemasResult {
   implementation: string;
   imports: GeneratorImport[];
+  strictMockSchemaTypeNames?: string[];
 }
 
 /**
@@ -215,26 +214,16 @@ export function generateFakerForSchemas(
   // Helper factories from union/discriminator handling (`splitMockImplementations`)
   // are emitted before the public `get<Schema>Mock` factories so call sites
   // declared after them resolve cleanly without TS hoisting concerns.
-  const strictHelperBlock = isStrictMock(mockOptions)
-    ? getStrictMockHelperTypeDeclarations()
-    : '';
-  const strictTypeDeclarations = isStrictMock(mockOptions)
-    ? [...strictMockTypeNames]
-        .map((typeName) => getStrictMockTypeDeclaration(typeName))
-        .join('\n\n')
-    : '';
-  const strictTypeBlock = strictTypeDeclarations;
-  const implementation = [
-    ...splitMockImplementations,
-    strictHelperBlock,
-    strictTypeBlock,
-    ...factories,
-  ]
+  const implementation = [...splitMockImplementations, ...factories]
     .filter(Boolean)
     .join('\n\n');
+
+  const aggregatedStrictNames = [...strictMockTypeNames];
 
   return {
     implementation,
     imports: uniqueImports,
+    strictMockSchemaTypeNames:
+      aggregatedStrictNames.length > 0 ? aggregatedStrictNames : undefined,
   };
 }

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -85,7 +85,6 @@ export {
 } from './faker';
 export {
   buildStrictMockTypeFileHeader,
-  collectStrictMockSchemaTypeNames,
   dedupeStrictMockTypeDeclarations,
 } from './mock-types';
 export { generateMSW, generateMSWImports } from './msw';

--- a/packages/mock/src/mock-types.test.ts
+++ b/packages/mock/src/mock-types.test.ts
@@ -4,8 +4,6 @@ import { describe, expect, it } from 'vitest';
 import {
   applyStrictMockReturnType,
   buildStrictMockTypeFileHeader,
-  collectStrictMockSchemaNamesFromUsage,
-  collectStrictMockSchemaTypeNames,
   dedupeStrictMockTypeDeclarations,
   getMockFactoryReturnType,
   getMockFactorySignatureParts,
@@ -152,34 +150,26 @@ describe('mock-types', () => {
       strictSchemaTypeNames: ['Pet'],
     };
 
-    it('hoists helpers and schema mock aliases once for concatenated operation mocks', () => {
-      const perOp = `${getStrictMockHelperTypeDeclarations()}\n\n${getStrictMockTypeDeclaration('Pet')}\n\nexport const getGetPetResponseMock = () => ({})`;
-      const duplicated = `${perOp}\n\n${perOp}\n\n${perOp}`;
+    it('prepends helpers and schema mock aliases once from structured type names', () => {
+      const body =
+        'export const getGetPetResponseMock = () => ({})\n\nexport const getListPetsResponseMock = () => []';
 
-      const result = dedupeStrictMockTypeDeclarations(
-        duplicated,
-        strictOptions,
-      );
+      const result = dedupeStrictMockTypeDeclarations(body, strictOptions);
 
       expect(result.match(/export type KeysWithNull/g)?.length).toBe(1);
       expect(
         result.match(/export type MockWithNullableOverrides/g)?.length,
       ).toBe(1);
       expect(result.match(/export type PetMock/g)?.length).toBe(1);
-      expect(result.match(/export const getGetPetResponseMock/g)?.length).toBe(
-        3,
+      expect(result.indexOf('export type PetMock')).toBeLessThan(
+        result.indexOf('export const getGetPetResponseMock'),
       );
-    });
-
-    it('strips invalid strict mock aliases for factory value imports', () => {
-      const invalid = `export type getPetMockMock = {
-  [K in keyof Required<getPetMock>]: NonNullable<Required<getPetMock>[K]>;
-};\n\nexport const getListPetsResponseMock = () => []`;
-
-      const result = dedupeStrictMockTypeDeclarations(invalid, strictOptions);
-
-      expect(result).not.toContain('getPetMockMock');
-      expect(result).not.toContain('Required<getPetMock>');
+      expect(result.match(/export const getGetPetResponseMock/g)?.length).toBe(
+        1,
+      );
+      expect(
+        result.match(/export const getListPetsResponseMock/g)?.length,
+      ).toBe(1);
     });
 
     it('is a no-op for non-strict mocks even when a schema is named WidgetMock', () => {
@@ -190,6 +180,16 @@ describe('mock-types', () => {
       expect(result).toBe(body);
       expect(result).not.toContain('export type KeysWithNull');
       expect(result).not.toContain('Required<Widget>');
+    });
+
+    it('returns implementation unchanged when strict mode is on but no type names are provided', () => {
+      const body = 'export const getGetPetResponseMock = () => ({})';
+
+      const result = dedupeStrictMockTypeDeclarations(body, {
+        mockOptions: { required: true, nonNullable: true },
+      });
+
+      expect(result).toBe(body);
     });
   });
 
@@ -269,49 +269,6 @@ describe('mock-types', () => {
 
       expect(header).toContain('export type KeysWithNull');
       expect(header.match(/export type PetMock/g)?.length).toBe(1);
-    });
-  });
-
-  describe('collectStrictMockSchemaTypeNames', () => {
-    it('reads schema names from strict mock alias declarations', () => {
-      const names = collectStrictMockSchemaTypeNames(
-        getStrictMockTypeDeclaration('Pet'),
-      );
-
-      expect(names).toEqual(['Pet']);
-    });
-  });
-
-  describe('collectStrictMockSchemaNamesFromUsage', () => {
-    it('collects schema names referenced by MockWithNullableOverrides factories', () => {
-      const names = collectStrictMockSchemaNamesFromUsage(
-        '(): MockWithNullableOverrides<Pet, O, PetMock> => ({}) as MockWithNullableOverrides<Pet, O, PetMock>;\nexport const getListPetsResponseMock = (): PetMock[] => []',
-      );
-
-      expect(names).toEqual(['Pet']);
-    });
-
-    it('does not treat a schema named WidgetMock as a strict alias usage', () => {
-      const names = collectStrictMockSchemaNamesFromUsage(
-        'export const getGetWidgetResponseMock = (overrideResponse: Partial<WidgetMock> = {}) => ({})',
-      );
-
-      expect(names).toEqual([]);
-    });
-  });
-
-  describe('dedupeStrictMockTypeDeclarations with usage-only mocks', () => {
-    it('hoists helpers when factories reference strict types without inline declarations', () => {
-      const body = `export const getGetPetResponseMock = (): MockWithNullableOverrides<Pet, O, PetMock> => ({}) as MockWithNullableOverrides<Pet, O, PetMock>;\nexport const getListPetsResponseMock = (): PetMock[] => []`;
-
-      const result = dedupeStrictMockTypeDeclarations(body, {
-        mockOptions: { required: true, nonNullable: true },
-        strictSchemaTypeNames: ['Pet'],
-      });
-
-      expect(result).toContain('export type KeysWithNull');
-      expect(result).toContain('export type PetMock');
-      expect(result.match(/export type PetMock/g)?.length).toBe(1);
     });
   });
 });

--- a/packages/mock/src/mock-types.ts
+++ b/packages/mock/src/mock-types.ts
@@ -175,6 +175,9 @@ export function buildStrictMockTypeFileHeader(
 /**
  * Prepends shared strict-mock helper types and each `{Schema}Mock` alias once at
  * the top of a mock file. Generators pass `strictSchemaTypeNames`; no scraping.
+ *
+ * Not idempotent — callers must invoke this exactly once per aggregated mock
+ * file (writers and `writeFakerSchemaMocks`), not from import hooks.
  */
 export function dedupeStrictMockTypeDeclarations(
   implementation: string,
@@ -191,10 +194,9 @@ export function dedupeStrictMockTypeDeclarations(
     return implementation;
   }
 
-  const trimmedBody = implementation.replace(/^\n+/, '').trimStart();
   const header = buildStrictMockTypeFileHeader(schemaTypeNames);
 
-  return header ? `${header}\n\n${trimmedBody}` : trimmedBody;
+  return `${header}\n\n${implementation.trimStart()}`;
 }
 
 export function applyStrictMockReturnType(

--- a/packages/mock/src/mock-types.ts
+++ b/packages/mock/src/mock-types.ts
@@ -161,41 +161,6 @@ export function getSchemaTypeNamesFromResponses(
   return [...names];
 }
 
-const STRICT_MOCK_SCHEMA_DECL_PATTERN =
-  /export type (\w+) = \{\n  \[K in keyof Required<(\w+)>]: NonNullable<Required<\2>\[K\]>;\n\};/g;
-
-/** Removes invalid strict-mock aliases emitted for value imports (e.g. getPetMockMock). */
-const INVALID_STRICT_MOCK_DECL_PATTERN =
-  /export type get\w+Mock = \{[\s\S]*?\};\n*/g;
-
-export function collectStrictMockSchemaTypeNames(
-  implementation: string,
-): string[] {
-  const names = new Set<string>();
-
-  for (const match of implementation.matchAll(
-    STRICT_MOCK_SCHEMA_DECL_PATTERN,
-  )) {
-    names.add(match[2]);
-  }
-
-  return [...names];
-}
-
-export function collectStrictMockSchemaNamesFromUsage(
-  implementation: string,
-): string[] {
-  const names = new Set<string>();
-
-  for (const match of implementation.matchAll(
-    /MockWithNullableOverrides<(\w+),/g,
-  )) {
-    names.add(match[1]);
-  }
-
-  return [...names];
-}
-
 export function buildStrictMockTypeFileHeader(
   schemaTypeNames: Iterable<string>,
 ): string {
@@ -208,8 +173,8 @@ export function buildStrictMockTypeFileHeader(
 }
 
 /**
- * MSW/faker operation mocks are concatenated per file with no dedup. Hoist the
- * shared strict-mock helper types and each `{Schema}Mock` alias once at the top.
+ * Prepends shared strict-mock helper types and each `{Schema}Mock` alias once at
+ * the top of a mock file. Generators pass `strictSchemaTypeNames`; no scraping.
  */
 export function dedupeStrictMockTypeDeclarations(
   implementation: string,
@@ -219,33 +184,12 @@ export function dedupeStrictMockTypeDeclarations(
     return implementation;
   }
 
-  let body = implementation.replaceAll(INVALID_STRICT_MOCK_DECL_PATTERN, '');
-
-  const schemaTypeNames = [
-    ...new Set([
-      ...(options.strictSchemaTypeNames ?? []),
-      ...collectStrictMockSchemaTypeNames(body),
-      ...collectStrictMockSchemaNamesFromUsage(body),
-    ]),
-  ];
-
-  if (
-    schemaTypeNames.length === 0 &&
-    !body.includes('MockWithNullableOverrides<') &&
-    !body.includes('export type KeysWithNull')
-  ) {
-    return body;
+  const schemaTypeNames = [...new Set(options.strictSchemaTypeNames ?? [])];
+  if (schemaTypeNames.length === 0) {
+    return implementation;
   }
 
-  const helperBlock = getStrictMockHelperTypeDeclarations();
-
-  body = body.replaceAll(helperBlock, '');
-
-  for (const typeName of schemaTypeNames) {
-    body = body.replaceAll(getStrictMockTypeDeclaration(typeName), '');
-  }
-
-  const trimmedBody = body.replace(/^\n+/, '').trimStart();
+  const trimmedBody = implementation.replace(/^\n+/, '').trimStart();
   const header = buildStrictMockTypeFileHeader(schemaTypeNames);
 
   return header ? `${header}\n\n${trimmedBody}` : trimmedBody;

--- a/packages/mock/src/mock-types.ts
+++ b/packages/mock/src/mock-types.ts
@@ -184,7 +184,9 @@ export function dedupeStrictMockTypeDeclarations(
     return implementation;
   }
 
-  const schemaTypeNames = [...new Set(options.strictSchemaTypeNames ?? [])];
+  const schemaTypeNames = options.strictSchemaTypeNames
+    ? [...new Set(options.strictSchemaTypeNames)]
+    : [];
   if (schemaTypeNames.length === 0) {
     return implementation;
   }

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -181,15 +181,19 @@ async function writeFakerSchemaMocks(
     output,
   };
 
-  const { implementation, imports } = generateFakerForSchemas(
-    schemasWithDef,
-    context,
-    fakerEntry,
-  );
+  const { implementation, imports, strictMockSchemaTypeNames } =
+    generateFakerForSchemas(schemasWithDef, context, fakerEntry);
 
   if (!implementation.trim()) {
     return undefined;
   }
+
+  const finalizedImplementation = builder.finalizeMockImplementation
+    ? builder.finalizeMockImplementation(implementation, {
+        mockOptions: output.override.mock,
+        strictSchemaTypeNames: strictMockSchemaTypeNames,
+      })
+    : implementation;
 
   let filePath: string;
   let schemaImportPath: string | undefined;
@@ -242,7 +246,7 @@ async function writeFakerSchemaMocks(
   }
 
   const importsHeader = generateDependencyImports(
-    implementation,
+    finalizedImplementation,
     [
       {
         exports: [{ name: 'faker', values: true }],
@@ -260,7 +264,7 @@ async function writeFakerSchemaMocks(
     false,
   );
 
-  const content = `${header}${importsHeader}\n\n${implementation}`;
+  const content = `${header}${importsHeader}\n\n${finalizedImplementation}`;
   await writeGeneratedFile(filePath, content);
   return filePath;
 }

--- a/tests/__snapshots__/mock/issue-3525/model/index.faker.ts
+++ b/tests/__snapshots__/mock/issue-3525/model/index.faker.ts
@@ -6,7 +6,7 @@
  */
 import { faker } from '@faker-js/faker';
 
-import type { Pet } from '.';
+import type { Pet, PetList, Score, Status } from '.';
 
 export type KeysWithNull<O> = {
   [K in keyof O]-?: null extends O[K] ? K : never;
@@ -24,6 +24,18 @@ export type PetMock = {
   [K in keyof Required<Pet>]: NonNullable<Required<Pet>[K]>;
 };
 
+export type StatusMock = {
+  [K in keyof Required<Status>]: NonNullable<Required<Status>[K]>;
+};
+
+export type PetListMock = {
+  [K in keyof Required<PetList>]: NonNullable<Required<PetList>[K]>;
+};
+
+export type ScoreMock = {
+  [K in keyof Required<Score>]: NonNullable<Required<Score>[K]>;
+};
+
 export const getPetMock = <O extends Partial<Pet> = {}>(
   overrideResponse?: O,
 ): MockWithNullableOverrides<Pet, O, PetMock> =>
@@ -38,3 +50,15 @@ export const getPetMock = <O extends Partial<Pet> = {}>(
     ).map(() => faker.string.alpha({ length: { min: 10, max: 20 } })),
     ...overrideResponse,
   }) as MockWithNullableOverrides<Pet, O, PetMock>;
+
+export const getStatusMock = (): StatusMock =>
+  faker.helpers.arrayElement(['active', 'inactive'] as const);
+
+export const getPetListMock = (): PetListMock =>
+  Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({ ...getPetMock() }));
+
+export const getScoreMock = (): ScoreMock =>
+  faker.number.float({ fractionDigits: 2 });

--- a/tests/__snapshots__/mock/issue-3525/model/petList.ts
+++ b/tests/__snapshots__/mock/issue-3525/model/petList.ts
@@ -4,8 +4,6 @@
  * Issue 3525 - strict mock return types (OpenAPI 3.0)
  * OpenAPI spec version: 1.0.0
  */
+import type { Pet } from './pet';
 
-export * from './pet';
-export * from './petList';
-export * from './score';
-export * from './status';
+export type PetList = Pet[];

--- a/tests/__snapshots__/mock/issue-3525/model/score.ts
+++ b/tests/__snapshots__/mock/issue-3525/model/score.ts
@@ -5,7 +5,4 @@
  * OpenAPI spec version: 1.0.0
  */
 
-export * from './pet';
-export * from './petList';
-export * from './score';
-export * from './status';
+export type Score = number;

--- a/tests/__snapshots__/mock/issue-3525/model/status.ts
+++ b/tests/__snapshots__/mock/issue-3525/model/status.ts
@@ -5,7 +5,9 @@
  * OpenAPI spec version: 1.0.0
  */
 
-export * from './pet';
-export * from './petList';
-export * from './score';
-export * from './status';
+export type Status = (typeof Status)[keyof typeof Status];
+
+export const Status = {
+  active: 'active',
+  inactive: 'inactive',
+} as const;

--- a/tests/specifications/issue-3525.yaml
+++ b/tests/specifications/issue-3525.yaml
@@ -9,6 +9,8 @@ info:
 # With override.mock.required and override.mock.nonNullable both true,
 # schema and operation mock factories should return a strict PetMock alias
 # while still accepting Partial<Pet> overrides (including null).
+# Top-level enum/array/scalar schemas are non-overridable but still need
+# {Schema}Mock aliases emitted via strictMockSchemaTypeNames + finalize.
 
 paths:
   /pet:
@@ -47,3 +49,14 @@ components:
           items:
             type: string
           nullable: true
+    Status:
+      type: string
+      enum:
+        - active
+        - inactive
+    PetList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Pet'
+    Score:
+      type: number


### PR DESCRIPTION
## Summary

Follow-up refactor from strict mock types (#3525). Aligns the faker `schemas: true` path with MSW/operation mocks: generators only emit factories, and `finalizeMockImplementation` prepends strict helpers and `{Schema}Mock` aliases once from `strictMockSchemaTypeNames`.

- `generateFakerForSchemas` returns `strictMockSchemaTypeNames` and no longer inlines strict type blocks
- `writeFakerSchemaMocks` calls `finalizeMockImplementation` (same as other writers)
- `dedupeStrictMockTypeDeclarations` only prepends from the structured set (removed regex scraping/strip logic)

Closes #3542

## Test plan

- [x] `@orval/mock` unit tests
- [x] `orval-tests build` (mock client typecheck)
- [x] CI green on PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faker mock generation now exposes strict schema type names separately, producing leaner mock implementations and enabling predictable header insertion and ordering.

* **Bug Fixes**
  * Finalized mock output is used when computing imports and emitting files so generated files reflect finalized implementation.

* **New Features**
  * Generated mock types and factory functions added for additional schemas (e.g., Status, PetList, Score).

* **Tests**
  * Updated/added tests covering strict-type exposure, deduplication/header behavior, and finalized-output flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->