### PR TITLE
feat(core): support package mutator paths

### DIFF
--- a/packages/core/src/generators/mutator.test.ts
+++ b/packages/core/src/generators/mutator.test.ts
@@ -1,0 +1,101 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { generateMutator } from './mutator';
+
+describe('generateMutator', () => {
+  it('inspects ESM-only package mutators from the workspace', async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-mutator-'));
+
+    try {
+      const output = path.join(workspace, 'generated', 'client.ts');
+      const packageDir = path.join(
+        workspace,
+        'node_modules',
+        '@acme',
+        'esm-mutator',
+      );
+
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        path.join(packageDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/esm-mutator',
+          type: 'module',
+          exports: {
+            './fetch': {
+              import: './fetch.js',
+            },
+          },
+        }),
+      );
+      await writeFile(
+        path.join(packageDir, 'fetch.js'),
+        'export const customInstance = (config, options) => config;\n',
+      );
+
+      const mutator = await generateMutator({
+        output,
+        name: 'client',
+        workspace,
+        mutator: {
+          path: '@acme/esm-mutator/fetch',
+          name: 'customInstance',
+          default: false,
+        },
+      });
+
+      expect(mutator).toMatchObject({
+        path: '@acme/esm-mutator/fetch',
+        name: 'customInstance',
+        hasSecondArg: true,
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('uses resolved package files for inspection and keeps the package import', async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-mutator-'));
+
+    try {
+      const output = path.join(workspace, 'generated', 'client.ts');
+      const packageDir = path.join(
+        workspace,
+        'node_modules',
+        '@acme',
+        'orval-mutator',
+      );
+      const resolvedPath = path.join(packageDir, 'fetch.js');
+
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        resolvedPath,
+        'export const customInstance = (config, options) => config;\n',
+      );
+
+      const mutator = await generateMutator({
+        output,
+        name: 'client',
+        workspace,
+        mutator: {
+          path: '@acme/orval-mutator/fetch',
+          resolvedPath,
+          name: 'customInstance',
+          default: false,
+        },
+      });
+
+      expect(mutator).toMatchObject({
+        path: '@acme/orval-mutator/fetch',
+        name: 'customInstance',
+        hasSecondArg: true,
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/generators/mutator.ts
+++ b/packages/core/src/generators/mutator.ts
@@ -14,6 +14,10 @@ const getImport = (
   mutator: NormalizedMutator,
   tsconfig?: Tsconfig,
 ) => {
+  if (mutator.resolvedPath || !path.isAbsolute(mutator.path)) {
+    return mutator.path;
+  }
+
   const outputFile = getFileInfo(output).path;
   // When the user hasn't pinned `mutator.extension`, derive it from the
   // mutator file's own extension so NodeNext / Node16 projects get the
@@ -47,6 +51,7 @@ export async function generateMutator({
   const isDefault = mutator.default;
   const importName = mutator.name ?? `${name}Mutator`;
   const importPath = mutator.path;
+  const inspectionPath = mutator.resolvedPath ?? mutator.path;
   const mutatorInfoName = isDefault ? 'default' : mutator.name;
 
   if (mutatorInfoName === undefined) {
@@ -58,16 +63,20 @@ export async function generateMutator({
     );
   }
 
-  let rawFile = await fs.readFile(importPath, 'utf8');
+  let rawFile = path.isAbsolute(inspectionPath)
+    ? await fs.readFile(inspectionPath, 'utf8')
+    : '';
   rawFile = removeComments(rawFile);
 
   const hasErrorType =
-    rawFile.includes('export type ErrorType') ||
-    rawFile.includes('export interface ErrorType');
+    !!rawFile &&
+    (rawFile.includes('export type ErrorType') ||
+      rawFile.includes('export interface ErrorType'));
 
   const hasBodyType =
-    rawFile.includes(`export type ${BODY_TYPE_NAME}`) ||
-    rawFile.includes(`export interface ${BODY_TYPE_NAME}`);
+    !!rawFile &&
+    (rawFile.includes(`export type ${BODY_TYPE_NAME}`) ||
+      rawFile.includes(`export interface ${BODY_TYPE_NAME}`));
 
   const errorTypeName = mutator.default
     ? `${pascal(name)}ErrorType`
@@ -77,7 +86,7 @@ export async function generateMutator({
     ? `${pascal(name)}${BODY_TYPE_NAME}`
     : BODY_TYPE_NAME;
 
-  const mutatorInfo = await getMutatorInfo(importPath, {
+  const mutatorInfo = await getMutatorInfo(inspectionPath, {
     root: workspace,
     namedExport: mutatorInfoName,
     alias: mutator.alias,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -186,6 +186,7 @@ export interface NormalizedOverrideOutput {
 
 export interface NormalizedMutator {
   path: string;
+  resolvedPath?: string;
   name?: string;
   default: boolean;
   alias?: Record<string, string>;

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -23,6 +23,311 @@ const createTempWorkspace = async () => {
 };
 
 describe('normalizeOptions', () => {
+  it('keeps package mutator specifiers as imports', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const packageDir = path.join(
+        workspace,
+        'node_modules',
+        '@acme',
+        'orval-mutator',
+      );
+      const validSpecPath = path.join(workspace, 'petstore.yaml');
+      const mutatorPath = path.join(packageDir, 'fetch.js');
+
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        path.join(packageDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/orval-mutator',
+          exports: {
+            './fetch': './fetch.js',
+          },
+        }),
+      );
+      await writeFile(
+        mutatorPath,
+        'export const customInstance = (config) => config;\n',
+      );
+      await writeFile(
+        validSpecPath,
+        'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+      );
+
+      const normalized = await normalizeOptions(
+        {
+          input: { target: validSpecPath },
+          output: {
+            target: './generated.ts',
+            override: {
+              mutator: {
+                path: '@acme/orval-mutator/fetch',
+                name: 'customInstance',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.mutator?.path).toBe(
+        '@acme/orval-mutator/fetch',
+      );
+      expect(normalized.output.override.mutator?.resolvedPath).toBe(
+        mutatorPath,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps ESM-only package mutator specifiers as imports', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const packageDir = path.join(
+        workspace,
+        'node_modules',
+        '@acme',
+        'esm-mutator',
+      );
+      const validSpecPath = path.join(workspace, 'petstore.yaml');
+
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        path.join(packageDir, 'package.json'),
+        JSON.stringify({
+          name: '@acme/esm-mutator',
+          type: 'module',
+          exports: {
+            './fetch': {
+              import: './fetch.js',
+            },
+          },
+        }),
+      );
+      await writeFile(
+        path.join(packageDir, 'fetch.js'),
+        'export const customInstance = (config) => config;\n',
+      );
+      await writeFile(
+        validSpecPath,
+        'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+      );
+
+      const normalized = await normalizeOptions(
+        {
+          input: { target: validSpecPath },
+          output: {
+            target: './generated.ts',
+            override: {
+              mutator: {
+                path: '@acme/esm-mutator/fetch',
+                name: 'customInstance',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.mutator).toMatchObject({
+        path: '@acme/esm-mutator/fetch',
+      });
+      expect(normalized.output.override.mutator?.resolvedPath).toBeUndefined();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps ESM-only unscoped package subpath mutator specifiers as imports', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const packageDir = path.join(workspace, 'node_modules', 'orval-mutator');
+      const validSpecPath = path.join(workspace, 'petstore.yaml');
+
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        path.join(packageDir, 'package.json'),
+        JSON.stringify({
+          name: 'orval-mutator',
+          type: 'module',
+          exports: {
+            './fetch': {
+              import: './fetch.js',
+            },
+          },
+        }),
+      );
+      await writeFile(
+        path.join(packageDir, 'fetch.js'),
+        'export const customInstance = (config) => config;\n',
+      );
+      await writeFile(
+        validSpecPath,
+        'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+      );
+
+      const normalized = await normalizeOptions(
+        {
+          input: { target: validSpecPath },
+          output: {
+            target: './generated.ts',
+            override: {
+              mutator: {
+                path: 'orval-mutator/fetch',
+                name: 'customInstance',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.mutator).toMatchObject({
+        path: 'orval-mutator/fetch',
+      });
+      expect(normalized.output.override.mutator?.resolvedPath).toBeUndefined();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps package subpath mutator specifiers when node_modules is above the workspace', async () => {
+    const repoRoot = await createTempWorkspace();
+
+    try {
+      const workspace = path.join(repoRoot, 'apps', 'api');
+      const packageDir = path.join(repoRoot, 'node_modules', 'orval-mutator');
+      const validSpecPath = path.join(workspace, 'petstore.yaml');
+
+      await mkdir(packageDir, { recursive: true });
+      await mkdir(workspace, { recursive: true });
+      await writeFile(
+        path.join(packageDir, 'package.json'),
+        JSON.stringify({
+          name: 'orval-mutator',
+          type: 'module',
+          exports: {
+            './fetch': {
+              import: './fetch.js',
+            },
+          },
+        }),
+      );
+      await writeFile(
+        path.join(packageDir, 'fetch.js'),
+        'export const customInstance = (config) => config;\n',
+      );
+      await writeFile(
+        validSpecPath,
+        'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+      );
+
+      const normalized = await normalizeOptions(
+        {
+          input: { target: validSpecPath },
+          output: {
+            workspace,
+            target: './generated.ts',
+            override: {
+              mutator: {
+                path: 'orval-mutator/fetch',
+                name: 'customInstance',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.mutator).toMatchObject({
+        path: 'orval-mutator/fetch',
+      });
+      expect(normalized.output.override.mutator?.resolvedPath).toBeUndefined();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps exact root-level local mutator files as local paths', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const validSpecPath = path.join(workspace, 'petstore.yaml');
+      const mutatorPath = path.join(workspace, 'mutator.ts');
+
+      await writeFile(
+        validSpecPath,
+        'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+      );
+      await writeFile(
+        mutatorPath,
+        'export const customInstance = (config) => config;\n',
+      );
+
+      const normalized = await normalizeOptions(
+        {
+          input: { target: validSpecPath },
+          output: {
+            target: './generated.ts',
+            override: {
+              mutator: {
+                path: 'mutator.ts',
+                name: 'customInstance',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.mutator).toMatchObject({
+        path: mutatorPath,
+      });
+      expect(normalized.output.override.mutator?.resolvedPath).toBeUndefined();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps unresolved non-relative mutator paths as local workspace paths', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const validSpecPath = path.join(workspace, 'petstore.yaml');
+      await writeFile(
+        validSpecPath,
+        'openapi: 3.1.0\ninfo:\n  title: Test\n  version: 1.0.0\npaths: {}\n',
+      );
+
+      const normalized = await normalizeOptions(
+        {
+          input: { target: validSpecPath },
+          output: {
+            target: './generated.ts',
+            override: {
+              mutator: {
+                path: 'src/mutator',
+                name: 'customInstance',
+              },
+            },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.override.mutator).toMatchObject({
+        path: path.join(workspace, 'src', 'mutator'),
+      });
+      expect(normalized.output.override.mutator?.resolvedPath).toBeUndefined();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('resolves the first existing input target from an input target array', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { access } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import nodePath from 'node:path';
 import { styleText } from 'node:util';
 
@@ -175,6 +177,66 @@ function validatePackageSpecifier(
     throw new Error(
       `\`${fieldName}\` must be a package specifier (e.g. '@acme/models'), not an absolute path. Received: "${value}"`,
     );
+  }
+}
+
+function looksLikePackageSpecifier(value: string): boolean {
+  return (
+    !!value &&
+    value.trim() === value &&
+    !value.startsWith('.') &&
+    !nodePath.isAbsolute(value) &&
+    !/^[A-Za-z]:[\\/]/.test(value) &&
+    !value.startsWith('\\\\')
+  );
+}
+
+function resolvePackageSpecifier(
+  workspace: string,
+  value: string,
+): string | undefined {
+  try {
+    return createRequire(nodePath.join(workspace, 'package.json')).resolve(
+      value,
+    );
+  } catch {
+    return;
+  }
+}
+
+function isPackageSpecifierCandidate(
+  workspace: string,
+  value: string,
+): boolean {
+  if (!looksLikePackageSpecifier(value)) {
+    return false;
+  }
+
+  if (existsSync(nodePath.resolve(workspace, value))) {
+    return false;
+  }
+
+  if (value.startsWith('@')) {
+    return true;
+  }
+
+  const [packageName] = value.split('/');
+
+  if (!value.includes('/')) {
+    return true;
+  }
+
+  for (let dir = workspace; ; ) {
+    if (existsSync(nodePath.join(dir, 'node_modules', packageName))) {
+      return true;
+    }
+
+    const parent = nodePath.dirname(dir);
+    if (parent === dir) {
+      return false;
+    }
+
+    dir = parent;
   }
 }
 
@@ -771,8 +833,15 @@ function normalizeMutator(
       throw new Error(styleText('red', `Mutator requires a path.`));
     }
 
+    const resolvedPath = looksLikePackageSpecifier(m.path)
+      ? resolvePackageSpecifier(workspace, m.path)
+      : undefined;
+    const isPackageSpecifier =
+      !!resolvedPath || isPackageSpecifierCandidate(workspace, m.path);
+
     return {
-      path: nodePath.resolve(workspace, m.path),
+      path: isPackageSpecifier ? m.path : nodePath.resolve(workspace, m.path),
+      ...(resolvedPath ? { resolvedPath } : {}),
       name: m.name,
       default: m.default ?? !m.name,
       alias: m.alias,
@@ -782,8 +851,15 @@ function normalizeMutator(
   }
 
   if (isString(mutator)) {
+    const resolvedPath = looksLikePackageSpecifier(mutator)
+      ? resolvePackageSpecifier(workspace, mutator)
+      : undefined;
+    const isPackageSpecifier =
+      !!resolvedPath || isPackageSpecifierCandidate(workspace, mutator);
+
     return {
-      path: nodePath.resolve(workspace, mutator),
+      path: isPackageSpecifier ? mutator : nodePath.resolve(workspace, mutator),
+      ...(resolvedPath ? { resolvedPath } : {}),
       default: true,
     };
   }


### PR DESCRIPTION
## Summary

Adds support for package import specifiers in mutator paths, including scoped packages and package subpaths.

The configured package specifier is preserved in generated imports, while Orval keeps a separate resolved path when one is available for mutator inspection.

This keeps existing local file mutator behavior intact and covers ESM-only package subpaths such as `orval-mutator/fetch`.

Closes #3366.

## Tests

- `bunx vitest run packages/orval/src/utils/options.test.ts -t "package mutator|non-relative mutator|unscoped package"`
- `bunx vitest run packages/core/src/generators/mutator.test.ts`
- `bun run build`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- `bun run test`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mutator `path` normalization now supports keeping package specifiers or resolving them to filesystem paths when possible, including export subpaths.
* **Bug Fixes**
  * Mutator inspection more reliably resolves ESM/package-export targets while preserving the configured mutator path.
* **Tests**
  * Added/expanded test coverage for package-specifier resolution, `resolvedPath` behavior, and ESM export scenarios using temporary workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->