### PR TITLE
feat: support x-codegen-request-body-name extension

### DIFF
--- a/packages/core/src/getters/body.test.ts
+++ b/packages/core/src/getters/body.test.ts
@@ -313,6 +313,27 @@ describe('getBody', () => {
 
       expect(result.implementation).toBe('myBody');
     });
+
+    it('falls back to default naming when extension is non-string', () => {
+      const result = getBody({
+        requestBody: {
+          'x-codegen-request-body-name': 123 as unknown as string,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+          required: true,
+        },
+        operationName: 'createPet',
+        context: createContext(),
+      });
+
+      expect(result.implementation).toBe('createPetBody');
+    });
   });
 });
 

--- a/packages/core/src/getters/body.test.ts
+++ b/packages/core/src/getters/body.test.ts
@@ -221,6 +221,99 @@ describe('getBody', () => {
 
     expect(result.isOptional).toBe(true);
   });
+
+  describe('x-codegen-request-body-name', () => {
+    it('uses custom name from inline request body extension', () => {
+      const result = getBody({
+        requestBody: {
+          'x-codegen-request-body-name': 'petData',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+          required: true,
+        },
+        operationName: 'createPet',
+        context: createContext(),
+      });
+
+      expect(result.implementation).toBe('petData');
+    });
+
+    it('uses custom name from referenced request body extension', () => {
+      const context = createContext();
+      context.spec.components = {
+        ...context.spec.components,
+        requestBodies: {
+          CreatePetBody: {
+            'x-codegen-request-body-name': 'resource',
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = getBody({
+        requestBody: { $ref: '#/components/requestBodies/CreatePetBody' },
+        operationName: 'createPet',
+        context,
+      });
+
+      expect(result.implementation).toBe('resource');
+    });
+
+    it('falls back to default naming when extension is absent', () => {
+      const result = getBody({
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+          required: true,
+        },
+        operationName: 'createPet',
+        context: createContext(),
+      });
+
+      expect(result.implementation).toBe('createPetBody');
+    });
+
+    it('sanitizes the extension value through standard naming pipeline', () => {
+      const result = getBody({
+        requestBody: {
+          'x-codegen-request-body-name': 'my-body',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
+          required: true,
+        },
+        operationName: 'createPet',
+        context: createContext(),
+      });
+
+      expect(result.implementation).toBe('myBody');
+    });
+  });
 });
 
 describe('getBodiesByContentType', () => {

--- a/packages/core/src/getters/body.ts
+++ b/packages/core/src/getters/body.ts
@@ -148,15 +148,18 @@ function getRequestBodyExtensionName(
   requestBody: OpenApiReferenceObject | OpenApiRequestBodyObject,
   context: ContextSpec,
 ): string | undefined {
+  let value: unknown;
   if (isReference(requestBody)) {
     const { schema } = resolveRef(requestBody, context);
-    return (schema as Record<string, unknown>)?.[
+    value = (schema as Record<string, unknown>)?.[
       'x-codegen-request-body-name'
-    ] as string | undefined;
+    ];
+  } else {
+    value = (requestBody as Record<string, unknown>)?.[
+      'x-codegen-request-body-name'
+    ];
   }
-  return (requestBody as Record<string, unknown>)?.[
-    'x-codegen-request-body-name'
-  ] as string | undefined;
+  return typeof value === 'string' ? value : undefined;
 }
 
 const CONTENT_TYPE_SUFFIX_MAP: Record<string, string> = {

--- a/packages/core/src/getters/body.ts
+++ b/packages/core/src/getters/body.ts
@@ -43,6 +43,11 @@ function buildBody(
         context.output.override.components.requestBodies.suffix
       : camel(definition);
 
+  const overrideName = getRequestBodyExtensionName(requestBody, context);
+  if (overrideName) {
+    implementation = camel(overrideName);
+  }
+
   let isOptional = false;
   if (implementation) {
     implementation = sanitize(implementation, {
@@ -137,6 +142,21 @@ export function getBodiesByContentType({
       contentTypeSuffix: suffix,
     };
   });
+}
+
+function getRequestBodyExtensionName(
+  requestBody: OpenApiReferenceObject | OpenApiRequestBodyObject,
+  context: ContextSpec,
+): string | undefined {
+  if (isReference(requestBody)) {
+    const { schema } = resolveRef(requestBody, context);
+    return (schema as Record<string, unknown>)?.[
+      'x-codegen-request-body-name'
+    ] as string | undefined;
+  }
+  return (requestBody as Record<string, unknown>)?.[
+    'x-codegen-request-body-name'
+  ] as string | undefined;
 }
 
 const CONTENT_TYPE_SUFFIX_MAP: Record<string, string> = {


### PR DESCRIPTION
## Problem

When a path parameter name matches the schema name (e.g., `lender` param + `Lender` schema), orval generates `TS2300: Duplicate identifier`. The `x-codegen-request-body-name` OpenAPI vendor extension exists to solve this, but orval ignores it.

Fixes #2491

## What changed

Read `x-codegen-request-body-name` from both inline and `` request bodies. When present, the extension value is used as the generated parameter name instead of the auto-generated one.

**Files changed:**
- `packages/core/src/getters/body.ts` — Added `getRequestBodyExtensionName` helper, override `implementation` when extension is present
- `packages/core/src/getters/body.test.ts` — Added 4 test cases covering inline, ``, default fallback, and sanitization

## Tests run

- `bun vitest run packages/core/src/getters/body.test.ts` — 15/15 passed
- `bun run typecheck` — passed (no new errors in core package)
- Full core test suite: 1970/1973 passed (3 pre-existing failures in `resolve-version.test.ts`)

## Limitations

- Does not add an explicit `codegenRequestBodyName` config option (the extension is read directly from the spec)
- Does not generate the extension in output (read-only)

## AI disclosure

This PR was developed with AI assistance (OpenCode/Codex).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow customizing generated request-body type/implementation names via the x-codegen-request-body-name OpenAPI extension for inline and referenced bodies; values are normalized, non-string or missing values fall back to default naming, ensuring consistent names in generated artifacts.

* **Tests**
  * Added tests covering extension handling, normalization, and fallback behavior across request-body scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->