### PR TITLE
fix(mock): invoke override.mock.properties functions in faker schema factories

### DIFF
--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -162,6 +162,68 @@ describe('discriminated GlobalMockOptions union', () => {
   });
 });
 
+describe('generateFakerForSchemas property overrides (schemas: true)', () => {
+  const idOverride = () => 'faker.string.uuid()';
+  const createdOverride = () => 'faker.date.recent().toISOString()';
+  const archiveDurationOverride = () =>
+    `P${'faker.number.int({ min: 1, max: 365 })'}D`;
+
+  const context = createTestContextSpec({
+    override: {
+      mock: {
+        properties: {
+          '/^([Ii]d)$/': idOverride,
+          '/^([Cc]reated)$/': createdOverride,
+          '/^([Aa]rchive[Dd]uration)$/': archiveDurationOverride,
+        },
+      },
+    },
+  });
+
+  const petSchema = {
+    name: 'Pet',
+    model: 'Pet',
+    imports: [],
+    schema: {
+      type: 'object',
+      required: ['id', 'name'],
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        created: { type: 'string', format: 'date-time' },
+        archiveDuration: { type: 'string' },
+      },
+    },
+  };
+
+  it('invokes override.mock.properties functions as IIFEs, not raw arrow functions', () => {
+    const result = generateFakerForSchemas([petSchema], context, {
+      type: OutputMockType.FAKER,
+      schemas: true,
+    });
+
+    expect(result.implementation).toContain(`id: (${String(idOverride)})()`);
+    expect(result.implementation).toContain(
+      `created: (${String(createdOverride)})()`,
+    );
+    expect(result.implementation).toContain(
+      `archiveDuration: (${String(archiveDurationOverride)})()`,
+    );
+    expect(result.implementation).not.toMatch(/\bid: \(\) =>/);
+    expect(result.implementation).not.toMatch(/\bcreated: \(\) =>/);
+    expect(result.implementation).not.toMatch(/\barchiveDuration: \(\) =>/);
+  });
+
+  it('keeps default faker generation for non-overridden properties', () => {
+    const result = generateFakerForSchemas([petSchema], context, {
+      type: OutputMockType.FAKER,
+      schemas: true,
+    });
+
+    expect(result.implementation).toContain('name: faker.string.alpha(');
+  });
+});
+
 describe('generateFakerForSchemas strict mock types (#3525)', () => {
   const context = createTestContextSpec({
     override: {

--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -2,6 +2,7 @@ import type {
   ClientMockBuilder,
   FakerMockOptions,
   GeneratorOptions,
+  GeneratorSchema,
   GeneratorVerbOptions,
   GlobalMockOptions,
   MswMockOptions,
@@ -180,7 +181,7 @@ describe('generateFakerForSchemas property overrides (schemas: true)', () => {
     },
   });
 
-  const petSchema = {
+  const petSchema: GeneratorSchema = {
     name: 'Pet',
     model: 'Pet',
     imports: [],

--- a/packages/mock/src/faker/index.ts
+++ b/packages/mock/src/faker/index.ts
@@ -18,6 +18,7 @@ import {
   isStrictMock,
 } from '../mock-types';
 import { generateMSW } from '../msw';
+import { getMockWithoutFunc } from '../msw/mocks';
 import { getMockScalar } from './getters';
 
 function getFakerDependencies(
@@ -115,7 +116,9 @@ export function generateFakerForSchemas(
     schemas.filter((s) => !!s.schema).map((s) => `get${pascal(s.name)}Mock`),
   );
 
-  const mockOptions = context.output.override.mock;
+  // Serialize override.mock.properties functions the same way operation
+  // response mocks do (IIFE expressions), not raw function references.
+  const mockOptions = getMockWithoutFunc(context.spec, context.output.override);
 
   for (const generatorSchema of schemas) {
     const { name, schema } = generatorSchema;

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -38,7 +38,7 @@ function getMockPropertiesWithoutFunc(
   return mockProperties;
 }
 
-function getMockWithoutFunc(
+export function getMockWithoutFunc(
   spec: OpenApiDocument,
   override?: NormalizedOverrideOutput,
 ): MockOptions {


### PR DESCRIPTION
## Summary

- Fix faker schema factory generation (`schemas: true`) so `override.mock.properties` function values are serialized as IIFEs, matching operation response mocks
- Reuse `getMockWithoutFunc` in `generateFakerForSchemas` instead of passing raw `override.mock` options
- Add regression tests for IIFE emission and default faker fallback on non-overridden properties

Closes #3584

## Test plan

- [x] `npx vitest run packages/mock` — 242 tests passing
- [x] New unit tests in `packages/mock/src/faker/index.test.ts` verify overridden properties emit `(() => ...)()` and not raw `() => ...` arrow functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying mock schema generation respects override property functions (serialized as immediately-invoked expressions) while leaving non-overridden properties using default fake data.

* **Refactor**
  * Updated mock option processing to serialize override functions in generated schema factories.
  * Exported an internal utility to improve modularity and reuse across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->