### PR TITLE
fix(samples): paginated response tags split correctly setup test:snap…

### DIFF
--- a/samples/paginated-response-tags-split/package.json
+++ b/samples/paginated-response-tags-split/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "generate-api": "vp exec orval",
     "test:snapshots": "vitest run --config vitest.snapshots.ts",
-    "test:snapshots:update": "vp run test:snapshots -- --update"
+    "test:snapshots:update": "vp run test:snapshots --update"
   },
   "devDependencies": {
     "orval": "workspace:*",


### PR DESCRIPTION
## What

Fixes the `test:snapshots:update` script in `samples/paginated-response-tags-split/package.json`:

```diff
- "test:snapshots:update": "vp run test:snapshots -- --update"
+ "test:snapshots:update": "vp run test:snapshots --update"

## Why

The stray -- caused vp to expand the script to:

vitest run --config vitest.snapshots.ts -- --update

Vitest treats everything after -- as a positional filename filter, so --update
was no longer interpreted as the update flag — vitest ran in check mode instead of
update mode. Every other sample uses vp run test:snapshots --update (no --).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm script configuration for sample project test automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->