### PR TITLE
fix(core): support named mutator re-exports

### DIFF
--- a/docs/content/docs/guides/custom-client.mdx
+++ b/docs/content/docs/guides/custom-client.mdx
@@ -66,6 +66,21 @@ export type ErrorType<Error> = AxiosError<Error>;
 export type BodyType<BodyData> = CamelCase<BodyData>;
 ```
 
+## Re-exporting a Mutator
+
+The file referenced by `mutator.path` can also re-export the named mutator from
+another module:
+
+```ts title="custom-instance.ts"
+export { customInstance } from '@acme/api-client/mutators';
+```
+
+Named re-exports are treated as valid mutator exports. Because the re-exported
+implementation is outside the configured file, Orval uses the standard
+single-request-argument mutator shape for argument detection. Use a local
+wrapper function with explicit parameters when generated clients need additional
+request option arguments.
+
 ## Angular HTTP Client
 
 For Angular, configure a mutator for the HttpClient:

--- a/docs/content/docs/zh/guides/custom-client.mdx
+++ b/docs/content/docs/zh/guides/custom-client.mdx
@@ -46,6 +46,16 @@ export const customClient = async <T>(url: string, options: RequestInit) => {
 };
 ```
 
+## 重新导出 mutator
+
+`mutator.path` 指向的文件也可以从其他模块重新导出指定的 mutator：
+
+```ts title="src/api/custom-client.ts"
+export { customClient } from '@acme/api-client/mutators';
+```
+
+Orval 会把 named re-export 视为有效的 mutator 导出。由于重新导出的实现不在当前配置文件中，Orval 会按标准的单请求参数 mutator 形态推断参数。如果生成的客户端需要额外的请求选项参数，请使用带显式参数的本地 wrapper 函数。
+
 ## Angular HTTP Client
 
 Angular 项目可以把 mutator 写成使用 `HttpClient` 的函数或 service。关键是保持生成代码期望的输入和返回类型一致。

--- a/packages/core/src/generators/__tests__/mutator-test-files/re-export-tests/external-named-export.ts
+++ b/packages/core/src/generators/__tests__/mutator-test-files/re-export-tests/external-named-export.ts
@@ -1,0 +1,5 @@
+// Regression fixture for https://github.com/orval-labs/orval/issues/2342:
+// the configured mutator file can re-export the named mutator from an
+// external package.
+// @ts-expect-error External package is intentionally unresolved in this fixture.
+export { customInstance } from '@orval-external/custom-instance';

--- a/packages/core/src/generators/mutator-info.test.ts
+++ b/packages/core/src/generators/mutator-info.test.ts
@@ -278,6 +278,20 @@ describe('getMutatorInfo', () => {
     });
   });
 
+  describe('named re-export', () => {
+    // Regression test for https://github.com/orval-labs/orval/issues/2342.
+    // A mutator file may re-export the configured mutator from another
+    // package. The external module is not bundled, so orval cannot inspect
+    // its arity and falls back to the standard single-arg mutator contract.
+    it('should accept a named mutator re-export from an external module', async () => {
+      const result = await getMutatorInfo(
+        path.join(basePath, 're-export-tests', 'external-named-export.ts'),
+        { namedExport: 'customInstance' },
+      );
+      expect(result).toEqual({ numberOfParams: 1 });
+    });
+  });
+
   describe('factory call expression', () => {
     // Regression test for https://github.com/orval-labs/orval/issues/3402.
     // When a mutator is defined as `export const foo = makeFactory(...)` or

--- a/packages/core/src/generators/mutator-info.ts
+++ b/packages/core/src/generators/mutator-info.ts
@@ -125,12 +125,13 @@ function isImportedBinding(ast: Program, name: string): boolean {
   });
 }
 
-// Default for mutator exports whose initializer is a CallExpression
-// (factory pattern, e.g. `axios.create({...})`). The AST cannot reveal
-// the returned callable's arity, so we assume the orval standard
-// contract: a single-arg mutator invoked as
-// `customInstance({ url, method, data, ... })`.
-// See https://github.com/orval-labs/orval/issues/3402.
+// Default for mutator exports where arity cannot be inspected:
+// factory-pattern CallExpression initializers (e.g. `axios.create({...})`)
+// and external re-exports. In both cases, the AST cannot reveal the returned
+// callable's arity, so we assume the orval standard contract:
+// a single-arg mutator invoked as `customInstance({ url, method, data, ... })`.
+// See https://github.com/orval-labs/orval/issues/3402 and
+// https://github.com/orval-labs/orval/issues/2342.
 function standardMutatorInfo(): GeneratorMutatorParsingInfo {
   return { numberOfParams: 1 };
 }

--- a/packages/core/src/generators/mutator-info.ts
+++ b/packages/core/src/generators/mutator-info.ts
@@ -78,24 +78,51 @@ function parseFile(
       sourceType: 'module',
     });
 
-    const foundSpecifier = ast.body
+    const foundExport = ast.body
       .filter((x) => x.type === 'ExportNamedDeclaration')
-      .flatMap((x) => x.specifiers)
-      .find(
-        (x) =>
-          x.exported.type === 'Identifier' &&
-          x.exported.name === name &&
-          x.local.type === 'Identifier',
-      );
+      .map((declaration) => ({
+        declaration,
+        specifier: declaration.specifiers.find(
+          (specifier) =>
+            specifier.exported.type === 'Identifier' &&
+            specifier.exported.name === name &&
+            specifier.local.type === 'Identifier',
+        ),
+      }))
+      .find((item) => item.specifier);
 
-    if (foundSpecifier && 'name' in foundSpecifier.local) {
+    const foundSpecifier = foundExport?.specifier;
+
+    if (foundExport && foundSpecifier && 'name' in foundSpecifier.local) {
       const exportedFuncName = foundSpecifier.local.name;
 
-      return parseFunction(ast, exportedFuncName);
+      const mutatorInfo = parseFunction(ast, exportedFuncName);
+      if (mutatorInfo) {
+        return mutatorInfo;
+      }
+
+      if (
+        foundExport.declaration.source ||
+        isImportedBinding(ast, exportedFuncName)
+      ) {
+        return standardMutatorInfo();
+      }
     }
   } catch {
     return;
   }
+}
+
+function isImportedBinding(ast: Program, name: string): boolean {
+  return ast.body.some((node) => {
+    if (node.type !== 'ImportDeclaration') {
+      return false;
+    }
+
+    return node.specifiers.some(
+      (specifier) => 'name' in specifier.local && specifier.local.name === name,
+    );
+  });
 }
 
 // Default for mutator exports whose initializer is a CallExpression


### PR DESCRIPTION
Fixes #2342.

This lets Orval accept a configured mutator file that re-exports the named mutator from another module, for example `export { customInstance } from '@acme/api-client/mutators'`.

The parser now keeps the existing local function/constant arity detection first, and only falls back to the standard single-request-argument mutator shape when the exported binding comes from a named re-export or an imported binding. That matches the existing factory-call fallback without trying to inspect external package code.

I also added a regression fixture/test for the external named re-export case and documented the supported pattern in the custom client guide, including the argument-detection limitation.

Validation run locally:

- `npx --yes bun run --filter @orval/core test src/generators/mutator-info.test.ts`
- `npx --yes bun run --filter @orval/core typecheck`
- `npx --yes bun run --filter @orval/core lint`
- `npx --yes bun run --filter @orval/core test`
- `npx --yes bun run format:check`
- `npx --yes bun run i18n:check` in `docs/`
- `npx --yes bun run types:check` in `docs/`
- `npx --yes bun run typecheck`
- `npx --yes bun run lint`
- `npx --yes bun run test`
- `git diff --check`

Note: `docs` full `bun run lint` currently reports existing Biome configuration/format diagnostics across unrelated docs source files, so I did not apply unrelated formatting changes. The touched MDX files pass the repo-level Prettier check and docs type generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified in English and Chinese guides that custom HTTP client mutator files may re-export named mutators from other modules and how to handle extra request options.

* **Bug Fixes**
  * Improved mutator detection so re-exported named mutators are recognized and treated with the standard single-argument contract.

* **Tests**
  * Added regression coverage for named re-export mutator scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->