### PR TITLE
Adds pkg.pr.new to publish PR preview versions

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -53,3 +53,30 @@ jobs:
 
       - name: Verify generated code can build
         run: vp run -F orval-tests build
+
+  publish-preview:
+    needs: pr-checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 24
+          cache: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Build packages
+        run: vp run -w build:release
+
+      - name: Publish preview packages
+        run: bun run pkg-pr-new publish './packages/*' --commentWithSha --packageManager=bun

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-checks:
     runs-on: ${{ matrix.os }}
@@ -57,11 +61,16 @@ jobs:
   publish-preview:
     needs: pr-checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![NPM Downloads](https://img.shields.io/npm/dm/orval?color=purple)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Orval%20Guru-006BFF)](https://gurubase.io/g/orval)
+[![pkg.pr.new](https://pkg.pr.new/badge/orval-labs/orval)](https://pkg.pr.new/~/orval-labs/orval)
 
 <p align="center">
   <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@commitlint/config-conventional": "^21.0.1",
         "@socketsecurity/bun-security-scanner": "^1.1.2",
         "@types/node": "catalog:",
+        "pkg-pr-new": "^0.0.75",
         "rimraf": "catalog:",
         "typescript": "catalog:",
         "vite-plus": "catalog:",
@@ -3433,6 +3434,8 @@
     "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pkg-pr-new": ["pkg-pr-new@0.0.75", "", { "bin": { "pkg-pr-new": "bin/cli.js" } }, "sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@commitlint/config-conventional": "^21.0.1",
     "@socketsecurity/bun-security-scanner": "^1.1.2",
     "@types/node": "catalog:",
+    "pkg-pr-new": "^0.0.75",
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:",


### PR DESCRIPTION
This PR adds a new step on `pr-check` workflow that uses https://pkg.pr.new/ to publish a preview version of orval on each PR opened.

You still need to connect pkg.pr.new github app to this repo before merging this :)

Hopefully this helps trying out new changes without disrupting orval's release scheduled or complex beta release publish flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated preview publishing step for pull request builds, generating release packages after checks complete.
  * Added an npm badge linking to the npm preview site for the package.
* **Chores**
  * Added a development dependency to support preview package publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->