### PR TITLE
fix(query): resolve global query mutators against output workspace

### DIFF
--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -743,6 +743,48 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('resolves global query mutators relative to the output workspace', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const outputWorkspace = path.join(workspace, 'generated');
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './api.ts',
+            workspace: './generated',
+            client: 'react-query',
+            override: {
+              query: {
+                queryKey: './queryKey.ts',
+                queryOptions: './queryOptions.ts',
+                mutationOptions: './mutationOptions.ts',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.query).toMatchObject({
+        queryKey: { path: path.join(outputWorkspace, 'queryKey.ts') },
+        queryOptions: { path: path.join(outputWorkspace, 'queryOptions.ts') },
+        mutationOptions: {
+          path: path.join(outputWorkspace, 'mutationOptions.ts'),
+        },
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('normalizes effect options without falling back to zod', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -339,7 +339,7 @@ export async function normalizeOptions(
     shouldExportQueryKey: true,
     shouldFilterQueryKey: false,
     shouldSplitQueryKey: false,
-    ...normalizeQueryOptions(outputOptions.override?.query, workspace),
+    ...normalizeQueryOptions(outputOptions.override?.query, outputWorkspace),
   };
 
   const normalizedOptions: NormalizedOptions = {


### PR DESCRIPTION
Global `override.query` mutators (`queryKey`, `queryOptions`, `mutationOptions`) were resolved against the config workspace, unlike operation/tag-level query mutators and other output mutators.

This resolves those global query paths against `output.workspace` and adds regression coverage. Follow-up to #3598, which aligned the global Zod mutators the same way; @melloware requested query be aligned too.

Validation:
- `vp fmt --check`
- `vp run -w build:release`
- `vp run -w lint`
- `vp run -w lint:samples`
- `vp run -w typecheck`
- `vp run -w test`
- `vp run -w test:snapshots`
- `vp run -F orval-tests build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution for query and mutation option mutators to correctly align with the configured output workspace directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->