### PR TITLE
fix(core): recover schema-factory imports in single-mode mock writer

### DIFF
--- a/packages/core/src/writers/single-mode.test.ts
+++ b/packages/core/src/writers/single-mode.test.ts
@@ -208,6 +208,6 @@ describe('writeSingleMode — recovers schema-factory imports stripped by aggreg
       path.join(tmpDir, 'mocks', 'petstore.faker.ts'),
       'utf8',
     );
-    expect(mockContent).toContain('getPetMock');
+    expect(mockContent).toMatch(/import\s*\{[^}]*getPetMock[^}]*\}\s*from/);
   });
 });

--- a/packages/core/src/writers/single-mode.test.ts
+++ b/packages/core/src/writers/single-mode.test.ts
@@ -9,7 +9,12 @@ import {
   createSplitModeOutput,
   createSplitModeProps,
 } from '../test-utils/split-modes';
-import { type GeneratorDependency, OutputMockType, OutputMode } from '../types';
+import {
+  type GeneratorDependency,
+  type GeneratorSchema,
+  OutputMockType,
+  OutputMode,
+} from '../types';
 import { writeSingleMode } from './single-mode';
 
 describe('writeSingleMode — separated mocks import inline schemas from the target file', () => {
@@ -79,5 +84,130 @@ describe('writeSingleMode — separated mocks import inline schemas from the tar
         expect.objectContaining({ dependency: '../petstore.schemas' }),
       ]),
     );
+  });
+});
+
+// Regression coverage for https://github.com/orval-labs/orval/issues/3627
+//
+// On wide specs with `faker schemas: true`, shared-array import aggregation
+// can strip `get<X>Mock()` factory imports from `mockOutput.imports`.
+// split-mode, tags-mode, and split-tags-mode all recover these by scanning
+// the finalized mock implementation. single-mode was the only writer missing
+// this recovery — both the inline branch and the de-inlined branch.
+
+const petSchema: GeneratorSchema = {
+  name: 'Pet',
+  model: 'export type Pet = { id: number };',
+  imports: [],
+  schema: { type: 'object', properties: { id: { type: 'integer' } } },
+};
+
+const createRecoveryProps = (target: string) => {
+  const baseProps = createSplitModeProps(target);
+  return {
+    ...baseProps,
+    builder: {
+      ...baseProps.builder,
+      schemas: [petSchema],
+      operations: {
+        listPets: createSplitModeOperation({
+          mockOutputs: [
+            {
+              type: OutputMockType.FAKER,
+              implementation: {
+                function:
+                  'export const getPetResponseMock = () => ({ ...getPetMock() });',
+                handler: '',
+                handlerName: '',
+              },
+              imports: [],
+            },
+          ],
+        }),
+      },
+    } as typeof baseProps.builder,
+    output: createSplitModeOutput(target, {
+      mode: OutputMode.SINGLE,
+      indexFiles: true,
+      schemas: path.join(path.dirname(target), 'model'),
+      mock: {
+        indexMockFiles: false,
+        generators: [{ type: OutputMockType.FAKER, schemas: true }],
+      },
+    }),
+  };
+};
+
+describe('writeSingleMode — recovers schema-factory imports stripped by aggregation (inline mocks)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orval-single-mode-'));
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpDir);
+  });
+
+  it('recovers getPetMock() missing from mockOutput.imports', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const importsMockCalls: Array<{ imports: readonly GeneratorDependency[] }> =
+      [];
+    const props = createRecoveryProps(target);
+
+    props.builder.importsMock = ({
+      imports,
+    }: {
+      imports: readonly GeneratorDependency[];
+    }) => {
+      importsMockCalls.push({ imports });
+      return '';
+    };
+
+    await writeSingleMode({ ...props, needSchema: false });
+
+    expect(importsMockCalls.length).toBeGreaterThan(0);
+    const allExportNames = importsMockCalls.flatMap((call) =>
+      call.imports.flatMap((dep) => dep.exports.map((entry) => entry.name)),
+    );
+    expect(allExportNames).toContain('getPetMock');
+  });
+});
+
+describe('writeSingleMode — recovers schema-factory imports stripped by aggregation (de-inlined mocks)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orval-single-mode-'));
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpDir);
+  });
+
+  it('recovers getPetMock() in the generated .faker.ts file', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const props = createRecoveryProps(target);
+
+    props.output.mock.path = path.join(tmpDir, 'mocks');
+    props.builder.importsMock = ({
+      imports,
+    }: {
+      imports: readonly GeneratorDependency[];
+    }) =>
+      imports
+        .map(
+          ({ dependency, exports }: GeneratorDependency) =>
+            `import { ${exports.map((entry) => entry.name).join(', ')} } from '${dependency}';`,
+        )
+        .join('\n');
+
+    await writeSingleMode({ ...props, needSchema: false });
+
+    const mockContent = await fs.readFile(
+      path.join(tmpDir, 'mocks', 'petstore.faker.ts'),
+      'utf8',
+    );
+    expect(mockContent).toContain('getPetMock');
   });
 });

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -20,6 +20,10 @@ import {
   filterLocalStrictMockTypeImports,
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
+import {
+  collectRecoveredSchemaFactoryImports,
+  mergeGeneratorImports,
+} from './mock-imports';
 import { collapseInlineMockOutputs } from './mock-outputs';
 import {
   getMockDir,
@@ -175,8 +179,29 @@ export async function writeSingleMode({
           output,
           mockOutput,
         );
+        const finalizedMockImplementation = builder.finalizeMockImplementation
+          ? builder.finalizeMockImplementation(
+              mockOutput.implementation,
+              finalizeMockOptions,
+            )
+          : mockOutput.implementation;
+        const usesSchemaFactories =
+          !!entry &&
+          !isFunction(entry) &&
+          entry.type === OutputMockType.FAKER &&
+          entry.schemas === true;
+        const recoveredSchemaFactoryImports =
+          usesSchemaFactories && output.schemas
+            ? collectRecoveredSchemaFactoryImports(
+                finalizedMockImplementation,
+                builder.schemas.filter((s) => s.schema).map((s) => s.name),
+              )
+            : [];
         const filteredMockImports = filterLocalStrictMockTypeImports(
-          mockOutput.imports.filter(
+          mergeGeneratorImports(
+            mockOutput.imports,
+            recoveredSchemaFactoryImports,
+          ).filter(
             (impMock) =>
               !normalizedImports.some(
                 (imp) =>
@@ -198,7 +223,7 @@ export async function writeSingleMode({
               '.',
             );
         data += builder.importsMock({
-          implementation: mockOutput.implementation,
+          implementation: finalizedMockImplementation,
           imports: importsMockForBuilder,
           projectName,
           hasSchemaDir: !!output.schemas,
@@ -303,26 +328,56 @@ export async function writeSingleMode({
           schemaCustomImportPath ??
           resolveMockSchemasPath(mockFilePath, schemasTarget);
 
+        const finalizeMockOptions = getFinalizeMockImplementationOptions(
+          output,
+          mockOutput,
+        );
+
+        const finalizedMockImplementation = builder.finalizeMockImplementation
+          ? builder.finalizeMockImplementation(
+              mockOutput.implementation,
+              finalizeMockOptions,
+            )
+          : mockOutput.implementation;
+
+        const usesSchemaFactories =
+          !isFunction(rawEntry) &&
+          rawEntry.type === OutputMockType.FAKER &&
+          rawEntry.schemas === true;
+        const recoveredSchemaFactoryImports =
+          usesSchemaFactories && output.schemas
+            ? collectRecoveredSchemaFactoryImports(
+                finalizedMockImplementation,
+                builder.schemas.filter((s) => s.schema).map((s) => s.name),
+              )
+            : [];
+
         const importsMockForBuilder =
           schemasPath || mockDir !== dirname
             ? generateImportsForBuilder(
                 output,
-                mockOutput.imports,
+                filterLocalStrictMockTypeImports(
+                  mergeGeneratorImports(
+                    mockOutput.imports,
+                    recoveredSchemaFactoryImports,
+                  ),
+                  finalizeMockOptions.strictSchemaTypeNames,
+                ),
                 mockRelativeSchemasPath,
               )
             : generateImportsForBuilder(
                 output,
-                mockOutput.imports.filter((imp) => !!imp.importPath),
+                filterLocalStrictMockTypeImports(
+                  mergeGeneratorImports(
+                    mockOutput.imports,
+                    recoveredSchemaFactoryImports,
+                  ),
+                  finalizeMockOptions.strictSchemaTypeNames,
+                ).filter((imp) => !!imp.importPath),
                 '.',
               );
 
         let mockData = header;
-        const finalizedMockImplementation = builder.finalizeMockImplementation
-          ? builder.finalizeMockImplementation(
-              mockOutput.implementation,
-              getFinalizeMockImplementationOptions(output, mockOutput),
-            )
-          : mockOutput.implementation;
         mockData += builder.importsMock({
           implementation: finalizedMockImplementation,
           imports: importsMockForBuilder,


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Summary

`single-mode.ts` was the only writer missing the `collectRecoveredSchemaFactoryImports` + `mergeGeneratorImports` recovery pattern that `split-mode`, `tags-mode`, and `split-tags-mode` all use (#3607, `66af3e25b`). On wide specs with `faker schemas: true`, shared-array import aggregation can strip `get<X>Mock()` factory imports from `mockOutput.imports`, producing uncompilable single-mode mock output.

## Changes

Both mock branches in `single-mode.ts` are updated:

**Inline branch** (`!shouldDeinlineMocks`):
- Added per-mockOutput `finalizedMockImplementation` computation, `usesSchemaFactories` check, and `collectRecoveredSchemaFactoryImports` + `mergeGeneratorImports` before `filterLocalStrictMockTypeImports`
- Passes the finalized implementation to `builder.importsMock` instead of raw `mockOutput.implementation` (matches the other three writers; required for the recovery scan to see `as PetMock` casts added during finalization)

**De-inlined branch** (`shouldDeinlineMocks`):
- Reordered so `finalizedMockImplementation` is computed *before* `importsMockForBuilder` (was computed after, making recovery impossible)
- Added the same recovery + merge + `filterLocalStrictMockTypeImports` pipeline

## Tests

Two regression tests in `single-mode.test.ts`:
- Inline branch: verifies `getPetMock` appears in `builder.importsMock` imports when missing from `mockOutput.imports`
- De-inlined branch: verifies the written `.faker.ts` file contains `getPetMock`

Closes #3627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-mode mock generation for Faker-based schemas to retain/recover required schema factory imports, even when imports are reorganized.
  * Applied mock finalization consistently across both inline mocks and separate generated mock files to ensure outputs remain complete and accurate.
* **Tests**
  * Added regression coverage for single-mode mock generation to confirm recovered imports are present in both inline and de-inlined mock outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->