### PR TITLE
feat(core): make output.schemas.type optional, defaulting to typescript

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -114,7 +114,7 @@ export default defineConfig({
 | Property   | Type     | Description                                     |
 | ---------- | -------- | ----------------------------------------------- |
 | `path`     | `string` | Filesystem path for schema output               |
-| `type`     | `string` | `'typescript'` or `'zod'`                       |
+| `type`     | `string` | `'typescript'` (default) or `'zod'` — optional |
 | `importPath` | `string` | Optional package import specifier (see below)  |
 
 ### importPath

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -307,7 +307,7 @@ export interface NormalizedFactoryMethodsOptions {
 
 export interface SchemaOptions {
   path: string;
-  type: SchemaGenerationType;
+  type?: SchemaGenerationType;
   importPath?: string;
 }
 

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -350,6 +350,40 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('defaults schemas.type to typescript when omitted', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './generated.ts',
+            schemas: {
+              path: './models',
+              importPath: '@acme/models',
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.schemas).toEqual({
+        path: expect.any(String) as string,
+        type: 'typescript',
+        importPath: '@acme/models',
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('rejects a relative path as schemas.importPath', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -155,7 +155,7 @@ function normalizeSchemasOption(
 
   return {
     path: normalizePath(schemas.path, workspace),
-    type: schemas.type,
+    type: schemas.type ?? 'typescript',
     importPath: schemas.importPath,
   };
 }


### PR DESCRIPTION
Makes `output.schemas.type` optional in the object form of `SchemaOptions`, defaulting to `'typescript'` when omitted.

This removes redundant boilerplate for the common case of setting `importPath` alongside the default TypeScript types — `type: 'typescript'` no longer has to be spelled out. It also aligns the object form with the string shorthand, where `type` is already implicit.

`NormalizedSchemaOptions.type` stays required (and is still always populated by `normalizeSchemasOption`), so every downstream consumer of the normalized output is unaffected. The only place that reads the now-optional raw `schemas.type` is the file-extension default logic in `normalizeOptions`, where `undefined === 'zod'` correctly falls through to the TypeScript (`.ts`) path.

Closes #3610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema type configuration is now optional and defaults to TypeScript.

* **Documentation**
  * Updated configuration reference to clarify default schema type behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->