### PR TITLE
fix(zod): resolve inline $dynamicAnchor overrides in dynamic scope

### DIFF
--- a/packages/core/src/resolvers/dynamic-ref.test.ts
+++ b/packages/core/src/resolvers/dynamic-ref.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest';
 
 import { createTestContextSpec } from '../test-utils/context';
 import type { OpenApiDocument } from '../types';
-import { buildDynamicScope, resolveDynamicRef } from './ref';
+import {
+  buildDynamicScope,
+  buildInlineDynamicScope,
+  resolveDynamicRef,
+} from './ref';
 
 function createContext(spec: OpenApiDocument) {
   return createTestContextSpec({
@@ -861,5 +865,155 @@ describe('null safety in $defs entries', () => {
       schemaName: 'foo_bar2',
       isParameter: true,
     });
+  });
+});
+
+describe('buildInlineDynamicScope', () => {
+  it('builds an inline entry from a direct $dynamicAnchor', () => {
+    const inlineSchema = {
+      $dynamicAnchor: 'Pet',
+      type: 'object',
+      properties: { meow: { type: 'boolean' } },
+    } as never;
+
+    const scope = buildInlineDynamicScope(inlineSchema);
+
+    expect(scope.Pet).toEqual({
+      name: 'Pet',
+      schemaName: 'Pet',
+      inlineSchema,
+    });
+  });
+
+  it('builds an inline entry from a $defs $dynamicAnchor without $ref', () => {
+    const defSchema = {
+      $dynamicAnchor: 'itemType',
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    };
+    const inlineSchema = {
+      type: 'object',
+      $defs: { itemType: defSchema },
+    } as never;
+
+    const scope = buildInlineDynamicScope(inlineSchema);
+
+    expect(scope.itemType).toEqual({
+      name: 'itemType',
+      schemaName: 'itemType',
+      inlineSchema: defSchema,
+    });
+  });
+
+  it('ignores $defs anchors that are bound via $ref', () => {
+    const inlineSchema = {
+      type: 'object',
+      $defs: {
+        itemType: {
+          $dynamicAnchor: 'itemType',
+          $ref: '#/components/schemas/User',
+        },
+      },
+    } as never;
+
+    const scope = buildInlineDynamicScope(inlineSchema);
+
+    expect(scope.itemType).toBeUndefined();
+  });
+
+  it('combines a direct anchor and $defs anchors', () => {
+    const defSchema = { $dynamicAnchor: 'child', type: 'string' };
+    const inlineSchema = {
+      $dynamicAnchor: 'parent',
+      type: 'object',
+      $defs: { child: defSchema },
+    } as never;
+
+    const scope = buildInlineDynamicScope(inlineSchema);
+
+    expect(scope.parent).toEqual({
+      name: 'parent',
+      schemaName: 'parent',
+      inlineSchema,
+    });
+    expect(scope.child).toEqual({
+      name: 'child',
+      schemaName: 'child',
+      inlineSchema: defSchema,
+    });
+  });
+
+  it('returns an empty scope for a schema without anchors', () => {
+    const inlineSchema = {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    } as never;
+
+    const scope = buildInlineDynamicScope(inlineSchema);
+
+    expect(scope).toEqual({});
+  });
+});
+
+describe('resolveDynamicRef — inline overrides', () => {
+  it('returns the inline schema when the scope entry carries one', () => {
+    const spec = {
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          Pet: {
+            $dynamicAnchor: 'Pet',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+    } as OpenApiDocument;
+    const inlineSchema = {
+      $dynamicAnchor: 'Pet',
+      type: 'object',
+      properties: { meow: { type: 'boolean' } },
+    } as never;
+    const context = {
+      ...createContext(spec),
+      dynamicScope: { Pet: { name: 'Pet', schemaName: 'Pet', inlineSchema } },
+    };
+
+    const result = resolveDynamicRef('Pet', context);
+
+    expect(result.schema).toBe(inlineSchema);
+    expect(result.resolvedTypeName).toBe('Pet');
+    expect(result.schemaName).toBeUndefined();
+  });
+
+  it('prefers the inline schema over a same-named component', () => {
+    const spec = {
+      openapi: '3.1.0',
+      components: {
+        schemas: {
+          Pet: {
+            $dynamicAnchor: 'Pet',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+    } as OpenApiDocument;
+    const inlineSchema = {
+      type: 'object',
+      properties: { purr: { type: 'boolean' } },
+    } as never;
+    const context = {
+      ...createContext(spec),
+      dynamicScope: { Pet: { name: 'Pet', schemaName: 'Pet', inlineSchema } },
+    };
+
+    const result = resolveDynamicRef('Pet', context);
+
+    expect(result.schema).toBe(inlineSchema);
+    // The global Pet component must not be resolved.
+    expect(
+      (result.schema as Record<string, unknown>).properties,
+    ).not.toHaveProperty('name');
   });
 });

--- a/packages/core/src/resolvers/ref.ts
+++ b/packages/core/src/resolvers/ref.ts
@@ -431,6 +431,65 @@ export function buildDynamicScope(
 }
 
 /**
+ * Build dynamic scope entries for an **anonymous inline** subschema that declares
+ * `$dynamicAnchor` without a `$ref` (e.g. inside `allOf`, `items`, nested props).
+ *
+ * Unlike {@link buildDynamicScope}, entries carry the concrete `inlineSchema` so
+ * that a descendant `$dynamicRef` resolves to the inline override rather than the
+ * outer/global component. Used when `dereference` enters a subschema without a
+ * named component `$ref`.
+ *
+ * Scope of handling (deliberate, see #3492):
+ *   - Direct `$dynamicAnchor` on the subschema → inline entry.
+ *   - `$defs` `$dynamicAnchor` *without* a `$ref` → inline entry. Note this
+ *     differs from `buildDynamicScope`, which treats unbound `$defs` anchors as
+ *     generic parameters (`isParameter`); inline subschemas are concrete
+ *     instances, so the anchor resolves to the inline schema object itself.
+ *   - `$defs` `$dynamicAnchor` *with* a `$ref` → intentionally NOT collected
+ *     here. Such anchors rely on `resolveDynamicRef`'s global fallback (which
+ *     finds them when the `$ref` target declares the same anchor). Fully
+ *     resolving them would duplicate `buildDynamicScope`'s `$defs` logic.
+ */
+export function buildInlineDynamicScope(
+  schema: OpenApiSchemaObject,
+): Record<string, DynamicScopeEntry> {
+  const scope: Record<string, DynamicScopeEntry> = {};
+  const schemaRecord = schema as Record<string, unknown>;
+
+  if (typeof schemaRecord.$dynamicAnchor === 'string') {
+    const anchor = schemaRecord.$dynamicAnchor;
+    scope[anchor] = {
+      name: anchor,
+      schemaName: anchor,
+      inlineSchema: schema,
+    };
+  }
+
+  const defs = schemaRecord.$defs as
+    | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
+    | undefined;
+  if (defs && typeof defs === 'object') {
+    for (const defSchema of Object.values(defs)) {
+      if (!defSchema || typeof defSchema !== 'object') continue;
+      const defRecord = defSchema as Record<string, unknown>;
+      if (
+        typeof defRecord.$dynamicAnchor === 'string' &&
+        !(defSchema as OpenApiReferenceObject).$ref
+      ) {
+        const anchor = defRecord.$dynamicAnchor;
+        scope[anchor] = {
+          name: anchor,
+          schemaName: anchor,
+          inlineSchema: defSchema as OpenApiSchemaObject,
+        };
+      }
+    }
+  }
+
+  return scope;
+}
+
+/**
  * Resolve a `$dynamicRef` anchor to its concrete type using the current dynamic scope.
  * Returns `{ schema: {}, resolvedTypeName: 'unknown' }` when no scope override exists.
  */
@@ -492,6 +551,15 @@ export function resolveDynamicRef(
   if (scopeEntry.isParameter) {
     return {
       schema: {},
+      imports,
+      resolvedTypeName: scopeEntry.name,
+      schemaName: undefined,
+    };
+  }
+
+  if (scopeEntry.inlineSchema) {
+    return {
+      schema: scopeEntry.inlineSchema,
       imports,
       resolvedTypeName: scopeEntry.name,
       schemaName: undefined,

--- a/packages/core/src/resolvers/value.ts
+++ b/packages/core/src/resolvers/value.ts
@@ -274,7 +274,11 @@ export function resolveValue({
       typeof refAnchor === 'string' &&
       context.dynamicScope?.[refAnchor] &&
       context.dynamicScope[refAnchor].name !== refName &&
-      !context.dynamicScope[refAnchor].isParameter
+      !context.dynamicScope[refAnchor].isParameter &&
+      // Inline overrides have no component source (`schemaName` is the anchor
+      // name, not a component key), so the allOf-derivation below does not
+      // apply to them.
+      !context.dynamicScope[refAnchor].inlineSchema
     ) {
       const scopeEntry = context.dynamicScope[refAnchor];
       const specSchemas = (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1209,11 +1209,18 @@ export interface ContextSpec {
  *   - `isParameter` — `true`, signals this is a generic type parameter
  *   - `name` — the `$dynamicAnchor` name used as the type parameter (e.g. `itemType`)
  *   - `schemaName` — same as `name` for parameters
+ *
+ * Inline entry (anonymous subschema overriding an anchor without a `$ref`):
+ *   - `inlineSchema` — the concrete schema object to resolve `$dynamicRef` against.
+ *     Takes precedence over the component lookup in `resolveDynamicRef`, so an
+ *     inline `$dynamicAnchor` (e.g. inside `allOf` / `items`) correctly shadows
+ *     the outer/global anchor. `schemaName` is the anchor name itself.
  */
 export interface DynamicScopeEntry {
   name: string;
   schemaName: string;
   isParameter?: boolean;
+  inlineSchema?: OpenApiSchemaObject;
 }
 
 export interface GlobalOptions {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -2,6 +2,7 @@
 
 import {
   buildDynamicScope,
+  buildInlineDynamicScope,
   camel,
   type ClientBuilder,
   type ClientGeneratorsBuilder,
@@ -1663,26 +1664,38 @@ function buildScopedContext(
   refName: string | undefined,
   resolvedSchema: OpenApiSchemaObject,
 ): ContextSpec {
-  if (!refName) return childContext;
+  if (refName) {
+    const schemaName = extractSchemaNameFromRef(refName);
+    if (!schemaName) return childContext;
 
-  const schemaName = extractSchemaNameFromRef(refName);
-  if (!schemaName) return childContext;
+    const schemaRecord = resolvedSchema as Record<string, unknown>;
+    const hasDynamicAnchor = typeof schemaRecord.$dynamicAnchor === 'string';
+    const defs = schemaRecord.$defs as Record<string, unknown> | undefined;
+    const hasDefsAnchors =
+      defs &&
+      typeof defs === 'object' &&
+      Object.values(defs).some(
+        (d) => d && typeof d === 'object' && '$dynamicAnchor' in d,
+      );
 
-  const schemaRecord = resolvedSchema as Record<string, unknown>;
-  const hasDynamicAnchor = typeof schemaRecord.$dynamicAnchor === 'string';
-  const defs = schemaRecord.$defs as Record<string, unknown> | undefined;
-  const hasDefsAnchors =
-    defs &&
-    typeof defs === 'object' &&
-    Object.values(defs).some(
-      (d) => d && typeof d === 'object' && '$dynamicAnchor' in d,
-    );
+    if (!hasDynamicAnchor && !hasDefsAnchors) return childContext;
 
-  if (!hasDynamicAnchor && !hasDefsAnchors) return childContext;
+    return {
+      ...childContext,
+      dynamicScope: buildDynamicScope(schemaName, resolvedSchema, childContext),
+    };
+  }
+
+  // Anonymous inline subschema (reached via allOf/items/nested props without a
+  // $ref). Detect inline $dynamicAnchor / $defs anchors and merge them over the
+  // existing scope so the inline override shadows the parent anchor while
+  // non-overridden parent anchors remain reachable. See #3492.
+  const inlineScope = buildInlineDynamicScope(resolvedSchema);
+  if (Object.keys(inlineScope).length === 0) return childContext;
 
   return {
     ...childContext,
-    dynamicScope: buildDynamicScope(schemaName, resolvedSchema, childContext),
+    dynamicScope: { ...childContext.dynamicScope, ...inlineScope },
   };
 }
 
@@ -1702,6 +1715,15 @@ function dereferenceDynamicRef(
     schemaName,
   } = resolveDynamicRef(anchorName, context);
 
+  // Cycle key. Inline overrides resolve with `schemaName: undefined`, so every
+  // resolution of the same anchor collapses to `@?`. This is correct for a
+  // self-referential inline override. A false positive is possible only in the
+  // contrived shape where an inline override A (reached via `$dynamicRef`) itself
+  // contains a *distinct* nested inline override B of the same anchor with a
+  // `$dynamicRef` descendant — B's resolution inherits A's key from `parents`
+  // and returns `{}` instead of B. Siblings don't leak (each `dereference` uses
+  // an immutable parent context), only this nested-via-`$dynamicRef` shape.
+  // Acceptable given how exotic it is. See #3492.
   const dynamicRefPath = `$dynamicRef:${dynamicRef}@${schemaName ?? '?'}`;
   if (context.parents?.includes(dynamicRefPath)) {
     return {};

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -9791,6 +9791,151 @@ describe('$dynamicRef / $dynamicAnchor', () => {
       expect(itemsProps.meow).toBeDefined();
     });
 
+    it('resolves $dynamicRef to an inline $dynamicAnchor override, shadowing the global anchor (#3492)', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              Owner: {
+                type: 'object',
+                properties: {
+                  pet: {
+                    allOf: [
+                      {
+                        // inline override reached without a $ref — previously
+                        // ignored, so #Pet below resolved to the global Pet.
+                        $dynamicAnchor: 'Pet',
+                        type: 'object',
+                        properties: {
+                          meow: { type: 'boolean' },
+                          playmates: {
+                            type: 'array',
+                            items: { $dynamicRef: '#Pet' },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference({ $ref: '#/components/schemas/Owner' }, ctx);
+
+      const pet = (resolved.properties as Record<string, unknown>)
+        .pet as Record<string, unknown>;
+      const inline = (pet.allOf as Record<string, unknown>[])[0];
+      const playmates = (inline.properties as Record<string, unknown>)
+        .playmates as Record<string, unknown>;
+      const items = playmates.items as Record<string, unknown>;
+      const itemsProps = items.properties as Record<string, unknown>;
+
+      // #Pet resolved to the inline override (meow), not the global Pet (name).
+      expect(itemsProps.meow).toBeDefined();
+      expect(itemsProps.name).toBeUndefined();
+    });
+
+    it('resolves $dynamicRef to an inline override reached via array items (#3492)', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Pet: {
+                $dynamicAnchor: 'Pet',
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              Owner: {
+                type: 'object',
+                properties: {
+                  pets: {
+                    type: 'array',
+                    items: {
+                      $dynamicAnchor: 'Pet',
+                      type: 'object',
+                      properties: {
+                        meow: { type: 'boolean' },
+                        sibling: { $dynamicRef: '#Pet' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference({ $ref: '#/components/schemas/Owner' }, ctx);
+
+      const pets = (resolved.properties as Record<string, unknown>)
+        .pets as Record<string, unknown>;
+      const items = pets.items as Record<string, unknown>;
+      const itemsProps = items.properties as Record<string, unknown>;
+
+      expect(itemsProps.meow).toBeDefined();
+      expect(itemsProps.name).toBeUndefined();
+      // The sibling $dynamicRef also resolves to the inline override.
+      const siblingProps = (itemsProps.sibling as Record<string, unknown>)
+        .properties as Record<string, unknown>;
+      expect(siblingProps.meow).toBeDefined();
+    });
+
+    it('breaks cycles for a self-referential inline $dynamicAnchor override (#3492)', () => {
+      const ctx = makeContextSpec({
+        spec: {
+          components: {
+            schemas: {
+              Owner: {
+                type: 'object',
+                properties: {
+                  pet: {
+                    allOf: [
+                      {
+                        $dynamicAnchor: 'Pet',
+                        type: 'object',
+                        properties: {
+                          meow: { type: 'boolean' },
+                          playmates: {
+                            type: 'array',
+                            items: { $dynamicRef: '#Pet' },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const resolved = dereference({ $ref: '#/components/schemas/Owner' }, ctx);
+
+      const pet = (resolved.properties as Record<string, unknown>)
+        .pet as Record<string, unknown>;
+      const inline = (pet.allOf as Record<string, unknown>[])[0];
+      const playmates = (inline.properties as Record<string, unknown>)
+        .playmates as Record<string, unknown>;
+      const items = playmates.items as Record<string, unknown>;
+      const itemsProps = items.properties as Record<string, unknown>;
+
+      // First-level resolution inlines the override...
+      expect(itemsProps.meow).toBeDefined();
+      // ...and the recursive $dynamicRef is broken into {} via parents tracking.
+      const innerPlaymates = itemsProps.playmates as Record<string, unknown>;
+      expect(innerPlaymates.items).toEqual({});
+    });
+
     it('returns empty for external $dynamicRef', () => {
       const ctx = makeContextSpec({
         spec: { components: { schemas: {} } },


### PR DESCRIPTION
## Problem

`buildScopedContext` in \`packages/zod/src/index.ts\` only seeded \`context.dynamicScope\` when entered via a named component \`\$ref\`. Anonymous inline subschemas (reached through \`allOf\`, \`items\`, nested \`properties\`, etc.) that declare \`\$dynamicAnchor\` never updated the scope, so a descendant \`\$dynamicRef\` resolved against the outer/global anchor instead of the inline override.

This is the exact gap identified during the review of #3490 and filed as #3492.

## Scenario

\`\`\`yaml
components:
  schemas:
    Pet:
      \$dynamicAnchor: Pet
      type: object
      properties:
        name: { type: string }
    Owner:
      type: object
      properties:
        pet:
          allOf:
            - \$dynamicAnchor: Pet        # inline override — previously ignored
              type: object
              properties:
                meow: { type: boolean }
                playmates:
                  type: array
                  items: { \$dynamicRef: \"#Pet\" }  # should resolve to inline, not global Pet
\`\`\`

The early \`if (!refName) return childContext\` meant the inline \`\$dynamicAnchor: Pet\` was dropped, and \`\$dynamicRef: \"#Pet\"\` resolved to the global \`Pet\`.

## Fix

Extends the dynamic scope to carry the concrete inline schema so \`\$dynamicRef\` resolves to the inline override rather than the global component.

- **\`@orval/core\`**
  - \`DynamicScopeEntry\` gains an optional \`inlineSchema\` field.
  - New \`buildInlineDynamicScope(schema)\` emits scope entries carrying the concrete \`inlineSchema\` for a direct \`\$dynamicAnchor\` and for \`\$defs\` anchors without a \`\$ref\`.
  - \`resolveDynamicRef\` returns the inline schema directly (\`schemaName: undefined\`) when an inline entry is present, skipping the component lookup.
  - \`resolveValue\`'s allOf-derivation is guarded against inline entries (whose \`schemaName\` is the anchor name, not a component key).
- **\`@orval/zod\`**
  - \`buildScopedContext\` splits into a named-\`\$ref\` path (unchanged) and an inline path that merges \`buildInlineDynamicScope\` over the existing scope — so the inline override shadows the parent anchor while non-overridden parent anchors remain reachable.

## Tests

- core: \`buildInlineDynamicScope\` (direct anchor, \`\$defs\` anchor, \`\\\$ref\`-bound defs ignored, combined, empty) and \`resolveDynamicRef\` inline overrides (returns inline schema; prefers inline over a same-named component). +7
- zod: inline override reached via \`allOf\` (issue scenario) and via array \`items\`, plus a self-referential inline override cycle. +3

All existing tests pass; \`typecheck\` and \`lint\` clean.

## Out of scope

The TS type generator (\`schema-definition.ts\` / \`resolveValue\`) resolves \`\$dynamicRef\` to a **type name**, not an inlined schema, and seeds scope once per component rather than per subschema. Wiring inline overrides into that path is a larger, architecturally different change and is left as a separate follow-up.

## Severity note

Low. Requires an anonymous inline subschema to declare \`\$dynamicAnchor\`, which is very uncommon in real OpenAPI specs.

Closes #3492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced schema resolution to support inline dynamic anchor overrides, allowing inline anchors to properly shadow parent anchors while maintaining fallback behavior.

* **Bug Fixes**
  * Fixed dynamic reference resolution to correctly handle inline dynamic anchors across various schema patterns.

* **Tests**
  * Added comprehensive regression test coverage for dynamic anchor scenarios, including inline overrides and recursive cycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->