### PR TITLE
fix(ci): trigger docker image publish on release

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,9 +1,9 @@
 name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: ["Publish Release"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -12,6 +12,10 @@ permissions:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.conclusion == 'success' && 
+      startsWith(github.event.workflow_run.head_branch, 'release/v')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -20,7 +24,28 @@ jobs:
 
       - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          VERSION="${HEAD_BRANCH#release/v}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not extract a valid version from branch '$HEAD_BRANCH'" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for npm package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for i in $(seq 1 30); do
+            if npm view "orval@${VERSION}" version > /dev/null 2>&1; then
+              exit 0
+            fi
+            echo "orval@${VERSION} not yet on npm, retrying..."
+            sleep 10
+          done
+          echo "Package never appeared on npm" && exit 1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -44,5 +69,5 @@ jobs:
           build-args: |
             ORVAL_VERSION=${{ steps.version.outputs.version }}
           tags: |
-            ghcr.io/orval-labs/orval:${{ steps.version.outputs.version }}
-            ghcr.io/orval-labs/orval:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}:latest

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -61,10 +61,10 @@ docker run --rm -v "${PWD}:/app" -w /app ghcr.io/orval-labs/orval
   </Tab>
 </Tabs>
 
-Pin a specific release with a version tag (for example `8.19.0`):
+Pin a specific release with a version tag (for example `8.21.0`):
 
 ```bash
-ghcr.io/orval-labs/orval:8.19.0
+ghcr.io/orval-labs/orval:8.21.0
 ```
 
 ### With a config file


### PR DESCRIPTION
Addresses an issue in which the Docker publish workflow wasn't running on new releases. Switched to using the `workflow_run` trigger on "Publish Release", updated `if:` condition, and bumped the pinned version number in the docs to the first version expected to have a docker image: `8.21.0`.

Fixes #3686 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker images are now published via the completed release workflow, using versioned and `latest` tags that reflect the current repository.
  * Image versioning is derived from the corresponding release branch.
* **Bug Fixes**
  * Added safeguards so publishing runs only after a successful release workflow and the matching version is available (with a short wait window).
* **Documentation**
  * Updated the Docker installation instructions to pin the image to version `8.21.0` (from `8.19.0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->