### PR TITLE
feat(mock): add schemasImportPath to faker generator

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -159,7 +159,10 @@ import statements change.
   package must also expose `./pet.zod` (e.g., `@acme/models/pet.zod`).
 - If using faker schema factories
   (`mock: { generators: [{ type: 'faker', schemas: true }] }`),
-  the package must also export `./index.faker`.
+  the package must also export `./index.faker`. When the package can't expose a
+  sub-path (e.g. `importPath` resolves to a single barrel file via tsconfig
+  path mappings), set [`schemasImportPath`](#schemasimportpath) on the faker
+  generator to point faker factories at a separate import path.
 - If using factory methods (`factoryMethods`), each schema is imported
   individually regardless of `indexFiles`.
 - When `importPath` is set, the relative-path computation in
@@ -558,10 +561,55 @@ The Faker generator emits the same `get<Op>ResponseMock` factories MSW would emi
 |--------|------|---------|-------------|
 | `type` | `'faker'` | required | Discriminator for Faker-only output. |
 | `path` | `String` | `undefined` | Output directory for this generator's mock files. Overrides the shared `mock.path` when set. When provided in `single` or `tags` mode, mock code is written to separate files (relative to `path`) instead of being inlined into the implementation file. |
+| `schemas` | `Boolean` | `false` | Emit a consolidated mock factory file (`get<SchemaName>Mock`) for every entry under `components/schemas`. |
+| `schemasImportPath` | `String` | `undefined` | Package specifier for importing the schema-level faker factories emitted by `schemas: true` (e.g. `@acme/models/fakers`). When set, used verbatim instead of appending `/index.faker` to `schemas.importPath` — useful when the production barrel can't expose a sub-path export. Requires `schemas: true` and `schemas.importPath`. Only applies when `schemas: true` is set on the same generator. |
+| `operationResponses` | `Boolean` | `true` | Emit per-operation response mock factories (the historical behavior). Set to `false` together with `schemas: true` to get only the consolidated schema factories. |
 | `useExamples` | `Boolean` | `false` | Use OpenAPI examples to seed response values. |
 | `generateEachHttpStatus` | `Boolean` | `false` | Generate response factories for every documented status code. |
 | `locale` | `String` | `'en'` | Faker.js locale. |
 | `preferredContentType` | `String` | `undefined` | Preferred content type when an operation lists more than one. |
+| `arrayItems` | `Boolean` | `false` | Emit reusable mock factories for object-like array item schemas in operation responses. |
+
+#### `schemasImportPath`
+
+Only applies when `schemas: true` is set on the same faker generator (requires
+both `schemas: true` and `schemas.importPath`). When `schemas.importPath`
+resolves to a single barrel file (e.g. via tsconfig path mappings), appending
+`/index.faker` produces an unresolvable sub-path. `schemasImportPath` lets you
+point faker factories at a separate import path so you can expose them through a
+dedicated barrel:
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      target: './libs/client/sdk/generated',
+      schemas: {
+        path: './libs/data-layer/sdk/generated',
+        importPath: '@acme/data-layer/sdk',
+      },
+      mock: {
+        path: './libs/client/sdk/mocks',
+        generators: [
+          {
+            type: 'faker',
+            schemas: true,
+            schemasImportPath: '@acme/data-layer/sdk/fakers',
+          },
+        ],
+      },
+    },
+  },
+});
+```
+
+```ts
+// Without schemasImportPath (default — joins importPath with /index.faker):
+import { getPetMock } from '@acme/data-layer/sdk/index.faker'; // may not resolve
+
+// With schemasImportPath: '@acme/data-layer/sdk/fakers':
+import { getPetMock } from '@acme/data-layer/sdk/fakers';
+```
 
 ## indexFiles
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -497,6 +497,13 @@ export interface FakerMockOptions extends CommonMockOptions {
   // `components/schemas` (one `get<SchemaName>Mock` per schema). Defaults to
   // `false` — schema factories are opt-in to preserve existing output.
   schemas?: boolean;
+  // Package specifier for importing the schema-level faker factories (the
+  // `get<SchemaName>Mock` functions emitted when `schemas: true`). When set,
+  // it is used verbatim as the schema factory import path instead of appending
+  // `/index.faker` to `schemas.importPath`. This lets consumers expose fakers
+  // through a dedicated barrel separate from the production type barrel.
+  // Requires `schemas.importPath` to also be set.
+  schemasImportPath?: string;
   // Emit per-operation response mock factories (the historical behavior).
   // Defaults to `true`. Set to `false` together with `schemas: true` to get
   // only the consolidated schema factories.

--- a/packages/core/src/writers/generate-imports-for-builder.test.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.test.ts
@@ -321,6 +321,72 @@ describe('generateImportsForBuilder', () => {
         },
       ]);
     });
+
+    it('should use faker schemasImportPath verbatim for schemaFactory imports', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+        mock: {
+          indexMockFiles: false,
+          generators: [
+            {
+              type: 'faker',
+              schemas: true,
+              schemasImportPath: '@acme/models/fakers',
+            },
+          ],
+        },
+      });
+      const imports: GeneratorImport[] = [
+        { name: 'createUser', schemaFactory: true },
+        { name: 'createPet', schemaFactory: true },
+      ];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [
+            { name: 'createUser', schemaFactory: true },
+            { name: 'createPet', schemaFactory: true },
+          ],
+          dependency: '@acme/models/fakers',
+        },
+      ]);
+    });
+
+    it('should fall back to index.faker join when schemasImportPath is not set', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        schemas: {
+          path: '/libs/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+        },
+        mock: {
+          indexMockFiles: false,
+          generators: [{ type: 'faker', schemas: true }],
+        },
+      });
+      const imports: GeneratorImport[] = [
+        { name: 'createUser', schemaFactory: true },
+      ];
+
+      const result = generateImportsForBuilder(output, imports, '@acme/models');
+
+      expect(result).toEqual([
+        {
+          exports: [{ name: 'createUser', schemaFactory: true }],
+          dependency: '@acme/models/index.faker',
+        },
+      ]);
+    });
   });
 
   describe('naming conventions', () => {

--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -1,11 +1,20 @@
 import { uniqueBy } from 'remeda';
 
-import type {
-  GeneratorDependency,
-  GeneratorImport,
-  NormalizedOutputOptions,
+import {
+  type FakerMockOptions,
+  type GeneratorDependency,
+  type GeneratorImport,
+  OutputMockType,
+  type NormalizedMocksConfig,
+  type NormalizedOutputOptions,
 } from '../types';
-import { conventionName, getImportExtension, isObject, upath } from '../utils';
+import {
+  conventionName,
+  getImportExtension,
+  isFunction,
+  isObject,
+  upath,
+} from '../utils';
 
 export function generateImportsForBuilder(
   output: NormalizedOutputOptions,
@@ -27,6 +36,19 @@ export function generateImportsForBuilder(
   const schemaFactoryImportExtension = isPackageImport
     ? ''
     : getImportExtension(output.fileExtension, output.tsconfig);
+
+  // When the faker generator configures a dedicated `schemasImportPath`, use
+  // it verbatim. This is needed because `schemas.importPath` is a package
+  // barrel specifier (e.g. `@acme/models`) that may resolve to a single file
+  // via tsconfig path mappings — appending `/index.faker` produces an
+  // unresolvable sub-path in that case.
+  const schemaFactoryDependency =
+    getFakerSchemasImportPath(output.mock) ??
+    upath.joinSafe(
+      relativeSchemasPath,
+      `index.faker${schemaFactoryImportExtension}`,
+    );
+
   const schemaFactoryDeps: GeneratorDependency[] =
     schemaFactoryImports.length > 0
       ? [
@@ -35,10 +57,7 @@ export function generateImportsForBuilder(
               schemaFactoryImports,
               (entry) => `${entry.name}|${entry.alias ?? ''}`,
             ),
-            dependency: upath.joinSafe(
-              relativeSchemasPath,
-              `index.faker${schemaFactoryImportExtension}`,
-            ),
+            dependency: schemaFactoryDependency,
           },
         ]
       : [];
@@ -112,4 +131,23 @@ export function generateImportsForBuilder(
   });
 
   return [...schemaImports, ...schemaFactoryDeps, ...otherImports];
+}
+
+/**
+ * Extracts the faker generator's `schemasImportPath` from the normalized mock
+ * config, if one is configured. Returns `undefined` when there is no faker
+ * generator with schema factories enabled, or when `schemasImportPath` is not
+ * set.
+ */
+function getFakerSchemasImportPath(
+  mock: NormalizedMocksConfig | undefined,
+): FakerMockOptions['schemasImportPath'] | undefined {
+  if (!mock) {
+    return undefined;
+  }
+  const faker = mock.generators.find(
+    (g): g is FakerMockOptions =>
+      !isFunction(g) && g.type === OutputMockType.FAKER && g.schemas === true,
+  );
+  return faker?.schemasImportPath;
 }

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -409,7 +409,7 @@ describe('normalizeOptions', () => {
           },
           workspace,
         ),
-      ).rejects.toThrow('schemas.importPath must be a package specifier');
+      ).rejects.toThrow('`schemas.importPath` must be a package specifier');
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }
@@ -441,7 +441,7 @@ describe('normalizeOptions', () => {
           workspace,
         ),
       ).rejects.toThrow(
-        'schemas.importPath must be a non-empty package specifier',
+        '`schemas.importPath` must be a non-empty package specifier',
       );
     } finally {
       await rm(workspace, { recursive: true, force: true });
@@ -473,7 +473,7 @@ describe('normalizeOptions', () => {
           },
           workspace,
         ),
-      ).rejects.toThrow('schemas.importPath must be a package specifier');
+      ).rejects.toThrow('`schemas.importPath` must be a package specifier');
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }
@@ -632,6 +632,259 @@ describe('normalizeOptions', () => {
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }
+  });
+
+  describe('faker schemasImportPath validation', () => {
+    it('rejects a relative path as schemasImportPath', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        await expect(
+          normalizeOptions(
+            {
+              input: {
+                target: {
+                  openapi: '3.1.0',
+                  info: { title: 'Test', version: '1.0.0' },
+                  paths: {},
+                },
+              },
+              output: {
+                target: './generated.ts',
+                schemas: {
+                  path: './models',
+                  type: 'typescript',
+                  importPath: '@acme/models',
+                },
+                mock: {
+                  generators: [
+                    {
+                      type: 'faker',
+                      schemas: true,
+                      schemasImportPath: './fakers',
+                    },
+                  ],
+                },
+              },
+            },
+            workspace,
+          ),
+        ).rejects.toThrow(
+          '`mock.generators[faker].schemasImportPath` must be a package specifier',
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects an empty string as schemasImportPath', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        await expect(
+          normalizeOptions(
+            {
+              input: {
+                target: {
+                  openapi: '3.1.0',
+                  info: { title: 'Test', version: '1.0.0' },
+                  paths: {},
+                },
+              },
+              output: {
+                target: './generated.ts',
+                schemas: {
+                  path: './models',
+                  type: 'typescript',
+                  importPath: '@acme/models',
+                },
+                mock: {
+                  generators: [
+                    {
+                      type: 'faker',
+                      schemas: true,
+                      schemasImportPath: '',
+                    },
+                  ],
+                },
+              },
+            },
+            workspace,
+          ),
+        ).rejects.toThrow(
+          '`mock.generators[faker].schemasImportPath` must be a non-empty package specifier',
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects an absolute path as schemasImportPath', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        await expect(
+          normalizeOptions(
+            {
+              input: {
+                target: {
+                  openapi: '3.1.0',
+                  info: { title: 'Test', version: '1.0.0' },
+                  paths: {},
+                },
+              },
+              output: {
+                target: './generated.ts',
+                schemas: {
+                  path: './models',
+                  type: 'typescript',
+                  importPath: '@acme/models',
+                },
+                mock: {
+                  generators: [
+                    {
+                      type: 'faker',
+                      schemas: true,
+                      schemasImportPath: '/abs/fakers',
+                    },
+                  ],
+                },
+              },
+            },
+            workspace,
+          ),
+        ).rejects.toThrow(
+          '`mock.generators[faker].schemasImportPath` must be a package specifier',
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects schemasImportPath when schemas.importPath is not set', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        await expect(
+          normalizeOptions(
+            {
+              input: {
+                target: {
+                  openapi: '3.1.0',
+                  info: { title: 'Test', version: '1.0.0' },
+                  paths: {},
+                },
+              },
+              output: {
+                target: './generated.ts',
+                schemas: {
+                  path: './models',
+                  type: 'typescript',
+                },
+                mock: {
+                  generators: [
+                    {
+                      type: 'faker',
+                      schemas: true,
+                      schemasImportPath: '@acme/models/fakers',
+                    },
+                  ],
+                },
+              },
+            },
+            workspace,
+          ),
+        ).rejects.toThrow(
+          '`mock.generators[faker].schemasImportPath` requires `schemas.importPath` to also be set',
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects schemasImportPath when schemas: true is not set on the faker generator', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        await expect(
+          normalizeOptions(
+            {
+              input: {
+                target: {
+                  openapi: '3.1.0',
+                  info: { title: 'Test', version: '1.0.0' },
+                  paths: {},
+                },
+              },
+              output: {
+                target: './generated.ts',
+                schemas: {
+                  path: './models',
+                  type: 'typescript',
+                  importPath: '@acme/models',
+                },
+                mock: {
+                  generators: [
+                    {
+                      type: 'faker',
+                      schemasImportPath: '@acme/models/fakers',
+                    },
+                  ],
+                },
+              },
+            },
+            workspace,
+          ),
+        ).rejects.toThrow(
+          '`mock.generators[faker].schemasImportPath` requires `schemas: true`',
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+
+    it('accepts a valid schemasImportPath when schemas.importPath is set', async () => {
+      const workspace = await createTempWorkspace();
+
+      try {
+        const normalized = await normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: {
+                path: './models',
+                type: 'typescript',
+                importPath: '@acme/models',
+              },
+              mock: {
+                generators: [
+                  {
+                    type: 'faker',
+                    schemas: true,
+                    schemasImportPath: '@acme/models/fakers',
+                  },
+                ],
+              },
+            },
+          },
+          workspace,
+        );
+
+        const fakerGenerator = normalized.output.mock.generators[0] as {
+          schemasImportPath?: string;
+        };
+        expect(fakerGenerator.schemasImportPath).toBe('@acme/models/fakers');
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
   });
 
   it('defaults zod dateTimeOptions to { offset: true } so RFC3339 offset values are accepted', async () => {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -6,6 +6,7 @@ import {
   type ConfigExternal,
   type EffectOptions,
   FormDataArrayHandling,
+  type FakerMockOptions,
   type GlobalMockOptions,
   type GlobalOptions,
   type HonoOptions,
@@ -118,46 +119,62 @@ function normalizeSchemasOption(
     return normalizePath(schemas, workspace);
   }
 
-  if (schemas.importPath !== undefined && !schemas.importPath) {
-    throw new Error(
-      `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received an empty string.`,
-    );
-  }
-
-  if (schemas.importPath?.trim() === '') {
-    throw new Error(
-      `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received a whitespace-only string.`,
-    );
-  }
-
-  if (schemas.importPath && schemas.importPath.trim() !== schemas.importPath) {
-    throw new Error(
-      `schemas.importPath must be a non-empty package specifier (e.g. '@acme/models'). Received a value with leading or trailing whitespace: "${schemas.importPath}"`,
-    );
-  }
-
-  if (schemas.importPath?.startsWith('.')) {
-    throw new Error(
-      `schemas.importPath must be a package specifier (e.g. '@acme/models'), not a relative path. Received: "${schemas.importPath}"`,
-    );
-  }
-
-  if (
-    schemas.importPath &&
-    (nodePath.isAbsolute(schemas.importPath) ||
-      /^[A-Za-z]:[\\/]/.test(schemas.importPath) ||
-      schemas.importPath.startsWith('\\\\'))
-  ) {
-    throw new Error(
-      `schemas.importPath must be a package specifier (e.g. '@acme/models'), not an absolute path. Received: "${schemas.importPath}"`,
-    );
-  }
+  validatePackageSpecifier(schemas.importPath, 'schemas.importPath');
 
   return {
     path: normalizePath(schemas.path, workspace),
     type: schemas.type ?? 'typescript',
     importPath: schemas.importPath,
   };
+}
+
+/**
+ * Validates that a config value is a valid package specifier (bare specifier
+ * or sub-path import like `@acme/models` / `@acme/models/fakers`). Rejects
+ * empty, whitespace-only, relative (`./`, `../`), and absolute paths with a
+ * clear, actionable error message. No-op when the value is `undefined`.
+ */
+function validatePackageSpecifier(
+  value: string | undefined,
+  fieldName: string,
+): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!value) {
+    throw new Error(
+      `\`${fieldName}\` must be a non-empty package specifier (e.g. '@acme/models'). Received an empty string.`,
+    );
+  }
+
+  if (value.trim() === '') {
+    throw new Error(
+      `\`${fieldName}\` must be a non-empty package specifier (e.g. '@acme/models'). Received a whitespace-only string.`,
+    );
+  }
+
+  if (value.trim() !== value) {
+    throw new Error(
+      `\`${fieldName}\` must be a non-empty package specifier (e.g. '@acme/models'). Received a value with leading or trailing whitespace: "${value}"`,
+    );
+  }
+
+  if (value.startsWith('.')) {
+    throw new Error(
+      `\`${fieldName}\` must be a package specifier (e.g. '@acme/models'), not a relative path. Received: "${value}"`,
+    );
+  }
+
+  if (
+    nodePath.isAbsolute(value) ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith('\\\\')
+  ) {
+    throw new Error(
+      `\`${fieldName}\` must be a package specifier (e.g. '@acme/models'), not an absolute path. Received: "${value}"`,
+    );
+  }
 }
 
 function normalizeEffectOptions(
@@ -286,6 +303,13 @@ export async function normalizeOptions(
       );
     }
     seenMockTypes.add(entry.type);
+
+    if (entry.type === OutputMockType.FAKER) {
+      validatePackageSpecifier(
+        entry.schemasImportPath,
+        'mock.generators[faker].schemasImportPath',
+      );
+    }
   }
 
   const defaultFileExtension = '.ts';
@@ -635,6 +659,42 @@ export async function normalizeOptions(
     throw new Error(
       styleText('red', `Config requires an output target or schemas.`),
     );
+  }
+
+  // The faker generator's `schemasImportPath` overrides where schema-level
+  // faker factories are imported from. Those factories are only emitted when
+  // `schemas: true`, and the override is only meaningful in package-import
+  // mode (`schemas.importPath`). Require both so a standalone
+  // `schemasImportPath` fails fast instead of silently doing nothing.
+  const fakerWithSchemasImportPath =
+    normalizedOptions.output.mock.generators.find(
+      (g): g is FakerMockOptions =>
+        !isFunction(g) &&
+        g.type === OutputMockType.FAKER &&
+        !!g.schemasImportPath,
+    );
+  if (fakerWithSchemasImportPath) {
+    if (fakerWithSchemasImportPath.schemas !== true) {
+      throw new Error(
+        styleText(
+          'red',
+          `\`mock.generators[faker].schemasImportPath\` requires \`schemas: true\` on the same generator. Schema-level faker factories are only emitted when \`schemas: true\`.`,
+        ),
+      );
+    }
+    if (
+      !(
+        isObject(normalizedOptions.output.schemas) &&
+        normalizedOptions.output.schemas.importPath
+      )
+    ) {
+      throw new Error(
+        styleText(
+          'red',
+          `\`mock.generators[faker].schemasImportPath\` requires \`schemas.importPath\` to also be set. It overrides the package specifier used for importing schema-level faker factories.`,
+        ),
+      );
+    }
   }
 
   // `paramsFilter` is only consumed by the Angular generator. That runs for


### PR DESCRIPTION
## Summary

Adds a `schemasImportPath` option to the faker mock generator so consumers can point schema-level faker factories at a dedicated barrel separate from the production type barrel (`schemas.importPath`).

When `schemas.importPath` resolves to a single barrel file (e.g. via tsconfig path mappings like `"@acme/models": ["libs/models/public-api.ts"]`), appending `/index.faker` produces an unresolvable sub-path — a barrel specifier isn't a directory prefix. `schemasImportPath` is used verbatim as the schema factory import path, sidestepping that limitation.

Resolves #3612.

```ts
output: {
  schemas: { path: './libs/models', importPath: '@acme/models' },
  mock: {
    generators: [
      { type: 'faker', schemas: true, schemasImportPath: '@acme/models/fakers' },
    ],
  },
}
```

```ts
// Before (default — joins importPath with /index.faker, may not resolve):
import { getPetMock } from '@acme/models/index.faker';
// After (schemasImportPath used verbatim):
import { getPetMock } from '@acme/models/fakers';
```

## Changes

- **`packages/core/src/types.ts`** — Add `schemasImportPath?: string` to `FakerMockOptions`.
- **`packages/core/src/writers/generate-imports-for-builder.ts`** — When the faker generator has `schemas: true` and `schemasImportPath` set, use it verbatim as the schema factory dependency instead of joining `importPath` with `index.faker`.
- **`packages/orval/src/utils/options.ts`** — Extract a shared `validatePackageSpecifier` helper (reused by `schemas.importPath`) and validate `schemasImportPath`: reject empty/whitespace/relative/absolute specifiers; require both `schemas: true` and `schemas.importPath`.
- **Tests** — `generate-imports-for-builder.test.ts` (+2), `options.test.ts` (+6 incl. a `describe` block for the new validation).
- **Docs** — Faker generator table updated (added `schemas`, `schemasImportPath`, `operationResponses`, `arrayItems` rows) plus a `schemasImportPath` example section.

## Checklist

- [x] Tests pass (`generate-imports-for-builder.test.ts`, `options.test.ts`)
- [x] Typecheck passes (core, orval, mock)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Format passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `schemasImportPath` configuration option for faker generators, enabling users to specify a custom import path for schema-level faker factories instead of using the default `/index.faker` pattern.

* **Documentation**
  * Updated configuration documentation to clarify export requirements and explain the new `schemasImportPath` override option for faker mock generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->