### PR TITLE
fix(core): support npm-aliased TypeScript versions

### DIFF
--- a/packages/core/src/utils/compare-version.test.ts
+++ b/packages/core/src/utils/compare-version.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions } from './compare-version';
+
+describe('compareVersions', () => {
+  it('compares npm alias version ranges', () => {
+    expect(compareVersions('npm:@typescript/typescript6@^6.0.0', '4.5.0')).toBe(
+      true,
+    );
+  });
+
+  it('compares npm alias exact versions', () => {
+    expect(compareVersions('npm:typescript@4.4.0', '4.5.0')).toBe(false);
+  });
+});

--- a/packages/core/src/utils/compare-version.ts
+++ b/packages/core/src/utils/compare-version.ts
@@ -1,22 +1,38 @@
 import { compare, type CompareOperator } from 'compare-versions';
 
+const getComparableVersion = (version: string) => {
+  const npmAliasVersion = version.match(/^npm:(?:@[^/]+\/)?[^@]+@(.+)$/)?.[1];
+
+  if (npmAliasVersion) {
+    return npmAliasVersion;
+  }
+
+  if (version.startsWith('npm:')) {
+    return 'latest';
+  }
+
+  return version;
+};
+
 export function compareVersions(
   firstVersion: string,
   secondVersions: string,
   operator: CompareOperator = '>=',
 ) {
-  if (firstVersion === 'latest' || firstVersion === '*') {
+  const comparableVersion = getComparableVersion(firstVersion);
+
+  if (comparableVersion === 'latest' || comparableVersion === '*') {
     return true;
   }
 
   // Handle workspace catalog references (pnpm/bun)
   // catalog: or catalog:name format - assume latest version
-  if (firstVersion.startsWith('catalog:')) {
+  if (comparableVersion.startsWith('catalog:')) {
     return true;
   }
 
   return compare(
-    firstVersion.replace(/(\s(.*))/, ''),
+    comparableVersion.replace(/(\s(.*))/, ''),
     secondVersions,
     operator,
   );

--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -9,12 +9,8 @@ import {
   OutputClient,
   type WriteSpecBuilder,
 } from '../types';
-import {
-  compareVersions,
-  getOperationTagKey,
-  isOperationInTagBucket,
-  pascal,
-} from '../utils';
+import { getOperationTagKey, isOperationInTagBucket, pascal } from '../utils';
+import { hasTypeScriptAwaitedType } from './typescript-version';
 
 /**
  * Ensures every operation has at least one tag by falling back to the
@@ -213,12 +209,7 @@ export function generateTargetForTags(
           .filter((operation) => isOperationInTagBucket(operation, tag))
           .map(({ operationName }) => operationName);
 
-        const typescriptVersion =
-          options.packageJson?.dependencies?.typescript ??
-          options.packageJson?.devDependencies?.typescript ??
-          '4.4.0';
-
-        const hasAwaitedType = compareVersions(typescriptVersion, '4.5.0');
+        const hasAwaitedType = hasTypeScriptAwaitedType(options.packageJson);
 
         const titles = builder.title({
           outputClient: options.client,

--- a/packages/core/src/writers/target.ts
+++ b/packages/core/src/writers/target.ts
@@ -7,7 +7,8 @@ import {
   OutputClient,
   type WriteSpecBuilder,
 } from '../types';
-import { compareVersions, pascal } from '../utils';
+import { pascal } from '../utils';
+import { hasTypeScriptAwaitedType } from './typescript-version';
 
 function emptyMockOutputFull(
   type: GeneratorMockOutputFull['type'],
@@ -127,12 +128,7 @@ export function generateTarget(
         isAngularClient ? mutator.hasThirdArg : mutator.hasSecondArg,
       );
 
-      const typescriptVersion =
-        options.packageJson?.dependencies?.typescript ??
-        options.packageJson?.devDependencies?.typescript ??
-        '4.4.0';
-
-      const hasAwaitedType = compareVersions(typescriptVersion, '4.5.0');
+      const hasAwaitedType = hasTypeScriptAwaitedType(options.packageJson);
 
       const header = builder.header({
         outputClient: options.client,

--- a/packages/core/src/writers/typescript-version.test.ts
+++ b/packages/core/src/writers/typescript-version.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasTypeScriptAwaitedType } from './typescript-version';
+
+describe('hasTypeScriptAwaitedType', () => {
+  it('prefers the resolved TypeScript version over package specifiers', () => {
+    expect(
+      hasTypeScriptAwaitedType({
+        devDependencies: {
+          typescript: '^4.0.0',
+        },
+        resolvedVersions: {
+          typescript: '6.0.3',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('supports npm-aliased TypeScript package specifiers', () => {
+    expect(
+      hasTypeScriptAwaitedType({
+        devDependencies: {
+          typescript: 'npm:@typescript/typescript6@^6.0.0',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the legacy fallback when no TypeScript version is detected', () => {
+    expect(hasTypeScriptAwaitedType()).toBe(false);
+  });
+});

--- a/packages/core/src/writers/typescript-version.ts
+++ b/packages/core/src/writers/typescript-version.ts
@@ -1,0 +1,15 @@
+import type { PackageJson } from '../types';
+import { compareVersions } from '../utils';
+
+const getTypeScriptVersion = (packageJson?: PackageJson): string => {
+  return (
+    packageJson?.resolvedVersions?.typescript ??
+    packageJson?.dependencies?.typescript ??
+    packageJson?.devDependencies?.typescript ??
+    packageJson?.peerDependencies?.typescript ??
+    '4.4.0'
+  );
+};
+
+export const hasTypeScriptAwaitedType = (packageJson?: PackageJson) =>
+  compareVersions(getTypeScriptVersion(packageJson), '4.5.0');


### PR DESCRIPTION

  Fixes #3331.

  This updates version detection so Orval can handle `package.json` entries such as:

  ```json
  {
    "devDependencies": {
      "typescript": "npm:@typescript/typescript6@^6.0.0"
    }
  }
```

  The awaited-type check now prefers the resolved installed TypeScript version when available, and compareVersions normalizes npm alias specifiers before passing them to compare-versions. That prevents
  generation from crashing with Invalid argument not valid semver.

  ## Verification

  I verified the bug still reproduces on master and does not reproduce on this branch using a minimal OpenAPI config with the npm-aliased TypeScript dependency.

  Flow repeated:

  1. master at 4a3e7fe74: reproduced Invalid argument not valid semver ('npm:@typescript/typescript6@^6.0.0' received).
  2. codex/issue-3331-typescript-alias: same repro generated successfully.
  3. master at 4a3e7fe74: reproduced the same semver failure again.
  4. codex/issue-3331-typescript-alias: same repro generated successfully again.

  Additional checks run:
```
  bunx vitest run packages/core/src/utils/compare-version.test.ts packages/core/src/writers/typescript-version.test.ts
  bun run build
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version comparison to properly interpret npm alias specifiers and related “latest/*” cases.
  * Refined TypeScript awaited-type detection used in header/footer generation to use a dedicated TypeScript version resolver.
* **Tests**
  * Added Vitest coverage for version comparison with npm aliases.
  * Added tests for awaited-type detection, including precedence rules, npm alias handling, and legacy fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->