### PR TITLE
fix(zod): emit hoisted sub-models for recursive reusable schemas

### DIFF
--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -616,6 +616,70 @@ describe('writeZodSchemas with generateReusableSchemas', () => {
 
     await fs.remove(root);
   });
+
+  it('emits the implicit sub-model an inline nested object hoists in a recursive schema', async () => {
+    // A recursive schema (self-loop via `next`) takes the explicit
+    // `zod.ZodType<T>` path, whose TS body is hand-written from
+    // `resolveValue().value`. That body references the implicit sub-model
+    // `resolveValue` mints for the inline `meta` object (`ActionMeta`), which
+    // arrives in `resolved.schemas`. Pre-fix the writer dropped
+    // `resolved.schemas`, so the body named a type that was never declared
+    // (TS2552 in single-file output, TS2305 in split). The acyclic path never
+    // hits this: it derives its type via `zod.input<typeof X>`.
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-reuse-sub-'));
+    const schemasPath = path.join(root, 'schemas');
+
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            Action: {
+              type: 'object',
+              properties: {
+                next: { $ref: '#/components/schemas/Action' },
+                meta: {
+                  type: 'object',
+                  properties: { label: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        { name: 'Action', schema: { $ref: '#/components/schemas/Action' } },
+      ],
+    } satisfies Parameters<typeof writeZodSchemas>[0];
+
+    const options = createOutputOptions();
+    options.override.zod.generateReusableSchemas = true;
+
+    await writeZodSchemas(builder, schemasPath, '.ts', '', options);
+
+    const actionContent = await fs.readFile(
+      path.join(schemasPath, 'Action.ts'),
+      'utf8',
+    );
+
+    // The recursive path is taken (so the hand-written body is in play) and
+    // references the hoisted sub-model.
+    expect(actionContent).toContain(
+      'export const Action: zod.ZodType<Action> = ',
+    );
+    expect(actionContent).toMatch(/meta\??: ActionMeta/);
+    // The sub-model is declared locally in the same file — not a dangling
+    // reference, not a cross-file import, and no sibling file is written for
+    // it (it isn't a component).
+    expect(actionContent).toContain('export type ActionMeta = ');
+    expect(actionContent).not.toMatch(/from '\.\/ActionMeta'/);
+    expect(await fs.pathExists(path.join(schemasPath, 'ActionMeta.ts'))).toBe(
+      false,
+    );
+    expect(actionContent).not.toContain('__REF_');
+
+    await fs.remove(root);
+  });
 });
 
 describe('buildSiblingImports', () => {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -311,7 +311,16 @@ function renderReusableSchemaEntry(
     // emitted here or the body references undeclared names (TS2552). The
     // acyclic branch never hits this — it derives its type via
     // `zod.input<typeof X>`, so it never names them.
-    const subModels = resolved?.schemas ?? [];
+    // Dedupe by name: `resolveValue` can surface the same sub-model twice
+    // (e.g. an allOf/oneOf branch re-resolving a shared inline shape), and two
+    // `export type X` for one name is a TS2300 duplicate-identifier error. The
+    // model writer dedupes the same way (group-by-name in writers/schemas.ts).
+    const seenSubModels = new Set<string>();
+    const subModels = (resolved?.schemas ?? []).filter((s) => {
+      if (seenSubModels.has(s.name)) return false;
+      seenSubModels.add(s.name);
+      return true;
+    });
     const subModelBlock = subModels.length
       ? `${subModels.map((s) => s.model.trimEnd()).join('\n')}\n\n`
       : '';

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -304,6 +304,19 @@ function renderReusableSchemaEntry(
       ? resolveValue({ schema, name: entry.name, context })
       : undefined;
     const typeBody = resolved ? resolved.value : 'unknown';
+    // The recursive type body is hand-written from `resolved.value`, which
+    // references the implicit sub-models `resolveValue` generates for inline
+    // enums and nested objects (e.g. `<Name>Type`, `<Name>Target`,
+    // `<Name><NestedProp>`). Those live in `resolved.schemas` and MUST be
+    // emitted here or the body references undeclared names (TS2552). The
+    // acyclic branch never hits this — it derives its type via
+    // `zod.input<typeof X>`, so it never names them.
+    const subModels = resolved?.schemas ?? [];
+    const subModelBlock = subModels.length
+      ? `${subModels.map((s) => s.model.trimEnd()).join('\n')}\n\n`
+      : '';
+    // Sub-models are declared locally above, so they're never imports.
+    const localNames = new Set(subModels.map((s) => s.name));
     // Dedupe by local binding name (`alias ?? name`). When `resolveValue`
     // surfaces the same component twice — e.g. once aliased, once not —
     // collapsing on the binding key keeps both the file's import list and the
@@ -311,7 +324,9 @@ function renderReusableSchemaEntry(
     const seen = new Set<string>();
     const extraImports: ExtraImport[] = [];
     for (const imp of resolved?.imports ?? []) {
-      if (!imp.name || imp.name === entry.name) continue;
+      if (!imp.name || imp.name === entry.name || localNames.has(imp.name)) {
+        continue;
+      }
       const bindingKey = imp.alias ?? imp.name;
       if (seen.has(bindingKey)) continue;
       seen.add(bindingKey);
@@ -323,7 +338,7 @@ function renderReusableSchemaEntry(
 
     return {
       content:
-        `${consts}export type ${entry.name} = ${typeBody};\n\n` +
+        `${consts}${subModelBlock}export type ${entry.name} = ${typeBody};\n\n` +
         `export const ${entry.name}: zod.ZodType<${entry.name}> = ${entry.zod};\n\n` +
         `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`,
       extraImports,


### PR DESCRIPTION
Closes #3651

## Problem

With `client: "zod"` + `override.zod.generateReusableSchemas: true`, a recursive component schema (one in a `$ref` cycle, pinned to `const X: zod.ZodType<X>`) generates a hand-written TS type body that references the implicit sub-models orval mints for that schema's inline enums and nested objects — but those sub-model declarations are never emitted, so the output doesn't compile (`TS2304`/`TS2552` in single-file, `TS2305` in split).

The recursive branch of `renderReusableSchemaEntry` builds the type body from `resolveValue().value` and consumes `.imports`, but drops `.schemas` — which is exactly where the hoisted sub-models (`<Name>Meta`, `<Name>Kind`, …) live. The acyclic branch never hits this because it derives its type via `zod.input<typeof X>` and never names them.

## Fix

Emit `resolved.schemas` alongside the recursive type body, and exclude those now-local names from the import list so split-mode doesn't import a sibling that's declared in the same file.

## Tests

Added a regression case in `write-zod-specs.test.ts`: a self-recursive schema with an inline nested object asserts the hoisted `ActionMeta` sub-model is declared locally (not a dangling reference, not a cross-file import, no sibling file). Fails before the change, passes after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Zod output for recursive schemas that include nested inline objects by hoisting the related sub-type into the same generated file.
  * Avoided emitting unnecessary companion files and removed leftover placeholder sentinels from the generated output.
* **Tests**
  * Added a regression test covering recursive schema generation where an inline nested `meta` object is correctly deduped and declared locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->