### PR TITLE
fix(core): restore Required<Pick> for allOf required fields lost after normalizeAllOfSchema

### DIFF
--- a/packages/core/src/getters/combine.test.ts
+++ b/packages/core/src/getters/combine.test.ts
@@ -35,7 +35,7 @@ const context = {
         Base: {
           type: 'object',
           properties: {
-            name: { type: 'string' },
+            baseProp: { type: 'string' },
           },
         },
         Status: {
@@ -74,7 +74,7 @@ describe('combineSchemas (allOf required handling)', () => {
   it('keeps Required<Pick> when parent requires properties defined only in subschemas', () => {
     const schema: OpenApiSchemaObject = {
       type: 'object',
-      required: ['name'],
+      required: ['baseProp'],
       allOf: [{ $ref: '#/components/schemas/Base' }],
     };
 
@@ -266,6 +266,32 @@ describe('combineSchemas (allOf required handling)', () => {
 
       expect(result.isEnum).toBe(false);
     });
+  });
+
+  it('promotes required field to Required<Pick> when field is defined on $ref parent but required in inline allOf sibling', () => {
+    const schema: OpenApiSchemaObject = {
+      allOf: [
+        { $ref: '#/components/schemas/Base' },
+        {
+          type: 'object',
+          required: ['baseProp'],
+          properties: {
+            url: { type: 'string' },
+          },
+        },
+      ],
+    };
+
+    const result = combineSchemas({
+      schema,
+      name: 'Child',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('Required<Pick');
+    expect(result.value).toContain("'baseProp'");
   });
 
   it('normalizes inline object in allOf to match parent object form', () => {

--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -283,7 +283,7 @@ export function combineSchemas({
     ),
     requiredProperties:
       separator === 'allOf'
-        ? ((schema.required as string[] | undefined) ?? [])
+        ? ((normalizedSchema.required as string[] | undefined) ?? [])
         : [],
   };
   for (const subSchema of items) {

--- a/tests/__snapshots__/mock/issue-2465/model/retrievedUser.ts
+++ b/tests/__snapshots__/mock/issue-2465/model/retrievedUser.ts
@@ -11,4 +11,11 @@ import type { BaseUser } from './baseUser';
  */
 export type RetrievedUser = BaseUser & {
   id: string;
-};
+} & Required<
+    Pick<
+      BaseUser & {
+        id: string;
+      },
+      'lastName' | 'email'
+    >
+  >;


### PR DESCRIPTION
## Problem

When an `allOf` schema has an inline member that lists a property in `required`, but that property is only defined on a sibling `$ref` member (not on the inline member itself), the generated TypeScript type emits the property as **optional** instead of required.

**Failing spec pattern:**

```yaml
Parent:
  type: object
  properties:
    baseProp:
      type: string    # optional on Parent

Child:
  allOf:
    - $ref: '#/components/schemas/Parent'
    - type: object
      required:
        - baseProp    # required here, but property is defined on Parent above
      properties:
        url:
          type: string
```

**Expected output:**

```typescript
export type Child = Parent & {
  url?: string;
} & Required<Pick<Parent & { url?: string }, 'baseProp'>>;
```

**Actual output (broken):**

```typescript
export type Child = Parent & {
  url?: string;
};
// baseProp silently optional — Required<Pick> missing
```

This is a regression introduced by `normalizeAllOfSchema` (the fix for #2458). The behavior worked correctly before v8.18.0 via `Required<Pick<...>>`, which was confirmed present in generated output through v8.17.x.

Related: #1670 (original fix via PR #1819), #2458 (the normalizeAllOfSchema PR that introduced the regression).

## Root cause

`combineSchemas` in `packages/core/src/getters/combine.ts` calls `normalizeAllOfSchema`, which merges inline allOf members that pass `isMergeableAllOfObject` into the parent schema — including promoting their `required` array onto `normalizedSchema.required`.

The `requiredProperties` initializer immediately after reads:

```typescript
requiredProperties:
  separator === 'allOf'
    ? ((schema.required as string[] | undefined) ?? [])
    : [],
```

`schema` is the original input — its `required` is `undefined` in this pattern (the `required` lived inside the inline allOf member). `normalizedSchema.required` is `['baseProp']`. Because the code reads `schema.required` instead of `normalizedSchema.required`, `requiredProperties` initializes to `[]` and the `Required<Pick<...>>` guard never fires.

## Fix

One-line change in `combineSchemas` (line 286):

```diff
- ? ((schema.required as string[] | undefined) ?? [])
+ ? ((normalizedSchema.required as string[] | undefined) ?? [])
```

`normalizedSchema` is already in scope from the `normalizeAllOfSchema` call above. This makes `requiredProperties` include fields promoted from merged inline members so the `Required<Pick<...>>` guard fires correctly.

## Tests

Added a regression test to `packages/core/src/getters/combine.test.ts` covering the exact failing pattern: a `$ref` parent with an optional property, and an inline allOf sibling that marks that same property as `required`. The test confirmed RED before the fix and GREEN after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of required fields when combining schemas, so fields defined through referenced or inline schema combinations are now recognized more consistently.
  * Fixed an issue where required-property tracking could become out of sync after schema normalization.

* **Tests**
  * Updated coverage for combined schema behavior and added a new case for required fields across referenced and inline schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->