### PR TITLE
refactor(mock): tighten strict schema name recovery (#3574 follow-up)

### DIFF
--- a/packages/mock/src/mock-types.test.ts
+++ b/packages/mock/src/mock-types.test.ts
@@ -288,6 +288,19 @@ describe('mock-types', () => {
         collectStrictMockSchemaTypeNamesFromImplementation(implementation),
       ).toEqual(['WidgetMock']);
     });
+
+    it('keeps both Widget and WidgetMock when both schemas are strict-mocked', () => {
+      const implementation = [
+        'export const getWidgetMock = <O extends Partial<Widget> = {}>(overrideResponse?: O): MockWithNullableOverrides<Widget, O, WidgetMock> => ({}) as MockWithNullableOverrides<Widget, O, WidgetMock>;',
+        'export const getWidgetTypeMock = <O extends Partial<WidgetMock> = {}>(overrideResponse?: O): MockWithNullableOverrides<WidgetMock, O, WidgetMockMock> => ({}) as MockWithNullableOverrides<WidgetMock, O, WidgetMockMock>;',
+      ].join('\n');
+
+      expect(
+        collectStrictMockSchemaTypeNamesFromImplementation(
+          implementation,
+        ).toSorted(),
+      ).toEqual(['Widget', 'WidgetMock']);
+    });
   });
 
   describe('buildStrictMockTypeFileHeader', () => {

--- a/packages/mock/src/mock-types.ts
+++ b/packages/mock/src/mock-types.ts
@@ -222,11 +222,25 @@ export function applyStrictMockReturnType(
 
 const STRICT_MOCK_SCHEMA_TYPE_FROM_OVERRIDES =
   /MockWithNullableOverrides<([A-Z]\w*),/g;
-const STRICT_MOCK_SCHEMA_TYPE_FROM_MOCK_ALIAS = /\b([A-Z]\w*)Mock\b/g;
+const STRICT_MOCK_SCHEMA_TYPE_FROM_OVERRIDE_ALIAS =
+  /MockWithNullableOverrides<[^,]+,\s*[^,]+,\s*([A-Z]\w*Mock)>/g;
+const STRICT_MOCK_SCHEMA_TYPE_FROM_MOCK_ALIAS_RETURN =
+  /\): ([A-Z]\w*Mock)(?:\[\]|;)/g;
+
+/** Inverse of {@link getStrictMockTypeName}: `PetMock` → `Pet`, `WidgetMockMock` → `WidgetMock`. */
+function getSchemaTypeNameFromStrictMockAlias(alias: string): string {
+  return alias.endsWith('Mock') ? alias.slice(0, -4) : alias;
+}
 
 /**
  * Collect schema type names referenced by strict mock factories in generated
  * implementation text (nested split factories, array item helpers, etc.).
+ *
+ * This reverse-parses emitted factory syntax and is therefore coupled to the
+ * current `formatMockFactoryDeclaration` / `getMockFactorySignatureParts`
+ * shape. The structurally robust alternative is to record each nested item's
+ * schema name where split factories are generated (array-item / faker getters,
+ * where the `$ref` name is known) and thread it into `strictMockSchemaTypeNames`.
  */
 export function collectStrictMockSchemaTypeNamesFromImplementation(
   implementation: string,
@@ -239,16 +253,16 @@ export function collectStrictMockSchemaTypeNamesFromImplementation(
     names.add(match[1]);
   }
 
-  for (const match of implementation.matchAll(
-    STRICT_MOCK_SCHEMA_TYPE_FROM_MOCK_ALIAS,
-  )) {
-    names.add(match[1]);
+  for (const pattern of [
+    STRICT_MOCK_SCHEMA_TYPE_FROM_OVERRIDE_ALIAS,
+    STRICT_MOCK_SCHEMA_TYPE_FROM_MOCK_ALIAS_RETURN,
+  ]) {
+    for (const match of implementation.matchAll(pattern)) {
+      names.add(getSchemaTypeNameFromStrictMockAlias(match[1]));
+    }
   }
 
-  // `\b([A-Z]\w*)Mock\b` also matches `Widget` inside `WidgetMock` when the
-  // schema itself is named `WidgetMock` (`WidgetMockMock` strict alias). Drop
-  // prefix captures when a longer `{name}Mock` schema name was also collected.
-  return [...names].filter((name) => !names.has(`${name}Mock`));
+  return [...names];
 }
 
 export function mergeStrictMockSchemaTypeNames(

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -430,6 +430,8 @@ export const ${handlerName} = (overrideResponse?: ${mockReturnType} | ((${infoPa
     strictMockSchemaTypeNames: strictMock
       ? mergeStrictMockSchemaTypeNames(
           schemaTypeNames,
+          // Nested split factories: see collectStrictMockSchemaTypeNamesFromImplementation
+          // re regex-coupling note — prefer threading names from getters long-term.
           collectStrictMockSchemaTypeNamesFromImplementation(
             mockImplementation,
           ),


### PR DESCRIPTION
Follow-up to #3575 (closes #3574).

#3575 landed the tags-split strict mock type fix; this PR addresses two review nits from that work:

## Changes

- **Document regex coupling** — `collectStrictMockSchemaTypeNamesFromImplementation` now notes it reverse-parses emitted factory syntax and that the robust long-term fix is threading schema names from array-item / faker getters at generation time.
- **Tighter alias recovery** — Replace the broad prefix scan and Widget/WidgetMock filter with targeted patterns:
  - `MockWithNullableOverrides` first type param (unchanged)
  - Third generic alias → schema via inverse of `getStrictMockTypeName`
  - Non-overridable array return types like `): TenantInfoDtoMock[]`

This fixes the residual edge case where both `Widget` and `WidgetMock` strict mocks in the same file would drop `Widget`, while keeping `issue-3525-widget-mock-strict` snapshot-stable.

## Test plan

- [x] `vitest run packages/mock/src/mock-types.test.ts`
- [x] New test: both `Widget` and `WidgetMock` collected when present
- [x] Existing WidgetMock-only regression test passes
- [x] `issue-3525-widget-mock-strict` / `issue-3574` fixtures unchanged

Relates to #3574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test to verify collection of multiple strict-mock schema names across factory implementations.

* **Refactor**
  * Improved internal pattern-matching for extracting strict-mock schema type names to increase accuracy and maintainability.

* **Documentation**
  * Added clarifying inline comments describing handling of nested factories and name-threading considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->