### PR TITLE
fix(zod): generate response schema for non-200 2xx (201/202) in single-response mode

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1977,10 +1977,15 @@ const getSingleResponse = (
     return;
   }
 
+  const otherSuccess = Object.entries(responses).find(
+    ([code]) => code.startsWith('2') && code !== '204' && code !== '205',
+  )?.[1];
+
   return (
     responses['200'] ??
     responses['2XX'] ??
     responses['2xx'] ??
+    otherSuccess ??
     responses['204'] ??
     responses['205']
   );

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -5211,6 +5211,142 @@ describe('generateResponseSchemaForNonJsonContentTypes', () => {
       'export const ClearCartResponse = zod.void()\n\n',
     );
   });
+
+  it('generates a response schema for a 201-only response in single mode', async () => {
+    const schema = {
+      pathRoute: '/items',
+      context: {
+        spec: {
+          paths: {
+            '/items': {
+              post: {
+                operationId: 'createItem',
+                responses: {
+                  '201': {
+                    description: 'Created',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          required: ['id'],
+                          properties: { id: { type: 'string' } },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+
+    const result = await generateZod(
+      {
+        pathRoute: '/items',
+        verb: 'post',
+        operationName: 'createItem',
+        override: {
+          zod: { strict: {}, generate: { response: true }, coerce: {} },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+
+    expect(result.implementation).toBe(
+      'export const CreateItemResponse = zod.object({\n  "id": zod.string()\n})\n\n',
+    );
+  });
+
+  it('generates a response schema for a 202-only response in single mode', async () => {
+    const schema = {
+      pathRoute: '/jobs',
+      context: {
+        spec: {
+          paths: {
+            '/jobs': {
+              post: {
+                operationId: 'runItem',
+                responses: {
+                  '202': {
+                    description: 'Accepted',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          required: ['job_id'],
+                          properties: { job_id: { type: 'string' } },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+
+    const result = await generateZod(
+      {
+        pathRoute: '/jobs',
+        verb: 'post',
+        operationName: 'runItem',
+        override: {
+          zod: { strict: {}, generate: { response: true }, coerce: {} },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+
+    expect(result.implementation).toBe(
+      'export const RunItemResponse = zod.object({\n  "job_id": zod.string()\n})\n\n',
+    );
+  });
+
+  it('generates zod.void() for a 201 response without a body in single mode', async () => {
+    const schema = {
+      pathRoute: '/items',
+      context: {
+        spec: {
+          paths: {
+            '/items': {
+              post: {
+                operationId: 'createItem',
+                responses: {
+                  '201': { description: 'Created' },
+                },
+              },
+            },
+          },
+        },
+        output: { override: { zod: { generateEachHttpStatus: false } } },
+      },
+    } as unknown as GeneratorOptions;
+
+    const result = await generateZod(
+      {
+        pathRoute: '/items',
+        verb: 'post',
+        operationName: 'createItem',
+        override: {
+          zod: { strict: {}, generate: { response: true }, coerce: {} },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      schema,
+      testOutput,
+    );
+
+    expect(result.implementation).toBe(
+      'export const CreateItemResponse = zod.void()\n\n',
+    );
+  });
 });
 
 describe('parsePrefixItemsArrayAsTupleZod', () => {


### PR DESCRIPTION
## Summary

fix #3565 

`@orval/zod` emits `zod.void()` for an operation whose only success response is a non-200 2xx such as `201` or `202`, dropping its JSON body schema. This is a regression from #3506. `getSingleResponse` only fell back through `200`/`2XX`/`2xx`/`204`/`205`, so a `201`-only operation resolved to no response and was treated as no-content. It now falls back to any other 2xx response before the no-content `204`/`205`, so the body schema is generated.

## Changes

The zod schema when openapi returns `201` with a response schema.

### before:

```ts
export const CreateItemResponse = zod.void()
```

### After

```ts
export const CreateItemResponse = zod.object({
  "id": zod.string(),
  "name": zod.string()
})
```