### PR TITLE
fix(zod): avoid useless escapes in generated RegExp pattern literals

### DIFF
--- a/packages/core/src/utils/string.test.ts
+++ b/packages/core/src/utils/string.test.ts
@@ -5,6 +5,7 @@ import {
   escape,
   escapeRegExp,
   jsStringEscape,
+  jsStringLiteralEscape,
   stringify,
 } from './string';
 
@@ -208,6 +209,62 @@ describe('jsStringEscape', () => {
       expect(jsStringEscape('\n\n')).toBe(String.raw`\n\n`);
       expect(jsStringEscape('/*')).toBe(String.raw`\/\*`);
       expect(jsStringEscape('*/')).toBe(String.raw`\*\/`);
+    });
+  });
+});
+
+describe('jsStringLiteralEscape', () => {
+  describe('escapes only what a single-quoted string literal needs', () => {
+    it('escapes single quotes', () => {
+      expect(jsStringLiteralEscape("don't")).toBe(String.raw`don\'t`);
+    });
+
+    it('escapes backslashes', () => {
+      expect(jsStringLiteralEscape(String.raw`path\to\file`)).toBe(
+        String.raw`path\\to\\file`,
+      );
+    });
+
+    it('escapes line terminators', () => {
+      expect(jsStringLiteralEscape('line1\nline2')).toBe(
+        String.raw`line1\nline2`,
+      );
+      expect(jsStringLiteralEscape('line1\rline2')).toBe(
+        String.raw`line1\rline2`,
+      );
+      // Line/paragraph separators (U+2028/U+2029) escape to text.
+      expect(jsStringLiteralEscape('\u2028\u2029')).toBe(
+        String.raw`\u2028\u2029`,
+      );
+    });
+  });
+
+  describe('does NOT escape characters that are meaningless inside a string literal', () => {
+    // These would produce `no-useless-escape` errors in generated code (#3337).
+    it('does not escape asterisks', () => {
+      expect(jsStringLiteralEscape('hello*world')).toBe('hello*world');
+    });
+
+    it('does not escape forward slashes', () => {
+      expect(jsStringLiteralEscape('path/to/file')).toBe('path/to/file');
+    });
+
+    it('does not escape double quotes', () => {
+      expect(jsStringLiteralEscape('say "hello"')).toBe('say "hello"');
+    });
+
+    it('does not escape comment delimiters', () => {
+      expect(jsStringLiteralEscape('/* comment */')).toBe('/* comment */');
+    });
+  });
+
+  describe('RegExp pattern (#3337)', () => {
+    it('keeps a quantifier pattern free of useless escapes', () => {
+      // `\d` survives the string-literal layer as `\\d`; `*` stays bare so the
+      // generated `new RegExp('...')` does not trip `no-useless-escape`.
+      const escaped = jsStringLiteralEscape(String.raw`^(0|[1-9]\d*)$`);
+      expect(escaped).toBe(String.raw`^(0|[1-9]\\d*)$`);
+      expect(escaped).not.toContain(String.raw`\*`);
     });
   });
 });

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -270,6 +270,47 @@ export function jsStringEscape(input: string) {
 }
 
 /**
+ * Escape a string for embedding inside a single-quoted JS string literal.
+ *
+ * Unlike {@link jsStringEscape}, this escapes only what a string literal
+ * actually needs: backslashes, single quotes, and line terminators. It
+ * deliberately does NOT escape `/` or `*`, which are meaningless inside a
+ * string literal, so escaping them produces "useless escapes" that round-trip
+ * to the same value but trip ESLint's `no-useless-escape` in generated code
+ * (e.g. RegExp pattern literals, see #3337).
+ *
+ * Use {@link jsStringEscape} instead when the value is embedded in a JS comment,
+ * where the comment delimiters must be neutralized.
+ *
+ * @param input String to escape
+ */
+export function jsStringLiteralEscape(input: string) {
+  return input.replaceAll(/['\\\n\r\u2028\u2029]/g, (character) => {
+    switch (character) {
+      case "'":
+      case '\\': {
+        return '\\' + character;
+      }
+      case '\n': {
+        return String.raw`\n`;
+      }
+      case '\r': {
+        return String.raw`\r`;
+      }
+      case '\u2028': {
+        return String.raw`\u2028`;
+      }
+      case '\u2029': {
+        return String.raw`\u2029`;
+      }
+      default: {
+        return '';
+      }
+    }
+  });
+}
+
+/**
  * Deduplicates a TypeScript union type string.
  * Handles types like "A | B | B" → "A | B" and "null | null" → "null".
  * Only splits on top-level | (not inside {} () [] <> or string literals).

--- a/packages/effect/src/effect.test.ts
+++ b/packages/effect/src/effect.test.ts
@@ -79,6 +79,17 @@ describe('constraints', () => {
     expect(effect).toContain('S.pattern(');
   });
 
+  it('emits a RegExp pattern literal without useless escapes (#3337)', () => {
+    const { consts } = gen({
+      type: 'string',
+      pattern: String.raw`^(0|[1-9]\d*)$`,
+    });
+    expect(consts).toContain('RegExp');
+    // The `*` quantifier must stay bare — `\*` would trip `no-useless-escape`.
+    expect(consts).not.toContain(String.raw`\*`);
+    expect(consts).toContain(String.raw`new RegExp('^(0|[1-9]\\d*)$')`);
+  });
+
   it('maps minItems/maxItems on array', () => {
     const { effect } = gen({
       type: 'array',

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -16,6 +16,7 @@ import {
   isObject,
   isString,
   jsStringEscape,
+  jsStringLiteralEscape,
   logVerbose,
   type OpenApiParameterObject,
   type OpenApiReferenceObject,
@@ -578,7 +579,7 @@ export const generateEffectValidationSchemaDefinition = (
     const isStartWithSlash = matches.startsWith('/');
     const isEndWithSlash = matches.endsWith('/');
 
-    const regexp = `new RegExp('${jsStringEscape(
+    const regexp = `new RegExp('${jsStringLiteralEscape(
       matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined),
     )}')`;
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -22,6 +22,7 @@ import {
   isObject,
   isString,
   jsStringEscape,
+  jsStringLiteralEscape,
   logVerbose,
   type OpenApiParameterObject,
   type OpenApiReferenceObject,
@@ -797,7 +798,7 @@ export const generateZodValidationSchemaDefinition = (
             } else if (schema.pattern && schema.format) {
               const isStartWithSlash = schema.pattern.startsWith('/');
               const isEndWithSlash = schema.pattern.endsWith('/');
-              const regexp = `new RegExp('${jsStringEscape(
+              const regexp = `new RegExp('${jsStringLiteralEscape(
                 schema.pattern.slice(
                   isStartWithSlash ? 1 : 0,
                   isEndWithSlash ? -1 : undefined,
@@ -1042,7 +1043,7 @@ export const generateZodValidationSchemaDefinition = (
     const isStartWithSlash = matches.startsWith('/');
     const isEndWithSlash = matches.endsWith('/');
 
-    const regexp = `new RegExp('${jsStringEscape(
+    const regexp = `new RegExp('${jsStringLiteralEscape(
       matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined),
     )}')`;
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -3660,6 +3660,34 @@ describe('generateZodValidationSchemaDefinition`', () => {
     expect(regexpConsts).toHaveLength(1);
   });
 
+  it('emits a RegExp pattern literal without useless escapes (#3337)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      pattern: String.raw`^(0|[1-9]\d*)$`,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schema,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'sbu',
+      false,
+      false,
+      { required: true },
+    );
+
+    const regexpConst = result.consts.find((c) => c.includes('RegExp'));
+    expect(regexpConst).toBeDefined();
+    // The `*` quantifier must stay bare — `\*` would trip `no-useless-escape`.
+    expect(regexpConst).not.toContain(String.raw`\*`);
+    expect(regexpConst).toContain(String.raw`new RegExp('^(0|[1-9]\\d*)$')`);
+  });
+
   it('does not emit stringFormat for custom format+pattern in v3', () => {
     const schemaFormatPattern: OpenApiSchemaObject = {
       type: 'string',


### PR DESCRIPTION
## What

Generated Zod (and Effect) `new RegExp('...')` pattern literals over-escape `*` (and `/`, `"`). For the schema in #3337:

```ts
// before
export const SbuRegExp = new RegExp('^(0|[1-9]\\d\*)$');
// after
export const SbuRegExp = new RegExp('^(0|[1-9]\\d*)$');
```

The `\*` round-trips to the same regex at runtime, but ESLint's [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) (part of `eslint:recommended`) flags it as `Unnecessary escape character: \*`, so generated code fails linting in consumers' projects.

## Why

The pattern is escaped with `jsStringEscape`, which — besides the characters a string literal actually needs — also escapes `/` and `*`. That extra escaping was added to neutralize JS **comment** delimiters (CVE-2026-25141 / #2882), where enum descriptions are embedded in a `/** … */` comment. It is correct for comments, but unnecessary (and lint-breaking) for single-quoted string literals such as RegExp patterns.

## How

- Add `jsStringLiteralEscape` in `@orval/core`, which escapes only what a single-quoted JS string literal needs: single quotes, backslashes, and line terminators (`\n`, `\r`, `\u2028`, `\u2029`). It intentionally does **not** escape `/`, `*`, or `"`.
- Use it for the RegExp pattern literals in `@orval/zod` (2 sites) and `@orval/effect` (1 site, same bug).
- `jsStringEscape` and the comment-generation path are **left completely untouched**, so the CVE-2026-25141 mitigation is fully preserved (verified: malicious `*/` in an enum description is still neutralized to `\*\/` and cannot break out of the comment; adversarial RegExp patterns cannot break out of the single-quoted literal).

## Tests

- `@orval/core`: unit tests for `jsStringLiteralEscape` (escapes `'`/`\`/line terminators; does **not** escape `*`/`/`/`"`).
- `@orval/zod` and `@orval/effect`: regression tests asserting the emitted `new RegExp('…')` has no `\*`.
- Existing snapshots are unchanged.

## Note (out of scope, possible follow-up)

A cleaner long-term direction is to emit regex **literals** (`z.string().regex(/^(0|[1-9]\d*)$/)`) instead of `new RegExp('…')`, which sidesteps string-escaping entirely — this is the direction Kubb took. It is an architectural change (named-const reuse/dedup, plus edge cases like `/` in patterns and empty patterns) and is deliberately left out here; happy to follow up if desired.

Closes #3337


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regex pattern generation across core, effect, and zod packages to produce cleaner literal output without unnecessary escape sequences.

* **Tests**
  * Added test coverage for regex pattern generation to verify correct handling of edge cases and expected output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->