### PR TITLE
fix(axios): eliminate module-level returnTypesToWrite map

### DIFF
--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -49,8 +49,6 @@ const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
-const returnTypesToWrite = new Map<string, (title?: string) => string>();
-
 export const getAxiosDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
   hasParamsSerializerOptions: boolean,
@@ -147,17 +145,14 @@ const generateAxiosImplementation = (
         )
       : '';
 
-    returnTypesToWrite.set(
-      operationName,
-      (title?: string) =>
-        `export type ${pascal(
-          operationName,
-        )}Result = NonNullable<Awaited<ReturnType<${
-          title
-            ? `ReturnType<typeof ${title}>['${operationName}']`
-            : `typeof ${operationName}`
-        }>>>`,
-    );
+    const returnType = (title?: string) =>
+      `export type ${pascal(
+        operationName,
+      )}Result = NonNullable<Awaited<ReturnType<${
+        title
+          ? `ReturnType<typeof ${title}>['${operationName}']`
+          : `typeof ${operationName}`
+      }>>>`;
 
     const propsImplementation =
       mutator.bodyTypeName && body.definition
@@ -167,16 +162,19 @@ const generateAxiosImplementation = (
           )
         : toObjectString(props, 'implementation');
 
-    return `const ${operationName} = (\n    ${propsImplementation}\n ${
-      isRequestOptions && mutator.hasSecondArg
-        ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}<${response.definition.success || 'unknown'}>>,`
-        : ''
-    }) => {${bodyForm}
+    return {
+      implementation: `const ${operationName} = (\n    ${propsImplementation}\n ${
+        isRequestOptions && mutator.hasSecondArg
+          ? `options${context.output.optionsParamRequired ? '' : '?'}: SecondParameter<typeof ${mutator.name}<${response.definition.success || 'unknown'}>>,`
+          : ''
+      }) => {${bodyForm}
       return ${mutator.name}<${response.definition.success || 'unknown'}>(
       ${mutatorConfig},
       ${requestOptions});
     }
-  `;
+  `,
+      returnType,
+    };
   }
 
   const options = generateOptions({
@@ -195,13 +193,10 @@ const generateAxiosImplementation = (
     hasSignal: false,
   });
 
-  returnTypesToWrite.set(
-    operationName,
-    () =>
-      `export type ${pascal(operationName)}Result = AxiosResponse<${
-        response.definition.success || 'unknown'
-      }>`,
-  );
+  const returnType = () =>
+    `export type ${pascal(operationName)}Result = AxiosResponse<${
+      response.definition.success || 'unknown'
+    }>`;
 
   // In factory mode, use the axiosInstance parameter
   // In functions mode with global import, .default may be needed based on tsconfig
@@ -209,14 +204,17 @@ const generateAxiosImplementation = (
     ? 'axiosInstance'
     : `axios${isSyntheticDefaultImportsAllowed ? '' : '.default'}`;
 
-  return `const ${operationName} = (\n    ${toObjectString(props, 'implementation')} ${
-    isRequestOptions
-      ? `options${context.output.optionsParamRequired ? '' : '?'}: AxiosRequestConfig\n`
-      : ''
-  } ): Promise<AxiosResponse<${response.definition.success || 'unknown'}>> => {${bodyForm}
+  return {
+    implementation: `const ${operationName} = (\n    ${toObjectString(props, 'implementation')} ${
+      isRequestOptions
+        ? `options${context.output.optionsParamRequired ? '' : '?'}: AxiosRequestConfig\n`
+        : ''
+    } ): Promise<AxiosResponse<${response.definition.success || 'unknown'}>> => {${bodyForm}
     return ${axiosRef}.${verb}(${options});
   }
-`;
+`,
+    returnType,
+  };
 };
 
 export const generateAxiosTitle: ClientTitleBuilder = (title) => {
@@ -258,6 +256,7 @@ ${
 
 export const generateAxiosFooter: ClientFooterBuilder = ({
   operationNames,
+  operations,
   title,
   noFunction,
   hasMutator,
@@ -275,13 +274,11 @@ export const generateAxiosFooter: ClientFooterBuilder = ({
 \n`;
   }
 
-  for (const operationName of operationNames) {
-    if (returnTypesToWrite.has(operationName)) {
-      // Map.has ensures Map.get will not return undefined, but TS still complains
-      // bug https://github.com/microsoft/TypeScript/issues/13086
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const func = returnTypesToWrite.get(operationName)!;
-      footer += func(noFunction ? undefined : title) + '\n';
+  if (operations) {
+    for (const operation of operations) {
+      if (operation.types?.result) {
+        footer += operation.types.result(noFunction ? undefined : title) + '\n';
+      }
     }
   }
 
@@ -294,27 +291,35 @@ export const generateAxios = (
   isFactoryMode = false,
 ) => {
   const imports = generateVerbImports(verbOptions);
-  const implementation = generateAxiosImplementation(
+  const { implementation, returnType } = generateAxiosImplementation(
     verbOptions,
     options,
     isFactoryMode,
   );
 
-  return { implementation, imports };
+  return { implementation, imports, returnType };
 };
 
 // Factory mode generator - axios is optional parameter
 export const generateAxiosFactory: ClientBuilder = (verbOptions, options) => {
-  const { implementation, imports } = generateAxios(verbOptions, options, true);
-  return { implementation, imports };
+  const { implementation, imports, returnType } = generateAxios(
+    verbOptions,
+    options,
+    true,
+  );
+  return { implementation, imports, returnType };
 };
 
 export const generateAxiosFunctions: ClientBuilder = (verbOptions, options) => {
-  const { implementation, imports } = generateAxios(verbOptions, options);
+  const { implementation, imports, returnType } = generateAxios(
+    verbOptions,
+    options,
+  );
 
   return {
     implementation: 'export ' + implementation,
     imports,
+    returnType,
   };
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1596,6 +1596,7 @@ export interface GeneratorClient {
   mutators?: GeneratorMutator[];
   /** When set, overrides the default verbOption.doc prepended to the implementation */
   docComment?: string;
+  returnType?: (title?: string) => string;
 }
 
 export interface GeneratorMutatorParsingInfo {
@@ -1660,6 +1661,7 @@ export type ClientHeaderBuilder = (params: {
 export type ClientFooterBuilder = (params: {
   noFunction?: boolean | undefined;
   operationNames: string[];
+  operations?: GeneratorOperation[];
   title?: string;
   hasAwaitedType: boolean;
   hasMutator: boolean;
@@ -1930,6 +1932,7 @@ export type GeneratorClientHeader = (data: {
 export type GeneratorClientFooter = (data: {
   outputClient: OutputClient | OutputClientFunc;
   operationNames: string[];
+  operations?: GeneratorOperation[];
   hasMutator: boolean;
   hasAwaitedType: boolean;
   titles: GeneratorClientExtra;

--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -206,8 +206,7 @@ export function generateTargetForTags(
           // `isOperationInTagBucket` keeps this in lockstep with how the
           // buckets above were built, including untagged operations that were
           // routed into the implicit `default` bucket by `addDefaultTagIfEmpty`.
-          .filter((operation) => isOperationInTagBucket(operation, tag))
-          .map(({ operationName }) => operationName);
+          .filter((operation) => isOperationInTagBucket(operation, tag));
 
         const hasAwaitedType = hasTypeScriptAwaitedType(options.packageJson);
 
@@ -220,7 +219,10 @@ export function generateTargetForTags(
 
         const footer = builder.footer({
           outputClient: options.client,
-          operationNames,
+          operationNames: operationNames.map(
+            ({ operationName }) => operationName,
+          ),
+          operations: operationNames,
           hasMutator: !!target.mutators?.length,
           hasAwaitedType,
           titles,

--- a/packages/core/src/writers/target.ts
+++ b/packages/core/src/writers/target.ts
@@ -156,6 +156,7 @@ export function generateTarget(
       const footer = builder.footer({
         outputClient: options.client,
         operationNames,
+        operations,
         hasMutator: target.mutators.length > 0,
         hasAwaitedType,
         titles,

--- a/packages/orval/src/api.ts
+++ b/packages/orval/src/api.ts
@@ -121,7 +121,14 @@ export async function getApiBuilder({
         acc.verbOptions[verbOption.operationId] = verbOption;
       }
       acc.schemas.push(...schemas);
-      acc.operations = { ...acc.operations, ...pathOperations };
+      for (const [key, value] of Object.entries(pathOperations)) {
+        let operationKey = key;
+        let counter = 1;
+        while (Object.hasOwn(acc.operations, operationKey)) {
+          operationKey = `${key}::${++counter}`;
+        }
+        acc.operations[operationKey] = value;
+      }
 
       return acc;
     },

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -159,6 +159,7 @@ export const generateClientHeader: GeneratorClientHeader = ({
 export const generateClientFooter: GeneratorClientFooter = ({
   outputClient,
   operationNames,
+  operations,
   hasMutator,
   hasAwaitedType,
   titles,
@@ -186,6 +187,7 @@ export const generateClientFooter: GeneratorClientFooter = ({
     } else {
       implementation = footer({
         operationNames,
+        operations,
         title: titles.implementation,
         hasMutator,
         hasAwaitedType,
@@ -194,6 +196,7 @@ export const generateClientFooter: GeneratorClientFooter = ({
   } catch {
     implementation = footer({
       operationNames,
+      operations,
       title: titles.implementation,
       hasMutator,
       hasAwaitedType,
@@ -345,6 +348,9 @@ export const generateOperations = (
         paramsFilter: verbOption.paramsFilter,
         operationName: verbOption.operationName,
         fetchReviver: verbOption.fetchReviver,
+        ...(client.returnType
+          ? { types: { result: client.returnType } }
+          : undefined),
       };
 
       return acc;

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -1261,3 +1261,101 @@ describe('generateSpec - schemas.splitByTags validation', () => {
     }
   });
 });
+
+describe('generateSpec - returnTypesToWrite isolation across tags (#3685)', () => {
+  it("each tag emits its own *Result type, not the other tag's", async () => {
+    const SPEC: OpenApiDocument = {
+      openapi: '3.1.0',
+      info: { title: 'Collision Demo', version: '1.0.0' },
+      paths: {
+        '/api/catalog/products': {
+          get: {
+            tags: ['catalog'],
+            operationId: 'getCatalogProducts',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Product' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/inventory/products': {
+          get: {
+            tags: ['inventory'],
+            operationId: 'getInventoryProducts',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Stock' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Product: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+          },
+          Stock: {
+            type: 'object',
+            properties: { count: { type: 'integer' } },
+          },
+        },
+      },
+    };
+
+    const workspace = await createTempWorkspace();
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: SPEC },
+          output: {
+            target: './endpoints.ts',
+            mode: 'tags-split',
+            schemas: './model',
+            client: 'axios',
+            override: {
+              operationName: () => 'getProducts',
+            },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const catalogContent = await fs.readFile(
+        path.join(workspace, 'catalog', 'catalog.ts'),
+        'utf-8',
+      );
+      const inventoryContent = await fs.readFile(
+        path.join(workspace, 'inventory', 'inventory.ts'),
+        'utf-8',
+      );
+
+      // Both tags share the same operationName (getProducts) via override,
+      // but each must emit its own *Result type with the correct schema.
+      // Before #3685, the module-level returnTypesToWrite map would
+      // overwrite catalog's entry with inventory's.
+      expect(catalogContent).toContain('AxiosResponse<Product>');
+      expect(catalogContent).not.toContain('AxiosResponse<Stock>');
+
+      expect(inventoryContent).toContain('AxiosResponse<Stock>');
+      expect(inventoryContent).not.toContain('AxiosResponse<Product>');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The axios generator used a module-level `Map` (`returnTypesToWrite`) to collect `*Result` type declarations during implementation generation, then read them during footer generation. In `tags-split` mode, all implementations are generated first (populating the map), then footers are generated per-tag. When two operations from different tags shared the same `operationName` (via `override.operationName`), the second overwrote the first's entry, causing the wrong `*Result` type to be emitted in the first tag's footer.

Closes #3685.

## Solution

Eliminate the module-level map entirely. The return type generator is now:
1. Returned from `generateAxiosImplementation` as `GeneratorClient.returnType`
2. Stored on `GeneratorOperation.types.result` in `generateOperations`
3. Passed to the footer via the new optional `operations` param on `ClientFooterBuilder` / `GeneratorClientFooter`
4. Read from `operations[].types.result` in `generateAxiosFooter`

This removes all module-level state and ordering concerns. Each tag's footer only emits types for its own operations.

## Changes

- `GeneratorClient` gains optional `returnType?: (title?) => string`
- `ClientFooterBuilder` and `GeneratorClientFooter` gain optional `operations?: GeneratorOperation[]`
- `generateAxiosImplementation` returns `{ implementation, returnType }` instead of side-effecting on a map
- `generateAxiosFooter` reads from `operations[].types.result` instead of the module-level map
- Module-level `returnTypesToWrite` Map deleted
- `target.ts` and `target-tags.ts` pass filtered `operations` to the footer
- `generateClientFooter` in `client.ts` passes `operations` through to per-client footers

## Tests

- New regression test: two tags with different return types verify each tag emits its own `*Result` type
- 3323 tests pass, 0 new failures (8 pre-existing failures unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Axios client typing so each operation uses its correct per-operation response type.
  * Fixed tag-split generation so return types stay isolated per tag, avoiding cross-tag type mixing.
  * Enhanced client/footer generation to retain per-operation result typing consistently.
* **New Features**
  * Added optional return-type and per-operation context to generator callback contracts.
* **Tests**
  * Added a new test suite to verify tag-split Axios return types are generated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->