### PR TITLE
docs(zod): correct stale JSDoc left on parseBodyAndResponse

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -2202,13 +2202,13 @@ export const generateFormDataZodSchema = (
 };
 
 /**
- * Generate zod schema for an application/x-www-form-urlencoded request body.
+ * Parse a request body or response into a zod validation schema definition.
  *
- * These bodies are serialized via URLSearchParams, whose values are always
- * strings, so — unlike multipart/form-data — file/binary top-level fields must
- * stay `string` rather than becoming `File`. This mirrors core's urlEncoded
- * handling in getScalar, which skips Blob coercion for such bodies (#1624).
- * Otherwise it behaves exactly like plain-object generation.
+ * Selects the relevant content type — JSON (and `+json` vendor types),
+ * `multipart/form-data`, or `application/x-www-form-urlencoded`, plus
+ * `text/plain` for responses — and generates the matching schema, handling
+ * array roots. The url-encoded string-contract rationale lives where the flag
+ * is derived (see `isFormUrlEncoded` below).
  */
 const parseBodyAndResponse = ({
   data,


### PR DESCRIPTION
Follow-up to #3665 — addresses review comment https://github.com/orval-labs/orval/pull/3665#discussion_r3504751238 (thanks @wadakatu).

When #3665 removed the `generateFormUrlEncodedZodSchema` helper, its JSDoc was left orphaned directly above `parseBodyAndResponse`, so it documented a function that no longer exists and made the general body/response parser read as url-encoded-specific.

Reworded it to describe `parseBodyAndResponse` accurately — JSON (and `+json` vendor types), `multipart/form-data`, and `application/x-www-form-urlencoded` request bodies, plus `text/plain` responses, with array-root handling. The url-encoded string-contract rationale already lives where the flag is derived (`isFormUrlEncoded`), per the reviewer's suggestion.

Docs-only; no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal API documentation to give a clearer, higher-level explanation of request and response parsing behavior.
  * Clarified supported content types, including JSON variants, form data, URL-encoded data, and plain text responses.
  * Added more context around schema generation and array handling for parsed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->