### PR TITLE
feat(core): add schemas.importPath for package import specifiers

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -166,9 +166,14 @@ import statements change.
   `factoryMethods.outputDirectory` is bypassed: factories resolve imports
   against the package specifier rather than the on-disk factory output
   directory.
+- Config normalization rejects invalid `importPath` values (empty, whitespace,
+  relative, or absolute paths) before generation runs — see
+  [Validation of `importPath`](#validation-of-importpath) below.
 
-**Validation of `importPath`** during config normalization rejects the
-following values with a clear error message before generation runs:
+### Validation of `importPath`{#validation-of-importpath}
+
+During config normalization, orval rejects the following `importPath` values
+with a clear error message before generation runs:
 
 - Empty string.
 - Strings that are empty after trimming whitespace (e.g. `"   "`), or that

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -167,6 +167,17 @@ import statements change.
   against the package specifier rather than the on-disk factory output
   directory.
 
+**Validation of `importPath`** during config normalization rejects the
+following values with a clear error message before generation runs:
+
+- Empty string.
+- Strings that are empty after trimming whitespace (e.g. `"   "`), or that
+  contain leading/trailing whitespace around a valid-looking specifier.
+- Relative specifiers starting with `./` or `../` (e.g. `./models`,
+  `../models`).
+- Absolute paths — POSIX (starting with `/`, e.g. `/abs/models`) or Windows
+  (drive-letter like `C:\models`, or UNC like `\\server\share\models`).
+
 ## operationSchemas
 
 **Type:** `String`

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -79,10 +79,12 @@ export default defineConfig({
 
 ## schemas
 
-**Type:** `String`
+**Type:** `String | Object | false`
 **Default:** Same as `target`
 
-Output path for generated model types.
+Output path for generated model types. Set to `false` to disable separate schema file output.
+
+### String form
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -93,6 +95,77 @@ export default defineConfig({
   },
 });
 ```
+
+### Object form
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      schemas: {
+        path: './api/model',
+        type: 'typescript', // 'typescript' | 'zod'
+      },
+    },
+  },
+});
+```
+
+| Property   | Type     | Description                                     |
+| ---------- | -------- | ----------------------------------------------- |
+| `path`     | `string` | Filesystem path for schema output               |
+| `type`     | `string` | `'typescript'` or `'zod'`                       |
+| `importPath` | `string` | Optional package import specifier (see below)  |
+
+### importPath
+
+When `importPath` is set, generated client files import schema types from
+that package specifier instead of computing a relative filesystem path:
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      target: './libs/client/angular/src/lib/endpoints',
+      schemas: {
+        path: './libs/client/models/src/lib',
+        type: 'typescript',
+        importPath: '@acme/client/models',
+      },
+    },
+  },
+});
+```
+
+```ts
+// Without importPath — computed relative path:
+import type { Pet } from '../models/pet';
+
+// With importPath: '@acme/client/models':
+import type { Pet } from '@acme/client/models';
+```
+
+Schemas are still written to the filesystem `path` — only the generated
+import statements change.
+
+**Requirements when using `importPath`:**
+
+- The target package must export the types at the specified import path.
+- With `indexFiles: true` (recommended), all types are imported from the
+  single `importPath` (e.g., `@acme/models`).
+- With `indexFiles: false`, each schema is imported individually
+  (e.g., `@acme/models/pet`). The package must support these subpath exports.
+  For Zod schemas (`type: 'zod'`) the per-file suffix is `.zod`, so the
+  package must also expose `./pet.zod` (e.g., `@acme/models/pet.zod`).
+- If using faker schema factories
+  (`mock: { generators: [{ type: 'faker', schemas: true }] }`),
+  the package must also export `./index.faker`.
+- If using factory methods (`factoryMethods`), each schema is imported
+  individually regardless of `indexFiles`.
+- When `importPath` is set, the relative-path computation in
+  `factoryMethods.outputDirectory` is bypassed: factories resolve imports
+  against the package specifier rather than the on-disk factory output
+  directory.
 
 ## operationSchemas
 

--- a/packages/core/src/generators/factory.test.ts
+++ b/packages/core/src/generators/factory.test.ts
@@ -611,3 +611,168 @@ describe('generateFactory', () => {
     );
   });
 });
+
+describe('generateFactory with schemas.importPath', () => {
+  it('uses importPath for $ref imports in split mode', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['target'],
+      properties: {
+        target: { $ref: '#/components/schemas/RefTarget' },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'WithRef',
+      createMockContext({
+        factoryMethods: { ...baseFactoryMethods, mode: 'split' },
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      }),
+    );
+    expect(result?.imports).toContainEqual({
+      name: 'createRefTarget',
+      importPath: '@acme/models/refTarget',
+      isConstant: true,
+    });
+    expect(result?.imports).toContainEqual({
+      name: 'RefTarget',
+      importPath: '@acme/models/refTarget',
+    });
+  });
+
+  it('uses importPath for circular reference casts in split mode', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['child'],
+      properties: {
+        child: { $ref: '#/components/schemas/CircularChild' },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'CircularParent',
+      createMockContext({
+        factoryMethods: { ...baseFactoryMethods, mode: 'split' },
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      }),
+    );
+    expect(result?.model).toContain('child: {} as CircularChild');
+    expect(result?.imports).toContainEqual({
+      name: 'CircularChild',
+      importPath: '@acme/models/circularChild',
+    });
+    expect(result?.imports).toContainEqual({
+      name: 'CircularParent',
+      importPath: '@acme/models/circularParent',
+    });
+  });
+
+  it('uses importPath for factory function imports in single mode', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['target'],
+      properties: {
+        target: { $ref: '#/components/schemas/RefTarget' },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'WithRef',
+      createMockContext({
+        factoryMethods: { ...baseFactoryMethods, mode: 'single' },
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      }),
+    );
+    expect(result?.imports).toContainEqual({
+      name: 'createRefTarget',
+      importPath: '@acme/models/refTarget',
+      isConstant: true,
+    });
+  });
+
+  it('uses importPath for type imports in single-split mode (factory combined into single file)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['target'],
+      properties: {
+        target: { $ref: '#/components/schemas/RefTarget' },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'WithRefCombined',
+      createMockContext({
+        factoryMethods: { ...baseFactoryMethods, mode: 'single-split' },
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      }),
+    );
+    expect(result?.imports).not.toContainEqual(
+      expect.objectContaining({ name: 'createRefTarget' }),
+    );
+    expect(result?.imports).toContainEqual({
+      name: 'RefTarget',
+      importPath: '@acme/models/refTarget',
+    });
+    expect(result?.imports).toContainEqual({
+      name: 'WithRefCombined',
+      importPath: '@acme/models/withRefCombined',
+    });
+  });
+
+  it('bypasses factoryMethods.outputDirectory when importPath is set (split mode)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['target'],
+      properties: {
+        target: { $ref: '#/components/schemas/RefTarget' },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'WithRef',
+      createMockContext({
+        factoryMethods: {
+          ...baseFactoryMethods,
+          mode: 'split',
+          outputDirectory: '/libs/factories',
+        },
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      }),
+    );
+
+    const factoryImport = result?.imports.find(
+      (i) => i.name === 'createRefTarget',
+    );
+    expect(factoryImport?.importPath).toBe('@acme/models/refTarget');
+    expect(factoryImport?.importPath).not.toContain('factories');
+
+    const typeImport = result?.imports.find((i) => i.name === 'RefTarget');
+    expect(typeImport?.importPath).toBe('@acme/models/refTarget');
+    expect(typeImport?.importPath).not.toContain('factories');
+  });
+});

--- a/packages/core/src/generators/factory.test.ts
+++ b/packages/core/src/generators/factory.test.ts
@@ -636,7 +636,7 @@ describe('generateFactory with schemas.importPath', () => {
     );
     expect(result?.imports).toContainEqual({
       name: 'createRefTarget',
-      importPath: '@acme/models/refTarget',
+      importPath: '@acme/models/refTarget.factory',
       isConstant: true,
     });
     expect(result?.imports).toContainEqual({
@@ -768,7 +768,7 @@ describe('generateFactory with schemas.importPath', () => {
     const factoryImport = result?.imports.find(
       (i) => i.name === 'createRefTarget',
     );
-    expect(factoryImport?.importPath).toBe('@acme/models/refTarget');
+    expect(factoryImport?.importPath).toBe('@acme/models/refTarget.factory');
     expect(factoryImport?.importPath).not.toContain('factories');
 
     const typeImport = result?.imports.find((i) => i.name === 'RefTarget');

--- a/packages/core/src/generators/factory.ts
+++ b/packages/core/src/generators/factory.ts
@@ -9,6 +9,7 @@ import { PropertySortOrder } from '../types';
 import {
   conventionName,
   getFileInfo,
+  getSchemasImportPath,
   isString,
   logWarning,
   pascal,
@@ -34,6 +35,13 @@ function getSchemaImportPath(
   if (context.output.factoryMethods?.mode === 'single') {
     return undefined;
   }
+
+  const importPathBase = getSchemasImportPath(context.output.schemas);
+  if (importPathBase) {
+    const baseName = conventionName(refName, context.output.namingConvention);
+    return upath.joinSafe(importPathBase, baseName);
+  }
+
   let outputDir = context.output.factoryMethods?.outputDirectory;
   let schemasPath = getSchemasPath(context);
 
@@ -328,15 +336,24 @@ function resolveImportPath(
   context: ContextSpec,
 ): string | undefined {
   const baseName = conventionName(refName, context.output.namingConvention);
+  const pkgBase = getSchemasImportPath(context.output.schemas);
+
   switch (mode) {
     case 'split': {
-      return `./${baseName}.factory`;
+      return pkgBase
+        ? upath.joinSafe(pkgBase, baseName)
+        : `./${baseName}.factory`;
     }
     case 'single-split': {
-      return `./${conventionName('factoryMethods', context.output.namingConvention)}`;
+      return pkgBase
+        ? upath.joinSafe(
+            pkgBase,
+            conventionName('factoryMethods', context.output.namingConvention),
+          )
+        : `./${conventionName('factoryMethods', context.output.namingConvention)}`;
     }
     case 'single': {
-      return `./${baseName}`;
+      return pkgBase ? upath.joinSafe(pkgBase, baseName) : `./${baseName}`;
     }
   }
 }

--- a/packages/core/src/generators/factory.ts
+++ b/packages/core/src/generators/factory.ts
@@ -341,7 +341,7 @@ function resolveImportPath(
   switch (mode) {
     case 'split': {
       return pkgBase
-        ? upath.joinSafe(pkgBase, baseName)
+        ? upath.joinSafe(pkgBase, `${baseName}.factory`)
         : `./${baseName}.factory`;
     }
     case 'single-split': {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -308,11 +308,13 @@ export interface NormalizedFactoryMethodsOptions {
 export interface SchemaOptions {
   path: string;
   type: SchemaGenerationType;
+  importPath?: string;
 }
 
 export interface NormalizedSchemaOptions {
   path: string;
   type: SchemaGenerationType;
+  importPath?: string;
 }
 
 export interface OutputOptions {

--- a/packages/core/src/utils/assertion.test.ts
+++ b/packages/core/src/utils/assertion.test.ts
@@ -23,6 +23,7 @@ describe('assertion testing', () => {
   it('checks for reference objects', () => {
     expect(isReference({ $ref: '#/components/schemas/User' })).toBeTruthy();
     expect(isReference({} as Record<string, unknown>)).toBeFalsy();
+    expect(isReference({ $dynamicRef: '#category' })).toBeFalsy();
     // eslint-disable-next-line unicorn/no-null -- testing null handling
     expect(isReference(null as unknown as object)).toBeFalsy();
   });
@@ -134,10 +135,6 @@ describe('isDynamicReference', () => {
     expect(isDynamicReference({ $dynamicRef: 123 } as unknown as object)).toBe(
       false,
     );
-  });
-
-  it('returns false for objects with $dynamicRef but not $ref in isReference', () => {
-    expect(isReference({ $dynamicRef: '#category' })).toBe(false);
   });
 
   it('returns true for objects with $ref in isReference', () => {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,6 +17,7 @@ export * from './merge-deep';
 export * from './occurrence';
 export * as upath from './path';
 export * from './resolve-version';
+export * from './schemas-options';
 export * from './sort';
 export * from './string';
 export * from './tsconfig';

--- a/packages/core/src/utils/schemas-options.test.ts
+++ b/packages/core/src/utils/schemas-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSchemasImportPath } from './schemas-options';
+
+describe('getSchemasImportPath', () => {
+  it('returns importPath when schemas is an object with importPath', () => {
+    expect(
+      getSchemasImportPath({
+        path: '/libs/models',
+        type: 'typescript',
+        importPath: '@acme/models',
+      }),
+    ).toBe('@acme/models');
+  });
+
+  it('returns undefined when schemas is an object without importPath', () => {
+    expect(
+      getSchemasImportPath({ path: '/libs/models', type: 'typescript' }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when schemas is a string', () => {
+    expect(getSchemasImportPath('./models')).toBeUndefined();
+  });
+
+  it('returns undefined when schemas is undefined', () => {
+    expect(getSchemasImportPath()).toBeUndefined();
+  });
+
+  it('returns undefined when schemas is false', () => {
+    expect(getSchemasImportPath(false)).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/schemas-options.ts
+++ b/packages/core/src/utils/schemas-options.ts
@@ -1,0 +1,20 @@
+import type { NormalizedSchemaOptions } from '../types';
+import { isObject } from './assertion';
+
+export interface SchemaOptionLike {
+  importPath?: string;
+}
+
+/**
+ * Extracts the custom package import specifier from a normalized `schemas`
+ * config. Returns `undefined` when `schemas` is a plain string, `false`,
+ * `undefined`, or when `importPath` is not set.
+ */
+export function getSchemasImportPath(
+  schemas?: string | NormalizedSchemaOptions | SchemaOptionLike | false | null,
+): string | undefined {
+  if (isObject(schemas)) {
+    return (schemas as SchemaOptionLike).importPath;
+  }
+  return undefined;
+}

--- a/packages/core/src/writers/generate-imports-for-builder.test.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.test.ts
@@ -199,6 +199,130 @@ describe('generateImportsForBuilder', () => {
     });
   });
 
+  describe('with importPath (package import specifier)', () => {
+    it('should use package import path with indexFiles', () => {
+      const output = createMockOutput({
+        indexFiles: true,
+        fileExtension: '.ts',
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      });
+      const imports = [createMockImport('User'), createMockImport('Pet')];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [{ name: 'User' }, { name: 'Pet' }],
+          dependency: '@acme/models',
+        },
+      ]);
+    });
+
+    it('should use package import path without file extension when indexFiles is false', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      });
+      const imports = [createMockImport('User'), createMockImport('Pet')];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [{ name: 'User' }],
+          dependency: '@acme/models/user',
+        },
+        {
+          exports: [{ name: 'Pet' }],
+          dependency: '@acme/models/pet',
+        },
+      ]);
+    });
+
+    it('should use package import path without file extension even with NodeNext tsconfig', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        tsconfig: {
+          compilerOptions: {
+            module: 'NodeNext' as const,
+            moduleResolution: 'NodeNext' as const,
+          },
+        },
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      });
+      const imports = [createMockImport('User')];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [{ name: 'User' }],
+          dependency: '@acme/models/user',
+        },
+      ]);
+    });
+
+    it('should preserve zod suffix with package import path when indexFiles is false', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        schemas: {
+          path: '/libs/models',
+          type: 'zod',
+          importPath: '@acme/models',
+        },
+      });
+      const imports = [createMockImport('User')];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [{ name: 'User', schemaName: undefined }],
+          dependency: '@acme/models/user.zod',
+        },
+      ]);
+    });
+
+    it('should omit file extension for schemaFactory imports with package import path', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+      });
+      const imports: GeneratorImport[] = [
+        { name: 'createUser', schemaFactory: true },
+      ];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [{ name: 'createUser', schemaFactory: true }],
+          dependency: '@acme/models/index.faker',
+        },
+      ]);
+    });
+  });
+
   describe('naming conventions', () => {
     it('should apply PASCAL_CASE convention with custom extension', () => {
       const output = createMockOutput({

--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -12,6 +12,9 @@ export function generateImportsForBuilder(
   imports: readonly GeneratorImport[],
   relativeSchemasPath: string,
 ): GeneratorDependency[] {
+  const isPackageImport =
+    isObject(output.schemas) && !!output.schemas.importPath;
+
   const isZodSchemaOutput =
     isObject(output.schemas) && output.schemas.type === 'zod';
 
@@ -21,10 +24,9 @@ export function generateImportsForBuilder(
   // Append `getImportExtension` so NodeNext / Node16 module resolution
   // gets the required local-file extension (e.g. `.js`).
   const schemaFactoryImports = imports.filter((i) => i.schemaFactory);
-  const schemaFactoryImportExtension = getImportExtension(
-    output.fileExtension,
-    output.tsconfig,
-  );
+  const schemaFactoryImportExtension = isPackageImport
+    ? ''
+    : getImportExtension(output.fileExtension, output.tsconfig);
   const schemaFactoryDeps: GeneratorDependency[] =
     schemaFactoryImports.length > 0
       ? [
@@ -69,10 +71,9 @@ export function generateImportsForBuilder(
         : (schemaImport.schemaName ?? schemaImport.name);
       const normalizedName = conventionName(baseName, output.namingConvention);
       const suffix = isZodSchemaOutput ? '.zod' : '';
-      const importExtension = getImportExtension(
-        output.fileExtension,
-        output.tsconfig,
-      );
+      const importExtension = isPackageImport
+        ? ''
+        : getImportExtension(output.fileExtension, output.tsconfig);
       const dependency = upath.joinSafe(
         relativeSchemasPath,
         `${normalizedName}${suffix}${importExtension}`,

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -3,6 +3,7 @@ import type { WriteModeProps } from '../types';
 import {
   conventionName,
   getFileInfo,
+  getSchemasImportPath,
   isFunction,
   isString,
   isSyntheticDefaultImportsAllow,
@@ -69,14 +70,16 @@ export async function writeSingleMode({
 
     let data = header;
 
+    const schemaCustomImportPath = getSchemasImportPath(output.schemas);
     const schemasPath = output.schemas
-      ? upath.getRelativeImportPath(
+      ? (schemaCustomImportPath ??
+        upath.getRelativeImportPath(
           path,
           getFileInfo(
             isString(output.schemas) ? output.schemas : output.schemas.path,
             { extension: output.fileExtension },
           ).dirname,
-        )
+        ))
       : undefined;
 
     const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -11,6 +11,7 @@ import {
   conventionName,
   getFileInfo,
   getImportExtension,
+  getSchemasImportPath,
   isFunction,
   isString,
   isSyntheticDefaultImportsAllow,
@@ -60,14 +61,16 @@ export async function writeSplitMode({
 
     let implementationData = header;
 
+    const schemaCustomImportPath = getSchemasImportPath(output.schemas);
     const relativeSchemasPath = output.schemas
-      ? upath.getRelativeImportPath(
+      ? (schemaCustomImportPath ??
+        upath.getRelativeImportPath(
           targetPath,
           getFileInfo(
             isString(output.schemas) ? output.schemas : output.schemas.path,
             { extension: output.fileExtension },
           ).dirname,
-        )
+        ))
       : './' + filename + '.schemas' + extension.replace(/\.ts$/, '');
 
     const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -12,6 +12,7 @@ import {
 import {
   conventionName,
   getFileInfo,
+  getSchemasImportPath,
   isFunction,
   isString,
   isSyntheticDefaultImportsAllow,
@@ -94,14 +95,16 @@ export async function writeSplitTagsMode({
         let implementationData = header;
 
         const importerPath = path.join(dirname, tag, tag + extension);
+        const schemaCustomImportPath = getSchemasImportPath(output.schemas);
         const relativeSchemasPath = output.schemas
-          ? upath.getRelativeImportPath(
+          ? (schemaCustomImportPath ??
+            upath.getRelativeImportPath(
               importerPath,
               getFileInfo(
                 isString(output.schemas) ? output.schemas : output.schemas.path,
                 { extension: output.fileExtension },
               ).dirname,
-            )
+            ))
           : '../' + filename + '.schemas' + extension.replace(/\.ts$/, '');
 
         // In tags-split mode, each tag lives in its own subdirectory

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -5,6 +5,7 @@ import type { WriteModeProps } from '../types';
 import {
   conventionName,
   getFileInfo,
+  getSchemasImportPath,
   isFunction,
   isString,
   isSyntheticDefaultImportsAllow,
@@ -80,14 +81,16 @@ export async function writeTagsMode({
 
         let data = header;
 
+        const schemaCustomImportPath = getSchemasImportPath(output.schemas);
         const schemasPathRelative = output.schemas
-          ? upath.getRelativeImportPath(
+          ? (schemaCustomImportPath ??
+            upath.getRelativeImportPath(
               targetPath,
               getFileInfo(
                 isString(output.schemas) ? output.schemas : output.schemas.path,
                 { extension: output.fileExtension },
               ).dirname,
-            )
+            ))
           : './' + filename + '.schemas' + extension.replace(/\.ts$/, '');
 
         const implementationImports = imports.filter((imp) => {

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -949,7 +949,7 @@ describe('generateSpec - schemas.importPath', () => {
       await generateSpec(workspace, options);
 
       const content = await fs.readFile(targetFile, 'utf8');
-      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).toMatch(/from\s+'@acme\/models'/);
       expect(content).not.toMatch(/from\s+'\.\./);
     } finally {
       await rm(workspace, { recursive: true, force: true });
@@ -987,7 +987,7 @@ describe('generateSpec - schemas.importPath', () => {
         path.join(workspace, tagFileName ?? ''),
         'utf8',
       );
-      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).toMatch(/from\s+'@acme\/models'/);
       expect(content).not.toMatch(/from\s+'\.\./);
     } finally {
       await rm(workspace, { recursive: true, force: true });
@@ -1023,7 +1023,7 @@ describe('generateSpec - schemas.importPath', () => {
       expect(tsFile).toBeTruthy();
       const tagFile = path.join(workspace, String(tsFile));
       const content = await fs.readFile(tagFile, 'utf8');
-      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).toMatch(/from\s+'@acme\/models'/);
       expect(content).not.toMatch(/from\s+'\.\./);
     } finally {
       await rm(workspace, { recursive: true, force: true });
@@ -1056,7 +1056,7 @@ describe('generateSpec - schemas.importPath', () => {
         path.join(workspace, 'endpoints.ts'),
         'utf8',
       );
-      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).toMatch(/from\s+'@acme\/models'/);
       expect(content).not.toMatch(/from\s+'\.\./);
     } finally {
       await rm(workspace, { recursive: true, force: true });

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -667,7 +667,6 @@ describe('generateSpec - generateReusableSchemas inline (pure-$ref operations)',
 });
 
 describe('generateSpec - generateReusableSchemas wrapper/import name collision (#3478)', () => {
-  // Regression: when pascal(operationId) + 'Response' equals an imported
   // component schema name, the operation wrapper used to be emitted with the
   // same identifier as the import:
   //
@@ -919,6 +918,177 @@ describe('generateSpec - useNamedParameters + zod schema output', () => {
         'utf8',
       );
       expect(endpoints).toMatch(/:\s*ShowPetByIdPathParameters/);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('generateSpec - schemas.importPath', () => {
+  it('uses package import specifier in generated endpoint imports (single mode)', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'endpoints.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './endpoints.ts',
+            mode: 'single',
+            schemas: {
+              path: './model',
+              type: 'typescript',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).not.toMatch(/from\s+'\.\./);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('uses package import specifier in generated endpoint imports (tags mode)', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './endpoints.ts',
+            mode: 'tags',
+            schemas: {
+              path: './model',
+              type: 'typescript',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const files = await fs.readdir(workspace);
+      const tagFileName = files.find(
+        (f) => f.endsWith('.ts') && f !== 'endpoints.ts',
+      );
+      expect(tagFileName).toBeTruthy();
+      const content = await fs.readFile(
+        path.join(workspace, tagFileName ?? ''),
+        'utf8',
+      );
+      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).not.toMatch(/from\s+'\.\./);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('uses package import specifier in generated endpoint imports (tags-split mode)', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './endpoints.ts',
+            mode: 'tags-split',
+            schemas: {
+              path: './model',
+              type: 'typescript',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const entries = await fs.readdir(workspace, { recursive: true });
+      const tsFile = entries.find(
+        (e) => String(e).endsWith('.ts') && !String(e).includes('model'),
+      );
+      expect(tsFile).toBeTruthy();
+      const tagFile = path.join(workspace, String(tsFile));
+      const content = await fs.readFile(tagFile, 'utf8');
+      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).not.toMatch(/from\s+'\.\./);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('uses package import specifier in generated endpoint imports (split mode)', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './endpoints.ts',
+            mode: 'split',
+            schemas: {
+              path: './model',
+              type: 'typescript',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(
+        path.join(workspace, 'endpoints.ts'),
+        'utf8',
+      );
+      expect(content).toMatch(/from\s+'@acme\/models/);
+      expect(content).not.toMatch(/from\s+'\.\./);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('uses package import specifier with indexFiles (single mode)', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'endpoints.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './endpoints.ts',
+            mode: 'single',
+            indexFiles: true,
+            schemas: {
+              path: './model',
+              type: 'typescript',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+      expect(content).toMatch(/from\s+'@acme\/models'/);
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -315,6 +315,198 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('preserves schemas.importPath through normalization', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './generated.ts',
+            schemas: {
+              path: './models',
+              type: 'typescript',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.schemas).toEqual({
+        path: expect.any(String) as string,
+        type: 'typescript',
+        importPath: '@acme/models',
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a relative path as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: './models',
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('schemas.importPath must be a package specifier');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an empty string as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: '',
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow(
+        'schemas.importPath must be a non-empty package specifier',
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a parent-relative path as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: '../models',
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('schemas.importPath must be a package specifier');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an absolute path as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: '/abs/models',
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('not an absolute path');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a whitespace-only string as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: '   ',
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('whitespace-only string');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('defaults zod dateTimeOptions to { offset: true } so RFC3339 offset values are accepted', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -569,6 +569,37 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('rejects leading/trailing whitespace in schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: '  @acme/models  ',
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('leading or trailing whitespace');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('defaults zod dateTimeOptions to { offset: true } so RFC3339 offset values are accepted', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -476,6 +476,68 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('rejects a Windows drive-letter absolute path as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: String.raw`C:\models`,
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('not an absolute path');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a Windows UNC path as schemas.importPath', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: String.raw`\\server\share\models`,
+              },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('not an absolute path');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a whitespace-only string as schemas.importPath', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -124,9 +124,15 @@ function normalizeSchemasOption(
     );
   }
 
-  if (schemas.importPath && schemas.importPath.trim() !== schemas.importPath) {
+  if (schemas.importPath?.trim() === '') {
     throw new Error(
       `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received a whitespace-only string.`,
+    );
+  }
+
+  if (schemas.importPath && schemas.importPath.trim() !== schemas.importPath) {
+    throw new Error(
+      `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received a value with leading or trailing whitespace: "${schemas.importPath}"`,
     );
   }
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -136,7 +136,12 @@ function normalizeSchemasOption(
     );
   }
 
-  if (schemas.importPath?.startsWith('/')) {
+  if (
+    schemas.importPath &&
+    (nodePath.isAbsolute(schemas.importPath) ||
+      /^[A-Za-z]:[\\/]/.test(schemas.importPath) ||
+      schemas.importPath.startsWith('\\\\'))
+  ) {
     throw new Error(
       `schemas.importPath must be a package specifier (e.g. '@acme/models'), not an absolute path. Received: "${schemas.importPath}"`,
     );

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -118,9 +118,34 @@ function normalizeSchemasOption(
     return normalizePath(schemas, workspace);
   }
 
+  if (schemas.importPath !== undefined && !schemas.importPath) {
+    throw new Error(
+      `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received an empty string.`,
+    );
+  }
+
+  if (schemas.importPath && schemas.importPath.trim() !== schemas.importPath) {
+    throw new Error(
+      `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received a whitespace-only string.`,
+    );
+  }
+
+  if (schemas.importPath?.startsWith('.')) {
+    throw new Error(
+      `schemas.importPath must be a package specifier (e.g. '@acme/models'), not a relative path. Received: "${schemas.importPath}"`,
+    );
+  }
+
+  if (schemas.importPath?.startsWith('/')) {
+    throw new Error(
+      `schemas.importPath must be a package specifier (e.g. '@acme/models'), not an absolute path. Received: "${schemas.importPath}"`,
+    );
+  }
+
   return {
     path: normalizePath(schemas.path, workspace),
     type: schemas.type,
+    importPath: schemas.importPath,
   };
 }
 


### PR DESCRIPTION
Closes #3535
Fix #353 

## Problem

When `output.schemas` points to a folder outside the generated client target, Orval emits imports based on filesystem paths. This works when schemas and clients are part of the same TypeScript compilation root, but can fail for package secondary entrypoints, where imports like `import type { Pet } from '/libs/client/models'` are emitted instead of a proper package specifier.

## Solution

Allow `output.schemas` to specify an import specifier independent from the filesystem output path:

```ts
output: {
  target: './libs/client/angular/src/lib/endpoints',
  schemas: {
    path: './libs/client/models/src/lib',
    type: 'typescript',
    importPath: '@acme/client/models',
  },
}
```

When `importPath` is set, generated client files import schema types from that package specifier. The filesystem `path` is still used for the on-disk schema output.

## Changes

- **core**: add `importPath` to `SchemaOptions` / `NormalizedSchemaOptions`
- **core**: extract `getSchemasImportPath` helper into its own module
- **core**: update all writers (single/split/tags/split-tags) to use the helper
- **core**: update factory generators to resolve factory and type imports from `importPath`
- **core**: skip per-file `.js`/ `.ts` extension in `generateImportsForBuilder` for package imports (no extension on package specifiers)
- **orval**: tighten `normalizeSchemasOption` validation for `importPath` — rejects empty strings, relative paths, absolute paths, and whitespace-only values
- **docs**: document `schemas` object form, the `importPath` option, and the zod `.zod` subpath requirement
- **tests**: cover all four write modes, zod suffix, faker subpath, and the `factoryMethods.outputDirectory` bypass

## Notes

- Validations fail fast at config-load time with a clear error message.
- When `importPath` is set, `factoryMethods.outputDirectory` is bypassed (factories resolve imports against the package specifier rather than the on-disk factory output directory) — documented.
- For zod schemas (`type: 'zod'`) the per-file suffix is `.zod`, so the package must expose `./pet.zod` (e.g., `@acme/models/pet.zod`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for package-style schema imports via a new schemas.importPath; generated schema and factory imports use this package specifier when provided.
* **Documentation**
  * output.schemas docs expanded to accept String | Object | false; added object form (path, type, importPath), examples, and import/index-file/extension rules.
* **Tests**
  * Added/expanded tests validating schemas.importPath across modes, import-resolution, and factory import behavior.
* **Validation**
  * schemas.importPath now rejects empty, whitespace-only, relative, and absolute specifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->