### PR TITLE
fix(zod): resolve global zod mutators against output workspace

### DIFF
--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -693,6 +693,56 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('resolves global zod mutators relative to the output workspace', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const outputWorkspace = path.join(workspace, 'generated');
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './api.ts',
+            workspace: './generated',
+            client: 'zod',
+            override: {
+              zod: {
+                preprocess: {
+                  param: './param.ts',
+                  query: './query.ts',
+                  header: './header.ts',
+                  body: './body.ts',
+                  response: './response.ts',
+                },
+                params: './params.ts',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.zod.preprocess).toMatchObject({
+        param: { path: path.join(outputWorkspace, 'param.ts') },
+        query: { path: path.join(outputWorkspace, 'query.ts') },
+        header: { path: path.join(outputWorkspace, 'header.ts') },
+        body: { path: path.join(outputWorkspace, 'body.ts') },
+        response: { path: path.join(outputWorkspace, 'response.ts') },
+      });
+      expect(normalized.output.override.zod.params?.path).toBe(
+        path.join(outputWorkspace, 'params.ts'),
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('normalizes effect options without falling back to zod', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -511,7 +511,7 @@ export async function normalizeOptions(
             ...(outputOptions.override?.zod?.preprocess?.param
               ? {
                   param: normalizeMutator(
-                    workspace,
+                    outputWorkspace,
                     outputOptions.override.zod.preprocess.param,
                   ),
                 }
@@ -519,7 +519,7 @@ export async function normalizeOptions(
             ...(outputOptions.override?.zod?.preprocess?.query
               ? {
                   query: normalizeMutator(
-                    workspace,
+                    outputWorkspace,
                     outputOptions.override.zod.preprocess.query,
                   ),
                 }
@@ -527,7 +527,7 @@ export async function normalizeOptions(
             ...(outputOptions.override?.zod?.preprocess?.header
               ? {
                   header: normalizeMutator(
-                    workspace,
+                    outputWorkspace,
                     outputOptions.override.zod.preprocess.header,
                   ),
                 }
@@ -535,7 +535,7 @@ export async function normalizeOptions(
             ...(outputOptions.override?.zod?.preprocess?.body
               ? {
                   body: normalizeMutator(
-                    workspace,
+                    outputWorkspace,
                     outputOptions.override.zod.preprocess.body,
                   ),
                 }
@@ -543,7 +543,7 @@ export async function normalizeOptions(
             ...(outputOptions.override?.zod?.preprocess?.response
               ? {
                   response: normalizeMutator(
-                    workspace,
+                    outputWorkspace,
                     outputOptions.override.zod.preprocess.response,
                   ),
                 }
@@ -552,7 +552,7 @@ export async function normalizeOptions(
           ...(outputOptions.override?.zod?.params
             ? {
                 params: normalizeMutator(
-                  workspace,
+                  outputWorkspace,
                   outputOptions.override.zod.params,
                 ),
               }


### PR DESCRIPTION
Global `override.zod.preprocess.*` and `override.zod.params` mutators were resolved against the config workspace, unlike operation/tag-level Zod mutators and other output mutators.

This resolves those six global Zod paths against `output.workspace` and adds regression coverage.

Out of scope: Global query mutators appear to share the same global-vs-operation workspace mismatch. They are intentionally excluded because this PR follows the six-path Zod scope confirmed in #3458. I can open a separate issue or PR if maintainers want query behavior aligned too.

Closes #3458

Validation:
- `vp fmt --check`
- `vp run -w build:release`
- `vp run -w lint`
- `vp run -w lint:samples`
- `vp run -w typecheck`
- `vp run -w test`
- `vp run -w test:snapshots`
- `vp run -F orval-tests build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying Zod mutator file paths resolve correctly relative to the output workspace directory

* **Bug Fixes**
  * Fixed path resolution for Zod mutator preprocess hooks and parameter configurations to correctly resolve relative to the output workspace directory instead of the base workspace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->