### PR TITLE
test(vue-query): align enabled-reactivity samples with #3241 nullish semantics

### DIFF
--- a/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-pet-id.spec.ts
+++ b/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-pet-id.spec.ts
@@ -6,7 +6,9 @@ import Pet from './query-enabled-reactivity-pet-id.vue';
 
 describe('Query `enabled` reactivity', () => {
   it('works', async () => {
-    // this test is to ensure that we use unref() for `enabled`, like so: `enabled: computed(() => !!unref(petId))`
+    // this test ensures we use unref() inside the `enabled` guard, like so:
+    // `enabled: computed(() => unref(petId) !== null && unref(petId) !== undefined)`
+    // (nullish check, not truthiness — see issue #3241)
 
     const spy = vi.spyOn(customInstanceModule, 'customInstance');
 
@@ -16,7 +18,7 @@ describe('Query `enabled` reactivity', () => {
       },
     });
 
-    // make sure the query is disabled at first, because `petId` is falsy (empty string)
+    // make sure the query is disabled at first, because `petId` is undefined (nullish)
     expect(spy).not.toHaveBeenCalled();
 
     // after the timeout inside of component, `overridePetId` is set to `123` and the query is enabled

--- a/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-pet-id.vue
+++ b/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-pet-id.vue
@@ -14,7 +14,11 @@ const overridePetId = ref<string | undefined>();
 setTimeout(() => {
   overridePetId.value = '123';
 }, 100);
-const petId = computed(() => overridePetId.value ?? '');
+// Keep `petId` nullish (undefined) until it is set, so the generated
+// `enabled` guard (`unref(petId) !== null && unref(petId) !== undefined`)
+// disables the query initially. Falsy-but-valid values like '' no longer
+// disable the query — see issue #3241.
+const petId = computed(() => overridePetId.value);
 const petQuery = useShowPetById(petId);
 const pet = computed(() => unref(petQuery?.data));
 </script>

--- a/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-version.spec.ts
+++ b/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-version.spec.ts
@@ -7,6 +7,7 @@ import Pet from './query-enabled-reactivity-version.vue';
 describe('Query `enabled` reactivity', () => {
   it('works for multiple arguments (version and petId)', async () => {
     // this test is to ensure we don't use `unref(version && petId)` which is not correct, see https://github.com/orval-labs/orval/pull/944/files#r1347320242
+    // Each argument gets its own nullish guard — see issue #3241.
 
     const spy = vi.spyOn(customInstanceModule, 'customInstance');
 
@@ -16,10 +17,10 @@ describe('Query `enabled` reactivity', () => {
       },
     });
 
-    // make sure the query is disabled at first, because `petId` is falsy (empty string)
+    // make sure the query is disabled at first, because `version` is undefined (nullish)
     expect(spy).not.toHaveBeenCalled();
 
-    // after the timeout inside of component, `overridePetId` is set to `123` and the query is enabled
+    // after the timeout inside of component, `version` is set to `1` and the query is enabled
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-version.vue
+++ b/samples/vue-query/vue-query-basic/src/components/tests/query-enabled-reactivity-version.vue
@@ -10,11 +10,14 @@
 import { computed, ref, unref } from 'vue';
 import { useShowPetById } from '../../api/endpoints/petstoreFromFileSpecWithTransformer';
 
+const petId = ref('123');
+// Keep `version` nullish (undefined) until it is set, so the generated
+// per-argument `enabled` guard disables the query initially. Falsy-but-valid
+// values like 0 no longer disable the query — see issue #3241.
+const version = ref<number | undefined>(undefined);
 setTimeout(() => {
   version.value = 1;
 }, 100);
-const petId = ref('123');
-const version = ref(0);
 const petQuery = useShowPetById(petId, version);
 const pet = computed(() => unref(petQuery?.data));
 </script>


### PR DESCRIPTION
## Summary

The two `query-enabled-reactivity-*` sample tests in `samples/vue-query/vue-query-basic` were failing on `master`.

**Root cause:** PR #3630 (issue #3241) intentionally changed the generated vue-query `enabled` guard from a truthiness check to a nullish check:

```ts
// before #3241:  enabled: computed(() => !!unref(petId))
// after  #3241:  enabled: computed(() => unref(petId) !== null && unref(petId) !== undefined)
```

This was a deliberate fix so that falsy-but-valid path params like `0` and `''` no longer disable the query (locked in by `packages/query/src/query-options.test.ts`, which asserts *"falsy values like 0 do not disable the query"* and `not.toContain('!!')`).

The two sample tests, however, still seeded the "not ready" state with `''` (pet-id) and `0` (version). Under the new semantics those values *enable* the query immediately, so the query fired before the timeout and the initial `expect(spy).not.toHaveBeenCalled()` assertion failed.

## Changes

- `query-enabled-reactivity-pet-id.vue`: `petId` stays `undefined` (nullish) until set, instead of defaulting to `''`.
- `query-enabled-reactivity-version.vue`: `version` starts as `ref<number | undefined>(undefined)` instead of `ref(0)`.
- Both `.spec.ts`: refreshed the stale comments to describe the nullish guard (referencing #3241).

No generated code changes — only the hand-written test fixtures.

## Verification

- `vue-query-basic`: 16/16 tests pass (the 2 formerly-failing specs now green).
- Full `test:samples`: exits 0 (was 4 failures).
- `vp lint samples/vue-query/vue-query-basic`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query activation behavior in the Vue example so queries stay disabled until required values are actually set.
  * Better handling of empty or unset values to avoid accidentally enabling or disabling queries too early.
  * Clarified example behavior around when queries become active, making the demo more consistent and easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->