### PR TITLE
test(zod): add regression test for v4 top-level string formats

### DIFF
--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -1737,6 +1737,57 @@ describe('generateZodValidationSchemaDefinition`', () => {
     expect(parsed.zod).not.toContain('.hostname()');
   });
 
+  // Regression test for #3472: in Zod v4, string formats must be emitted as
+  // top-level APIs (e.g. `zod.uuid()`, `zod.iso.datetime()`) rather than the
+  // deprecated method-chain form (`zod.string().uuid()`). Zod v3 keeps the
+  // method-chain form. Mirrors the minimal `Example` schema from the issue.
+  it('emits top-level string format validators in v4 and method-chain in v3 (issue #3472)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid' },
+        createdAt: { type: 'string', format: 'date-time' },
+      },
+    };
+
+    const context = {
+      output: {
+        override: {
+          useDates: false,
+          zod: { dateTimeOptions: {}, timeOptions: {} },
+        },
+      },
+    } as ContextSpec;
+
+    const generate = (isZodV4: boolean) =>
+      parseZodValidationSchemaDefinition(
+        generateZodValidationSchemaDefinition(
+          schema,
+          context,
+          'Example',
+          false,
+          isZodV4,
+          { required: true },
+        ),
+        context,
+        false,
+        false,
+        isZodV4,
+      ).zod;
+
+    // Zod v4: top-level APIs, no `zod.string()` prefix.
+    const v4 = generate(true);
+    expect(v4).toContain('zod.uuid()');
+    expect(v4).toContain('zod.iso.datetime(');
+    expect(v4).not.toContain('zod.string().uuid()');
+    expect(v4).not.toContain('zod.string().datetime(');
+
+    // Zod v3: method-chain form is retained.
+    const v3 = generate(false);
+    expect(v3).toContain('zod.string().uuid()');
+    expect(v3).toContain('zod.string().datetime(');
+  });
+
   describe('description handling', () => {
     const context = makeContextSpec({
       override: {


### PR DESCRIPTION
The `zod` v4 string-format issue reported in #3472 (`zod.string().uuid()` / `zod.string().datetime()` instead of the top-level `zod.uuid()` / `zod.iso.datetime()`) was already fixed by #2061 and released in v7.10.0: for Zod v4, predefined string formats are emitted as top-level APIs without the deprecated `zod.string()` prefix.

There was no regression test covering the issue's exact scenario, though — the existing v4 format test (`uses regex after predefined format validator in v4`) always supplies a `pattern` and never asserts the absence of the `zod.string()` prefix.

This PR adds a focused regression test mirroring the minimal `Example` schema from the issue (`id: uuid`, `createdAt: date-time`, no pattern):

- Zod v4: emits `zod.uuid()` / `zod.iso.datetime(...)` and **not** `zod.string().uuid()` / `zod.string().datetime(...)`.
- Zod v3: keeps the method-chain form `zod.string().uuid()` / `zod.string().datetime(...)`.

No generator behavior changes; test-only.

Closes #3472


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify proper handling of string format validator code generation across different Zod versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->