### PR TITLE
feat(coderabbit): setup config and add filter for snapshots

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_filters:
+    # Exclude generated test snapshots from review (noise, not human-authored)
+    - "!**/__snapshots__/**"


### PR DESCRIPTION
## What

Adds a `.coderabbit.yaml` config that excludes all `__snapshots__/**`
directories from CodeRabbit's review scope via `reviews.path_filters`.

## Why

Snapshot files (Vitest `.snap` under `tests/` and across `samples/**`) are
generated, not human-authored. CodeRabbit currently reviews them on every PR,
which produces a lot of noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to exclude generated snapshot files from automated review scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->