### PR TITLE
fix(core): extract named enums in nullable object compositions

### DIFF
--- a/packages/core/src/generators/schema-definition.test.ts
+++ b/packages/core/src/generators/schema-definition.test.ts
@@ -373,6 +373,85 @@ describe('generateSchemasDefinition', () => {
     ).toContain('as const');
   });
 
+  // Regression test for #3563 (follow-up to #3340): the explicit OAS 3.1
+  // composition `anyOf: [{ object }, { type: 'null' }]` (and the analogous
+  // `oneOf`) must extract nested-object enum properties into named `as const`
+  // consts, exactly like the `type: ['object', 'null']` shape fixed in #3340.
+  // This shape routes through `combineSchemas` rather than the type-array
+  // branch, so it needs its own coverage.
+  it.each(['anyOf', 'oneOf'] as const)(
+    'extracts named const enums from a nullable object composition (%s, #3563)',
+    (separator) => {
+      const schemas: OpenApiSchemasObject = {
+        Test: {
+          type: 'object',
+          properties: {
+            monthSelection: {
+              [separator]: [
+                {
+                  type: 'object',
+                  properties: {
+                    months: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                        enum: ['JANUARY', 'FEBRUARY', 'MARCH'],
+                      },
+                    },
+                    months2: {
+                      type: 'string',
+                      enum: ['JANUARY', 'FEBRUARY', 'MARCH'],
+                    },
+                  },
+                },
+                { type: 'null' },
+              ],
+            },
+          },
+        },
+      };
+
+      const specContext = {
+        ...context,
+        output: {
+          ...context.output,
+          override: {
+            enumGenerationType: 'const',
+            namingConvention: {},
+            components: {
+              schemas: { suffix: '', itemSuffix: 'Item' },
+              responses: { suffix: '' },
+              parameters: { suffix: '' },
+              requestBodies: { suffix: 'RequestBody' },
+            },
+          },
+        },
+        spec: { components: { schemas } },
+      } as unknown as ContextSpec;
+
+      const result = generateSchemasDefinition(schemas, specContext, '');
+
+      // The nullable object references the named enum types instead of inlining
+      // the union, and preserves its ` | null`.
+      const monthSelection = result.find(
+        (s) => s.name === 'TestMonthSelection',
+      );
+      expect(monthSelection).toBeDefined();
+      expect(monthSelection?.model).not.toContain(`'JANUARY'`);
+      expect(monthSelection?.model).toContain('TestMonthSelectionMonthsItem');
+      expect(monthSelection?.model).toContain('TestMonthSelectionMonths2');
+      expect(monthSelection?.model).toContain('| null');
+
+      // Each nested enum is emitted as its own `as const` schema.
+      expect(
+        result.find((s) => s.name === 'TestMonthSelectionMonthsItem')?.model,
+      ).toContain('as const');
+      expect(
+        result.find((s) => s.name === 'TestMonthSelectionMonths2')?.model,
+      ).toContain('as const');
+    },
+  );
+
   it('should avoid invalid spreads for nullable or boolean oneOf enums', () => {
     const schemas: OpenApiSchemasObject = {
       NumberEnum: {

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -219,10 +219,19 @@ export function getObject({
     // name and inlines those enums. Divert the single object member to the
     // property-iteration path instead — the same fix #3340 applied one level
     // down for the `type: ['object', 'null']` shape. See issue #3563.
-    // `allOf` is intersection, not a nullable union, so it is excluded; real
-    // unions, `$ref` object members, primitive members, and empty objects keep
-    // the combineSchemas behavior via the guard below.
-    const members = itemAnyOf ?? itemOneOf;
+    // Real unions, `$ref` object members, primitive members, and empty objects
+    // keep the combineSchemas behavior via the guard below.
+    //
+    // Read members from the active `separator` (not `itemAnyOf ?? itemOneOf`)
+    // so this check and the combineSchemas fallback below operate on the same
+    // composition. `allOf` is intersection, not a nullable union, so it yields
+    // no members here and always falls through to combineSchemas.
+    const members =
+      separator === 'anyOf'
+        ? itemAnyOf
+        : separator === 'oneOf'
+          ? itemOneOf
+          : undefined;
     if (members) {
       const isNullMember = (
         member: OpenApiSchemaObject | OpenApiReferenceObject,
@@ -239,37 +248,37 @@ export function getObject({
         );
       };
 
-      const objectMembers = members.filter((member) => !isNullMember(member));
-      const objectMember = objectMembers[0];
+      const nonNullMembers = members.filter((member) => !isNullMember(member));
+      const nonNullMember = nonNullMembers[0];
       // Bridge assertion: AnyOtherAttribute infects member property access to
       // `any`; cast to the documented shapes after excluding `$ref` members.
-      const objectMemberType =
-        objectMember && !isReference(objectMember)
-          ? (objectMember.type as string | string[] | undefined)
+      const nonNullMemberType =
+        nonNullMember && !isReference(nonNullMember)
+          ? (nonNullMember.type as string | string[] | undefined)
           : undefined;
-      const objectMemberProperties =
-        objectMember && !isReference(objectMember)
-          ? (objectMember.properties as
+      const nonNullMemberProperties =
+        nonNullMember && !isReference(nonNullMember)
+          ? (nonNullMember.properties as
               | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
               | undefined)
           : undefined;
 
       const isNullableObjectComposition =
         members.some(isNullMember) &&
-        objectMembers.length === 1 &&
-        objectMember != null &&
-        !isReference(objectMember) &&
-        (objectMemberType === 'object' ||
-          (objectMemberType == null && objectMemberProperties != null)) &&
-        objectMemberProperties != null &&
-        Object.keys(objectMemberProperties).length > 0;
+        nonNullMembers.length === 1 &&
+        nonNullMember != null &&
+        !isReference(nonNullMember) &&
+        (nonNullMemberType === 'object' ||
+          (nonNullMemberType == null && nonNullMemberProperties != null)) &&
+        nonNullMemberProperties != null &&
+        Object.keys(nonNullMemberProperties).length > 0;
 
       if (isNullableObjectComposition) {
         // `nullable` is empty for the composition form (the null lives in a
         // member, not on the parent), so synthesize ` | null`; the
         // property-iteration path appends it to the rendered object.
         return getObject({
-          item: objectMember as OpenApiSchemaObject,
+          item: nonNullMember as OpenApiSchemaObject,
           name,
           context,
           nullable: nullable || ' | null',

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -211,6 +211,73 @@ export function getObject({
   if (itemAllOf || itemOneOf || itemAnyOf) {
     const separator = itemAllOf ? 'allOf' : itemOneOf ? 'oneOf' : 'anyOf';
 
+    // A nullable object spelled as the explicit OAS 3.1 composition
+    // `anyOf|oneOf: [{ inline object with properties }, { type: 'null' }]` must
+    // keep its `name` so nested enum properties are extracted into named
+    // `as const` consts. Routing it through combineSchemas resolves the object
+    // member with `combined: true` and an undefined propName, which drops the
+    // name and inlines those enums. Divert the single object member to the
+    // property-iteration path instead — the same fix #3340 applied one level
+    // down for the `type: ['object', 'null']` shape. See issue #3563.
+    // `allOf` is intersection, not a nullable union, so it is excluded; real
+    // unions, `$ref` object members, primitive members, and empty objects keep
+    // the combineSchemas behavior via the guard below.
+    const members = itemAnyOf ?? itemOneOf;
+    if (members) {
+      const isNullMember = (
+        member: OpenApiSchemaObject | OpenApiReferenceObject,
+      ): boolean => {
+        if (isReference(member)) {
+          return false;
+        }
+        const memberType = member.type as string | string[] | undefined;
+        return (
+          memberType === 'null' ||
+          (Array.isArray(memberType) &&
+            memberType.length === 1 &&
+            memberType[0] === 'null')
+        );
+      };
+
+      const objectMembers = members.filter((member) => !isNullMember(member));
+      const objectMember = objectMembers[0];
+      // Bridge assertion: AnyOtherAttribute infects member property access to
+      // `any`; cast to the documented shapes after excluding `$ref` members.
+      const objectMemberType =
+        objectMember && !isReference(objectMember)
+          ? (objectMember.type as string | string[] | undefined)
+          : undefined;
+      const objectMemberProperties =
+        objectMember && !isReference(objectMember)
+          ? (objectMember.properties as
+              | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
+              | undefined)
+          : undefined;
+
+      const isNullableObjectComposition =
+        members.some(isNullMember) &&
+        objectMembers.length === 1 &&
+        objectMember != null &&
+        !isReference(objectMember) &&
+        (objectMemberType === 'object' ||
+          (objectMemberType == null && objectMemberProperties != null)) &&
+        objectMemberProperties != null &&
+        Object.keys(objectMemberProperties).length > 0;
+
+      if (isNullableObjectComposition) {
+        // `nullable` is empty for the composition form (the null lives in a
+        // member, not on the parent), so synthesize ` | null`; the
+        // property-iteration path appends it to the rendered object.
+        return getObject({
+          item: objectMember as OpenApiSchemaObject,
+          name,
+          context,
+          nullable: nullable || ' | null',
+          formDataContext,
+        });
+      }
+    }
+
     return combineSchemas({
       schema: schemaItem,
       name,


### PR DESCRIPTION
## What

Follow-up to #3340 (PR #3560). Enum properties inside a nested object are now extracted into named `as const` consts when the object's nullability is spelled as the explicit OAS 3.1 composition `anyOf: [{ object }, { type: "null" }]` (and the analogous `oneOf`), matching how top-level, non-nullable nested, and `type: ["object", "null"]` objects already behave.

### Before
```ts
export type TestMonthSelection = {
  months: ('JANUARY' | 'FEBRUARY' | 'MARCH')[];
  months2?: 'JANUARY' | 'FEBRUARY' | 'MARCH';
} | null;
```

### After
```ts
export type TestMonthSelection = {
  months: TestMonthSelectionMonthsItem[];
  months2?: TestMonthSelectionMonths2;
} | null;
// + TestMonthSelectionMonthsItem / TestMonthSelectionMonths2 emitted as `... as const`
```

## Why

`#3340` fixed the `type: ["object", "null"]` shape, but the explicit `anyOf`/`oneOf` + `null`-member form takes a different path: it enters the combiner branch of `getObject` (`packages/core/src/getters/object.ts`) and is handed to `combineSchemas`, which resolves each member with `combined: true` and — under the v8 default `aliasCombinedTypes: false` — an undefined `propName`. The object member's `getObject` therefore receives `name = undefined`, and the enum-extraction guard in `resolvers/object.ts` is blocked (both `propName` empty and `combined` true), so the nested enums inline.

## How

In the combiner branch, before delegating to `combineSchemas`, detect a "nullable object composition" — an `anyOf`/`oneOf` whose members are exactly one **inline object with properties** plus one or more **`null`-type** members — and divert that single object member to the normal property-iteration path with its `name` preserved and a synthesized ` | null`. This mirrors the #3340 fix one level up.

The guard is deliberately narrow; these keep the existing `combineSchemas` behavior:
- `allOf` (intersection semantics, not a nullable union)
- `$ref` object members (e.g. `anyOf: [{ $ref }, { null }]` → `Ref | null`; the referenced schema extracts at its own definition)
- real multi-member unions (`[{ object }, { string }, { null }]`)
- primitive nullable unions (`[{ string }, { null }]`)
- empty-properties objects (kept as `{ [key: string]: unknown } | null`)

The divert is unconditional w.r.t. `aliasCombinedTypes`, consistent with #3340 (which also drops the `…AnyOf` wrapper for the equivalent type-array shape).

Related precedent: #2710 / PR #3424 (`isNullableEnumComposition`) made nullable **enum** compositions transparent inside `combineSchemas`; this is the **object-level** analogue.

## Tests

- `packages/core/src/generators/schema-definition.test.ts`: parametrized regression test over `anyOf` **and** `oneOf` asserting the nested enums extract as named `as const` schemas and the object keeps its ` | null`.
- Full suite green: 1980 core unit tests, the snapshot suite (samples + orval-tests) with **zero** changes to existing generated output, `typecheck`, and `lint`.
- Verified end-to-end via the CLI for both `anyOf` and `oneOf`, including `aliasCombinedTypes: true`; the generated schema files compile under `tsc --strict`.

Closes #3563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema generation for nullable object compositions so nested enum properties are extracted and referenced rather than inlined. Generated types now preserve the nullable union (e.g., "... | null") and reuse named enum schemas, reducing duplication and improving clarity of produced schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->