### PR TITLE
fix(core): skip discriminator mapping entries whose target schema is absent

### DIFF
--- a/packages/core/src/getters/discriminators.test.ts
+++ b/packages/core/src/getters/discriminators.test.ts
@@ -733,7 +733,7 @@ describe('resolveDiscriminators getter', () => {
     // assertions below already proves it was skipped. The surviving subtype is
     // still augmented with its discriminant.
     const result = resolveDiscriminators(structuredClone(schemas), context);
-    const catProps = (result.Cat as OpenApiSchemaObject).properties as
+    const catProps = result.Cat.properties as
       | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
       | undefined;
     expect(catProps?.petType).toMatchObject({

--- a/packages/core/src/getters/discriminators.test.ts
+++ b/packages/core/src/getters/discriminators.test.ts
@@ -729,11 +729,9 @@ describe('resolveDiscriminators getter', () => {
       },
     };
 
-    expect(() =>
-      resolveDiscriminators(structuredClone(schemas), context),
-    ).not.toThrow();
-
-    // The surviving subtype is still augmented with its discriminant.
+    // Dereferencing the absent `Dog` target would throw, so reaching the
+    // assertions below already proves it was skipped. The surviving subtype is
+    // still augmented with its discriminant.
     const result = resolveDiscriminators(structuredClone(schemas), context);
     const catProps = (result.Cat as OpenApiSchemaObject).properties as
       | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>

--- a/packages/core/src/getters/discriminators.test.ts
+++ b/packages/core/src/getters/discriminators.test.ts
@@ -707,4 +707,40 @@ describe('resolveDiscriminators getter', () => {
 
     expect(animalSchema.oneOf).toHaveLength(2);
   });
+
+  it('skips mapping entries whose target schema is absent', () => {
+    // A discriminator mapping may reference a schema that is absent from the
+    // set (e.g. a subtype removed by tag filtering). The missing target must
+    // be skipped rather than dereferenced.
+    const schemas: OpenApiSchemasObject = {
+      Pet: {
+        type: 'object',
+        discriminator: {
+          propertyName: 'petType',
+          mapping: {
+            cat: '#/components/schemas/Cat',
+            dog: '#/components/schemas/Dog', // Dog is absent below
+          },
+        },
+      },
+      Cat: {
+        type: 'object',
+        properties: { huntingSkill: { type: 'string' } },
+      },
+    };
+
+    expect(() =>
+      resolveDiscriminators(structuredClone(schemas), context),
+    ).not.toThrow();
+
+    // The surviving subtype is still augmented with its discriminant.
+    const result = resolveDiscriminators(structuredClone(schemas), context);
+    const catProps = (result.Cat as OpenApiSchemaObject).properties as
+      | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
+      | undefined;
+    expect(catProps?.petType).toMatchObject({
+      type: 'string',
+      enum: ['cat'],
+    });
+  });
 });

--- a/packages/core/src/getters/discriminators.ts
+++ b/packages/core/src/getters/discriminators.ts
@@ -46,11 +46,15 @@ export function resolveDiscriminators(
         }
 
         // The mapped subtype may be missing from the schema set — e.g. a
-        // subtype removed by `filters.tags`, or absent in a malformed spec —
-        // in which case there is nothing to augment. Skip it rather than
-        // dereferencing `undefined`.
+        // subtype removed by `filters.tags`, or absent in a malformed spec — in
+        // which case indexing yields `undefined` at runtime. `!subTypeSchema`
+        // skips that (and the `false` boolean-schema case) before we dereference
+        // it; an explicit `=== undefined` check isn't possible here because the
+        // project does not enable `noUncheckedIndexedAccess`, so indexed access
+        // is typed as always-present. This mirrors the `!variantSchema` guard in
+        // the second loop below.
         if (
-          subTypeSchema === undefined ||
+          !subTypeSchema ||
           isBoolean(subTypeSchema) ||
           propertyName === undefined
         ) {

--- a/packages/core/src/getters/discriminators.ts
+++ b/packages/core/src/getters/discriminators.ts
@@ -45,7 +45,15 @@ export function resolveDiscriminators(
           subTypeSchema = transformedSchemas[mappingValue];
         }
 
-        if (isBoolean(subTypeSchema) || propertyName === undefined) {
+        // The mapped subtype may be missing from the schema set — e.g. a
+        // subtype removed by `filters.tags`, or absent in a malformed spec —
+        // in which case there is nothing to augment. Skip it rather than
+        // dereferencing `undefined`.
+        if (
+          subTypeSchema === undefined ||
+          isBoolean(subTypeSchema) ||
+          propertyName === undefined
+        ) {
           continue;
         }
 


### PR DESCRIPTION
Close #3550 

## Problem

When `input.filters.tags` is used and a surviving schema is a discriminator **base** (has `discriminator.mapping`), generation crashes:

```
🛑 <project> - Cannot read properties of undefined (reading 'properties')
```

It fails during schema generation, before any client code is emitted, so it is not client-specific — every client/`httpClient` combination fails identically.

### Root cause

`filters.tags` prunes schemas not reachable via a real `$ref` from a matching operation. A `discriminator.mapping` value is a bare string (`'#/components/schemas/Foo'`), not a `$ref` object, so `collectReferencedComponents` correctly does not follow it (following it would re-pull most of the spec and defeat filtering). The kept base therefore retains its full `discriminator.mapping`, which now lists subtypes that were just pruned.

`resolveDiscriminators` iterates that mapping, looks each target up in the filtered schema set, and the existing guard only checked `isBoolean(subTypeSchema)` — not `subTypeSchema === undefined` — so it dereferenced `.properties` on the first missing target.

## Fix

Make `resolveDiscriminators` skip a mapping entry whose target is absent (`subTypeSchema === undefined`) instead of dereferencing it. The kept base is emitted, surviving subtypes are generated with their discriminant, and pruned subtypes are simply ignored.

This also hardens against malformed specs that reference a non-existent subtype.

### Why resolver-side only

The issue suggests two composable fixes: (1) trim pruned entries from kept bases' mappings on the filter side, and (2) guard the resolver. In the end I went with **(2) only**, deliberately:

- `discriminator.mapping` has exactly one consumer that dereferences the target schema — `resolveDiscriminators`. This guard makes it safe. Other consumers (`core` combine, `mock` value/combine) read the mapping only as strings and never chase a target, so a leftover entry is inert. The mapping is never emitted
  into generated code.
- A filter-side trim adds code that runs on every tag-filtered generation and needs casing normalization to match against the kept set — a new, small failure mode (it could wrongly drop a *valid* entry) for only a cosmetically cleaner intermediate spec. For a stability fix it's probably not the right call.

## Testing

- New regression test in `discriminators.test.ts`: a mapping with an absent target no longer throws, and the surviving subtype is still augmented with its discriminant.
- Verified against the issue's minimal repro (`filters.tags: ['cats']`, prunes `Dog`): generates cleanly; `Pet` + `Cat` emitted with `Cat.petType` constrained, `Dog` absent.
- Verified against a real-world spec (72 discriminator bases, tag-filtered): all projects generate — axios, react-query, and msw mock — and the output type-checks under `tsc --strict`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of mappings that reference missing or undefined target schemas to prevent errors; only existing subtypes are augmented with their discriminator property.

* **Tests**
  * Added a test ensuring mappings to absent schemas are skipped and remaining subtypes receive the expected discriminator restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->