### PR TITLE
fix: escape spec-controlled strings in generated template literals and object keys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "esutils": "2.0.3",
         "fs-extra": "^11.3.2",
         "jiti": "^2.6.1",
+        "jsesc": "^3.0.0",
         "remeda": "^2.33.6",
         "tinyglobby": "^0.2.16",
         "typedoc": "^0.28.19",
@@ -61,6 +62,7 @@
         "@types/debug": "^4.1.12",
         "@types/esutils": "^2.0.2",
         "@types/fs-extra": "^11.0.4",
+        "@types/jsesc": "^3.0.3",
         "rimraf": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
@@ -243,9 +245,11 @@
       "version": "8.20.0",
       "dependencies": {
         "@orval/core": "workspace:*",
+        "jsesc": "^3.0.0",
         "remeda": "^2.33.6",
       },
       "devDependencies": {
+        "@types/jsesc": "^3.0.3",
         "rimraf": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
@@ -1982,6 +1986,8 @@
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
+    "@types/jsesc": ["@types/jsesc@3.0.3", "", {}, "sha512-YZZ9ZOAiiSVC6KApWd/fTCDTdTOOMiRU4Lq3/VSmXNPse8IvCVOn5kYRRLu900Ub1lTPurVZFI5unEqLDJR7wg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "esutils": "2.0.3",
     "fs-extra": "^11.3.2",
     "jiti": "^2.6.1",
+    "jsesc": "^3.0.0",
     "remeda": "^2.33.6",
     "tinyglobby": "^0.2.16",
     "typedoc": "^0.28.19"
@@ -40,6 +41,7 @@
     "@types/debug": "^4.1.12",
     "@types/esutils": "^2.0.2",
     "@types/fs-extra": "^11.0.4",
+    "@types/jsesc": "^3.0.3",
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/core/src/getters/keys.test.ts
+++ b/packages/core/src/getters/keys.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getKey } from './keys';
+
+describe('getKey', () => {
+  it('escapes single quote in key', () => {
+    const result = getKey("x':[require('fs').execSync('id'),");
+    expect(result).toMatch(/^'(.*)'$/);
+    const inner = result.slice(1, -1);
+    expect(inner).not.toMatch(/(?<!\\)'/);
+  });
+
+  it('escapes backslash in key', () => {
+    const result = getKey('a\\b');
+    expect(result).toBe(String.raw`'a\\b'`);
+  });
+});

--- a/packages/core/src/getters/keys.ts
+++ b/packages/core/src/getters/keys.ts
@@ -1,5 +1,9 @@
 import { keyword } from 'esutils';
 
+import { jsStringLiteralEscape } from '../utils';
+
 export function getKey(key: string) {
-  return keyword.isIdentifierNameES5(key) ? key : `'${key}'`;
+  return keyword.isIdentifierNameES5(key)
+    ? key
+    : `'${jsStringLiteralEscape(key)}'`;
 }

--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -202,6 +202,70 @@ describe('getFullRoute getter', () => {
   }
 });
 
+describe('getFullRoute — GHSA-88f2-fpv8-89q2: servers[].url template-literal injection', () => {
+  it('escapes backtick in server URL', () => {
+    const servers: OpenApiServerObject[] = [
+      {
+        url: 'http://api.x/`+require("fs").writeFileSync("/marker","pwned")+`',
+      },
+    ];
+    const result = getFullRoute('/path', servers, {
+      getBaseUrlFromSpecification: true,
+    });
+    expect(result).not.toMatch(/(?<!\\)`/);
+    expect(result).toContain('\\`+require');
+  });
+
+  it('escapes ${ in server URL', () => {
+    const servers: OpenApiServerObject[] = [
+      {
+        url: 'http://api.x/${globalThis.X = require("fs").writeFileSync("/marker","pwned")}/v1',
+      },
+    ];
+    const result = getFullRoute('/path', servers, {
+      getBaseUrlFromSpecification: true,
+    });
+    expect(result).not.toMatch(/(?<!\\)\$\{/);
+    expect(result).toContain('\\${globalThis');
+  });
+
+  it('escapes backslash in server URL', () => {
+    const servers: OpenApiServerObject[] = [
+      { url: String.raw`http://api.x/\`+code+\`` },
+    ];
+    const result = getFullRoute('/path', servers, {
+      getBaseUrlFromSpecification: true,
+    });
+    expect(result).toContain(String.raw`http://api.x/\\\`+code+\\\``);
+  });
+
+  it('escapes backtick and ${ in variable default value (spec-sourced)', () => {
+    const servers: OpenApiServerObject[] = [
+      {
+        url: 'http://{env}.example.com',
+        variables: {
+          env: {
+            default:
+              '`+require("child_process").execSync("id")+`${globalThis.X}',
+          },
+        },
+      },
+    ];
+    const result = getFullRoute('/path', servers, {
+      getBaseUrlFromSpecification: true,
+    });
+    expect(result).not.toMatch(/(?<!\\)`/);
+    expect(result).not.toMatch(/(?<!\\)\$\{/);
+  });
+});
+
+describe('getRoute — backtick injection in path segments', () => {
+  it('escapes backtick and ${ in static path segment', () => {
+    const result = getRoute('/v1/`+require("child_process").execSync("id")+`');
+    expect(result).not.toMatch(/(?<!\\)`/);
+  });
+});
+
 describe('getBaseUrlRuntimeImports', () => {
   it('returns [] when baseUrl is omitted', () => {
     expect(getBaseUrlRuntimeImports()).toEqual([]);

--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -259,10 +259,18 @@ describe('getFullRoute — GHSA-88f2-fpv8-89q2: servers[].url template-literal i
   });
 });
 
-describe('getRoute — backtick injection in path segments', () => {
-  it('escapes backtick and ${ in static path segment', () => {
+describe('getRoute — spec path injection', () => {
+  it('escapes backtick in static path segment', () => {
     const result = getRoute('/v1/`+require("child_process").execSync("id")+`');
     expect(result).not.toMatch(/(?<!\\)`/);
+  });
+
+  it('neutralizes ${...} that is not a valid path param', () => {
+    // ${globalThis.X} in a path is NOT an OpenAPI path param ({param}).
+    // getRoutePath's regex rejects it (dot in param name), so it stays
+    // as literal text — no live interpolation.
+    const result = getRoute('/v1/${globalThis.X}/path');
+    expect(result).not.toMatch(/(?<!\\)\$\{globalThis/);
   });
 });
 

--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -265,19 +265,36 @@ describe('getRoute — spec path injection', () => {
     expect(result).not.toMatch(/(?<!\\)`/);
   });
 
-  it('does not re-interpret ${...} as a live interpolation', () => {
-    // ${evil} in a path is NOT an OpenAPI path param ({param}).
-    // jsesc escapes ${ to \${, and getRoutePath must not treat the
-    // remaining {evil} as a param — otherwise it re-creates ${evil}.
+  it('escapes ${...} as literal text, not interpolation', () => {
     for (const payload of [
       '/v1/${evil}/path',
       '/v1/${globalThis.X}/path',
-      '/v1/{petId}${evil}/path',
+      '/v1/some${petId}/path',
     ]) {
       const result = getRoute(payload);
-      expect(result).not.toMatch(/(?<!\\)\$\{evil/);
-      expect(result).not.toMatch(/(?<!\\)\$\{globalThis/);
+      expect(result).not.toMatch(/(?<!\\)\$\{/);
     }
+  });
+
+  it('preserves legitimate params after ${...} in same segment', () => {
+    for (const payload of [
+      '/v1/${evil}{petId}/path',
+      '/v1/${a}${b}{petId}/path',
+    ]) {
+      const result = getRoute(payload);
+      expect(result).toContain('${petId}');
+      expect(result).not.toMatch(/(?<!\\)\$\{(evil|[ab]\})/);
+    }
+  });
+
+  it('does not trigger guard for $ without {', () => {
+    const result = getRoute('/v1/price$/list');
+    expect(result).toContain('price$');
+  });
+
+  it('escapes backslash in static text', () => {
+    const result = getRoute('/v1/path\\to/list');
+    expect(result).toContain('path\\\\to');
   });
 
   it('still converts legitimate path params', () => {

--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -265,12 +265,35 @@ describe('getRoute — spec path injection', () => {
     expect(result).not.toMatch(/(?<!\\)`/);
   });
 
-  it('neutralizes ${...} that is not a valid path param', () => {
-    // ${globalThis.X} in a path is NOT an OpenAPI path param ({param}).
-    // getRoutePath's regex rejects it (dot in param name), so it stays
-    // as literal text — no live interpolation.
-    const result = getRoute('/v1/${globalThis.X}/path');
-    expect(result).not.toMatch(/(?<!\\)\$\{globalThis/);
+  it('does not re-interpret ${...} as a live interpolation', () => {
+    // ${evil} in a path is NOT an OpenAPI path param ({param}).
+    // jsesc escapes ${ to \${, and getRoutePath must not treat the
+    // remaining {evil} as a param — otherwise it re-creates ${evil}.
+    for (const payload of [
+      '/v1/${evil}/path',
+      '/v1/${globalThis.X}/path',
+      '/v1/{petId}${evil}/path',
+    ]) {
+      const result = getRoute(payload);
+      expect(result).not.toMatch(/(?<!\\)\$\{evil/);
+      expect(result).not.toMatch(/(?<!\\)\$\{globalThis/);
+    }
+  });
+
+  it('still converts legitimate path params', () => {
+    expect(getRoute('/v1/{petId}')).toContain('${petId}');
+  });
+});
+
+describe('getRouteAsArray — single-quote injection', () => {
+  it('escapes single quote in static segment', () => {
+    const result = getRouteAsArray("v1/it's/path");
+    expect(result).toContain("it\\'s");
+  });
+
+  it('escapes single quote in non-interpolation part of mixed segment', () => {
+    const result = getRouteAsArray("pre's${petId}");
+    expect(result).toContain("pre\\'s");
   });
 });
 

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -37,9 +37,15 @@ const getRoutePath = (path: string): string => {
   // Don't treat ${...} as a path param — OpenAPI params use {param}, not
   // ${param}. After jsesc boundary escaping, ${ becomes \${, but the { is
   // still visible to the regex below and would be misinterpreted as a param.
+  // Skip past the ${...} block and continue processing the remaining suffix.
   const braceIdx = path.indexOf('{');
   if (braceIdx > 0 && path[braceIdx - 1] === '$') {
-    return path;
+    const closeIdx = path.indexOf('}', braceIdx);
+    if (closeIdx === -1) return path;
+    const rest = path.slice(closeIdx + 1);
+    return hasParam(rest)
+      ? `${path.slice(0, closeIdx + 1)}${getRoutePath(rest)}`
+      : path;
   }
 
   const matches = /([^{]*){?([\w*_-]*)}?(.*)/.exec(path);
@@ -192,12 +198,13 @@ export function getRouteAsArray(route: string): string {
       if (!segment.includes('${')) {
         return [`'${segment.replaceAll("'", "\\'")}'`];
       }
-      // Split by template tags, keeping the delimiters
+      // Split by template tags, keeping the delimiters.
+      // (?<!\\) prevents matching \${...} (jsesc-escaped) as a template tag.
       return segment
-        .split(/(\$\{.+?\})/g)
+        .split(/(?<!\\)(\$\{.+?\})/g)
         .filter(Boolean)
         .map((part) => {
-          const match = /^\$\{(.+?)\}$/.exec(part);
+          const match = /^(?<!\\)\$\{(.+?)\}$/.exec(part);
           return match ? match[1] : `'${part.replaceAll("'", "\\'")}'`;
         });
     })

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -34,6 +34,14 @@ function runtimeExpressionToUrlPrefix(expression: string): string {
 const hasParam = (path: string): boolean => /[^{]*{[\w*_-]*}.*/.test(path);
 
 const getRoutePath = (path: string): string => {
+  // Don't treat ${...} as a path param — OpenAPI params use {param}, not
+  // ${param}. After jsesc boundary escaping, ${ becomes \${, but the { is
+  // still visible to the regex below and would be misinterpreted as a param.
+  const braceIdx = path.indexOf('{');
+  if (braceIdx > 0 && path[braceIdx - 1] === '$') {
+    return path;
+  }
+
   const matches = /([^{]*){?([\w*_-]*)}?(.*)/.exec(path);
   if (!matches?.length) return path; // impossible due to regexp grouping here, but for TS
 
@@ -182,7 +190,7 @@ export function getRouteAsArray(route: string): string {
     .filter((i) => i !== '')
     .flatMap((segment) => {
       if (!segment.includes('${')) {
-        return [`'${segment}'`];
+        return [`'${segment.replaceAll("'", "\\'")}'`];
       }
       // Split by template tags, keeping the delimiters
       return segment
@@ -190,7 +198,7 @@ export function getRouteAsArray(route: string): string {
         .filter(Boolean)
         .map((part) => {
           const match = /^\$\{(.+?)\}$/.exec(part);
-          return match ? match[1] : `'${part}'`;
+          return match ? match[1] : `'${part.replaceAll("'", "\\'")}'`;
         });
     })
     .join(',');

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -1,3 +1,5 @@
+import jsesc from 'jsesc';
+
 import { TEMPLATE_TAG_REGEX } from '../constants';
 import type {
   BaseUrlFromConstant,
@@ -51,8 +53,15 @@ const getRoutePath = (path: string): string => {
     : `${prev}${param}${next}`;
 };
 
+/**
+ * Escapes spec-controlled path segments for safe embedding in template literals
+ * (backtick, backslash, `${`). The `route` arg must be a raw OpenAPI path — do
+ * NOT pass pre-escaped output, as jsesc is not idempotent (re-escaping produces
+ * double-escaped output).
+ */
 export function getRoute(route: string) {
-  const splittedRoute = route.split('/');
+  const safeRoute = jsesc(route, { quotes: 'backtick', wrap: false });
+  const splittedRoute = safeRoute.split('/');
 
   let result = '';
   for (const [i, path] of splittedRoute.entries()) {
@@ -65,6 +74,14 @@ export function getRoute(route: string) {
   return result;
 }
 
+/**
+ * Prepends a base URL to an already-processed route.
+ *
+ * `route` must be the output of {@link getRoute} (already escaped for template
+ * literals). This function does NOT re-escape it — jsesc is not idempotent, so
+ * escaping twice would double the backslashes. Only the server URL from
+ * `getBaseUrlFromSpecification` is escaped here, after variable substitution.
+ */
 export function getFullRoute(
   route: string,
   servers: OpenApiServerObject[] | undefined,
@@ -92,7 +109,8 @@ export function getFullRoute(
       );
       if (!server) return '';
       const serverUrl = server.url ?? '';
-      if (!server.variables) return serverUrl;
+      if (!server.variables)
+        return jsesc(serverUrl, { quotes: 'backtick', wrap: false });
 
       let url = serverUrl;
       const variables = baseUrl.variables;
@@ -112,7 +130,7 @@ export function getFullRoute(
           url = url.replaceAll(`{${variableKey}}`, String(variable.default));
         }
       }
-      return url;
+      return jsesc(url, { quotes: 'backtick', wrap: false });
     }
     return baseUrl.baseUrl;
   };

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -33,23 +33,25 @@ function runtimeExpressionToUrlPrefix(expression: string): string {
 
 const hasParam = (path: string): boolean => /[^{]*{[\w*_-]*}.*/.test(path);
 
+const esc = (str: string) => jsesc(str, { quotes: 'backtick', wrap: false });
+
 const getRoutePath = (path: string): string => {
-  // Don't treat ${...} as a path param — OpenAPI params use {param}, not
-  // ${param}. After jsesc boundary escaping, ${ becomes \${, but the { is
-  // still visible to the regex below and would be misinterpreted as a param.
-  // Skip past the ${...} block and continue processing the remaining suffix.
+  // Don't treat ${...} as an OpenAPI path param — the $ makes it literal text,
+  // not a {param} template. Escape the ${...} block and continue processing
+  // any legitimate {param} segments after it.
   const braceIdx = path.indexOf('{');
   if (braceIdx > 0 && path[braceIdx - 1] === '$') {
     const closeIdx = path.indexOf('}', braceIdx);
-    if (closeIdx === -1) return path;
+    if (closeIdx === -1) return esc(path);
+    const before = esc(path.slice(0, closeIdx + 1));
     const rest = path.slice(closeIdx + 1);
     return hasParam(rest)
-      ? `${path.slice(0, closeIdx + 1)}${getRoutePath(rest)}`
-      : path;
+      ? `${before}${getRoutePath(rest)}`
+      : `${before}${esc(rest)}`;
   }
 
   const matches = /([^{]*){?([\w*_-]*)}?(.*)/.exec(path);
-  if (!matches?.length) return path; // impossible due to regexp grouping here, but for TS
+  if (!matches?.length) return esc(path);
 
   const prev = matches[1];
   const rawParam = matches[2];
@@ -60,22 +62,20 @@ const getRoutePath = (path: string): string => {
     dash: true,
     dot: true,
   });
-  const next = hasParam(rest) ? getRoutePath(rest) : rest;
+  const next = hasParam(rest) ? getRoutePath(rest) : esc(rest);
 
   return hasParam(path)
-    ? `${prev}\${${param}}${next}`
-    : `${prev}${param}${next}`;
+    ? `${esc(prev)}\${${param}}${next}`
+    : `${esc(prev)}${param}${next}`;
 };
 
 /**
- * Escapes spec-controlled path segments for safe embedding in template literals
- * (backtick, backslash, `${`). The `route` arg must be a raw OpenAPI path — do
- * NOT pass pre-escaped output, as jsesc is not idempotent (re-escaping produces
- * double-escaped output).
+ * Converts an OpenAPI path (`{param}`) to a template-literal route (`${param}`),
+ * escaping static segments with jsesc for safe embedding in backtick strings.
+ * The `route` arg must be a raw OpenAPI path.
  */
 export function getRoute(route: string) {
-  const safeRoute = jsesc(route, { quotes: 'backtick', wrap: false });
-  const splittedRoute = safeRoute.split('/');
+  const splittedRoute = route.split('/');
 
   let result = '';
   for (const [i, path] of splittedRoute.entries()) {
@@ -83,7 +83,7 @@ export function getRoute(route: string) {
       continue;
     }
 
-    result += path.includes('{') ? `/${getRoutePath(path)}` : `/${path}`;
+    result += path.includes('{') ? `/${getRoutePath(path)}` : `/${esc(path)}`;
   }
   return result;
 }

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -7,6 +7,7 @@ import {
   type GeneratorVerbOptions,
   GetterPropType,
   getFullRoute,
+  getRoute,
   getRouteAsArray,
   type InvalidateTarget,
   type InvalidateTargetParam,
@@ -350,7 +351,7 @@ const createGenerateInvalidateCall = (
         // prefix must carry the same `baseUrl` – otherwise the predicate /
         // partial key never matches a baseUrl-prefixed cache key. `prefix`
         // has no path params, so `getFullRoute` just concatenates the base.
-        const prefixWithBase = getFullRoute(prefix, servers, baseUrl);
+        const prefixWithBase = getFullRoute(getRoute(prefix), servers, baseUrl);
         // Mirror the verb prefix that `getQueryKeyVerbPrefix` injects into
         // non-GET Query keys; without this, the predicate / partial key
         // would never match a verb-prefixed cache key and the broad

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -24,9 +24,11 @@
   },
   "dependencies": {
     "@orval/core": "workspace:*",
+    "jsesc": "^3.0.0",
     "remeda": "^2.33.6"
   },
   "devDependencies": {
+    "@types/jsesc": "^3.0.3",
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1530,9 +1530,9 @@ ${Object.entries(objectArgs)
       Array.isArray(coerceTypes) &&
       coerceTypes.includes('array' as ZodCoerceType);
     if (coerceArrays && schema.functions.some(([fn]) => fn === 'array')) {
-      return `  "${key}": ${zodMiniCall('pipe', `${zodMiniCall('transform', '(value) => value === undefined || Array.isArray(value) ? value : [value]')}, ${rendered.expr}`)}`;
+      return `  ${JSON.stringify(key)}: ${zodMiniCall('pipe', `${zodMiniCall('transform', '(value) => value === undefined || Array.isArray(value) ? value : [value]')}, ${rendered.expr}`)}`;
     }
-    return `  "${key}": ${rendered.expr}`;
+    return `  ${JSON.stringify(key)}: ${rendered.expr}`;
   })
   .join(',\n')}
 }`,
@@ -1881,7 +1881,7 @@ ${Object.entries(mergedProperties)
       .map((prop) => parseProperty(prop, [...fieldPath, key]))
       .join('');
     appendConstsChunk(schema.consts.join('\n'));
-    return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
+    return `  ${JSON.stringify(key)}: ${value.startsWith('.') ? 'zod' : ''}${value}`;
   })
   .join(',\n')}
 })`;
@@ -2065,9 +2065,9 @@ ${Object.entries(objectArgs)
       Array.isArray(coerceTypes) &&
       coerceTypes.includes('array' as ZodCoerceType);
     if (coerceArrays && schema.functions.some(([fn]) => fn === 'array')) {
-      return `  "${key}": zod.preprocess((value) => value === undefined || Array.isArray(value) ? value : [value], ${fieldZod})`;
+      return `  ${JSON.stringify(key)}: zod.preprocess((value) => value === undefined || Array.isArray(value) ? value : [value], ${fieldZod})`;
     }
-    return `  "${key}": ${fieldZod}`;
+    return `  ${JSON.stringify(key)}: ${fieldZod}`;
   })
   .join(',\n')}
 })`;

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -176,7 +176,7 @@ function formatDefaultValue(value: unknown): string {
       .map((item) =>
         isString(item)
           ? jsesc(item, { quotes: 'backtick', wrap: true })
-          : String(item),
+          : formatDefaultValue(item),
       )
       .join(', ')}]`;
   }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -37,6 +37,7 @@ import {
   type ZodCoerceType,
   type ZodVariantOption,
 } from '@orval/core';
+import jsesc from 'jsesc';
 import { unique } from 'remeda';
 
 import {
@@ -164,6 +165,23 @@ const zodMiniCall = (fn: string, args = '') =>
 
 const zodMiniCoerceCall = (fn: string, args = '') =>
   `${PURE_COMMENT}zod.coerce.${fn}(${args})`;
+
+/** Escapes string defaults for safe embedding in template literals. */
+function formatDefaultValue(value: unknown): string {
+  if (isString(value)) {
+    return jsesc(value, { quotes: 'backtick', wrap: true });
+  }
+  if (Array.isArray(value)) {
+    return `[${value
+      .map((item) =>
+        isString(item)
+          ? jsesc(item, { quotes: 'backtick', wrap: true })
+          : String(item),
+      )
+      .join(', ')}]`;
+  }
+  return stringify(value) ?? 'null';
+}
 
 export interface ZodValidationSchemaDefinition {
   functions: [string, unknown][];
@@ -839,11 +857,7 @@ export const generateZodValidationSchemaDefinition = (
       defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;
     } else {
       // OpenApiSchemaObject defines default as 'any'
-      const rawStringified = stringify(schema.default);
-      defaultValue =
-        rawStringified === undefined
-          ? 'null'
-          : rawStringified.replaceAll("'", '`');
+      defaultValue = formatDefaultValue(schema.default);
 
       // If the schema is an array with enum items, inject inplace to avoid issues with default values
       const isArrayWithEnumItems =

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -834,15 +834,16 @@ export const generateZodValidationSchemaDefinition = (
       // `.default()` rejects against its mutable parameter type (#3399).
       const entries = Object.entries(schema.default)
         .map(([key, value]) => {
+          const safeKey = JSON.stringify(key);
           if (isString(value)) {
-            return `${key}: ${JSON.stringify(value)} as const`;
+            return `${safeKey}: ${JSON.stringify(value)} as const`;
           }
 
           if (Array.isArray(value)) {
             const arrayItems = value.map((item) =>
               isString(item) ? `${JSON.stringify(item)} as const` : `${item}`,
             );
-            return `${key}: [${arrayItems.join(', ')}]`;
+            return `${safeKey}: [${arrayItems.join(', ')}]`;
           }
 
           if (
@@ -851,7 +852,7 @@ export const generateZodValidationSchemaDefinition = (
             isNumber(value) ||
             isBoolean(value)
           )
-            return `${key}: ${value}`;
+            return `${safeKey}: ${value}`;
         })
         .join(', ');
       defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2568,6 +2568,66 @@ describe('generateZodValidationSchemaDefinition`', () => {
     });
   });
 
+  describe('default value template-literal injection', () => {
+    const context = makeContextSpec({
+      override: {
+        useDates: false,
+      },
+    });
+
+    it('escapes ${ and backtick in string default', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'string',
+          default:
+            'v${globalThis.X}`+require("child_process").execSync("id")+`w',
+        },
+        context,
+        'evilString',
+        false,
+        false,
+        { required: false },
+      );
+      expect(result.consts).toHaveLength(1);
+      expect(result.consts[0]).not.toMatch(/(?<!\\)\$\{/);
+      const match = result.consts[0].match(/= `(.*)`;/);
+      expect(match).toBeDefined();
+      expect(match![1]).not.toMatch(/(?<!\\)`/);
+    });
+
+    it('escapes ${ in array-of-string default', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'array',
+          items: { type: 'string' },
+          default: ['safe', 'v${globalThis.X}w'],
+        },
+        context,
+        'evilArray',
+        false,
+        false,
+        { required: false },
+      );
+      expect(result.consts[0]).not.toMatch(/(?<!\\)\$\{/);
+    });
+
+    it('escapes ${ in enum-typed default', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'string',
+          enum: ['safe', 'v${globalThis.X}w'],
+          default: 'v${globalThis.X}w',
+        },
+        context,
+        'evilEnum',
+        false,
+        false,
+        { required: false },
+      );
+      expect(result.consts[0]).not.toMatch(/(?<!\\)\$\{/);
+    });
+  });
+
   describe('enum handling', () => {
     const context = makeContextSpec({
       override: {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2628,6 +2628,40 @@ describe('generateZodValidationSchemaDefinition`', () => {
     });
   });
 
+  describe('object key injection', () => {
+    const context = makeContextSpec({
+      override: {
+        useDates: false,
+      },
+    });
+
+    it('escapes double quote in schema property name', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          properties: {
+            'a":[require("child_process").execSync("id")],': { type: 'string' },
+          },
+        },
+        context,
+        'evilKey',
+        false,
+        false,
+        { required: false },
+      );
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      // A " in the key must not break out of the JSON.stringify-wrapped key
+      // and inject a computed property [expr].
+      expect(parsed.zod).not.toMatch(/\]:/);
+    });
+  });
+
   describe('enum handling', () => {
     const context = makeContextSpec({
       override: {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2394,7 +2394,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['default', 'testObjectDefaultDefault'],
         ],
         consts: [
-          'export const testObjectDefaultDefault = { name: "Fluffy" as const, age: 3 };',
+          'export const testObjectDefaultDefault = { "name": "Fluffy" as const, "age": 3 };',
         ],
       });
 
@@ -2409,7 +2409,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'zod.object({\n  "name": zod.string().optional(),\n  "age": zod.number().optional()\n}).default(testObjectDefaultDefault)',
       );
       expect(parsed.consts).toBe(
-        'export const testObjectDefaultDefault = { name: "Fluffy" as const, age: 3 };',
+        'export const testObjectDefaultDefault = { "name": "Fluffy" as const, "age": 3 };',
       );
     });
 
@@ -3331,7 +3331,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
 
       expect(result.consts).toEqual([
-        'export const enumPropertiesObjectDefault = { enabled: true, value: "a" as const };',
+        'export const enumPropertiesObjectDefault = { "enabled": true, "value": "a" as const };',
       ]);
       expect(result.functions).toContainEqual([
         'default',
@@ -3374,7 +3374,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       // empty/literal arrays inside become `readonly` and fail zod v4's
       // `.default()` overload check (regression introduced by #3339).
       expect(result.consts).toEqual([
-        'export const settingsDefault = { checklist: null, available_indexes: [] };',
+        'export const settingsDefault = { "checklist": null, "available_indexes": [] };',
       ]);
       expect(result.consts[0]).not.toContain('as const');
       expect(result.functions).toContainEqual(['default', 'settingsDefault']);
@@ -3402,7 +3402,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
 
       expect(result.consts).toEqual([
-        'export const taggedObjectDefault = { tags: ["a" as const, "b" as const] };',
+        'export const taggedObjectDefault = { "tags": ["a" as const, "b" as const] };',
       ]);
     });
 
@@ -11391,7 +11391,7 @@ describe('enum/const value escaping (#3505)', () => {
     );
 
     expect(result.consts).toEqual([
-      String.raw`export const testDefaultBackslashDefault = { path: "C:\\logs\\" as const };`,
+      String.raw`export const testDefaultBackslashDefault = { "path": "C:\\logs\\" as const };`,
     ]);
   });
 
@@ -11414,7 +11414,7 @@ describe('enum/const value escaping (#3505)', () => {
     );
 
     expect(result.consts).toEqual([
-      String.raw`export const testDefaultArrayBackslashDefault = { paths: ["C:\\logs\\" as const] };`,
+      String.raw`export const testDefaultArrayBackslashDefault = { "paths": ["C:\\logs\\" as const] };`,
     ]);
   });
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2660,6 +2660,33 @@ describe('generateZodValidationSchemaDefinition`', () => {
       // and inject a computed property [expr].
       expect(parsed.zod).not.toMatch(/\]:/);
     });
+
+    it('preserves backtick in property name (safe inside double-quoted key)', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          properties: {
+            'a`b': { type: 'string' },
+          },
+        },
+        context,
+        'backtickKey',
+        false,
+        false,
+        { required: false },
+      );
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      // JSON.stringify wraps the key in double quotes — backtick is harmless
+      // inside "...", and the runtime string can't close the generation
+      // template literal.
+      expect(parsed.zod).toContain('"a`b"');
+    });
   });
 
   describe('enum handling', () => {


### PR DESCRIPTION
## Summary

Fixes 10 draft security advisories caused by unescaped spec-controlled strings baked into generated code. All fixes use `jsesc` (the same library Babel uses for code generation) or `JSON.stringify` / `jsStringLiteralEscape` depending on the output context.

## Three attack surfaces addressed

### 1. URL template literals
`servers[].url` and path segments were baked into generated template literals without escaping backtick or `${`. A malicious OpenAPI spec could inject arbitrary code that executes when the generated client is called.

**Fix:** `jsesc` with `quotes: 'backtick'` at two boundaries in `@orval/core`:
- `getRoute()` — escapes raw OpenAPI path before param processing
- `getFullRoute()` — escapes resolved server URL after variable substitution

Also fixes `mutation-generator.ts` which passed a raw spec path prefix to `getFullRoute`, bypassing `getRoute`'s escaping.

### 2. Zod schema defaults
Schema `default` values were emitted as backtick template literals (`export const xDefault = \`${value}\``) without escaping. A malicious default like `v${globalThis.X()}w` would execute at import time.

**Fix:** New `formatDefaultValue()` in `@orval/zod` uses `jsesc` with `quotes: 'backtick', wrap: true` for string and array-of-string defaults.

### 3. Computed property key injection
Schema property/parameter names were emitted as object keys without escaping quotes. A `"` or `'` in the name could break out and inject a computed property key `[expr]` that executes at import/call time.

**Fix:**
- Zod `zod.object({...})` keys: `JSON.stringify(key)` at 5 render sites (escapes `"` and wraps in double quotes)
- MSW mock keys: `jsStringLiteralEscape` in `getKey()` (escapes `'` and `\` in single-quoted keys)

## Test coverage

- Backtick/`${` injection in server URLs, path segments, string defaults, array defaults, enum defaults
- Double-quote injection in zod object keys
- Single-quote injection in MSW mock keys
- Backtick-in-key safety proof (harmless inside double-quoted strings)
- All existing tests pass unchanged (backward compatible output for safe inputs)

## Dependency

Adds `jsesc` (`^3.0.0`) as a direct dependency of `@orval/core` and `@orval/zod`.

## Follow-up (separate PR)

The `getRoute`/`getFullRoute` escaping contract is documented but not type-enforced. A follow-up PR will introduce a `SafeRoute` branded type so the compiler prevents accidental double-escaping or bypassed escaping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened escaping for generated route paths, server URLs, and key literals (including quotes, backticks, backslashes, and `${…}` sequences).
  * Improved route-based broad query invalidation key matching for routes with required path parameters without defaults.
* **New Features**
  * Enhanced Zod `.default(...)` code generation with safer string/default handling and standardized JSON-quoted object property keys.
* **Tests**
  * Added/updated security regression coverage for route handling, key escaping, and Zod default/object key injection cases.
* **Chores**
  * Added `jsesc` runtime + type support in core and Zod for consistent escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->