### PR TITLE
fix(query): attach queryKey to solid result without mutating the store

### DIFF
--- a/packages/query/src/dependencies.ts
+++ b/packages/query/src/dependencies.ts
@@ -328,6 +328,13 @@ const getSolidQueryImports = (
       ],
       dependency: '@tanstack/solid-query',
     },
+    {
+      // `mergeProps` lets the query hook attach `queryKey` to the result
+      // without mutating the read-only Solid Store (see #3347). Imported only
+      // when actually referenced, so mutation-only files stay unaffected.
+      exports: [{ name: 'mergeProps', values: true }],
+      dependency: 'solid-js',
+    },
   ];
 };
 

--- a/packages/query/src/dependencies.ts
+++ b/packages/query/src/dependencies.ts
@@ -330,8 +330,10 @@ const getSolidQueryImports = (
     },
     {
       // `mergeProps` lets the query hook attach `queryKey` to the result
-      // without mutating the read-only Solid Store (see #3347). Imported only
-      // when actually referenced, so mutation-only files stay unaffected.
+      // without mutating the read-only Solid Store (see #3347). `addDependency`
+      // only emits an import when the export name appears in the generated
+      // file, so mutation-only outputs never receive an unused `mergeProps`
+      // import.
       exports: [{ name: 'mergeProps', values: true }],
       dependency: 'solid-js',
     },

--- a/packages/query/src/frameworks/solid.test.ts
+++ b/packages/query/src/frameworks/solid.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSolidQueryDependencies } from '../dependencies';
+import { createFrameworkAdapter } from '.';
+
+describe('solid-query getQueryReturnStatement (issue #3347)', () => {
+  it('attaches queryKey without mutating the Solid store', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'solid-query' });
+
+    const statement = adapter.getQueryReturnStatement({
+      hasQueryV5: true,
+      hasQueryV5WithDataTagError: true,
+      queryResultVarName: 'query',
+      queryOptionsVarName: 'queryOptions',
+    });
+
+    // Solid query results are read-only stores. `Object.assign` hits the
+    // store's `set` trap, which warns "Cannot mutate a Store directly" and
+    // never actually attaches queryKey. `mergeProps` composes a new accessor
+    // object via getters, leaving the store untouched. See #3347.
+    expect(statement).toContain(
+      'mergeProps(query, { queryKey: queryOptions.queryKey })',
+    );
+    expect(statement).not.toContain('Object.assign(query');
+  });
+
+  it('imports mergeProps from solid-js so the return statement resolves', () => {
+    const dependencies = getSolidQueryDependencies(false, false, undefined);
+
+    const solidJsDependency = dependencies.find(
+      (dependency) => dependency.dependency === 'solid-js',
+    );
+
+    expect(solidJsDependency).toBeDefined();
+    expect(solidJsDependency?.exports).toContainEqual({
+      name: 'mergeProps',
+      values: true,
+    });
+  });
+});

--- a/packages/query/src/frameworks/solid.ts
+++ b/packages/query/src/frameworks/solid.ts
@@ -124,9 +124,15 @@ export const createSolidAdapter = ({
     queryResultVarName,
     queryOptionsVarName,
   }: QueryReturnStatementContext): string {
-    // Use Object.assign to attach queryKey to the result and cast to any to satisfy TypeScript
-    // The type is properly enforced by the function signature
-    return `return Object.assign(${queryResultVarName}, { queryKey: ${queryOptionsVarName}.queryKey }) as any;`;
+    // Attach queryKey without mutating the Solid Store. The query result is a
+    // read-only store, so `Object.assign` hits its `set` trap: in dev it warns
+    // "Cannot mutate a Store directly", and in every build the assignment is a
+    // no-op (queryKey is never actually attached). `mergeProps` is Solid's
+    // first-party way to compose a new accessor object via getters, so the
+    // queryKey is exposed while the underlying store stays untouched and
+    // reactive. The type is properly enforced by the function signature.
+    // See #3347.
+    return `return mergeProps(${queryResultVarName}, { queryKey: ${queryOptionsVarName}.queryKey }) as any;`;
   },
 
   generateQueryInvocationArgs({

--- a/packages/query/src/frameworks/solid.ts
+++ b/packages/query/src/frameworks/solid.ts
@@ -130,8 +130,10 @@ export const createSolidAdapter = ({
     // no-op (queryKey is never actually attached). `mergeProps` is Solid's
     // first-party way to compose a new accessor object via getters, so the
     // queryKey is exposed while the underlying store stays untouched and
-    // reactive. The type is properly enforced by the function signature.
-    // See #3347.
+    // reactive. The `as any` cast is required because mergeProps infers a
+    // concrete result type that TS cannot prove assignable to the generic
+    // `…Result<TData, TError>`; the caller-facing type comes from the hook's
+    // explicit return-type annotation. See #3347.
     return `return mergeProps(${queryResultVarName}, { queryKey: ${queryOptionsVarName}.queryKey }) as any;`;
   },
 


### PR DESCRIPTION
## Goal

Fixes the `solid-query` client so generated query hooks no longer trigger Solid's `Cannot mutate a Store directly` warning on every call.

Closes #3347

## Root cause

The generated Solid query hooks ended with:

```ts
return Object.assign(query, { queryKey: queryOptions.queryKey }) as any;
```

`query` is the read-only Solid Store returned by `@tanstack/solid-query`. `Object.assign` goes through the store's `set` trap, which in dev warns `Cannot mutate a Store directly`. Worse, that trap is a no-op, so `queryKey` was **never actually attached** in any build — the `& { queryKey }` part of the return type was effectively a lie on Solid.

## Fix

Use Solid's first-party [`mergeProps`](https://docs.solidjs.com/reference/component-apis/merge-props) to compose a new accessor object via getters instead of mutating the store:

```ts
import { mergeProps } from 'solid-js';
...
return mergeProps(query, { queryKey: queryOptions.queryKey }) as any;
```

This is the Solid analogue of the React adapter's non-mutating spread (`{ ...query, queryKey }`). It leaves the underlying store untouched (verified: no own `queryKey` property is added to the store), keeps the result reactive, and exposes a working `queryKey`. The `solid-js` import is added to the query dependencies and is only emitted in files that actually reference `mergeProps`, so mutation-only output is unaffected.

I deliberately avoided `Object.defineProperty`, which only sidesteps the warning by relying on a known unimplemented `defineProperty` trap in Solid's store proxy (solidjs/solid#1392) — a gap the Solid team intends to close.

## Tests

- Added `packages/query/src/frameworks/solid.test.ts`: asserts the Solid return statement uses `mergeProps` (not the mutating `Object.assign`) and that `mergeProps` is wired into the `solid-js` imports.
- `samples/solid-query/*` regenerate to the new output and pass `tsc --noEmit`.
- Full `test`, `test:snapshots`, `lint`, `lint:samples`, and generated-code build all pass; no other client output changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Solid Query integration so query keys are attached without mutating reactive stores, preserving correct reactive/accessor behavior.

* **Tests**
  * Added tests validating the non-mutating return behavior and that Solid-related dependencies export the required utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->