### PR TITLE
feat(zod): coerce single-value array query params via opt-in coerce: ['array']

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -833,7 +833,16 @@ export interface EffectOptions {
   useBrandedTypes?: boolean;
 }
 
-export type ZodCoerceType = 'string' | 'number' | 'boolean' | 'bigint' | 'date';
+export type ZodCoerceType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'bigint'
+  | 'date'
+  // Not a real `z.coerce.array()` — opting 'array' into `coerce.<location>`
+  // wraps array params in a single→array preprocess so a single repeated-key
+  // query value (delivered as a scalar by the server framework) still parses.
+  | 'array';
 
 export interface NormalizedZodOptions {
   strict: {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1405,7 +1405,19 @@ ${Object.entries(objectArgs)
       .map((prop) => parseProperty(prop, [...fieldPath, key]))
       .join('');
     appendConstsChunk(schema.consts.join('\n'));
-    return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
+    const fieldZod = `${value.startsWith('.') ? 'zod' : ''}${value}`;
+    // Opt-in via `coerce.<location>: ['array', ...]`: a server framework (e.g.
+    // Hono) delivers a single repeated-key value as a scalar, not a 1-element
+    // array, so `?t=a` would fail z.array(...). Wrap so both `?t=a` and
+    // `?t=a&t=b` parse. Undefined passes through so an outer `.optional()`/
+    // `.default()` still applies. Already-arrays are left untouched (no-op for
+    // JSON-body arrays).
+    const coerceArrays =
+      Array.isArray(coerceTypes) && coerceTypes.includes('array');
+    if (coerceArrays && schema.functions.some(([fn]) => fn === 'array')) {
+      return `  "${key}": zod.preprocess((value) => value === undefined || Array.isArray(value) ? value : [value], ${fieldZod})`;
+    }
+    return `  "${key}": ${fieldZod}`;
   })
   .join(',\n')}
 })`;

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4620,6 +4620,51 @@ const bodyOnlyApiSchema = {
     },
   },
 } as unknown as GeneratorOptions;
+
+// An operation with an array query param, to assert the single→array coercion
+// (`coerce.query: ['array']`) that lets a single repeated-key value parse.
+const arrayQueryApiSchema = {
+  pathRoute: '/cats',
+  context: {
+    spec: {
+      paths: {
+        '/cats': {
+          post: {
+            operationId: 'listCats',
+            parameters: [
+              {
+                name: 'tags',
+                in: 'query',
+                required: false,
+                explode: true,
+                schema: { type: 'array', items: { type: 'string' } },
+              },
+            ],
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { name: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+} as unknown as GeneratorOptions;
 describe('generatePartOfSchemaGenerateZod', () => {
   it('Default Config', async () => {
     const result = await generateZod(
@@ -5138,6 +5183,97 @@ describe('generatePartOfSchemaGenerateZod', () => {
     expect(names).not.toContain('prependParam');
     expect(names).not.toContain('prependQuery');
     expect(names).not.toContain('prependHeader');
+  });
+
+  it("wraps array query params in a single→array preprocess when coerce includes 'array'", async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: ['array'],
+              header: false,
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      arrayQueryApiSchema,
+      testOutput,
+    );
+
+    // A single repeated-key value arrives as a scalar; the wrap turns it into a
+    // 1-element array so both `?tags=a` and `?tags=a&tags=b` satisfy z.array(...).
+    expect(result.implementation).toContain(
+      'zod.preprocess((value) => value === undefined || Array.isArray(value) ? value : [value], zod.array(zod.string())',
+    );
+  });
+
+  it("leaves array query params untouched when coerce does not include 'array' (opt-in)", async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/cats',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: true,
+              body: true,
+              response: true,
+              query: true,
+              header: true,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      arrayQueryApiSchema,
+      testOutput,
+    );
+
+    expect(result.implementation).toContain(
+      '"tags": zod.array(zod.string()).optional()',
+    );
+    expect(result.implementation).not.toContain('zod.preprocess');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #3608.

Array query params (`type: array`, `explode: true`) serialize fine client-side but **fail server-side validation on a single value**: a server framework (e.g. Hono) delivers one repeated-key value as a scalar (`?tags=a` → `"a"`), which the generated `zod.array(...)` rejects.

## Change

Opt-in: `override.zod.coerce.<location>` accepts a new **`'array'`** target. When set, array params in that location are wrapped in a single→array `preprocess`:
```ts
// coerce.query: ['array']  (combines with ['number','array'])
tags: zod.preprocess(
  (value) => (value === undefined || Array.isArray(value) ? value : [value]),
  zod.array(zod.string()).optional(),
)
```
`?tags=a` → `["a"]`, `?tags=a&tags=b` → `["a","b"]`, omitted → `undefined` (so an outer `.optional()`/`.default()` still applies), invalid item → still rejected.

It's not a real `z.coerce.array()` — it's a structural single→array normalization, routed through `coerce` to reuse its per-location plumbing. The leaf `array` branch returns before the `.coerce.<fn>` path, so reading `'array'` from `coerce` doesn't affect primitive coercion. Happy to switch to a dedicated option if preferred.

## Tests

- Two regression tests in `packages/zod/src/zod.test.ts`: wrap emitted when `coerce.query` includes `'array'`; untouched when it doesn't (opt-in).
- `@orval/zod` unit suite green (246).
- All generation snapshots unchanged (opt-in → zero churn).
- Validated end-to-end against a Hono + zod backend (`?tags=a` and `?tags=a&tags=b` both parse).

Related: #3231 (client-side explode default).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced array parameter coercion: scalar values are now automatically converted to single-element arrays when array coercion is enabled for query parameters.

* **Tests**
  * Added test coverage for array query parameter validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->