### PR TITLE
test(core): add regression tests for schemas import paths in split modes

### DIFF
--- a/packages/core/src/writers/split-mode.test.ts
+++ b/packages/core/src/writers/split-mode.test.ts
@@ -9,7 +9,12 @@ import {
   createSplitModeOutput,
   createSplitModeProps,
 } from '../test-utils/split-modes';
-import { type GeneratorDependency, OutputMockType, OutputMode } from '../types';
+import {
+  type GeneratorDependency,
+  OutputClient,
+  OutputMockType,
+  OutputMode,
+} from '../types';
 import { writeSplitMode } from './split-mode';
 
 // Regression coverage for https://github.com/orval-labs/orval/issues/2309
@@ -55,6 +60,51 @@ describe('writeSplitMode — schemas path follows needSchema (#2309)', () => {
     const schemasPath = path.join(tmpDir, 'petstore.schemas.ts');
     expect(paths).toContain(schemasPath);
     expect(fs.existsSync(schemasPath)).toBe(true);
+  });
+
+  it('imports from the configured schemas directory even before it exists', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const schemaPath = path.join(tmpDir, 'sample.schemas');
+    const props = createSplitModeProps(target);
+    const builder = props.builder;
+    builder.operations = {
+      listPets: createSplitModeOperation({
+        imports: [{ name: 'Pet' }],
+        implementation: 'export type ListPetsResponse = Pet;',
+      }),
+    };
+    builder.imports = ({ imports }) =>
+      imports
+        .map(
+          ({ dependency, exports }) =>
+            `import type { ${exports
+              .map((entry) => entry.name)
+              .join(', ')} } from '${dependency}';`,
+        )
+        .join('\n');
+
+    const output = createSplitModeOutput(target, {
+      client: OutputClient.ANGULAR,
+      indexFiles: true,
+      mode: OutputMode.SPLIT,
+      schemas: schemaPath,
+    });
+
+    await writeSplitMode({
+      ...props,
+      builder,
+      output,
+      needSchema: false,
+    });
+
+    const content = await fs.readFile(
+      path.join(tmpDir, 'petstore.service.ts'),
+      'utf8',
+    );
+
+    expect(content).toContain("from './sample.schemas'");
+    expect(content).not.toContain("from './.'");
+    expect(content).not.toContain("from './sample'");
   });
 });
 

--- a/packages/core/src/writers/split-tags-mode.test.ts
+++ b/packages/core/src/writers/split-tags-mode.test.ts
@@ -9,7 +9,12 @@ import {
   createSplitModeOutput,
   createSplitModeProps,
 } from '../test-utils/split-modes';
-import { type GeneratorDependency, OutputMockType, OutputMode } from '../types';
+import {
+  type GeneratorDependency,
+  OutputClient,
+  OutputMockType,
+  OutputMode,
+} from '../types';
 import { writeSplitTagsMode } from './split-tags-mode';
 
 // Regression coverage for https://github.com/orval-labs/orval/issues/2309
@@ -55,6 +60,52 @@ describe('writeSplitTagsMode — schemas path follows needSchema (#2309)', () =>
     const schemasPath = path.join(tmpDir, 'petstore.schemas.ts');
     expect(paths).toContain(schemasPath);
     expect(fs.existsSync(schemasPath)).toBe(true);
+  });
+
+  it('imports from the configured schemas directory even before it exists', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const schemaPath = path.join(tmpDir, 'sample.schemas');
+    const props = createSplitModeProps(target);
+    const builder = props.builder;
+    builder.operations = {
+      listPets: createSplitModeOperation({
+        tags: ['Pets'],
+        imports: [{ name: 'Pet' }],
+        implementation: 'export type ListPetsResponse = Pet;',
+      }),
+    };
+    builder.imports = ({ imports }) =>
+      imports
+        .map(
+          ({ dependency, exports }) =>
+            `import type { ${exports
+              .map((entry) => entry.name)
+              .join(', ')} } from '${dependency}';`,
+        )
+        .join('\n');
+
+    const output = createSplitModeOutput(target, {
+      client: OutputClient.ANGULAR,
+      indexFiles: true,
+      mode: OutputMode.TAGS_SPLIT,
+      schemas: schemaPath,
+    });
+
+    await writeSplitTagsMode({
+      ...props,
+      builder,
+      output,
+      needSchema: false,
+    });
+
+    const content = await fs.readFile(
+      path.join(tmpDir, 'pets', 'pets.service.ts'),
+      'utf8',
+    );
+
+    expect(content).toContain("from '../sample.schemas'");
+    expect(content).not.toContain("from '../.'");
+    expect(content).not.toContain("from '../sample'");
   });
 });
 


### PR DESCRIPTION
Adds tests that verify schema imports use correct directory paths and do not generate invalid './.' or './sample' imports.

This prevents regression of issue #3624 where Angular httpResource in split mode could generate imports from './.' instead of the correct schemas directory path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test coverage verifying correct handling of schema import paths when configured schema directories do not yet exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->