### PR TITLE
fix(core): http verbs include OPTIONS

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1222,15 +1222,23 @@ export type HooksOptions<T = HookCommand | NormalizedHookCommand> = Partial<
 
 export type NormalizedHookOptions = HooksOptions<NormalizedHookCommand>;
 
-export type Verbs = 'post' | 'put' | 'get' | 'patch' | 'delete' | 'head';
+export type Verbs =
+  | 'get'
+  | 'put'
+  | 'post'
+  | 'delete'
+  | 'options'
+  | 'head'
+  | 'patch';
 
 export const Verbs = {
-  POST: 'post' as Verbs,
-  PUT: 'put' as Verbs,
   GET: 'get' as Verbs,
-  PATCH: 'patch' as Verbs,
+  PUT: 'put' as Verbs,
+  POST: 'post' as Verbs,
   DELETE: 'delete' as Verbs,
+  OPTIONS: 'options' as Verbs,
   HEAD: 'head' as Verbs,
+  PATCH: 'patch' as Verbs,
 };
 
 /**

--- a/packages/core/src/utils/assertion.test.ts
+++ b/packages/core/src/utils/assertion.test.ts
@@ -71,7 +71,18 @@ describe('assertion testing', () => {
 
   it('checks for verbs', () => {
     expect(isVerb(Verbs.GET)).toBeTruthy();
-    expect(isVerb('options')).toBeFalsy();
+    expect(isVerb(Verbs.PUT)).toBeTruthy();
+    expect(isVerb(Verbs.POST)).toBeTruthy();
+    expect(isVerb(Verbs.DELETE)).toBeTruthy();
+    expect(isVerb(Verbs.OPTIONS)).toBeTruthy();
+    expect(isVerb(Verbs.HEAD)).toBeTruthy();
+    expect(isVerb(Verbs.PATCH)).toBeTruthy();
+
+    // Negative checks: casing and unknown verbs
+    expect(isVerb('unknown')).toBeFalsy();
+    expect(isVerb('')).toBeFalsy();
+    expect(isVerb(undefined as unknown as string)).toBeFalsy();
+    expect(isVerb(null as unknown as string)).toBeFalsy();
   });
 
   it('checks for valid URLs', () => {


### PR DESCRIPTION
Fix #3660 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `OPTIONS` HTTP verb in the public verb list.
  * Updated the exported verb values so all common HTTP methods are explicitly included and consistent.
* **Tests**
  * Expanded verb validation tests to cover additional standard methods and strengthen rejection of invalid, empty, or case-mismatched inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->