### PR TITLE
fix(mock): apply bare-key property overrides to nested objects (#3470)

### DIFF
--- a/packages/mock/src/faker/resolvers/value.test.ts
+++ b/packages/mock/src/faker/resolvers/value.test.ts
@@ -125,16 +125,16 @@ describe('resolveMockOverride (#2465 — bare-key matching across array boundari
     );
   });
 
-  it('still does not match bare keys against non-array nested paths (semantic preserved)', () => {
+  it('matches bare keys against non-array nested paths (#3470)', () => {
     // The non-array nested case (`#.user.firstName` produced by an object
-    // property `user` containing baseUser) was never matched by a bare key
-    // and remains unmatched — users must use an explicit `user.firstName`
-    // key or a regex. #2465 is intentionally scoped to array transparency.
+    // property `user` containing baseUser) is now transparent too, mirroring
+    // the array transparency added in #2465. A bare `firstName` key applies
+    // wherever the property literally appears, at any nesting depth.
     const item: Item = { name: 'firstName', path: '#.user.firstName' };
 
     const result = resolveMockOverride(properties, item);
 
-    expect(result).toBeUndefined();
+    expect(result?.value).toBe('() => faker.person.firstName()');
   });
 
   it('regex keys still match item.name regardless of array markers in the path', () => {
@@ -152,6 +152,50 @@ describe('resolveMockOverride (#2465 — bare-key matching across array boundari
     const item: Item = { name: 'lastName', path: '#.[].lastName' };
 
     const result = resolveMockOverride(properties, item);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('resolveMockOverride (#3470 — nested transparency precedence)', () => {
+  // A bare key and an explicit dotted-path key both target `name`. The
+  // dotted-path key is more specific, so it must win for its own path while
+  // the bare key covers every other occurrence (most-specific-wins).
+  const properties = {
+    name: "'bare'",
+    'country.name': "'France'",
+  };
+
+  it('prefers the explicit dotted-path key for its target path', () => {
+    const item: Item = { name: 'name', path: '#.country.name' };
+
+    const result = resolveMockOverride(properties, item);
+
+    expect(result?.value).toBe("'France'");
+  });
+
+  it('falls back to the bare key for other nested occurrences', () => {
+    const item: Item = { name: 'name', path: '#.user.name' };
+
+    const result = resolveMockOverride(properties, item);
+
+    expect(result?.value).toBe("'bare'");
+  });
+
+  it('keeps the bare key matching the top level', () => {
+    const item: Item = { name: 'name', path: '#.name' };
+
+    const result = resolveMockOverride(properties, item);
+
+    expect(result?.value).toBe("'bare'");
+  });
+
+  it('does not let a dotted key match a leaf at the wrong path (stays anchored)', () => {
+    // `country.name` is a root-anchored path, not a depth-independent name
+    // match. It must not bleed onto `#.address.country.name`.
+    const item: Item = { name: 'name', path: '#.address.country.name' };
+
+    const result = resolveMockOverride({ 'country.name': "'France'" }, item);
 
     expect(result).toBeUndefined();
   });

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -44,7 +44,12 @@ export function resolveMockOverride(
   // Regex keys still match against the original (un-normalized) path so users
   // can opt into array-scoped targeting explicitly if ever needed.
   const normalizedPath = stripArrayMarkerSegments(path);
-  const property = Object.entries(properties).find(([key]) => {
+  const entries = Object.entries(properties);
+
+  // Tier 1 — explicit matches: regex (against name or full path) and exact
+  // array-transparent path. Checked first so a specific override (regex or
+  // dotted path like `country.name`) always wins over the bare-name fallback.
+  let property = entries.find(([key]) => {
     if (isRegex(key)) {
       const regex = new RegExp(key.slice(1, -1));
       if (regex.test(item.name) || regex.test(path)) {
@@ -58,6 +63,16 @@ export function resolveMockOverride(
 
     return false;
   });
+
+  // Tier 2 — bare property-name transparency (#3470): a dot-less key applies
+  // wherever the property literally appears, including inside non-array nested
+  // objects, mirroring the array transparency from #2465. Only reached when no
+  // explicit Tier 1 key matched, so it never overrides a more specific key.
+  if (!property) {
+    property = entries.find(
+      ([key]) => !isRegex(key) && !key.includes('.') && key === item.name,
+    );
+  }
 
   if (!property) {
     return;

--- a/tests/__snapshots__/mock/petstore/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore/endpoints.ts
@@ -353,7 +353,7 @@ export const getShowPetWithOwnerResponseMock = (
     ]),
     '@id': faker.string.alpha({ length: { min: 10, max: 30 } }),
     id: faker.number.int({ min: 0, max: 100 }),
-    name: faker.string.alpha({ length: { min: 10, max: 30 } }),
+    name: 'jon',
     tag: faker.string.alpha({ length: { min: 10, max: 30 } }),
     email: (() => faker.internet.email())(),
     callingCode: faker.helpers.arrayElement(['+33', '+420', '+33'] as const),


### PR DESCRIPTION
## Description

Bare-key `override.mock.properties` (e.g. `{ name: 'jon' }`) reached the response root and — since #2465 — array items, but stopped at **non-array nested objects**: `PetWithTag.pet.name` fell back to faker instead of the override.

This is the nested-object follow-up to #2465 / #3471, with the direction (Option A′) agreed by @melloware and @Hypenate in #3470.

### Before / After

petstore mock (`properties: { name: 'jon' }`):

| occurrence | path | before | after |
|---|---|---|---|
| top-level | `#.name` | `'jon'` | `'jon'` |
| array item (`listPets`) | `#.[].name` | `'jon'` (#2465) | `'jon'` |
| **nested object** (`PetWithTag.pet.name`) | `#.pet.name` | `faker.string.alpha(...)` | `'jon'` |

## How

`resolveMockOverride` now matches in two tiers:

1. **Tier 1 (unchanged)** — regex keys (against name or full path) and exact array-transparent path matching. Explicit keys (regex, or a dotted path like `country.name`) still win.
2. **Tier 2 (new)** — bare-name transparency: a dot-less key applies wherever the property literally appears, at any nesting depth, mirroring the array transparency from #2465. Only reached when no Tier 1 key matched, so **the most specific key always wins**.

This preserves the existing granular tools — dotted-path keys (`country.name`) and regex keys (`/^name$/`) behave exactly as before — so `country.name` vs `user.name` targeting is unaffected.

## Tests

- `packages/mock/src/faker/resolvers/value.test.ts`: the previously "still does not match nested" case is flipped to assert it now matches (#3470), plus a new describe block covering precedence (dotted key wins its path, bare key covers the rest) and anchoring (a dotted key stays root-anchored and does not bleed onto a deeper path).
- Snapshot: the only generated change across the whole suite is petstore `getShowPetWithOwnerResponseMock` nested `pet.name` flipping faker → `'jon'`.

### Local gates

- `@orval/mock` vitest: 229/229
- typecheck, lint: pass
- `tests` workspace build (typecheck-generated for 16 clients + verify-mock-generated): pass
- `test:snapshots`: 4582/4582 (1 snapshot updated)

Closes #3470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock override matching with a two-tier precedence so specific path/regex overrides take priority while bare property-name overrides apply for nested non-array occurrences.

* **Tests**
  * Expanded tests covering nested override precedence and edge cases.
  * Updated mock snapshot to use a stable example value for an inner object name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->