### PR TITLE
fix(core): generate requiredNullableParamKeys only if preserveRequire…

### DIFF
--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -42,11 +42,21 @@ export const getAngularFilteredParamsExpression = (
     }
 `
     : '';
-  const preserveNullableBranch = preserveRequiredNullables
-    ? `    } else if (value === null && requiredNullableParamKeys.has(key)) {
+
+  // Generate requiredNullableParamKeys only if preserveRequiredNullables are 'true'
+  // Otherwise, typescript throw an error (TS6133: 'requiredNullableParamKeys' is declared but its value is never read.)
+  let preserveNullableBranch: string;
+  let requiredNullableParamKeysBranch: string;
+  if (preserveRequiredNullables) {
+    preserveNullableBranch = `    } else if (value === null && requiredNullableParamKeys.has(key)) {
       filteredParams[key] = null;
-`
-    : '';
+`;
+    requiredNullableParamKeysBranch = `const requiredNullableParamKeys = new Set<string>(${JSON.stringify(requiredNullableParamKeys)});`;
+  } else {
+    preserveNullableBranch = '';
+    requiredNullableParamKeysBranch = '';
+  }
+
   const scalarBranch = `    } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -61,7 +71,7 @@ export const getAngularFilteredParamsExpression = (
     : '';
 
   return `(() => {
-${passthroughDecl}  const requiredNullableParamKeys = new Set<string>(${JSON.stringify(requiredNullableParamKeys)});
+${passthroughDecl}  ${requiredNullableParamKeysBranch}
   const filteredParams: Record<string, ${filteredParamValueType}> = {};
   for (const [key, value] of Object.entries(${paramsExpression})) {
 ${passthroughBranch}    if (Array.isArray(value)) {

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -228,7 +228,6 @@ export class PetsService {
         url: `/v${version}/pets`,
         method: 'GET',
         params: (() => {
-          const requiredNullableParamKeys = new Set<string>([]);
           const filteredParams: Record<
             string,
             string | number | boolean | Array<string | number | boolean>

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -228,7 +228,6 @@ export class PetsService {
         url: `/v${version}/pets`,
         method: 'GET',
         params: (() => {
-          const requiredNullableParamKeys = new Set<string>([]);
           const filteredParams: Record<
             string,
             string | number | boolean | Array<string | number | boolean>

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -114,10 +114,6 @@ export const searchPets = (
       url: `/search`,
       method: 'GET',
       params: (() => {
-        const requiredNullableParamKeys = new Set<string>([
-          'requirednullableString',
-          'requirednullableStringTwo',
-        ]);
         const filteredParams: Record<
           string,
           string | number | boolean | Array<string | number | boolean>
@@ -242,7 +238,6 @@ export const listPets = (
       url: `/pets`,
       method: 'GET',
       params: (() => {
-        const requiredNullableParamKeys = new Set<string>([]);
         const filteredParams: Record<
           string,
           string | number | boolean | Array<string | number | boolean>

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -114,10 +114,6 @@ export const searchPets = (
       url: `/search`,
       method: 'GET',
       params: (() => {
-        const requiredNullableParamKeys = new Set<string>([
-          'requirednullableString',
-          'requirednullableStringTwo',
-        ]);
         const filteredParams: Record<
           string,
           string | number | boolean | Array<string | number | boolean>
@@ -242,7 +238,6 @@ export const listPets = (
       url: `/pets`,
       method: 'GET',
       params: (() => {
-        const requiredNullableParamKeys = new Set<string>([]);
         const filteredParams: Record<
           string,
           string | number | boolean | Array<string | number | boolean>

--- a/tests/__snapshots__/angular/custom-client/endpoints.ts
+++ b/tests/__snapshots__/angular/custom-client/endpoints.ts
@@ -42,7 +42,6 @@ export class SwaggerPetstoreService {
         url: `/v${version}/pets`,
         method: 'GET',
         params: (() => {
-          const requiredNullableParamKeys = new Set<string>([]);
           const filteredParams: Record<
             string,
             string | number | boolean | Array<string | number | boolean>
@@ -90,7 +89,6 @@ export class SwaggerPetstoreService {
         headers: { 'Content-Type': 'application/json' },
         data: createPetsBody,
         params: (() => {
-          const requiredNullableParamKeys = new Set<string>([]);
           const filteredParams: Record<
             string,
             string | number | boolean | Array<string | number | boolean>


### PR DESCRIPTION
When preserveRequiredNullables is false (no paramsSerializer configured), the requiredNullableParamKeys variable is declared but never used, causing TS6133 error with noUnusedLocals: true.

This fix only declares requiredNullableParamKeys when the preserveNullable branch is active.

Closes: #3593 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated compiler warnings by removing unused variable declarations from query parameter construction logic.
  * Refined query parameter filtering to consistently exclude undefined and null values while preserving allowed scalar types across Angular services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->