### PR TITLE
feat(docker): add official CLI image and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,46 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            ORVAL_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ghcr.io/orval-labs/orval:${{ steps.version.outputs.version }}
+            ghcr.io/orval-labs/orval:latest

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Extract version
         id: version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine
+
+ARG ORVAL_VERSION=latest
+
+RUN npm install -g "orval@${ORVAL_VERSION}"
+
+ENV NODE_PATH=/usr/local/lib/node_modules
+
+WORKDIR /app
+
+ENTRYPOINT ["orval"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,16 @@ FROM node:22-alpine
 
 ARG ORVAL_VERSION=latest
 
-RUN npm install -g "orval@${ORVAL_VERSION}"
+RUN npm install -g "orval@${ORVAL_VERSION}" \
+  && addgroup -g 1001 -S orval \
+  && adduser -S orval -u 1001 -G orval
 
 ENV NODE_PATH=/usr/local/lib/node_modules
 
 WORKDIR /app
+
+RUN chown -R orval:orval /app
+
+USER orval
 
 ENTRYPOINT ["orval"]

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
 MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
 
 # Windows CMD
+cd /d "C:\path\to\your-project"
 docker run --rm -v "%cd%:/app" -w /app ghcr.io/orval-labs/orval
 
 # Windows PowerShell
+cd "C:\path\to\your-project"
 docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval
 ```
 
@@ -91,9 +93,11 @@ docker run --rm --add-host=host.docker.internal:host-gateway -v "$(pwd):/app" -w
 MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
 
 # Windows CMD
-docker run --rm -v "%cd%:/app" -w /app -e ORVAL_SWAGGER_URL=https://host.docker.internal:7142/swagger/v1/swagger.json -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+cd /d "C:\path\to\your-project"
+docker run --rm -v "%cd%:/app" -w /app -e "ORVAL_SWAGGER_URL=https://host.docker.internal:7142/swagger/v1/swagger.json" -e "NODE_TLS_REJECT_UNAUTHORIZED=0" ghcr.io/orval-labs/orval --config ./orval.config.ts
 
 # Windows PowerShell
+cd "C:\path\to\your-project"
 docker run --rm -v "${PWD}:/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,47 @@ You can find some samples below:
 
 Try Orval out for yourself using our [Playground](https://orval.dev/playground) application!
 
+### Docker
+
+Orval 8+ requires Node.js 22.18 or newer. Projects on an older Node LTS can run code generation with the official Docker image.
+
+**Basic usage**
+
+```bash
+# macOS / Linux
+docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
+
+# Windows Git Bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
+
+# Windows CMD
+docker run --rm -v "%cd%:/app" -w /app ghcr.io/orval-labs/orval
+
+# Windows PowerShell
+docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval
+```
+
+**Local API (`localhost` → `host.docker.internal`)**
+
+```bash
+# macOS / Linux
+docker run --rm -v "$(pwd):/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+
+# Linux (native Docker)
+docker run --rm --add-host=host.docker.internal:host-gateway -v "$(pwd):/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+
+# Windows Git Bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+
+# Windows CMD
+docker run --rm -v "%cd%:/app" -w /app -e ORVAL_SWAGGER_URL=https://host.docker.internal:7142/swagger/v1/swagger.json -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+
+# Windows PowerShell
+docker run --rm -v "${PWD}:/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+
+Replace `ghcr.io/orval-labs/orval` with `orval:local` when testing locally before the official image is published. See the [installation docs](https://orval.dev/docs/installation#docker) for details.
+
 ## A note about AI
 
 First of all, we do not reject the use of AI agents outright. That said, please do not submit AI-generated output in a PR without reviewing it yourself. Every change must have a clear intent and purpose — do not submit changes you cannot explain in your own words. Making the effort to understand orval's codebase, TypeScript, and API clients beforehand, and reviewing what AI produces, is the contributor's responsibility, not the reviewer's. Finally, we will continue to welcome new contributors and actively support you through review and iteration.

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -30,6 +30,139 @@ pnpm add orval -D
   </Tab>
 </Tabs>
 
+## Docker
+
+Orval 8+ requires Node.js 22.18 or newer. If your project targets an older Node LTS version, you can run code generation with the official Docker image instead of installing Orval locally.
+
+`/app` is only a path inside the container. Your project does not need an `app` folder — mount your project root to any container path and set `-w` to match.
+
+### Basic usage
+
+<Tabs items={["macOS / Linux", "Windows (Git Bash)", "Windows (CMD)", "Windows (PowerShell)"]}>
+  <Tab value="macOS / Linux">
+```bash
+docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+  <Tab value="Windows (Git Bash)">
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+  <Tab value="Windows (CMD)">
+```bat
+docker run --rm -v "%cd%:/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+  <Tab value="Windows (PowerShell)">
+```powershell
+docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+</Tabs>
+
+Pin a specific release with a version tag (for example `8.19.0`):
+
+```bash
+ghcr.io/orval-labs/orval:8.19.0
+```
+
+### With a config file
+
+<Tabs items={["macOS / Linux", "Windows (Git Bash)", "Windows (CMD)", "Windows (PowerShell)"]}>
+  <Tab value="macOS / Linux">
+```bash
+docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (Git Bash)">
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (CMD)">
+```bat
+docker run --rm -v "%cd%:/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (PowerShell)">
+```powershell
+docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+</Tabs>
+
+On Windows Git Bash, prefix commands with `MSYS_NO_PATHCONV=1` so Docker receives `/app` instead of `C:/Program Files/Git/app`.
+
+### Fetching OpenAPI from localhost
+
+Inside a container, `localhost` refers to the container itself, not your machine. If your `orval.config.ts` fetches a spec from a local API (for example `https://localhost:7142/swagger/v1/swagger.json`), replace `localhost` with `host.docker.internal` and pass the URL via an environment variable.
+
+| Host OS | Use instead of `localhost` |
+| --- | --- |
+| Windows / macOS (Docker Desktop) | `host.docker.internal` |
+| Linux (Docker Desktop) | `host.docker.internal` |
+| Linux (native Docker) | `host.docker.internal` with `--add-host=host.docker.internal:host-gateway` |
+
+Read the URL from an environment variable in your config:
+
+```ts
+const inputTarget =
+  process.env.ORVAL_SWAGGER_URL ?? 'https://localhost:7142/swagger/v1/swagger.json';
+```
+
+Set `NODE_TLS_REJECT_UNAUTHORIZED=0` only when your local API uses a self-signed certificate. For CI or offline builds, point Orval at a committed file such as `./src/swagger.json` instead.
+
+Replace `ghcr.io/orval-labs/orval` with `orval:local` when testing with a locally built image before the official image is published.
+
+<Tabs items={["macOS / Linux", "Linux (native Docker)", "Windows (Git Bash)", "Windows (CMD)", "Windows (PowerShell)"]}>
+  <Tab value="macOS / Linux">
+```bash
+docker run --rm \
+  -v "$(pwd):/app" \
+  -w /app \
+  -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  ghcr.io/orval-labs/orval \
+  --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Linux (native Docker)">
+```bash
+docker run --rm --add-host=host.docker.internal:host-gateway \
+  -v "$(pwd):/app" \
+  -w /app \
+  -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  ghcr.io/orval-labs/orval \
+  --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (Git Bash)">
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm \
+  -v "$(pwd):/app" \
+  -w /app \
+  -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  ghcr.io/orval-labs/orval \
+  --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (CMD)">
+```bat
+cd /d "C:\path\to\your-project"
+docker run --rm -v "%cd%:/app" -w /app -e ORVAL_SWAGGER_URL=https://host.docker.internal:7142/swagger/v1/swagger.json -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (PowerShell)">
+```powershell
+cd "C:\path\to\your-project"
+docker run --rm -v "${PWD}:/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+</Tabs>
+
 ## Global Installation
 
 You can also install Orval globally:

--- a/docs/content/docs/zh/installation.mdx
+++ b/docs/content/docs/zh/installation.mdx
@@ -30,6 +30,139 @@ pnpm add orval -D
   </Tab>
 </Tabs>
 
+## Docker
+
+Orval 8+ 需要 Node.js 22.18 或更高版本。如果项目仍使用较旧的 Node LTS，可以用官方 Docker 镜像运行代码生成，而无需在本地安装 Orval。
+
+`/app` 只是容器内的路径。你的项目**不需要** `app` 文件夹 — 把项目根目录挂载到任意容器路径，并让 `-w` 与挂载目标一致即可。
+
+### 基本用法
+
+<Tabs items={["macOS / Linux", "Windows (Git Bash)", "Windows (CMD)", "Windows (PowerShell)"]}>
+  <Tab value="macOS / Linux">
+```bash
+docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+  <Tab value="Windows (Git Bash)">
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+  <Tab value="Windows (CMD)">
+```bat
+docker run --rm -v "%cd%:/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+  <Tab value="Windows (PowerShell)">
+```powershell
+docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval
+```
+  </Tab>
+</Tabs>
+
+通过版本标签固定到特定发布版本（例如 `8.19.0`）：
+
+```bash
+ghcr.io/orval-labs/orval:8.19.0
+```
+
+### 使用配置文件
+
+<Tabs items={["macOS / Linux", "Windows (Git Bash)", "Windows (CMD)", "Windows (PowerShell)"]}>
+  <Tab value="macOS / Linux">
+```bash
+docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (Git Bash)">
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd):/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (CMD)">
+```bat
+docker run --rm -v "%cd%:/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (PowerShell)">
+```powershell
+docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+</Tabs>
+
+在 Windows Git Bash 中，请在命令前加上 `MSYS_NO_PATHCONV=1`，否则 Docker 会把 `/app` 错误解析为 `C:/Program Files/Git/app`。
+
+### 从 localhost 获取 OpenAPI
+
+容器内的 `localhost` 指向容器自身，而不是你的电脑。如果 `orval.config.ts` 从本地 API 拉取 spec（例如 `https://localhost:7142/swagger/v1/swagger.json`），请把 `localhost` 替换为 `host.docker.internal`，并通过环境变量传入 URL。
+
+| 宿主机系统 | 替代 `localhost` 的地址 |
+| --- | --- |
+| Windows / macOS（Docker Desktop） | `host.docker.internal` |
+| Linux（Docker Desktop） | `host.docker.internal` |
+| Linux（原生 Docker） | `host.docker.internal`，并添加 `--add-host=host.docker.internal:host-gateway` |
+
+在配置中通过环境变量读取 URL：
+
+```ts
+const inputTarget =
+  process.env.ORVAL_SWAGGER_URL ?? 'https://localhost:7142/swagger/v1/swagger.json';
+```
+
+仅在本地 API 使用自签名证书时设置 `NODE_TLS_REJECT_UNAUTHORIZED=0`。在 CI 或离线构建中，应改为使用已提交的文件，例如 `./src/swagger.json`。
+
+在官方镜像发布前本地测试时，可将 `ghcr.io/orval-labs/orval` 替换为 `orval:local`。
+
+<Tabs items={["macOS / Linux", "Linux（原生 Docker）", "Windows (Git Bash)", "Windows (CMD)", "Windows (PowerShell)"]}>
+  <Tab value="macOS / Linux">
+```bash
+docker run --rm \
+  -v "$(pwd):/app" \
+  -w /app \
+  -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  ghcr.io/orval-labs/orval \
+  --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Linux（原生 Docker）">
+```bash
+docker run --rm --add-host=host.docker.internal:host-gateway \
+  -v "$(pwd):/app" \
+  -w /app \
+  -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  ghcr.io/orval-labs/orval \
+  --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (Git Bash)">
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm \
+  -v "$(pwd):/app" \
+  -w /app \
+  -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  ghcr.io/orval-labs/orval \
+  --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (CMD)">
+```bat
+cd /d "C:\path\to\your-project"
+docker run --rm -v "%cd%:/app" -w /app -e ORVAL_SWAGGER_URL=https://host.docker.internal:7142/swagger/v1/swagger.json -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+  <Tab value="Windows (PowerShell)">
+```powershell
+cd "C:\path\to\your-project"
+docker run --rm -v "${PWD}:/app" -w /app -e ORVAL_SWAGGER_URL="https://host.docker.internal:7142/swagger/v1/swagger.json" -e NODE_TLS_REJECT_UNAUTHORIZED=0 ghcr.io/orval-labs/orval --config ./orval.config.ts
+```
+  </Tab>
+</Tabs>
+
 ## 全局安装
 
 也可以把 Orval 安装为全局命令：


### PR DESCRIPTION
Ship a minimal Node 22 Alpine image so projects on older Node LTS versions can run Orval at build time without upgrading Node. Includes multi-arch GHCR publishing on release tags and installation docs for Windows, macOS, and Linux including localhost via host.docker.internal.
#3510 resolving this issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker-based usage to run Orval without a local installation, including an official container entrypoint and non-root execution.
  * Automatically publish multi-architecture Docker images (versioned `v*` tags plus `latest`) to a container registry.

* **Documentation**
  * Added a “Docker” section to the README with basic commands and local API guidance for macOS/Linux/Windows.
  * Expanded installation docs (including Chinese) with Docker workflows, config-file usage, localhost-to-host access tips, and self-signed certificate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->