### PR TITLE
fix(core): extract named enums inside nullable nested objects

### DIFF
--- a/packages/core/src/generators/schema-definition.test.ts
+++ b/packages/core/src/generators/schema-definition.test.ts
@@ -355,18 +355,22 @@ describe('generateSchemasDefinition', () => {
 
     const result = generateSchemasDefinition(schemas, specContext, '');
 
-    // The nullable nested object references named enum types instead of
+    // The nullable nested object references the named enum types instead of
     // inlining the union, and preserves its ` | null`.
     const monthSelection = result.find((s) => s.name === 'TestMonthSelection');
     expect(monthSelection).toBeDefined();
     expect(monthSelection?.model).not.toContain(`'JANUARY'`);
-    expect(monthSelection?.model).toMatch(/months2\?: [A-Z]\w+;/);
+    expect(monthSelection?.model).toContain('TestMonthSelectionMonthsItem');
+    expect(monthSelection?.model).toContain('TestMonthSelectionMonths2');
     expect(monthSelection?.model).toContain('| null');
 
-    // The nested enums are emitted as standalone `as const` schemas.
-    const constEnums = result.filter((s) => s.model.includes('as const'));
-    expect(constEnums.length).toBeGreaterThanOrEqual(2);
-    expect(constEnums.every((s) => s.model.includes('JANUARY'))).toBe(true);
+    // Each nested enum is emitted as its own `as const` schema.
+    expect(
+      result.find((s) => s.name === 'TestMonthSelectionMonthsItem')?.model,
+    ).toContain('as const');
+    expect(
+      result.find((s) => s.name === 'TestMonthSelectionMonths2')?.model,
+    ).toContain('as const');
   });
 
   it('should avoid invalid spreads for nullable or boolean oneOf enums', () => {

--- a/packages/core/src/generators/schema-definition.test.ts
+++ b/packages/core/src/generators/schema-definition.test.ts
@@ -305,6 +305,70 @@ describe('generateSchemasDefinition', () => {
     );
   });
 
+  // Regression test for #3340: enum properties inside a *nullable* nested
+  // object must still be extracted into named `as const` consts, exactly like
+  // non-nullable nested objects and top-level properties. OAS 3.0's
+  // `nullable: true` is upgraded to `type: ['object', 'null']` before
+  // generation, so that is the shape exercised here.
+  it('extracts named const enums from a nullable nested object (#3340)', () => {
+    const schemas: OpenApiSchemasObject = {
+      Test: {
+        type: 'object',
+        properties: {
+          monthSelection: {
+            type: ['object', 'null'],
+            properties: {
+              months: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['JANUARY', 'FEBRUARY', 'MARCH'],
+                },
+              },
+              months2: {
+                type: 'string',
+                enum: ['JANUARY', 'FEBRUARY', 'MARCH'],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const specContext = {
+      ...context,
+      output: {
+        ...context.output,
+        override: {
+          enumGenerationType: 'const',
+          namingConvention: {},
+          components: {
+            schemas: { suffix: '', itemSuffix: 'Item' },
+            responses: { suffix: '' },
+            parameters: { suffix: '' },
+            requestBodies: { suffix: 'RequestBody' },
+          },
+        },
+      },
+      spec: { components: { schemas } },
+    } as unknown as ContextSpec;
+
+    const result = generateSchemasDefinition(schemas, specContext, '');
+
+    // The nullable nested object references named enum types instead of
+    // inlining the union, and preserves its ` | null`.
+    const monthSelection = result.find((s) => s.name === 'TestMonthSelection');
+    expect(monthSelection).toBeDefined();
+    expect(monthSelection?.model).not.toContain(`'JANUARY'`);
+    expect(monthSelection?.model).toMatch(/months2\?: [A-Z]\w+;/);
+    expect(monthSelection?.model).toContain('| null');
+
+    // The nested enums are emitted as standalone `as const` schemas.
+    const constEnums = result.filter((s) => s.model.includes('as const'));
+    expect(constEnums.length).toBeGreaterThanOrEqual(2);
+    expect(constEnums.every((s) => s.model.includes('JANUARY'))).toBe(true);
+  });
+
   it('should avoid invalid spreads for nullable or boolean oneOf enums', () => {
     const schemas: OpenApiSchemasObject = {
       NumberEnum: {

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -223,20 +223,44 @@ export function getObject({
 
   if (Array.isArray(itemType)) {
     const typeArray = itemType;
-    // Bridge: item is OpenApiSchemaObject which includes AnyOtherAttribute index signature.
-    // Spreading it directly would carry `any` into the result. Cast to break the chain.
-    const baseItem = schemaItem as Record<string, unknown>;
-    return combineSchemas({
-      schema: {
-        anyOf: typeArray.map(
-          (type) => ({ ...baseItem, type }) as OpenApiSchemaObject,
-        ),
-      },
-      name,
-      separator: 'anyOf',
-      context,
-      nullable,
-    });
+    // A nullable object (`type: ['object', 'null']`, e.g. OAS 3.0 `nullable: true`
+    // after the @scalar upgrade) must stay on the object property-iteration path
+    // below so its `name` is preserved and nested enum properties keep being
+    // extracted into named consts. Routing it through combineSchemas resolves the
+    // object variant with an undefined propName, which drops the name and inlines
+    // those enums instead. See issue #3340. Real unions (e.g. `['string', 'number']`)
+    // keep the combineSchemas path.
+    const nonNullTypes = typeArray.filter((type) => type !== 'null');
+    const typeArrayProperties = schemaItem.properties as
+      | Record<string, unknown>
+      | undefined;
+    // Only divert when there are properties to walk — an empty nullable object
+    // has no nested enums to extract, and routing it through the property path
+    // would render it as `unknown` instead of `{ [key: string]: unknown }`.
+    const isNullableObject =
+      nonNullTypes.length === 1 &&
+      nonNullTypes[0] === 'object' &&
+      typeArrayProperties != null &&
+      Object.keys(typeArrayProperties).length > 0;
+
+    if (!isNullableObject) {
+      // Bridge: item is OpenApiSchemaObject which includes AnyOtherAttribute index signature.
+      // Spreading it directly would carry `any` into the result. Cast to break the chain.
+      const baseItem = schemaItem as Record<string, unknown>;
+      return combineSchemas({
+        schema: {
+          anyOf: typeArray.map(
+            (type) => ({ ...baseItem, type }) as OpenApiSchemaObject,
+          ),
+        },
+        name,
+        separator: 'anyOf',
+        context,
+        nullable,
+      });
+    }
+    // Fall through to the property-iteration path; `nullable` already carries
+    // the ` | null` computed by getScalar for this type array.
   }
 
   // Bridge assertion: item.properties is typed as { [name: string]: ReferenceObject | SchemaObject }

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -231,8 +231,10 @@ export function getObject({
     // those enums instead. See issue #3340. Real unions (e.g. `['string', 'number']`)
     // keep the combineSchemas path.
     const nonNullTypes = typeArray.filter((type) => type !== 'null');
+    // Bridge assertion: AnyOtherAttribute infects `properties` to `any`; cast to
+    // the documented property-map shape, matching the itemProperties cast below.
     const typeArrayProperties = schemaItem.properties as
-      | Record<string, unknown>
+      | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
       | undefined;
     // Only divert when there are properties to walk — an empty nullable object
     // has no nested enums to extract, and routing it through the property path


### PR DESCRIPTION
## Problem

Closes #3340.

Since v8.0.0, `enum` values declared inside a **nullable** nested object are inlined as string-literal unions instead of being extracted into a named `const … = { … } as const`. Top-level properties and **non-nullable** nested objects still extract correctly, so the behavior is inconsistent.

```ts
// before (v8.x)
export type TestMonthSelection = {
  months: ('JANUARY' | 'FEBRUARY' | 'MARCH')[];   // ❌ inlined
  months2?: 'JANUARY' | 'FEBRUARY' | 'MARCH';      // ❌ inlined
} | null;

// after (matches v7.21.0)
export type TestMonthSelection = {
  months: TestMonthSelectionMonthsItem[];          // ✅ named `as const`
  months2?: TestMonthSelectionMonths2;             // ✅ named `as const`
} | null;
```

## Root cause

A `nullable: true` object is upgraded to `type: ['object', 'null']`, which makes `getObject` route it through `combineSchemas` instead of the normal object property-iteration path. With the v8 default (`aliasCombinedTypes: false`), `combineSchemas` resolves the object variant with an **undefined `propName`**, so the inner `getObject` receives no `name`. Without a name, nested enum properties can't build the identifier they'd be extracted under (`if (propName && resolvedValue.isEnum && …)` in `resolvers/object.ts`), so they fall back to inline unions.

A non-nullable object keeps `type: 'object'` (a string), stays on the property-iteration path with `name` intact, and extracts correctly — hence the asymmetry.

## Fix

In `getObject`'s type-array branch, detect a nullable object (`type` array whose only non-null entry is `object`, **with** properties) and let it fall through to the existing property-iteration path instead of `combineSchemas`. This preserves `name` so nested enums extract as before; `nullable` already carries the trailing ` | null`.

The guard is deliberately narrow:
- **Real unions** (e.g. `['string', 'number']`) → unchanged (`combineSchemas`).
- **Empty nullable objects** (no properties) → unchanged (`combineSchemas`), so they keep rendering as `{ [key: string]: unknown } | null` rather than `unknown`.
- Only nullable objects **with** properties — the buggy case — change.

No new config option: this just restores the consistent extract-everywhere behavior.

## Tests & verification

- Added a `generateSchemasDefinition` regression test (`schema-definition.test.ts`) covering the `type: ['object','null']` shape with an enum array + scalar enum.
- `@orval/core` unit tests: 1971 passing.
- Full snapshot suite (`test:snapshots`, samples + orval-tests): passing, **no changes to any committed sample output**.
- `typecheck` + `lint`: passing.
- Generated output for the issue's spec now matches v7.21.0. Verified a broad edge-case spec (real unions, nullable scalars/arrays, `$ref` children, deep nesting, `additionalProperties`, top-level nullable component, nullable object inside arrays, empty nullable object) compiles cleanly under `tsc --strict`.

## Out of scope

The OAS 3.1 explicit `anyOf`/`oneOf: [{ object }, { type: null }]` spelling routes through a different (combiner) branch and still inlines its child enums. Happy to follow up on that separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed enum extraction for properties inside nullable nested objects so enums are generated as named constants and nullable types include `null`.

* **Tests**
  * Added a regression test to verify correct enum extraction and naming for nested nullable object schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->