### PR TITLE
@orval/mcp: no Zod input schema generated for application/x-www-form-urlencoded request bodies (#3664)

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1935,9 +1935,10 @@ const parseBodyAndResponse = ({
     | OpenApiResponseObject
     | OpenApiRequestBodyObject;
 
-  // Only handle JSON, form-data and form-urlencoded; other content types (e.g.,
-  // application/octet-stream) are skipped - unclear if this is correct behavior
-  // for root-level binary/text bodies.
+  // Only handle JSON, form-data and form-urlencoded here; other content types
+  // (e.g., application/octet-stream) are skipped - unclear if this is correct
+  // behavior for root-level binary/text bodies. The one exception is text/plain
+  // responses, which are handled separately below (as a plain string schema).
   const contentEntries = Object.entries(resolvedRef.content ?? {});
 
   const jsonContent = contentEntries.find(

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -235,6 +235,15 @@ export const generateZodValidationSchemaDefinition = (
      */
     useReusableSchemas?: boolean;
     /**
+     * When true, suppress File/Blob coercion for binary string fields anywhere
+     * in the tree (`format: binary` / `contentMediaType: application/octet-stream`),
+     * keeping them as `string`. Set for `application/x-www-form-urlencoded` bodies,
+     * which serialize via URLSearchParams (string-only) — mirrors core's
+     * `formDataContext.urlEncoded` handling in getScalar (#1624). Threaded into
+     * every recursive call so nested/array/composed fields are covered too.
+     */
+    urlEncoded?: boolean;
+    /**
      * When true (and `isZodV4`), the top-level (named component) schema emits a
      * `.meta({ id, description?, deprecated? })` instead of `.describe(...)`.
      * Set ONLY for top-level component-schema generation — recursive calls omit
@@ -389,6 +398,7 @@ export const generateZodValidationSchemaDefinition = (
   }
 
   const useReusableSchemas = rules?.useReusableSchemas ?? false;
+  const urlEncoded = rules?.urlEncoded ?? false;
   const consts: string[] = [];
   const constNameRegistry = rules?.constNameRegistry ?? {};
   const constsCounter = isNumber(constNameRegistry[name])
@@ -517,6 +527,7 @@ export const generateZodValidationSchemaDefinition = (
           additionalRequired: allOfRequired,
           constNameRegistry,
           useReusableSchemas,
+          urlEncoded,
         },
       ),
     );
@@ -544,6 +555,7 @@ export const generateZodValidationSchemaDefinition = (
             additionalRequired: allOfRequired,
             constNameRegistry,
             useReusableSchemas,
+            urlEncoded,
           },
         );
 
@@ -654,6 +666,7 @@ export const generateZodValidationSchemaDefinition = (
             required: true,
             constNameRegistry,
             useReusableSchemas,
+            urlEncoded,
           },
         ),
       ),
@@ -713,6 +726,7 @@ export const generateZodValidationSchemaDefinition = (
                     required: true,
                     constNameRegistry,
                     useReusableSchemas,
+                    urlEncoded,
                   },
                 ),
               ),
@@ -735,6 +749,7 @@ export const generateZodValidationSchemaDefinition = (
                     required: true,
                     constNameRegistry,
                     useReusableSchemas,
+                    urlEncoded,
                   },
                 ),
               ]);
@@ -756,6 +771,7 @@ export const generateZodValidationSchemaDefinition = (
               required: true,
               constNameRegistry,
               useReusableSchemas,
+              urlEncoded,
             },
           ),
         ]);
@@ -774,7 +790,9 @@ export const generateZodValidationSchemaDefinition = (
           break;
         }
 
-        if (schema.format === 'binary') {
+        // url-encoded bodies serialize via URLSearchParams (strings only), so
+        // binary fields stay `string` rather than becoming `File` (#3664).
+        if (!urlEncoded && schema.format === 'binary') {
           functions.push(['instanceof', 'File']);
           break;
         }
@@ -784,6 +802,7 @@ export const generateZodValidationSchemaDefinition = (
         // Swagger 2.0 / OAS 3.0 → OAS 3.1. Treat it the same as
         // format: binary so $ref-based model types generate File validation.
         if (
+          !urlEncoded &&
           schema.contentMediaType === 'application/octet-stream' &&
           !schema.contentEncoding
         ) {
@@ -919,6 +938,7 @@ export const generateZodValidationSchemaDefinition = (
                       required: requiredKeys.has(key),
                       constNameRegistry,
                       useReusableSchemas,
+                      urlEncoded,
                     },
                   ),
               }))
@@ -959,6 +979,7 @@ export const generateZodValidationSchemaDefinition = (
                 required: true,
                 constNameRegistry,
                 useReusableSchemas,
+                urlEncoded,
               },
             ),
           ]);
@@ -1838,62 +1859,6 @@ export const generateFormDataZodSchema = (
  * handling in getScalar, which skips Blob coercion for such bodies (#1624).
  * Otherwise it behaves exactly like plain-object generation.
  */
-export const generateFormUrlEncodedZodSchema = (
-  schema: OpenApiSchemaObject,
-  context: ContextSpec,
-  name: string,
-  strict: boolean,
-  isZodV4: boolean,
-  useReusableSchemas?: boolean,
-): ZodValidationSchemaDefinition => {
-  // Force any top-level field that generateZodValidationSchemaDefinition would
-  // otherwise turn into `File` (format: binary or contentMediaType:
-  // application/octet-stream) back to `string`.
-  const propertyOverrides: Record<string, ZodValidationSchemaDefinition> = {};
-
-  if (schema.properties) {
-    for (const key of Object.keys(schema.properties)) {
-      const propSchema = schema.properties[key];
-      const resolved = propSchema
-        ? dereference(
-            propSchema as OpenApiSchemaObject | OpenApiReferenceObject,
-            context,
-          )
-        : undefined;
-
-      const isBinaryLike =
-        resolved?.type === 'string' &&
-        (resolved.format === 'binary' ||
-          (resolved.contentMediaType === 'application/octet-stream' &&
-            !resolved.contentEncoding));
-
-      if (isBinaryLike) {
-        const stringFunctions: [string, unknown][] = [['string', undefined]];
-        if (!schema.required?.includes(key)) {
-          stringFunctions.push(['optional', undefined]);
-        }
-        propertyOverrides[key] = { functions: stringFunctions, consts: [] };
-      }
-    }
-  }
-
-  return generateZodValidationSchemaDefinition(
-    schema,
-    context,
-    name,
-    strict,
-    isZodV4,
-    {
-      required: true,
-      propertyOverrides:
-        Object.keys(propertyOverrides).length > 0
-          ? propertyOverrides
-          : undefined,
-      useReusableSchemas,
-    },
-  );
-};
-
 const parseBodyAndResponse = ({
   data,
   context,
@@ -1970,6 +1935,10 @@ const parseBodyAndResponse = ({
           ] as const)
         : [undefined, undefined];
 
+  // url-encoded bodies serialize via URLSearchParams (strings only); the flag is
+  // threaded into the generator so binary fields stay `string` at any depth.
+  const isFormUrlEncoded = contentType === 'application/x-www-form-urlencoded';
+
   const schema = mediaType?.schema;
 
   if (!schema) {
@@ -2031,6 +2000,7 @@ const parseBodyAndResponse = ({
         {
           required: true,
           useReusableSchemas,
+          urlEncoded: isFormUrlEncoded,
         },
       ),
       isArray: true,
@@ -2054,7 +2024,6 @@ const parseBodyAndResponse = ({
         : resolvedJsonSchema;
 
   const isFormData = contentType === 'multipart/form-data';
-  const isFormUrlEncoded = contentType === 'application/x-www-form-urlencoded';
 
   return {
     input: isFormData
@@ -2067,23 +2036,14 @@ const parseBodyAndResponse = ({
           encoding,
           useReusableSchemas,
         )
-      : isFormUrlEncoded
-        ? generateFormUrlEncodedZodSchema(
-            effectiveSchema,
-            context,
-            name,
-            strict,
-            isZodV4,
-            useReusableSchemas,
-          )
-        : generateZodValidationSchemaDefinition(
-            effectiveSchema,
-            context,
-            name,
-            strict,
-            isZodV4,
-            { required: true, useReusableSchemas },
-          ),
+      : generateZodValidationSchemaDefinition(
+          effectiveSchema,
+          context,
+          name,
+          strict,
+          isZodV4,
+          { required: true, useReusableSchemas, urlEncoded: isFormUrlEncoded },
+        ),
     isArray: false,
   };
 };

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1870,9 +1870,9 @@ const parseBodyAndResponse = ({
     | OpenApiResponseObject
     | OpenApiRequestBodyObject;
 
-  // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
-  // Only handle JSON and form-data; other content types (e.g., application/octet-stream)
-  // are skipped - unclear if this is correct behavior for root-level binary/text bodies.
+  // Only handle JSON, form-data and form-urlencoded; other content types (e.g.,
+  // application/octet-stream) are skipped - unclear if this is correct behavior
+  // for root-level binary/text bodies.
   const contentEntries = Object.entries(resolvedRef.content ?? {});
 
   const jsonContent = contentEntries.find(
@@ -1888,11 +1888,21 @@ const parseBodyAndResponse = ({
   const formDataContent = contentEntries.find(
     isMediaType(String.raw`^multipart\/form-data$`),
   );
+  // form-urlencoded bodies are plain objects serialized via URLSearchParams, so
+  // they validate like JSON (no file fields) — emit a regular object schema.
+  const formUrlEncodedContent = contentEntries.find(
+    isMediaType(String.raw`^application\/x-www-form-urlencoded$`),
+  );
   const [contentType, mediaType] = jsonContent
     ? (['application/json', jsonContent[1]] as const)
     : formDataContent
       ? (['multipart/form-data', formDataContent[1]] as const)
-      : [undefined, undefined];
+      : formUrlEncodedContent
+        ? ([
+            'application/x-www-form-urlencoded',
+            formUrlEncodedContent[1],
+          ] as const)
+        : [undefined, undefined];
 
   const schema = mediaType?.schema;
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1829,6 +1829,71 @@ export const generateFormDataZodSchema = (
   );
 };
 
+/**
+ * Generate zod schema for an application/x-www-form-urlencoded request body.
+ *
+ * These bodies are serialized via URLSearchParams, whose values are always
+ * strings, so — unlike multipart/form-data — file/binary top-level fields must
+ * stay `string` rather than becoming `File`. This mirrors core's urlEncoded
+ * handling in getScalar, which skips Blob coercion for such bodies (#1624).
+ * Otherwise it behaves exactly like plain-object generation.
+ */
+export const generateFormUrlEncodedZodSchema = (
+  schema: OpenApiSchemaObject,
+  context: ContextSpec,
+  name: string,
+  strict: boolean,
+  isZodV4: boolean,
+  useReusableSchemas?: boolean,
+): ZodValidationSchemaDefinition => {
+  // Force any top-level field that generateZodValidationSchemaDefinition would
+  // otherwise turn into `File` (format: binary or contentMediaType:
+  // application/octet-stream) back to `string`.
+  const propertyOverrides: Record<string, ZodValidationSchemaDefinition> = {};
+
+  if (schema.properties) {
+    for (const key of Object.keys(schema.properties)) {
+      const propSchema = schema.properties[key];
+      const resolved = propSchema
+        ? dereference(
+            propSchema as OpenApiSchemaObject | OpenApiReferenceObject,
+            context,
+          )
+        : undefined;
+
+      const isBinaryLike =
+        resolved?.type === 'string' &&
+        (resolved.format === 'binary' ||
+          (resolved.contentMediaType === 'application/octet-stream' &&
+            !resolved.contentEncoding));
+
+      if (isBinaryLike) {
+        const stringFunctions: [string, unknown][] = [['string', undefined]];
+        if (!schema.required?.includes(key)) {
+          stringFunctions.push(['optional', undefined]);
+        }
+        propertyOverrides[key] = { functions: stringFunctions, consts: [] };
+      }
+    }
+  }
+
+  return generateZodValidationSchemaDefinition(
+    schema,
+    context,
+    name,
+    strict,
+    isZodV4,
+    {
+      required: true,
+      propertyOverrides:
+        Object.keys(propertyOverrides).length > 0
+          ? propertyOverrides
+          : undefined,
+      useReusableSchemas,
+    },
+  );
+};
+
 const parseBodyAndResponse = ({
   data,
   context,
@@ -1988,6 +2053,7 @@ const parseBodyAndResponse = ({
         : resolvedJsonSchema;
 
   const isFormData = contentType === 'multipart/form-data';
+  const isFormUrlEncoded = contentType === 'application/x-www-form-urlencoded';
 
   return {
     input: isFormData
@@ -2000,14 +2066,23 @@ const parseBodyAndResponse = ({
           encoding,
           useReusableSchemas,
         )
-      : generateZodValidationSchemaDefinition(
-          effectiveSchema,
-          context,
-          name,
-          strict,
-          isZodV4,
-          { required: true, useReusableSchemas },
-        ),
+      : isFormUrlEncoded
+        ? generateFormUrlEncodedZodSchema(
+            effectiveSchema,
+            context,
+            name,
+            strict,
+            isZodV4,
+            useReusableSchemas,
+          )
+        : generateZodValidationSchemaDefinition(
+            effectiveSchema,
+            context,
+            name,
+            strict,
+            isZodV4,
+            { required: true, useReusableSchemas },
+          ),
     isArray: false,
   };
 };

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -5736,6 +5736,100 @@ describe('generateFormData', () => {
   });
 });
 
+const formUrlEncodedSchema = {
+  pathRoute: '/token',
+  context: {
+    spec: {
+      paths: {
+        '/token': {
+          post: {
+            operationId: 'xyz',
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    required: ['grant_type'],
+                    properties: {
+                      grant_type: {
+                        type: 'string',
+                      },
+                      client_secret: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+} as unknown as GeneratorOptions;
+
+describe('generateFormUrlEncoded', () => {
+  // application/x-www-form-urlencoded bodies are plain objects (no file fields),
+  // so they get a regular object schema like JSON — see #3664, where the mcp
+  // client had no <Op>Body to register as the tool inputSchema.
+  it('generates request body schema for application/x-www-form-urlencoded', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/token',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: false,
+              body: true,
+              response: false,
+              query: false,
+              header: false,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      formUrlEncodedSchema,
+      testOutput,
+    );
+    expect(result.implementation).toBe(
+      'export const TestBody = zod.object({\n  "grant_type": zod.string(),\n  "client_secret": zod.string().optional()\n})\n\n',
+    );
+  });
+});
+
 const schemaWithRefProperty = {
   pathRoute: '/cats',
   context: {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -5829,6 +5829,77 @@ const formUrlEncodedBinarySchema = {
   },
 } as unknown as GeneratorOptions;
 
+const formUrlEncodedNestedBinarySchema = {
+  pathRoute: '/upload',
+  context: {
+    spec: {
+      paths: {
+        '/upload': {
+          post: {
+            operationId: 'xyz',
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    required: ['id'],
+                    properties: {
+                      id: {
+                        type: 'string',
+                      },
+                      // OAS 3.1 nullable union + the post-upgrade octet-stream
+                      // shape the @scalar upgrader produces from format: binary
+                      attachment: {
+                        type: ['string', 'null'],
+                        contentMediaType: 'application/octet-stream',
+                      },
+                      // array of binary strings
+                      files: {
+                        type: 'array',
+                        items: {
+                          type: 'string',
+                          format: 'binary',
+                        },
+                      },
+                      // binary nested inside allOf composition
+                      meta: {
+                        allOf: [
+                          {
+                            type: 'object',
+                            properties: {
+                              blob: {
+                                type: 'string',
+                                format: 'binary',
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+} as unknown as GeneratorOptions;
+
 describe('generateFormUrlEncoded', () => {
   // application/x-www-form-urlencoded bodies are plain objects (no file fields),
   // so they get a regular object schema like JSON — see #3664, where the mcp
@@ -5919,6 +5990,56 @@ describe('generateFormUrlEncoded', () => {
     expect(result.implementation).toBe(
       'export const TestBody = zod.object({\n  "name": zod.string(),\n  "attachment": zod.string().optional()\n})\n\n',
     );
+  });
+
+  // The URLSearchParams string contract must hold at ANY depth: nullable unions,
+  // array items, and allOf-composed fields all coerce binary → string, never
+  // File — matching the generated TS model (#3664 review).
+  it('coerces binary to string at any depth for application/x-www-form-urlencoded', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/upload',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: false,
+              body: true,
+              response: false,
+              query: false,
+              header: false,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      formUrlEncodedNestedBinarySchema,
+      testOutput,
+    );
+    expect(result.implementation).not.toContain('zod.instanceof(File)');
+    expect(result.implementation).toContain('"id": zod.string()');
+    expect(result.implementation).toContain(
+      '"attachment": zod.string().nullish()',
+    );
+    expect(result.implementation).toContain('zod.array(zod.string())');
+    expect(result.implementation).toContain('"blob": zod.string()');
   });
 });
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -5782,6 +5782,53 @@ const formUrlEncodedSchema = {
   },
 } as unknown as GeneratorOptions;
 
+const formUrlEncodedBinarySchema = {
+  pathRoute: '/upload',
+  context: {
+    spec: {
+      paths: {
+        '/upload': {
+          post: {
+            operationId: 'xyz',
+            requestBody: {
+              required: true,
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    required: ['name'],
+                    properties: {
+                      name: {
+                        type: 'string',
+                      },
+                      attachment: {
+                        type: 'string',
+                        format: 'binary',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+              },
+            },
+          },
+        },
+      },
+    },
+    output: {
+      override: {
+        zod: {
+          generateEachHttpStatus: false,
+        },
+      },
+    },
+  },
+} as unknown as GeneratorOptions;
+
 describe('generateFormUrlEncoded', () => {
   // application/x-www-form-urlencoded bodies are plain objects (no file fields),
   // so they get a regular object schema like JSON — see #3664, where the mcp
@@ -5826,6 +5873,51 @@ describe('generateFormUrlEncoded', () => {
     );
     expect(result.implementation).toBe(
       'export const TestBody = zod.object({\n  "grant_type": zod.string(),\n  "client_secret": zod.string().optional()\n})\n\n',
+    );
+  });
+
+  // URLSearchParams serializes every value to a string, so binary/file fields
+  // must stay zod.string() rather than zod.instanceof(File) (#3664 review).
+  it('keeps binary fields as string for application/x-www-form-urlencoded', async () => {
+    const result = await generateZod(
+      {
+        pathRoute: '/upload',
+        verb: 'post',
+        operationName: 'test',
+        override: {
+          zod: {
+            strict: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generate: {
+              param: false,
+              body: true,
+              response: false,
+              query: false,
+              header: false,
+            },
+            coerce: {
+              param: false,
+              body: false,
+              response: false,
+              query: false,
+              header: false,
+            },
+            generateEachHttpStatus: false,
+            dateTimeOptions: {},
+            timeOptions: {},
+          },
+        },
+      } as unknown as Parameters<typeof generateZod>[0],
+      formUrlEncodedBinarySchema,
+      testOutput,
+    );
+    expect(result.implementation).toBe(
+      'export const TestBody = zod.object({\n  "name": zod.string(),\n  "attachment": zod.string().optional()\n})\n\n',
     );
   });
 });


### PR DESCRIPTION
Closes #3664

<!-- michi:plan -->
- [x] T1 <!--m:u1ec--> Generate a Zod `<Op>Body` schema for `application/x-www-form-urlencoded` request bodies in the zod generator (treat as a plain object, like JSON)
- [x] T2 <!--m:tz2m--> Add a regression test covering form-urlencoded body schema generation
- [x] T3 <!--m:f3rm--> Keep binary/file fields as `string` for form-urlencoded bodies (URLSearchParams contract; review #3494850502) + regression test
- [x] T4 <!--m:c0py--> Clarify media-type selection comment to note the text/plain response exception (review #3494840918)
- [x] T5 <!--m:wf5x--> Rework url-encoded binary handling: thread an `urlEncoded` flag through the generator so binary→string holds at any depth (nullable unions, allOf/array/nested); drop the narrow helper; add recursion test (adversarial review)
<!-- /michi:plan -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for generating schemas from `application/x-www-form-urlencoded` request/response bodies.
* **Bug Fixes**
  * Improved URL-encoded schema generation so binary-formatted fields are emitted as plain string-based types (instead of file-upload style types).
  * More accurate required vs. optional field handling for URL-encoded inputs, including nested and composed schemas.
* **Tests**
  * Added expanded fixtures and coverage for URL-encoded schema generation, including deep “binary-like” field behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



