### PR TITLE
docs(faker): use faker generator in arrayItems example

### DIFF
--- a/docs/content/docs/guides/faker.mdx
+++ b/docs/content/docs/guides/faker.mdx
@@ -114,7 +114,7 @@ Set `arrayItems: true` on any mock generator entry to emit reusable mock factori
 mock: {
   generators: [
     {
-      type: 'msw',
+      type: 'faker',
       arrayItems: true,
     },
   ],


### PR DESCRIPTION
## Summary

Follow-up to #3577 review feedback from @wadakatu: restore `type: 'faker'` in the Faker guide's Array Item Factories example config. The MSW guide already documents the MSW-specific example, so readers copying from the Faker page get the expected generator type.

## Test plan

- [x] Docs-only change; no code or tests affected
- [x] Verified the example snippet in `faker.mdx` shows `type: 'faker'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the faker guide example to reflect the correct configuration method for mock generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->