### PR TITLE
fix(query): remove unused getHttpFunctionQueryProps

### DIFF
--- a/packages/query/src/client.test.ts
+++ b/packages/query/src/client.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest';
 import {
   generateRequestOptionsArguments,
   getHookOptions,
-  getHttpFunctionQueryProps,
   getQueryArgumentsRequestType,
   getQueryHeader,
   getQueryOptions,
@@ -115,102 +114,6 @@ describe('getQueryHeader', () => {
     } as never);
 
     expect(header).toContain('function filterParams');
-  });
-});
-
-describe('getHttpFunctionQueryProps', () => {
-  describe('without mutator (native Angular)', () => {
-    it('should prefix with http for Angular httpClient', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.ANGULAR,
-        'params',
-        true,
-        false,
-      );
-      expect(result).toBe('http, params');
-    });
-
-    it('should return just http when no query properties for Angular', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.ANGULAR,
-        '',
-        true,
-        false,
-      );
-      expect(result).toBe('http');
-    });
-
-    it('should prefix with http when isAngular is true', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.AXIOS,
-        'params',
-        true,
-        false,
-      );
-      expect(result).toBe('http, params');
-    });
-  });
-
-  describe('with mutator (custom Angular mutator)', () => {
-    it('should NOT prefix with http when mutator is used', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.ANGULAR,
-        'params',
-        true,
-        true,
-      );
-      expect(result).toBe('params');
-    });
-
-    it('should return empty string when no query properties and mutator is used', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.ANGULAR,
-        '',
-        true,
-        true,
-      );
-      expect(result).toBe('');
-    });
-
-    it('should NOT prefix with http even when isAngular is true if mutator is used', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.AXIOS,
-        'params',
-        true,
-        true,
-      );
-      expect(result).toBe('params');
-    });
-  });
-
-  describe('non-Angular clients', () => {
-    it('should return query properties without http prefix for axios', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.AXIOS,
-        'params',
-        false,
-        false,
-      );
-      expect(result).toBe('params');
-    });
-
-    it('should return query properties without http prefix for fetch', () => {
-      const result = getHttpFunctionQueryProps(
-        false,
-        OutputHttpClient.FETCH,
-        'params',
-        false,
-        false,
-      );
-      expect(result).toBe('params');
-    });
   });
 });
 

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -751,31 +751,6 @@ export const getMutationRequestArgs = (
     : '';
 };
 
-export const getHttpFunctionQueryProps = (
-  isVue: boolean,
-  httpClient: OutputHttpClient,
-  queryProperties: string,
-  isAngular = false,
-  hasMutator = false,
-) => {
-  const result =
-    isVue && httpClient === OutputHttpClient.FETCH && queryProperties
-      ? queryProperties
-          .split(',')
-          .map((prop) => `unref(${prop})`)
-          .join(',')
-      : queryProperties;
-
-  // For Angular, prefix with http since request functions take HttpClient as first param
-  // Skip when custom mutator is used - mutator handles HTTP client internally
-  // http is required as first param so no assertion needed
-  if ((isAngular || httpClient === OutputHttpClient.ANGULAR) && !hasMutator) {
-    return result ? `http, ${result}` : 'http';
-  }
-
-  return result;
-};
-
 export const getQueryHeader: ClientHeaderBuilder = (params) => {
   if (params.output.httpClient === OutputHttpClient.FETCH) {
     return generateFetchHeader(params);


### PR DESCRIPTION
While working on https://github.com/orval-labs/orval/issues/3412 noticed some unused code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal query client implementation by removing a helper function, simplifying the query property transformation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->