### PR TITLE
fix(mcp): order handler body/query args and propagate optional body to handler + tool schema

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,6 +12,7 @@ import {
   getFileInfo,
   getFullRoute,
   getParamsInPath,
+  GetterPropType,
   isObject,
   isString,
   jsDoc,
@@ -174,8 +175,18 @@ ${handlerArgsTypes.join('\n')}
 
     fetchParams.push(pathParamsArgs);
   }
-  if (verbOptions.body.definition) fetchParams.push(`args.bodyParams`);
-  if (verbOptions.queryParams) fetchParams.push(`args.queryParams`);
+  // Body and query args must follow the same order as the generated client
+  // function signature, which sorts required params before optional ones (see
+  // `getProps`/`sortByPriority`). Emitting a fixed body-then-query order would
+  // swap the two arguments whenever the query param is required and the body is
+  // optional, sending the body as the query string and vice versa.
+  for (const prop of verbOptions.props) {
+    if (prop.type === GetterPropType.BODY) {
+      fetchParams.push('args.bodyParams');
+    } else if (prop.type === GetterPropType.QUERY_PARAM) {
+      fetchParams.push('args.queryParams');
+    }
+  }
 
   const handlerName = `${verbOptions.operationName}Handler`;
   const handlerImplementation = `

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -154,7 +154,9 @@ export const generateMcp: ClientBuilder = (verbOptions) => {
     );
   }
   if (verbOptions.body.definition) {
-    handlerArgsTypes.push(`  bodyParams: ${verbOptions.body.definition};`);
+    handlerArgsTypes.push(
+      `  bodyParams${verbOptions.body.isOptional ? '?' : ''}: ${verbOptions.body.definition};`,
+    );
   }
 
   const handlerArgsName = `${verbOptions.operationName}Args`;
@@ -251,7 +253,9 @@ export const generateServer = (
       if (verbOption.queryParams)
         inputSchemaTypes.push(`queryParams: ${pascalOperationName}QueryParams`);
       if (verbOption.body.definition)
-        inputSchemaTypes.push(`bodyParams: ${pascalOperationName}Body`);
+        inputSchemaTypes.push(
+          `bodyParams: ${pascalOperationName}Body${verbOption.body.isOptional ? '.optional()' : ''}`,
+        );
 
       const inputSchemaImplementation =
         inputSchemaTypes.length > 0

--- a/samples/mcp/petstore/__snapshots__/handlers.ts
+++ b/samples/mcp/petstore/__snapshots__/handlers.ts
@@ -13,6 +13,8 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import {
+  FilterPetsByStatusParams,
+  Pet,
   FindPetsByStatusParams,
   FindPetsByTagsParams,
   UpdatePetWithFormParams,
@@ -20,6 +22,7 @@ import {
 } from './http-schemas';
 
 import {
+  filterPetsByStatus,
   findPetsByStatus,
   findPetsByTags,
   getPetById,
@@ -33,6 +36,51 @@ import {
   getUserByName,
   deleteUser,
 } from './http-client';
+
+/**
+ * Has a required query parameter alongside an optional request body, so the
+ * generated client sorts the query parameter before the body. Guards against
+ * the MCP handler passing the body and query arguments in the wrong order.
+ * @summary Filter pets by status with an optional example body.
+ */
+
+export type filterPetsByStatusArgs = {
+  queryParams: FilterPetsByStatusParams;
+  bodyParams: Pet;
+};
+
+export const filterPetsByStatusHandler = async (
+  args: filterPetsByStatusArgs,
+  options?: RequestInit,
+) => {
+  const res = await filterPetsByStatus(
+    args.queryParams,
+    args.bodyParams,
+    options,
+  );
+
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(res.data ?? null),
+      },
+    ],
+    structuredContent: res.data,
+  };
+};
 
 /**
  * Multiple status values can be provided with comma separated strings.

--- a/samples/mcp/petstore/__snapshots__/handlers.ts
+++ b/samples/mcp/petstore/__snapshots__/handlers.ts
@@ -46,7 +46,7 @@ import {
 
 export type filterPetsByStatusArgs = {
   queryParams: FilterPetsByStatusParams;
-  bodyParams: Pet;
+  bodyParams?: Pet;
 };
 
 export const filterPetsByStatusHandler = async (

--- a/samples/mcp/petstore/__snapshots__/http-schemas/filterPetsByStatusParams.ts
+++ b/samples/mcp/petstore/__snapshots__/http-schemas/filterPetsByStatusParams.ts
@@ -13,19 +13,9 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-export * from './apiResponse';
-export * from './category';
-export * from './filterPetsByStatusParams';
-export * from './findPetsByStatusParams';
-export * from './findPetsByTagsParams';
-export * from './getInventory200';
-export * from './loginUserParams';
-export * from './order';
-export * from './orderStatus';
-export * from './pet';
-export * from './petBody';
-export * from './petStatus';
-export * from './tag';
-export * from './updatePetWithFormParams';
-export * from './user';
-export * from './userArrayBody';
+export type FilterPetsByStatusParams = {
+  /**
+   * Status value that needs to be considered for filter
+   */
+  status: string;
+};

--- a/samples/mcp/petstore/petstore.yaml
+++ b/samples/mcp/petstore/petstore.yaml
@@ -36,6 +36,47 @@ tags:
   - name: user
     description: Operations about user
 paths:
+  /pet/filterByStatus:
+    post:
+      tags:
+        - pet
+      summary: Filter pets by status with an optional example body.
+      description: |-
+        Has a required query parameter alongside an optional request body, so the
+        generated client sorts the query parameter before the body. Guards against
+        the MCP handler passing the body and query arguments in the wrong order.
+      operationId: filterPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status value that needs to be considered for filter
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Optional example pet to match against
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+        default:
+          description: Unexpected error
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
   /pet/findByStatus:
     get:
       tags:

--- a/samples/mcp/petstore/src/handlers.ts
+++ b/samples/mcp/petstore/src/handlers.ts
@@ -13,6 +13,8 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 import {
+  FilterPetsByStatusParams,
+  Pet,
   FindPetsByStatusParams,
   FindPetsByTagsParams,
   UpdatePetWithFormParams,
@@ -20,6 +22,7 @@ import {
 } from './http-schemas';
 
 import {
+  filterPetsByStatus,
   findPetsByStatus,
   findPetsByTags,
   getPetById,
@@ -33,6 +36,51 @@ import {
   getUserByName,
   deleteUser,
 } from './http-client';
+
+/**
+ * Has a required query parameter alongside an optional request body, so the
+ * generated client sorts the query parameter before the body. Guards against
+ * the MCP handler passing the body and query arguments in the wrong order.
+ * @summary Filter pets by status with an optional example body.
+ */
+
+export type filterPetsByStatusArgs = {
+  queryParams: FilterPetsByStatusParams;
+  bodyParams: Pet;
+};
+
+export const filterPetsByStatusHandler = async (
+  args: filterPetsByStatusArgs,
+  options?: RequestInit,
+) => {
+  const res = await filterPetsByStatus(
+    args.queryParams,
+    args.bodyParams,
+    options,
+  );
+
+  if (res.status >= 400) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(res.data ?? null),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(res.data ?? null),
+      },
+    ],
+    structuredContent: res.data,
+  };
+};
 
 /**
  * Multiple status values can be provided with comma separated strings.

--- a/samples/mcp/petstore/src/handlers.ts
+++ b/samples/mcp/petstore/src/handlers.ts
@@ -46,7 +46,7 @@ import {
 
 export type filterPetsByStatusArgs = {
   queryParams: FilterPetsByStatusParams;
-  bodyParams: Pet;
+  bodyParams?: Pet;
 };
 
 export const filterPetsByStatusHandler = async (

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -15,6 +15,7 @@
 
 import {
   Pet,
+  FilterPetsByStatusParams,
   FindPetsByStatusParams,
   FindPetsByTagsParams,
   UpdatePetWithFormParams,
@@ -65,6 +66,80 @@ export type HTTPStatusCodes =
   | HTTPStatusCode3xx
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
+
+export type filterPetsByStatusResponse200 = {
+  data: Pet[];
+  status: 200;
+};
+
+export type filterPetsByStatusResponse400 = {
+  data: void;
+  status: 400;
+};
+
+export type filterPetsByStatusResponseDefault = {
+  data: void;
+  status: Exclude<HTTPStatusCodes, 200 | 400>;
+};
+
+export type filterPetsByStatusResponseSuccess =
+  filterPetsByStatusResponse200 & {
+    headers: Headers;
+  };
+export type filterPetsByStatusResponseError = (
+  | filterPetsByStatusResponse400
+  | filterPetsByStatusResponseDefault
+) & {
+  headers: Headers;
+};
+
+export type filterPetsByStatusResponse =
+  | filterPetsByStatusResponseSuccess
+  | filterPetsByStatusResponseError;
+
+export const getFilterPetsByStatusUrl = (params: FilterPetsByStatusParams) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : String(value));
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `https://petstore3.swagger.io/api/v3/pet/filterByStatus?${stringifiedParams}`
+    : `https://petstore3.swagger.io/api/v3/pet/filterByStatus`;
+};
+
+/**
+ * Has a required query parameter alongside an optional request body, so the
+ * generated client sorts the query parameter before the body. Guards against
+ * the MCP handler passing the body and query arguments in the wrong order.
+ * @summary Filter pets by status with an optional example body.
+ */
+export const filterPetsByStatus = async (
+  params: FilterPetsByStatusParams,
+  pet?: Pet,
+  options?: RequestInit,
+): Promise<filterPetsByStatusResponse> => {
+  const res = await fetch(getFilterPetsByStatusUrl(params), {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(pet),
+  });
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+  const data: filterPetsByStatusResponse['data'] = body ? JSON.parse(body) : {};
+  return {
+    data,
+    status: res.status,
+    headers: res.headers,
+  } as filterPetsByStatusResponse;
+};
 
 export type findPetsByStatusResponse200ApplicationJson = {
   data: Pet[];

--- a/samples/mcp/petstore/src/http-schemas/filterPetsByStatusParams.ts
+++ b/samples/mcp/petstore/src/http-schemas/filterPetsByStatusParams.ts
@@ -13,19 +13,9 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-export * from './apiResponse';
-export * from './category';
-export * from './filterPetsByStatusParams';
-export * from './findPetsByStatusParams';
-export * from './findPetsByTagsParams';
-export * from './getInventory200';
-export * from './loginUserParams';
-export * from './order';
-export * from './orderStatus';
-export * from './pet';
-export * from './petBody';
-export * from './petStatus';
-export * from './tag';
-export * from './updatePetWithFormParams';
-export * from './user';
-export * from './userArrayBody';
+export type FilterPetsByStatusParams = {
+  /**
+   * Status value that needs to be considered for filter
+   */
+  status: string;
+};

--- a/samples/mcp/petstore/src/http-schemas/index.ts
+++ b/samples/mcp/petstore/src/http-schemas/index.ts
@@ -15,6 +15,7 @@
 
 export * from './apiResponse';
 export * from './category';
+export * from './filterPetsByStatusParams';
 export * from './findPetsByStatusParams';
 export * from './findPetsByTagsParams';
 export * from './getInventory200';

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -81,7 +81,7 @@ const createMcpServer = (
         'Has a required query parameter alongside an optional request body, so the\ngenerated client sorts the query parameter before the body. Guards against\nthe MCP handler passing the body and query arguments in the wrong order.',
       inputSchema: {
         queryParams: FilterPetsByStatusQueryParams,
-        bodyParams: FilterPetsByStatusBody,
+        bodyParams: FilterPetsByStatusBody.optional(),
       },
       outputSchema: FilterPetsByStatusResponse,
       annotations: { destructiveHint: false },

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -21,6 +21,7 @@ import {
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import {
+  filterPetsByStatusHandler,
   findPetsByStatusHandler,
   findPetsByTagsHandler,
   getPetByIdHandler,
@@ -35,6 +36,9 @@ import {
   deleteUserHandler,
 } from './handlers';
 import {
+  FilterPetsByStatusQueryParams,
+  FilterPetsByStatusBody,
+  FilterPetsByStatusResponse,
   FindPetsByStatusQueryParams,
   FindPetsByStatusResponse,
   FindPetsByTagsQueryParams,
@@ -68,6 +72,22 @@ const createMcpServer = (
     version: '1.0.0',
   });
   const tools: Record<string, RegisteredTool> = {};
+
+  tools.filterPetsByStatus = server.registerTool(
+    'filterPetsByStatus',
+    {
+      title: 'Filter pets by status with an optional example body.',
+      description:
+        'Has a required query parameter alongside an optional request body, so the\ngenerated client sorts the query parameter before the body. Guards against\nthe MCP handler passing the body and query arguments in the wrong order.',
+      inputSchema: {
+        queryParams: FilterPetsByStatusQueryParams,
+        bodyParams: FilterPetsByStatusBody,
+      },
+      outputSchema: FilterPetsByStatusResponse,
+      annotations: { destructiveHint: false },
+    },
+    (args) => filterPetsByStatusHandler(args, options),
+  );
 
   tools.findPetsByStatus = server.registerTool(
     'findPetsByStatus',

--- a/samples/mcp/petstore/src/tool-schemas.zod.ts
+++ b/samples/mcp/petstore/src/tool-schemas.zod.ts
@@ -14,6 +14,63 @@
  */
 import { z as zod } from 'zod';
 
+export const FilterPetsByStatusQueryParams = zod.object({
+  status: zod
+    .string()
+    .describe('Status value that needs to be considered for filter'),
+});
+
+export const FilterPetsByStatusBody = zod.object({
+  id: zod.number().optional(),
+  name: zod.string(),
+  category: zod
+    .object({
+      id: zod.number().optional(),
+      name: zod.string().optional(),
+    })
+    .optional(),
+  photoUrls: zod.array(zod.string()),
+  tags: zod
+    .array(
+      zod.object({
+        id: zod.number().optional(),
+        name: zod.string().optional(),
+      }),
+    )
+    .optional(),
+  status: zod
+    .enum(['available', 'pending', 'sold'])
+    .optional()
+    .describe('pet status in the store'),
+});
+
+export const FilterPetsByStatusResponseItem = zod.object({
+  id: zod.number().optional(),
+  name: zod.string(),
+  category: zod
+    .object({
+      id: zod.number().optional(),
+      name: zod.string().optional(),
+    })
+    .optional(),
+  photoUrls: zod.array(zod.string()),
+  tags: zod
+    .array(
+      zod.object({
+        id: zod.number().optional(),
+        name: zod.string().optional(),
+      }),
+    )
+    .optional(),
+  status: zod
+    .enum(['available', 'pending', 'sold'])
+    .optional()
+    .describe('pet status in the store'),
+});
+export const FilterPetsByStatusResponse = zod.array(
+  FilterPetsByStatusResponseItem,
+);
+
 export const FindPetsByStatusQueryParams = zod.object({
   status: zod
     .string()


### PR DESCRIPTION
## Description

Fixes #3599.

Two related correctness issues in the MCP generator's handler/tool wiring, both
exercised by one new sample operation (required query param + optional body).

### 1. Argument order (the reported bug)

The generated MCP handler called the fetch client with a hardcoded
body-then-query argument order:

    await createItem(args.bodyParams, args.queryParams, options);

But the generated client sorts its parameters required-before-optional
(`getProps` -> `sortByPriority`). When an operation has a **required query param
and an optional body**, the signature is query-first:

    export const createItem = (params: CreateItemParams, item?: Item, options?: RequestInit) => ...

so the handler passed body into the query slot and vice-versa: the generated
`handlers.ts` failed to type-check (`TS2345`), and if compiled past that, sent the
body as the URL query string and the query object as the JSON body. (Operations
with a required body happened to line up, which is why it went unnoticed.)

**Fix:** build the body/query arguments by iterating `verbOptions.props` — the
same already-sorted list the client signature is generated from — so the call
order can never diverge from the signature.

### 2. Optional request body typed as required (raised in review)

When the OpenAPI `requestBody` is optional, the handler still typed `bodyParams`
as required and the tool `inputSchema` required it, even though the client accepts
`pet?: Pet` — making the tool impossible to call without a body.

**Fix:** consult `body.isOptional` so the handler emits `bodyParams?` and the tool
`inputSchema` emits `Body.optional()`, keeping the MCP contract consistent with
the OpenAPI spec and the client signature.

## Tests

Adds a `filterPetsByStatus` operation (required query param + optional body) to
`samples/mcp/petstore` and its snapshots — it exercises both fixes at once
(`await filterPetsByStatus(args.queryParams, args.bodyParams, options)` with
`bodyParams?: Pet` and `FilterPetsByStatusBody.optional()`). Reverting the
ordering fix makes **only** `samples/mcp/petstore/src/handlers.ts` fail the
snapshot test, confirming it guards exactly that regression. Existing mcp sample
snapshots are unchanged and the full package test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “filter pets by status” MCP tool/API endpoint.
  * Supports a required `status` query parameter plus an optional JSON request body.
  * Returns filtered pet results with success and error responses (including a default unexpected-error case).
  * Uses OAuth2 security with scopes that require both write and read permissions.

* **Bug Fixes**
  * Improved MCP handler argument ordering to avoid mismatches between query and body parameters when optionality differs.
  * Ensures optional request bodies are treated as optional in the generated schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->