### PR TITLE
fix(angular): keep httpResource response imports type-only

### DIFF
--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -429,6 +429,40 @@ describe('angular httpResource generator', () => {
       expect(importNames).toContain('Pet');
       expect(importNames).not.toContain('Error');
     });
+
+    it('keeps zod array response imports type-only when parse is not generated', async () => {
+      const output = createOutput({
+        schemas: {
+          type: 'zod',
+          path: '/tmp/schemas',
+        } as NormalizedOutputOptions['schemas'],
+      });
+      const verbOption = createVerbOption({
+        response: baseResponse({
+          imports: [{ name: 'Pet' }],
+          definition: { success: 'Pet[]', errors: 'Error' },
+          types: {
+            success: [createSuccessType('Pet[]', 'application/json')],
+            errors: [],
+          },
+        }),
+      });
+
+      const result = await generateHttpResourceClient(
+        verbOption,
+        createGeneratorOptions({
+          route: '/api/pets',
+          context: createContextSpec(output),
+          override: output.override,
+          output: output.target,
+        }),
+        'angular',
+        output,
+      );
+
+      expect(result.imports).toContainEqual({ name: 'Pet' });
+      expect(result.imports).not.toContainEqual({ name: 'Pet', values: true });
+    });
   });
 
   // ─── Route registry fallback ──────────────────────────────────────

--- a/packages/angular/src/http-resource.ts
+++ b/packages/angular/src/http-resource.ts
@@ -542,25 +542,86 @@ const getHttpResourceResponseImports = (
   });
 };
 
+const getParseSchemaName = (
+  response: {
+    readonly imports: readonly { name: string; isZodSchema?: boolean }[];
+    readonly definition: { readonly success?: string };
+  },
+  factory: HttpResourceFactoryName,
+  output: NormalizedOutputOptions,
+  responseTypeOverride?: string,
+): string | undefined => {
+  if (factory !== 'httpResource') return undefined;
+
+  // Explicit isZodSchema flag on imports (forward-compatible)
+  const zodSchema = response.imports.find((imp) => imp.isZodSchema);
+  if (zodSchema) return zodSchema.name;
+
+  // Check if runtime validation is disabled
+  if (!output.override.angular.runtimeValidation) return undefined;
+
+  // Auto-detect: when schemas.type === 'zod', use the response type as the schema name
+  if (!isZodSchemaOutput(output)) return undefined;
+
+  const responseType = responseTypeOverride ?? response.definition.success;
+  if (!responseType) return undefined;
+  if (isPrimitiveType(responseType)) return undefined;
+
+  // Verify a matching import exists (the response type name resolves to a zod schema)
+  const hasMatchingImport = response.imports.some(
+    (imp) => imp.name === responseType,
+  );
+  if (!hasMatchingImport) return undefined;
+
+  return responseType;
+};
+
+const getHttpResourceZodParsedImportNames = (
+  response: GeneratorVerbOptions['response'],
+  output: NormalizedOutputOptions,
+): Set<string> => {
+  const names = new Set<string>();
+
+  for (const successType of response.types.success) {
+    const schemaName = getParseSchemaName(
+      response,
+      getHttpResourceFactory(
+        response,
+        successType.contentType,
+        successType.value,
+      ),
+      output,
+      successType.value,
+    );
+
+    if (schemaName) {
+      names.add(schemaName);
+    }
+  }
+
+  return names;
+};
+
 const getHttpResourceVerbImports = (
   verbOptions: GeneratorVerbOptions,
   output: NormalizedOutputOptions,
 ): GeneratorImport[] => {
   const { response, body, queryParams, props, headers, params } = verbOptions;
-  const responseImports = isZodSchemaOutput(output)
-    ? [
-        ...getHttpResourceResponseImports(response).map((imp) => ({
-          ...imp,
-          values: true,
-        })),
-        ...getHttpResourceResponseImports(response)
-          .filter((imp) => !isPrimitiveType(imp.name))
-          .map((imp) => ({ name: getSchemaOutputTypeRef(imp.name) })),
-      ]
-    : getHttpResourceResponseImports(response);
+  const responseImports = getHttpResourceResponseImports(response);
+  const parsedZodImportNames = isZodSchemaOutput(output)
+    ? getHttpResourceZodParsedImportNames(response, output)
+    : new Set<string>();
+  const parsedZodImports = responseImports.filter((imp) =>
+    parsedZodImportNames.has(imp.name),
+  );
 
   return [
-    ...responseImports,
+    ...responseImports.map((imp) =>
+      parsedZodImportNames.has(imp.name) ? { ...imp, values: true } : imp,
+    ),
+    ...parsedZodImports
+      .filter((imp) => !isPrimitiveType(imp.name))
+      .map((imp) => ({ name: getSchemaOutputTypeRef(imp.name) })),
     ...body.imports,
     ...props.flatMap((prop) =>
       prop.type === GetterPropType.NAMED_PATH_PARAMS
@@ -583,29 +644,14 @@ const getParseExpression = (
   output: NormalizedOutputOptions,
   responseTypeOverride?: string,
 ): string | undefined => {
-  if (factory !== 'httpResource') return undefined;
-
-  // Explicit isZodSchema flag on imports (forward-compatible)
-  const zodSchema = response.imports.find((imp) => imp.isZodSchema);
-  if (zodSchema) return `${zodSchema.name}.parse`;
-
-  // Check if runtime validation is disabled
-  if (!output.override.angular.runtimeValidation) return undefined;
-
-  // Auto-detect: when schemas.type === 'zod', use the response type as the schema name
-  if (!isZodSchemaOutput(output)) return undefined;
-
-  const responseType = responseTypeOverride ?? response.definition.success;
-  if (!responseType) return undefined;
-  if (isPrimitiveType(responseType)) return undefined;
-
-  // Verify a matching import exists (the response type name resolves to a zod schema)
-  const hasMatchingImport = response.imports.some(
-    (imp) => imp.name === responseType,
+  const schemaName = getParseSchemaName(
+    response,
+    factory,
+    output,
+    responseTypeOverride,
   );
-  if (!hasMatchingImport) return undefined;
 
-  return `${responseType}.parse`;
+  return schemaName ? `${schemaName}.parse` : undefined;
 };
 
 /**

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
@@ -31,15 +31,13 @@ import {
   Observable
 } from 'rxjs';
 
-import {
-  Pet,
-  PetWithTag,
-  Pets
-} from './model';
 import type {
   CreatePetsBody,
   CreatePetsParams,
-  ListPetsParams
+  ListPetsParams,
+  Pet,
+  PetWithTag,
+  Pets
 } from './model';
 
 import {

--- a/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
@@ -31,15 +31,13 @@ import {
   Observable
 } from 'rxjs';
 
-import {
-  Pet,
-  PetWithTag,
-  Pets
-} from './model';
 import type {
   CreatePetsBody,
   CreatePetsParams,
-  ListPetsParams
+  ListPetsParams,
+  Pet,
+  PetWithTag,
+  Pets
 } from './model';
 
 import {


### PR DESCRIPTION
Fixes #3625.

## Summary

Angular `httpResource` generation for Zod schema output was marking response model imports as value imports even when the generated resource only used those models in type positions.

This changes the import classification so response models stay type-only unless the generated code actually needs the schema value for runtime validation, e.g. `parse: Pet.parse`.

## Approach

I extracted the existing runtime-validation decision into `getParseSchemaName()` and reuse it in two places:

- `getParseExpression()` still emits `Schema.parse` when runtime validation is generated.
- `getHttpResourceVerbImports()` marks only those same schemas as value imports.

That keeps generated imports aligned with generated runtime code instead of treating every Zod response import as a value import.

## Alternatives considered

| Option | Downside |
|---|---|
| Only special-case array responses like `Pet[]` | Smallest patch, but it fixes this symptom rather than the underlying rule. Other non-validated response shapes could still be over-imported as values. |
| Exact-match only on `response.definition.success` | Smaller diff, but too naive for content-type branches and explicit Zod schema imports. |
| Scan generated output for `Schema.parse` | Mirrors final output, but feels brittle/stringly for generator code. |
| Build a broader type-vs-value import classifier | Cleaner long-term, but much larger and riskier than this bug needs. |

I went with the shared-helper approach because it keeps one source of truth for when a schema value is required.

## Tests

- `vitest run packages/angular/src/http-resource.test.ts -t "keeps zod array response imports type-only"`
- `vitest run packages/angular/src/http-resource.test.ts`
- `vp fmt --check packages/angular/src/http-resource.ts packages/angular/src/http-resource.test.ts tests/__snapshots__/angular/http-resource-zod/endpoints.ts tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test verifying Zod array response import handling when runtime parsing is disabled.

* **Bug Fixes**
  * Improved Zod schema import selection and parse expression generation in generated Angular resource code to correctly distinguish between schema values and type imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->