### PR TITLE
refactor(query): route axios isVue flag through the framework adapter

### DIFF
--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -22,7 +22,8 @@ import {
 } from '@orval/core';
 import { generateFetchHeader } from '@orval/fetch';
 
-import { getHasSignal, vueUnRefParams, vueWrapTypeWithMaybeRef } from './utils';
+import type { FrameworkAdapter } from './framework-adapter';
+import { getHasSignal } from './utils';
 
 export const AXIOS_DEPENDENCIES = [
   {
@@ -288,18 +289,16 @@ export const generateAxiosRequestFunction = (
     paramsSerializer,
   }: GeneratorVerbOptions,
   { route: _route, context }: GeneratorOptions,
-  isVue: boolean,
+  adapter: FrameworkAdapter,
 ) => {
-  let props = _props;
+  const props = adapter.transformProps(_props);
   let route = _route;
-
-  if (isVue) {
-    props = vueWrapTypeWithMaybeRef(_props);
-  }
 
   if (context.output.urlEncodeParameters) {
     route = makeRouteSafe(route);
   }
+
+  const unrefStatements = adapter.getRequestUnrefStatements(props);
 
   const isRequestOptions = override.requestOptions !== false;
   const isFormData = !override.formData.disabled;
@@ -359,7 +358,7 @@ export const generateAxiosRequestFunction = (
           : '';
 
       const callback = `(\n    ${propsImplementation}\n ${hookSecondArg}${getSignalDefinition({ hasSignal, hasSignalParam })}) => {
-        ${isVue ? vueUnRefParams(props) : ''}
+        ${unrefStatements}
         ${bodyForm}
         return ${operationName}(
           ${mutatorConfig},
@@ -373,7 +372,7 @@ export const generateAxiosRequestFunction = (
           response.definition.success || 'unknown'
         }>();
 
-        return ${isVue ? callback : `useCallback(${callback}, [${operationName}])`}
+        return ${adapter.wrapHookMutatorCallback(callback, operationName)}
       }
     `;
     }
@@ -383,7 +382,7 @@ export const generateAxiosRequestFunction = (
         ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}>,`
         : ''
     }${getSignalDefinition({ hasSignal, hasSignalParam })}) => {
-      ${isVue ? vueUnRefParams(props) : ''}
+      ${unrefStatements}
       ${bodyForm}
       return ${mutator.name}<${response.definition.success || 'unknown'}>(
       ${mutatorConfig},
@@ -424,7 +423,7 @@ export const generateAxiosRequestFunction = (
   const httpRequestFunctionImplementation = `${override.query.shouldExportHttpClient ? 'export ' : ''}const ${operationName} = (\n    ${queryProps} ${optionsArgs} ): Promise<AxiosResponse<${
     response.definition.success || 'unknown'
   }>> => {
-    ${isVue ? vueUnRefParams(props) : ''}
+    ${unrefStatements}
     ${bodyForm}
     return axios${
       isSyntheticDefaultImportsAllowed ? '' : '.default'

--- a/packages/query/src/framework-adapter.ts
+++ b/packages/query/src/framework-adapter.ts
@@ -148,8 +148,14 @@ export interface FrameworkAdapter {
   /** Vue/Angular: skip DataTag annotation on queryKey. Others: include it. */
   shouldAnnotateQueryKey(): boolean;
 
-  /** Vue: unref named path params inside queryOptionsFn. Others: empty string. */
-  getUnrefStatements(props: GetterProps): string;
+  /** Vue: unref all params at the top of the HTTP request fn. Others: empty string. */
+  getRequestUnrefStatements(props: GetterProps): string;
+
+  /**
+   * Vue: unref named path params inside queryOptionsFn (other params stay
+   * reactive for the query key). Others: empty string.
+   */
+  getQueryOptionsUnrefStatements(props: GetterProps): string;
 
   // --- Query Hook Generation ---
   /** Angular: inject(HttpClient). Svelte v6: empty. Others: queryOptions = fn(...). */
@@ -271,6 +277,12 @@ export interface FrameworkAdapter {
     options: GeneratorOptions,
   ): string;
 
+  /**
+   * Wrap a hook-mutator request callback for the HTTP request function.
+   * React/Solid/Svelte: memoize with `useCallback`. Vue: return the callback unchanged.
+   */
+  wrapHookMutatorCallback(callback: string, operationName: string): string;
+
   /** Map a prop to its representation in query properties (e.g., destructured for named path params or name) */
   getQueryPropertyForProp(
     prop: GetterProp,
@@ -314,7 +326,10 @@ type DefaultableFields =
   | 'isAngularHttp'
   | 'getHttpFirstParam'
   | 'getMutationHttpPrefix'
-  | 'getUnrefStatements'
+  | 'getRequestUnrefStatements'
+  | 'getQueryOptionsUnrefStatements'
+  | 'wrapHookMutatorCallback'
+  | 'generateRequestFunction'
   | 'getQueryInvocationSuffix'
   | 'transformProps'
   | 'shouldDestructureNamedPathParams'

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -7,11 +7,16 @@ import {
   type OutputClient,
   OutputClient as OutputClientConst,
   type OutputClientFunc,
+  OutputHttpClient,
   type PackageJson,
   toObjectString,
 } from '@orval/core';
+import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
 
-import { getQueryArgumentsRequestType } from '../client';
+import {
+  generateAxiosRequestFunction,
+  getQueryArgumentsRequestType,
+} from '../client';
 import {
   isQueryV5,
   isQueryV5WithDataTagError,
@@ -37,177 +42,202 @@ import { createSvelteAdapter } from './svelte';
 import { createVueAdapter } from './vue';
 
 /** Fill in defaults for fields that most adapters leave empty or share a common implementation. */
-const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => ({
-  // --- Original defaults (false / empty string) ---
-  isAngularHttp: false,
-  getHttpFirstParam: () => '',
-  getMutationHttpPrefix: () => '',
-  getUnrefStatements: () => '',
-  getQueryInvocationSuffix: () => '',
+const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => {
+  // `composed` is the fully-built adapter (defaults + overrides). Defaults that
+  // need sibling fields close over it instead of using `this`, so they stay
+  // correct even if a method is destructured off the adapter.
+  const composed: FrameworkAdapter = {
+    // --- Original defaults (false / empty string) ---
+    isAngularHttp: false,
+    getHttpFirstParam: () => '',
+    getMutationHttpPrefix: () => '',
+    getRequestUnrefStatements: () => '',
+    getQueryOptionsUnrefStatements: () => '',
+    wrapHookMutatorCallback: (callback, operationName) =>
+      `useCallback(${callback}, [${operationName}])`,
+    getQueryInvocationSuffix: () => '',
 
-  // --- Identity / pass-through defaults ---
-  transformProps: (props) => props,
-  getHttpFunctionQueryProps: (qp) => qp,
-  getQueryType: (type) => type,
+    // --- Identity / pass-through defaults ---
+    transformProps: (props) => props,
+    getHttpFunctionQueryProps: (qp) => qp,
+    getQueryType: (type) => type,
 
-  // --- Boolean defaults ---
-  shouldDestructureNamedPathParams: () => true,
-  shouldAnnotateQueryKey: () => true,
-  shouldGenerateOverrideTypes: () => false,
-  shouldCastQueryResult: () => true,
-  shouldCastQueryOptions: () => true,
+    // --- Boolean defaults ---
+    shouldDestructureNamedPathParams: () => true,
+    shouldAnnotateQueryKey: () => true,
+    shouldGenerateOverrideTypes: () => false,
+    shouldCastQueryResult: () => true,
+    shouldCastQueryOptions: () => true,
 
-  // --- String defaults ---
-  getQueryKeyPrefix: () => 'queryOptions?.queryKey ?? ',
-  getQueryOptionsDefinitionPrefix: () => 'Use',
+    // --- String defaults ---
+    getQueryKeyPrefix: () => 'queryOptions?.queryKey ?? ',
+    getQueryOptionsDefinitionPrefix: () => 'Use',
 
-  // --- Common implementation defaults ---
-  getHookPropsDefinitions: (props) => toObjectString(props, 'implementation'),
+    // --- Common implementation defaults ---
+    getHookPropsDefinitions: (props) => toObjectString(props, 'implementation'),
 
-  getQueryKeyRouteString(route, shouldSplitQueryKey) {
-    if (shouldSplitQueryKey) {
-      return getRouteAsArray(route);
-    }
-    return `\`${route}\``;
-  },
+    getQueryKeyRouteString(route, shouldSplitQueryKey) {
+      if (shouldSplitQueryKey) {
+        return getRouteAsArray(route);
+      }
+      return `\`${route}\``;
+    },
 
-  generateEnabledOption(params, options) {
-    if (params.length === 0) return '';
-    if (!isObject(options) || !Object.hasOwn(options, 'enabled')) {
-      return `enabled: ${params
-        .map(({ name }) => `${name} !== null && ${name} !== undefined`)
-        .join(' && ')},`;
-    }
-    return '';
-  },
+    generateEnabledOption(params, options) {
+      if (params.length === 0) return '';
+      if (!isObject(options) || !Object.hasOwn(options, 'enabled')) {
+        return `enabled: ${params
+          .map(({ name }) => `${name} !== null && ${name} !== undefined`)
+          .join(' && ')},`;
+      }
+      return '';
+    },
 
-  getQueryPropertyForProp(prop: GetterProp, body: { implementation: string }) {
-    if (prop.type === GetterPropType.NAMED_PATH_PARAMS)
-      return prop.destructured;
-    return prop.type === GetterPropType.BODY ? body.implementation : prop.name;
-  },
+    getQueryPropertyForProp(
+      prop: GetterProp,
+      body: { implementation: string },
+    ) {
+      if (prop.type === GetterPropType.NAMED_PATH_PARAMS)
+        return prop.destructured;
+      return prop.type === GetterPropType.BODY
+        ? body.implementation
+        : prop.name;
+    },
 
-  getInfiniteQueryHttpProps(props: GetterProps, queryParam: string) {
-    return props
-      .map((param) => {
-        if (param.type === GetterPropType.NAMED_PATH_PARAMS)
-          return param.destructured;
-        return param.name === 'params'
-          ? `{...params, '${queryParam}': pageParam ?? params?.['${queryParam}']}`
-          : param.name;
-      })
-      .join(',');
-  },
+    generateRequestFunction(verbOptions, options) {
+      return options.context.output.httpClient === OutputHttpClient.AXIOS
+        ? generateAxiosRequestFunction(verbOptions, options, composed)
+        : generateFetchRequestFunction(verbOptions, options);
+    },
 
-  generateQueryInit({ queryOptionsFnName, queryProperties, isRequestOptions }) {
-    const queryOptionsVarName = isRequestOptions ? 'queryOptions' : 'options';
-    return `const ${queryOptionsVarName} = ${queryOptionsFnName}(${queryProperties}${
-      queryProperties ? ',' : ''
-    }${isRequestOptions ? 'options' : 'queryOptions'})`;
-  },
+    getInfiniteQueryHttpProps(props: GetterProps, queryParam: string) {
+      return props
+        .map((param) => {
+          if (param.type === GetterPropType.NAMED_PATH_PARAMS)
+            return param.destructured;
+          return param.name === 'params'
+            ? `{...params, '${queryParam}': pageParam ?? params?.['${queryParam}']}`
+            : param.name;
+        })
+        .join(',');
+    },
 
-  generateQueryInvocationArgs({
-    queryOptionsVarName,
-    optionalQueryClientArgument,
-  }) {
-    return `${queryOptionsVarName}${optionalQueryClientArgument ? ', queryClient' : ''}`;
-  },
+    generateQueryInit({
+      queryOptionsFnName,
+      queryProperties,
+      isRequestOptions,
+    }) {
+      const queryOptionsVarName = isRequestOptions ? 'queryOptions' : 'options';
+      return `const ${queryOptionsVarName} = ${queryOptionsFnName}(${queryProperties}${
+        queryProperties ? ',' : ''
+      }${isRequestOptions ? 'options' : 'queryOptions'})`;
+    },
 
-  getOptionalQueryClientArgument() {
-    return adapter.hasQueryV5 ? ', queryClient?: QueryClient' : '';
-  },
+    generateQueryInvocationArgs({
+      queryOptionsVarName,
+      optionalQueryClientArgument,
+    }) {
+      return `${queryOptionsVarName}${optionalQueryClientArgument ? ', queryClient' : ''}`;
+    },
 
-  generateQueryArguments({
-    operationName,
-    definitions,
-    mutator,
-    isRequestOptions,
-    type,
-    queryParams,
-    queryParam,
-    initialData,
-    httpClient,
-    hasInvalidation,
-    useRuntimeFetcher,
-  }) {
-    const prefix = adapter.getQueryOptionsDefinitionPrefix?.() ?? 'Use';
-    const definition = getQueryOptionsDefinition({
+    getOptionalQueryClientArgument() {
+      return composed.hasQueryV5 ? ', queryClient?: QueryClient' : '';
+    },
+
+    generateQueryArguments({
       operationName,
-      mutator,
       definitions,
+      mutator,
+      isRequestOptions,
       type,
-      prefix,
-      hasQueryV5: adapter.hasQueryV5,
-      hasQueryV5WithInfiniteQueryOptionsError:
-        adapter.hasQueryV5WithInfiniteQueryOptionsError,
       queryParams,
       queryParam,
-      isReturnType: false,
       initialData,
-      adapter: adapter as FrameworkAdapter,
-    });
-
-    if (!isRequestOptions) {
-      return `${type ? 'queryOptions' : 'mutationOptions'}${
-        initialData === 'defined' ? '' : '?'
-      }: ${definition}`;
-    }
-
-    const requestType = getQueryArgumentsRequestType(
       httpClient,
-      mutator,
+      hasInvalidation,
       useRuntimeFetcher,
-    );
-    const isQueryRequired = initialData === 'defined';
-    const skipInvalidationProp =
-      !type && hasInvalidation ? 'skipInvalidation?: boolean, ' : '';
-    const optionsType = `{ ${
-      type ? 'query' : 'mutation'
-    }${isQueryRequired ? '' : '?'}:${definition}, ${skipInvalidationProp}${requestType}}`;
+    }) {
+      const prefix = composed.getQueryOptionsDefinitionPrefix();
+      const definition = getQueryOptionsDefinition({
+        operationName,
+        mutator,
+        definitions,
+        type,
+        prefix,
+        hasQueryV5: composed.hasQueryV5,
+        hasQueryV5WithInfiniteQueryOptionsError:
+          composed.hasQueryV5WithInfiniteQueryOptionsError,
+        queryParams,
+        queryParam,
+        isReturnType: false,
+        initialData,
+        adapter: composed,
+      });
 
-    return `options${isQueryRequired ? '' : '?'}: ${optionsType}\n`;
-  },
+      if (!isRequestOptions) {
+        return `${type ? 'queryOptions' : 'mutationOptions'}${
+          initialData === 'defined' ? '' : '?'
+        }: ${definition}`;
+      }
 
-  generateMutationOnSuccess({
-    operationName,
-    definitions,
-    isRequestOptions,
-    generateInvalidateCall,
-    uniqueInvalidates,
-  }: MutationOnSuccessContext): string {
-    const invalidateCalls = uniqueInvalidates
-      .map((t) => generateInvalidateCall(t))
-      .join('\n');
-    if (adapter.hasQueryV5WithMutationContextOnSuccess) {
-      if (isRequestOptions) {
+      const requestType = getQueryArgumentsRequestType(
+        httpClient,
+        mutator,
+        useRuntimeFetcher,
+      );
+      const isQueryRequired = initialData === 'defined';
+      const skipInvalidationProp =
+        !type && hasInvalidation ? 'skipInvalidation?: boolean, ' : '';
+      const optionsType = `{ ${
+        type ? 'query' : 'mutation'
+      }${isQueryRequired ? '' : '?'}:${definition}, ${skipInvalidationProp}${requestType}}`;
+
+      return `options${isQueryRequired ? '' : '?'}: ${optionsType}\n`;
+    },
+
+    generateMutationOnSuccess({
+      operationName,
+      definitions,
+      isRequestOptions,
+      generateInvalidateCall,
+      uniqueInvalidates,
+    }: MutationOnSuccessContext): string {
+      const invalidateCalls = uniqueInvalidates
+        .map((t) => generateInvalidateCall(t))
+        .join('\n');
+      if (composed.hasQueryV5WithMutationContextOnSuccess) {
+        if (isRequestOptions) {
+          return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
+        if (!options?.skipInvalidation) {
+    ${invalidateCalls}
+        }
+        mutationOptions?.onSuccess?.(data, variables, onMutateResult, context);
+      };`;
+        }
         return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
-        if (!options?.skipInvalidation) {
-    ${invalidateCalls}
-        }
-        mutationOptions?.onSuccess?.(data, variables, onMutateResult, context);
-      };`;
-      }
-      return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
     ${invalidateCalls}
         mutationOptions?.onSuccess?.(data, variables, onMutateResult, context);
       };`;
-    } else {
-      if (isRequestOptions) {
-        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${adapter.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
+      } else {
+        if (isRequestOptions) {
+          return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${composed.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
         if (!options?.skipInvalidation) {
     ${invalidateCalls}
         }
         mutationOptions?.onSuccess?.(data, variables, context);
       };`;
-      }
-      return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${adapter.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
+        }
+        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${composed.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
     ${invalidateCalls}
         mutationOptions?.onSuccess?.(data, variables, context);
       };`;
-    }
-  },
-  ...adapter,
-});
+      }
+    },
+    ...adapter,
+  };
+
+  return composed;
+};
 
 type QueryClientType =
   | 'react-query'

--- a/packages/query/src/frameworks/react.ts
+++ b/packages/query/src/frameworks/react.ts
@@ -1,13 +1,5 @@
-import {
-  type GeneratorOptions,
-  type GeneratorVerbOptions,
-  OutputClient,
-  OutputHttpClient,
-  pascal,
-} from '@orval/core';
-import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
+import { OutputClient, pascal } from '@orval/core';
 
-import { generateAxiosRequestFunction } from '../client';
 import type {
   FrameworkAdapterConfig,
   MutationHookBodyContext,
@@ -97,14 +89,5 @@ export const createReactAdapter = ({
     optionalQueryClientArgument,
   }: MutationHookBodyContext): string {
     return `      ${hasInvalidation ? `const backupQueryClient = useQueryClient();\n      ` : ''}return ${operationPrefix}Mutation(${mutationImplementation}${optionalQueryClientArgument ? `, queryClient` : ''});`;
-  },
-
-  generateRequestFunction(
-    verbOptions: GeneratorVerbOptions,
-    options: GeneratorOptions,
-  ): string {
-    return options.context.output.httpClient === OutputHttpClient.AXIOS
-      ? generateAxiosRequestFunction(verbOptions, options, false)
-      : generateFetchRequestFunction(verbOptions, options);
   },
 });

--- a/packages/query/src/frameworks/solid.ts
+++ b/packages/query/src/frameworks/solid.ts
@@ -1,12 +1,5 @@
-import {
-  type GeneratorOptions,
-  type GeneratorVerbOptions,
-  OutputClient,
-  OutputHttpClient,
-} from '@orval/core';
-import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
+import { OutputClient } from '@orval/core';
 
-import { generateAxiosRequestFunction } from '../client';
 import type {
   FrameworkAdapterConfig,
   MutationHookBodyContext,
@@ -181,14 +174,5 @@ export const createSolidAdapter = ({
   getOptionalQueryClientArgument(): string {
     // Solid Query expects queryClient to be an Accessor: () => QueryClient
     return ', queryClient?: () => QueryClient';
-  },
-
-  generateRequestFunction(
-    verbOptions: GeneratorVerbOptions,
-    options: GeneratorOptions,
-  ): string {
-    return options.context.output.httpClient === OutputHttpClient.AXIOS
-      ? generateAxiosRequestFunction(verbOptions, options, false)
-      : generateFetchRequestFunction(verbOptions, options);
   },
 });

--- a/packages/query/src/frameworks/svelte.ts
+++ b/packages/query/src/frameworks/svelte.ts
@@ -1,18 +1,11 @@
 import {
-  type GeneratorOptions,
-  type GeneratorVerbOptions,
   type GetterProps,
   OutputClient,
-  OutputHttpClient,
   pascal,
   toObjectString,
 } from '@orval/core';
-import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
 
-import {
-  generateAxiosRequestFunction,
-  getQueryArgumentsRequestType,
-} from '../client';
+import { getQueryArgumentsRequestType } from '../client';
 import type {
   FrameworkAdapterConfig,
   MutationHookBodyContext,
@@ -249,15 +242,6 @@ export const createSvelteAdapter = ({
         return getQueryTypeForFramework(type);
       }
       return type;
-    },
-
-    generateRequestFunction(
-      verbOptions: GeneratorVerbOptions,
-      options: GeneratorOptions,
-    ): string {
-      return options.context.output.httpClient === OutputHttpClient.AXIOS
-        ? generateAxiosRequestFunction(verbOptions, options, false)
-        : generateFetchRequestFunction(verbOptions, options);
     },
   };
 };

--- a/packages/query/src/frameworks/vue.ts
+++ b/packages/query/src/frameworks/vue.ts
@@ -1,6 +1,4 @@
 import {
-  type GeneratorOptions,
-  type GeneratorVerbOptions,
   getRouteAsArray,
   type GetterParams,
   type GetterProp,
@@ -11,9 +9,7 @@ import {
   OutputHttpClient,
   pascal,
 } from '@orval/core';
-import { generateRequestFunction as generateFetchRequestFunction } from '@orval/fetch';
 
-import { generateAxiosRequestFunction } from '../client';
 import type {
   FrameworkAdapterConfig,
   MutationHookBodyContext,
@@ -140,10 +136,19 @@ export const createVueAdapter = ({
     return false;
   },
 
-  getUnrefStatements(props: GetterProps): string {
+  getRequestUnrefStatements(props: GetterProps): string {
+    return vueUnRefParams(props);
+  },
+
+  getQueryOptionsUnrefStatements(props: GetterProps): string {
     return vueUnRefParams(
       props.filter((prop) => prop.type === GetterPropType.NAMED_PATH_PARAMS),
     );
+  },
+
+  wrapHookMutatorCallback(callback: string): string {
+    // Vue does not wrap the hook mutator callback with useCallback.
+    return callback;
   },
 
   generateEnabledOption(
@@ -225,15 +230,6 @@ export const createVueAdapter = ({
     optionalQueryClientArgument,
   }: MutationHookBodyContext): string {
     return `      ${hasInvalidation ? `const backupQueryClient = useQueryClient();\n      ` : ''}return ${operationPrefix}Mutation(${mutationImplementation}${optionalQueryClientArgument ? `, queryClient` : ''});`;
-  },
-
-  generateRequestFunction(
-    verbOptions: GeneratorVerbOptions,
-    options: GeneratorOptions,
-  ): string {
-    return options.context.output.httpClient === OutputHttpClient.AXIOS
-      ? generateAxiosRequestFunction(verbOptions, options, true)
-      : generateFetchRequestFunction(verbOptions, options);
   },
 
   getQueryPropertyForProp(

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -664,7 +664,7 @@ ${hookOptions}
       httpFunctionProps ? ', ' : ''
     }${queryOptions});
 
-      ${adapter.getUnrefStatements(props)}
+      ${adapter.getQueryOptionsUnrefStatements(props)}
 
       ${
         queryOptionsMutator


### PR DESCRIPTION
**Please review using `Hide Whitespace` otherwise you will see many changed files.**

This PR replaces the raw `isVue` in `generateAxiosRequestFunction` with the existing FrameworkAdapter. Vue's prop-transform, unref, and callback-wrapping behavior is now through adapter methods. This lets the four identical copies of `generateRequestFunction` collapse into a single shared default.

With next release where we want to do breaking changes we should discuss dropping `unref` from axios, as fetch and axios now behave differently and cause this code mess internally.

axios
```ts
export const showPetById = (
  petId: MaybeRef<string>,            // ← param typed MaybeRef
  options?: AxiosRequestConfig,
): Promise<AxiosResponse<Pet>> => {
  petId = unref(petId);               // ← unref INSIDE the body

  return axios.get(`/pets/${petId}`, options);
};

// caller passes the raw ref:
//   ({ signal }) => showPetById(petId, { signal, ...axiosOptions })
```

fetch
```ts
export const showPetById = async (
  petId: string,                      // ← plain value, no MaybeRef
  options?: RequestInit,
): Promise<showPetByIdResponse> => {
  const res = await fetch(getShowPetByIdUrl(petId), {   // ← no unref in body
    ...options,
    method: 'GET',
  });
  // ...
};

// caller unrefs at the call site:
//   ({ signal }) => showPetById(unref(petId), { signal, ...fetchOptions })
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved framework adapter abstraction to better separate concerns around reactive property unwrapping across different frameworks.
  * Consolidated request function generation logic into the default adapter implementation, reducing duplication across framework-specific configurations.
  * Enhanced consistency in how frameworks handle callback wrapping and property unwrapping for queries and mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->