### PR TITLE
test: cover optional security alternatives

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -87,6 +87,36 @@ const TEST_SPEC: OpenApiDocument = {
   },
 };
 
+const OPTIONAL_SECURITY_SPEC: OpenApiDocument = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Optional Security API',
+    version: '1.0.0',
+  },
+  paths: {
+    '/public-or-authenticated': {
+      get: {
+        operationId: 'publicOrAuthenticated',
+        security: [{}, { ApiKeyAuth: [] }],
+        responses: {
+          '200': {
+            description: 'Success',
+          },
+        },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      ApiKeyAuth: {
+        type: 'apiKey',
+        name: 'x-api-key',
+        in: 'header',
+      },
+    },
+  },
+};
+
 const SSE_ITEM_SCHEMA_SPEC: OpenApiDocument = {
   openapi: '3.1.0',
   info: {
@@ -147,6 +177,24 @@ const SSE_ITEM_SCHEMA_SPEC: OpenApiDocument = {
 };
 
 describe('validation', () => {
+  it('should accept optional security alternatives during import', async () => {
+    const workspace = 'test';
+    const normalizedOptions = await normalizeOptions(
+      {
+        output: { target: '' },
+        input: { target: OPTIONAL_SECURITY_SPEC },
+      },
+      workspace,
+      {},
+    );
+
+    const spec = await importSpecs(workspace, normalizedOptions);
+    expect(spec.verbOptions).toHaveProperty('publicOrAuthenticated');
+    expect(
+      spec.spec.paths?.['/public-or-authenticated']?.get?.security,
+    ).toEqual([{}, { ApiKeyAuth: [] }]);
+  });
+
   it('should throw on non-standard fields like itemSchema by default', async () => {
     const workspace = 'test';
     const normalizedOptions = await normalizeOptions(


### PR DESCRIPTION
Summary
- Adds an import-spec regression test for an OpenAPI security array that allows anonymous access or API key auth.
- Verifies Orval keeps importing the operation when the security alternatives include an empty requirement.

Validation
- git diff whitespace check passed.
- Full workspace test command not run because this shallow clone has no installed workspace dependencies or vp binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API routes that allow either public access or authenticated access.
* **Tests**
  * Added validation coverage for importing OpenAPI specs with optional security, ensuring operations preserve the expected combined security behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->