### PR TITLE
feat(mock): add override.mock.schemas for per-schema property overrides

### DIFF
--- a/docs/content/docs/guides/faker.mdx
+++ b/docs/content/docs/guides/faker.mdx
@@ -210,6 +210,44 @@ override: {
 
 You can also scope overrides per-operation or per-tag via `override.operations` and `override.tags`.
 
+### Per-schema overrides
+
+`override.mock.properties` matches by property name, so a `color` override applies to
+**every** schema that has a `color` property. To give the same property name different
+mock values depending on the schema it belongs to, scope the override to a schema by name
+under `override.mock.schemas`:
+
+```ts title="orval.config.ts"
+override: {
+  mock: {
+    schemas: {
+      Apple: {
+        properties: {
+          color: () => faker.helpers.arrayElement(['red', 'green']),
+        },
+      },
+      Car: {
+        properties: {
+          color: () => 'midnight black',
+        },
+      },
+    },
+  },
+}
+```
+
+`getAppleMock()` now mocks `color` as a fruit color and `getCarMock()` as a car color,
+even though both schemas declare `color: string`.
+
+The keys under `properties` use the same matching rules as `override.mock.properties` —
+bare property name, regex (`/.../`), or exact path (`#.foo.bar`) — but only apply to
+properties of the named schema (matched against the schema's own `parentName`). When
+`schemas: true` is enabled, each `get<SchemaName>Mock` factory bakes its schema-scoped
+override in, so references that delegate to the factory keep the override.
+
+**Precedence** (first match wins): `override.operations` → `override.tags` →
+`override.mock.schemas` → `override.mock.properties`.
+
 ## Usage
 
 ### Unit Tests

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -2015,6 +2015,13 @@ export default defineConfig({
             '/tag|name/': 'jon',
             email: () => faker.internet.email(),
           },
+          schemas: {
+            Apple: {
+              properties: {
+                color: () => faker.helpers.arrayElement(['red', 'green']),
+              },
+            },
+          },
           format: {
             email: () => faker.internet.email(),
             iban: () => faker.finance.iban(),
@@ -2037,7 +2044,16 @@ export default defineConfig({
 
 ### properties
 
-Override mock values per property path or regex.
+Override mock values per property path or regex. Applies to every schema that has a
+matching property.
+
+### schemas
+
+Scope property overrides to a named schema, so the same property name can mock differently
+per schema (e.g. `color` on `Apple` vs. `Car`). Keyed by schema name; each entry holds a
+`properties` map using the same matching rules as `properties` (bare name, `/regex/`, exact
+`#.path`). Takes precedence over the global `properties` overrides. See the
+[Faker guide](/docs/guides/faker#per-schema-overrides) for a worked example.
 
 ### format
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -577,14 +577,22 @@ export type OverrideMockOptions = Partial<GlobalMockOptions> & {
   required?: boolean; // When true, all properties are required (and thus not optional) in mocks.
   nonNullable?: boolean; // When true, nullable mock values are never wrapped in `arrayElement([value, null])`.
   properties?: MockProperties;
+  // Scope property overrides to a named schema (e.g. `components/schemas/Apple`),
+  // so the same property name can mock differently per schema. Matching rules are
+  // identical to `properties` (bare name, `/regex/`, exact `#.path`).
+  schemas?: Record<string, { properties: MockProperties }>;
   format?: Record<string, unknown>;
   fractionDigits?: number;
 };
 
-export type MockOptions = Omit<OverrideMockOptions, 'properties'> & {
+export type MockOptions = Omit<
+  OverrideMockOptions,
+  'properties' | 'schemas'
+> & {
   properties?: Record<string, unknown>;
   operations?: Record<string, { properties: Record<string, unknown> }>;
   tags?: Record<string, { properties: Record<string, unknown> }>;
+  schemas?: Record<string, { properties: Record<string, unknown> }>;
 };
 
 export type MockPropertiesObject = Record<string, unknown>;

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1071,3 +1071,98 @@ describe('getMockScalar (enum value escaping #3505)', () => {
     );
   });
 });
+
+describe('getMockScalar (schema-scoped overrides)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  const colorItem = (parentName: string) => ({
+    type: 'string' as OpenApiSchemaObjectType,
+    name: 'color',
+    parentName,
+  });
+
+  it('applies a schema-scoped override only inside the matching schema', () => {
+    const mockOptions = {
+      schemas: {
+        Apple: { properties: { color: "'red'" } },
+        Car: { properties: { color: "'midnight black'" } },
+      },
+    };
+
+    const apple = getMockScalar({
+      ...baseArg,
+      item: colorItem('Apple'),
+      mockOptions,
+      context: scalarContext(),
+    });
+    expect(apple.value).toBe("'red'");
+    expect(apple.overrided).toBe(true);
+
+    const car = getMockScalar({
+      ...baseArg,
+      item: colorItem('Car'),
+      mockOptions,
+      context: scalarContext(),
+    });
+    expect(car.value).toBe("'midnight black'");
+  });
+
+  it('falls through to the default mock when the schema name does not match', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: colorItem('Banana'),
+      mockOptions: { schemas: { Apple: { properties: { color: "'red'" } } } },
+      context: scalarContext(),
+    });
+
+    expect(result.value).not.toBe("'red'");
+    expect(result.value).toContain('faker.string.alpha');
+  });
+
+  it('does not apply a schema-scoped override when the item has no parentName', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: { type: 'string' as OpenApiSchemaObjectType, name: 'color' },
+      mockOptions: { schemas: { Apple: { properties: { color: "'red'" } } } },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toContain('faker.string.alpha');
+  });
+
+  it('prefers an operation-scoped override over a schema-scoped one', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: colorItem('Apple'),
+      mockOptions: {
+        operations: {
+          'test-operation': { properties: { color: "'op-color'" } },
+        },
+        schemas: { Apple: { properties: { color: "'red'" } } },
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe("'op-color'");
+  });
+
+  it('prefers a schema-scoped override over a global property override', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: colorItem('Apple'),
+      mockOptions: {
+        properties: { color: "'global-color'" },
+        schemas: { Apple: { properties: { color: "'red'" } } },
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe("'red'");
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -106,6 +106,24 @@ export function getMockScalar({
     return tagProperty;
   }
 
+  // Schema-scoped overrides (#override.mock.schemas): apply only to properties
+  // of a named schema. `item.parentName` is the enclosing schema name, set when
+  // an object property is resolved (see getters/object.ts) — so the same
+  // property name can mock differently per schema. More specific
+  // operation/tag rules above still win; this beats the global `properties`.
+  const schemaName = item.parentName;
+  const schemaProperty = schemaName
+    ? resolveMockOverride(
+        safeMockOptions.schemas?.[schemaName]?.properties,
+        item,
+        nonNullableOption,
+      )
+    : undefined;
+
+  if (schemaProperty) {
+    return schemaProperty;
+  }
+
   const property = resolveMockOverride(
     safeMockOptions.properties,
     item,

--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -228,6 +228,89 @@ describe('generateFakerForSchemas property overrides (schemas: true)', () => {
   });
 });
 
+describe('generateFakerForSchemas schema-scoped overrides (override.mock.schemas)', () => {
+  const appleColor = () => `'red'`;
+  const carColor = () => `'midnight black'`;
+
+  const context = createTestContextSpec({
+    override: {
+      mock: {
+        schemas: {
+          Apple: { properties: { color: appleColor } },
+          Car: { properties: { color: carColor } },
+        },
+      },
+    },
+  });
+
+  const appleSchema: GeneratorSchema = {
+    name: 'Apple',
+    model: 'Apple',
+    imports: [],
+    schema: {
+      type: 'object',
+      required: ['color'],
+      properties: { color: { type: 'string' } },
+    },
+  };
+
+  const carSchema: GeneratorSchema = {
+    name: 'Car',
+    model: 'Car',
+    imports: [],
+    schema: {
+      type: 'object',
+      required: ['color'],
+      properties: { color: { type: 'string' } },
+    },
+  };
+
+  it('applies a different override to the same property name per schema', () => {
+    const result = generateFakerForSchemas([appleSchema, carSchema], context, {
+      type: OutputMockType.FAKER,
+      schemas: true,
+    });
+
+    expect(result.implementation).toContain(`color: (${String(appleColor)})()`);
+    expect(result.implementation).toContain(`color: (${String(carColor)})()`);
+  });
+
+  it('applies the Apple schema-scoped override inside a referencing schema', () => {
+    const basketSchema: GeneratorSchema = {
+      name: 'Basket',
+      model: 'Basket',
+      imports: [],
+      schema: {
+        type: 'object',
+        required: ['apple'],
+        properties: { apple: { $ref: '#/components/schemas/Apple' } },
+      },
+    };
+
+    context.spec.components = {
+      schemas: {
+        Apple: appleSchema.schema as Record<string, unknown>,
+      },
+    };
+
+    const result = generateFakerForSchemas(
+      [appleSchema, basketSchema],
+      context,
+      { type: OutputMockType.FAKER, schemas: true },
+    );
+
+    // `Apple.color` resolves through the Apple schema-scoped override whether
+    // Basket inlines Apple's body or delegates to getAppleMock() — the factory
+    // is built with the same mock options, so the override is baked into both.
+    const basketBody = result.implementation.slice(
+      result.implementation.indexOf('getBasketMock'),
+    );
+    expect(basketBody).toMatch(
+      /apple: (\{ \.\.\.getAppleMock\(\) \}|\{color: \(\(\) => `'red'`\)\(\)\})/,
+    );
+  });
+});
+
 describe('generateFakerForSchemas strict mock types (#3525)', () => {
   const context = createTestContextSpec({
     override: {
@@ -440,5 +523,68 @@ describe('resolveMockValue returns one factory import per ref-property (#3606)',
       name: 'getLeafDTOMock',
       schemaFactory: true,
     });
+  });
+});
+
+describe('schema-scoped overrides are preserved through factory delegation', () => {
+  // A schema-scoped override targets a schema's *own* properties, so its
+  // get<X>Mock factory bakes the override in. A referencing schema can keep
+  // delegating to that factory — the override rides along.
+  const appleColor = () => `'red'`;
+  const context = createTestContextSpec({
+    output: {
+      schemas: 'model',
+      mock: {
+        indexMockFiles: false,
+        generators: [{ type: OutputMockType.FAKER, schemas: true }],
+      },
+    },
+    override: {
+      mock: { schemas: { Apple: { properties: { color: appleColor } } } },
+    },
+    spec: {
+      components: {
+        schemas: {
+          Apple: {
+            type: 'object',
+            required: ['color'],
+            properties: { color: { type: 'string' } },
+          },
+        },
+      },
+    },
+  });
+
+  it('bakes the override into the factory and delegates from referencing schemas', () => {
+    const result = generateFakerForSchemas(
+      [
+        {
+          name: 'Apple',
+          model: 'Apple',
+          imports: [],
+          schema: {
+            type: 'object',
+            required: ['color'],
+            properties: { color: { type: 'string' } },
+          },
+        },
+        {
+          name: 'Basket',
+          model: 'Basket',
+          imports: [],
+          schema: {
+            type: 'object',
+            required: ['apple'],
+            properties: { apple: { $ref: '#/components/schemas/Apple' } },
+          },
+        },
+      ],
+      context,
+      { type: OutputMockType.FAKER, schemas: true },
+    );
+
+    // Factory carries the override; Basket delegates to it.
+    expect(result.implementation).toContain(`color: (${String(appleColor)})()`);
+    expect(result.implementation).toContain('apple: { ...getAppleMock() }');
   });
 });

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -159,6 +159,11 @@ function isComponentsSchemaRef(refPaths: string[] | undefined): boolean {
  * the schema body so the override actually applies; the shared
  * `get<X>Mock` factory has no knowledge of operation-scoped overrides.
  *
+ * Schema-scoped overrides (`override.mock.schemas`) need no special handling
+ * here: they target a schema's *own* properties, so the schema's `get<X>Mock`
+ * factory — built with the same mock options — already bakes them in, and
+ * delegating to it preserves the override.
+ *
  * Reuses `resolveMockOverride` so the same matching rules apply as for
  * regular property mocks — bare name, regex (`/.../`), and exact-path
  * (`#.foo.bar`). The parent's `path` (where the `$ref` appears in the

--- a/packages/mock/src/msw/mocks.test.ts
+++ b/packages/mock/src/msw/mocks.test.ts
@@ -1,8 +1,12 @@
-import type { ResReqTypesValue } from '@orval/core';
+import type {
+  NormalizedOverrideOutput,
+  OpenApiDocument,
+  ResReqTypesValue,
+} from '@orval/core';
 import { describe, expect, it } from 'vitest';
 
 import { createTestContextSpec } from '../../../core/src/test-utils/context';
-import { getResponsesMockDefinition } from './mocks';
+import { getMockWithoutFunc, getResponsesMockDefinition } from './mocks';
 
 describe('getResponsesMockDefinition', () => {
   it('aggregates imports when response.imports is undefined (#3590)', () => {
@@ -90,5 +94,37 @@ describe('getResponsesMockDefinition (useExamples + transformer)', () => {
     expect(definitions[0]).toBe(
       'wrap({ createdAt: new Date("2023-12-31T06:46:39.477Z"), birthDate: new Date("2023-12-31") })',
     );
+  });
+});
+
+describe('getMockWithoutFunc (override.mock.schemas)', () => {
+  const spec = {} as OpenApiDocument;
+
+  it('serializes function-valued schema-scoped overrides into IIFE strings', () => {
+    const colorFn = () => 'faker.color.human()';
+    const override = {
+      mock: { schemas: { Apple: { properties: { color: colorFn } } } },
+    } as unknown as NormalizedOverrideOutput;
+
+    const result = getMockWithoutFunc(spec, override);
+
+    expect(result.schemas).toEqual({
+      Apple: { properties: { color: `(${String(colorFn)})()` } },
+    });
+  });
+
+  it('keeps non-function schema-scoped overrides as stringified values', () => {
+    const override = {
+      mock: { schemas: { Car: { properties: { color: 'midnight black' } } } },
+    } as unknown as NormalizedOverrideOutput;
+
+    const result = getMockWithoutFunc(spec, override);
+
+    expect(result.schemas?.Car.properties.color).toBe("'midnight black'");
+  });
+
+  it('omits schemas when no schema-scoped overrides are configured', () => {
+    const result = getMockWithoutFunc(spec, {} as NormalizedOverrideOutput);
+    expect(result.schemas).toBeUndefined();
   });
 });

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -88,6 +88,23 @@ export function getMockWithoutFunc(
         return tagMocks;
       })()
     : undefined;
+  const schemas = override?.mock?.schemas
+    ? (() => {
+        const schemaMocks: Exclude<MockOptions['schemas'], undefined> = {};
+
+        for (const [key, value] of Object.entries(override.mock.schemas)) {
+          if (!value?.properties) {
+            continue;
+          }
+
+          schemaMocks[key] = {
+            properties: getMockPropertiesWithoutFunc(value.properties, spec),
+          };
+        }
+
+        return schemaMocks;
+      })()
+    : undefined;
 
   return {
     arrayMin: override?.mock?.arrayMin,
@@ -114,6 +131,7 @@ export function getMockWithoutFunc(
       : {}),
     ...(operations ? { operations } : {}),
     ...(tags ? { tags } : {}),
+    ...(schemas ? { schemas } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

`override.mock.properties` matches by property name, so an override for `color` applies to **every** schema that has a `color` property. There was no way to give the same property name different mock values depending on which schema it belongs to.

This adds **`override.mock.schemas`**, keyed by schema name, so the same property name can mock differently per schema:

```ts
override: {
  mock: {
    schemas: {
      Apple: { properties: { color: () => faker.helpers.arrayElement(['red', 'green']) } },
      Car:   { properties: { color: () => 'midnight black' } },
    },
  },
}
```

`getAppleMock()` now mocks `color` as a fruit color and `getCarMock()` as a car color, even though both declare `color: string`.

The keys under `properties` use the same matching rules as `override.mock.properties` — bare name, `/regex/`, or exact `#.path`.

**Precedence** (first match wins): `override.operations` → `override.tags` → `override.mock.schemas` → `override.mock.properties`.

## Generated output

Given two schemas that both have `color: string`:

```ts
// Apple-scoped override applied
export const getAppleMock = (overrideResponse: Partial<Apple> = {}): Apple => ({
  color: faker.helpers.arrayElement(['red', 'green']),
  ...overrideResponse,
});

// Car-scoped override applied
export const getCarMock = (overrideResponse: Partial<Car> = {}): Car => ({
  color: 'midnight black',
  ...overrideResponse,
});
```

With `schemas: true`, a referencing schema keeps delegating to the factory and the override rides along:

```ts
export const getBasketMock = (overrideResponse: Partial<Basket> = {}): Basket => ({
  apple: { ...getAppleMock() }, // getAppleMock() already bakes in the Apple-scoped override
  ...overrideResponse,
});
```

## Changes

- **`packages/core`** — add `schemas?: Record<string, { properties }>` to `OverrideMockOptions` (user-facing) and `MockOptions` (serialized form).
- **`packages/mock` (msw/mocks.ts)** — `getMockWithoutFunc` serializes function-valued schema overrides to IIFE strings, mirroring the existing `operations`/`tags` handling.
- **`packages/mock` (faker/getters/scalar.ts)** — `getMockScalar` resolves a schema-scoped tier keyed on the property's enclosing schema (`item.parentName`), between the tag and global-property tiers.
- **Docs** — new "Per-schema overrides" section in the Faker guide + an `override.mock.schemas` reference entry.

## Notes

- Schema-scoped overrides apply to a schema's **own** properties (matched by immediate `parentName`). No change to `hasOverrideTouchingSchema` was needed for `schemas: true`: each `get<Schema>Mock` factory is built with the same mock options, so delegation preserves the override (verified by test).
- Works with both the `faker` and `msw` generators.

## Tests

- Added unit tests in `scalar.test.ts` (override applied per schema; falls through when the schema name doesn't match; precedence vs operation/global).
- Added end-to-end tests in `index.test.ts` (different override per schema; preserved through factory delegation).
- Added serialization tests in `mocks.test.ts` (function → IIFE, value stringification, omitted when unset).
- Full suite: mock 293/293, core 2084/2084. Both packages typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for schema-scoped mock property overrides, allowing users to customize mock values for specific OpenAPI schemas with clearly defined precedence rules.

* **Documentation**
  * Added "Per-schema overrides" guide explaining scoping rules and behavior.
  * Expanded configuration reference with examples and override precedence order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->