### PR TITLE
feat: allow zod discriminatedUnion generation

### DIFF
--- a/docs/content/docs/guides/zod.mdx
+++ b/docs/content/docs/guides/zod.mdx
@@ -189,7 +189,7 @@ export default defineConfig({
 
 Per-operation and per-tag overrides accept the settings that apply to an individual schema: `strict`, `generate`, `coerce`, `preprocess`, `params`, and `useBrandedTypes`.
 
-Output-wide settings — `variant`, `version`, `dateTimeOptions`, `timeOptions`, `generateEachHttpStatus`, `generateReusableSchemas`, and `generateMeta` — only make sense for the whole output and must stay on `override.zod`. If you place one on an operation or tag it is ignored — the value from `override.zod` still applies — and Orval prints a build warning:
+Output-wide settings — `variant`, `version`, `dateTimeOptions`, `timeOptions`, `generateEachHttpStatus`, `generateReusableSchemas`, `generateMeta`, and `generateDiscriminatedUnion` — only make sense for the whole output and must stay on `override.zod`. If you place one on an operation or tag it is ignored — the value from `override.zod` still applies — and Orval prints a build warning:
 
 ```
 ⚠️  override.operations.listPets.zod only supports strict, generate, coerce, preprocess, params, and useBrandedTypes. Ignoring unsupported field: zod.version.

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1401,6 +1401,7 @@ export default defineConfig({
           generateEachHttpStatus: true,
           useBrandedTypes: true,
           generateReusableSchemas: true,
+          generateDiscriminatedUnion: true,
         },
       },
     },
@@ -1573,6 +1574,29 @@ Behavior:
 - `id` is always emitted; `description`/`deprecated` only when present. Property-level descriptions still use `.describe()`.
 - **zod v3** has no `.meta()` — the option is a no-op there, and descriptions continue to emit via `.describe()`.
 - The registry `id` makes [`z.toJSONSchema()`](https://zod.dev/json-schema) reference the schema as `#/$defs/<id>`, round-tripping the component structure.
+
+### generateDiscriminatedUnion
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+Emit a `oneOf`/`anyOf` that carries an OpenAPI [`discriminator`](https://spec.openapis.org/oas/v3.1.0#discriminator-object) as [`zod.discriminatedUnion(key, [...])`](https://zod.dev/api?id=discriminated-unions) instead of a plain `zod.union([...])`. A discriminated union picks the branch by its discriminator value first, so validation errors point at the offending field (`type.name`) instead of collapsing into a single "no union member matched" at the union root.
+
+```ts
+// override: { zod: { generateDiscriminatedUnion: true } }
+export const Pet = zod.discriminatedUnion('petType', [
+  zod.object({ petType: zod.literal('cat'), meows: zod.boolean() }),
+  zod.object({ petType: zod.literal('dog'), barks: zod.boolean() }),
+]);
+```
+
+Behavior:
+
+- **Opt-in.** Left `false`, unions are emitted exactly as before, so existing output is unchanged.
+- **Safe fallback.** A discriminated union is emitted only when every branch can be represented as an object carrying a literal (`const`/`enum`) discriminator. If any branch is a non-object, a nested union, or lacks a literal discriminator, generation falls back to a plain `zod.union([...])` rather than emitting code that throws at construction.
+- **Inheritance (`allOf`).** Branches composed with `allOf` are flattened into a single object so they remain valid discriminated-union options — this is the case that previously forced the feature to be reverted ([#2085](https://github.com/orval-labs/orval/issues/2085)). With [`generateReusableSchemas`](#generatereusableschemas), a branch that references an `allOf` schema stays a plain union (the referenced schema can't be guaranteed to be an object from the reference alone).
+- Works with both Zod v3 (>= 3.20) and v4, and with the [`mini`](#variant) variant.
 
 ---
 

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -100,6 +100,7 @@ const createOutput = (
         generateEachHttpStatus: false,
         generateReusableSchemas: false,
         generateMeta: false,
+        generateDiscriminatedUnion: false,
         useBrandedTypes: false,
         dateTimeOptions: {},
         timeOptions: {},

--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -111,6 +111,7 @@ const createOutput = (
         useBrandedTypes: false,
         generateReusableSchemas: false,
         generateMeta: false,
+        generateDiscriminatedUnion: false,
         dateTimeOptions: {},
         timeOptions: {},
       },

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -132,6 +132,7 @@ export function createTestContextSpec({
         useBrandedTypes: false,
         generateReusableSchemas: false,
         generateMeta: false,
+        generateDiscriminatedUnion: false,
         dateTimeOptions: {},
         timeOptions: { precision: 3 },
       },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -884,6 +884,14 @@ export interface ZodOptions extends BaseZodOptions {
    * via `.describe()`. Default `false`.
    */
   generateMeta?: boolean;
+  /**
+   * When true, a `oneOf`/`anyOf` that carries an OpenAPI `discriminator` is
+   * emitted as `zod.discriminatedUnion(key, [...])` (better per-branch errors)
+   * instead of a plain `zod.union([...])`, but only when every branch can be
+   * represented as an object — otherwise it safely falls back to a union.
+   * Default `false` (opt-in), so existing output is unchanged.
+   */
+  generateDiscriminatedUnion?: boolean;
 }
 
 /**
@@ -948,6 +956,7 @@ export interface NormalizedZodOptions {
   useBrandedTypes: boolean;
   generateReusableSchemas: boolean;
   generateMeta: boolean;
+  generateDiscriminatedUnion: boolean;
   dateTimeOptions: ZodDateTimeOptions;
   timeOptions: ZodTimeOptions;
 }

--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -128,6 +128,7 @@ function createMockContext(): ContextSpec {
           useBrandedTypes: false,
           generateReusableSchemas: false,
           generateMeta: false,
+          generateDiscriminatedUnion: false,
           dateTimeOptions: {},
           timeOptions: { precision: 3 },
         },

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -657,6 +657,8 @@ export async function normalizeOptions(
           generateReusableSchemas:
             outputOptions.override?.zod?.generateReusableSchemas ?? false,
           generateMeta: outputOptions.override?.zod?.generateMeta ?? false,
+          generateDiscriminatedUnion:
+            outputOptions.override?.zod?.generateDiscriminatedUnion ?? false,
           dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {
             offset: true,
           },
@@ -993,6 +995,7 @@ function normalizeOperationsAndTags(
     'generateEachHttpStatus',
     'generateReusableSchemas',
     'generateMeta',
+    'generateDiscriminatedUnion',
   ] as const;
 
   return Object.fromEntries(

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -133,6 +133,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         useBrandedTypes: false,
         generateReusableSchemas: false,
         generateMeta: false,
+        generateDiscriminatedUnion: false,
         dateTimeOptions: {},
         timeOptions: { precision: 3 },
       },

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -216,6 +216,157 @@ const COMPONENT_SCHEMAS_REF_PATTERN = /^#\/components\/schemas\/[^/]+$/;
 const isComponentSchemaRef = (ref: string): boolean =>
   COMPONENT_SCHEMAS_REF_PATTERN.test(ref);
 
+// --- Discriminated unions -------------------------------------------------
+//
+// A `oneOf`/`anyOf` carrying an OpenAPI `discriminator` maps naturally onto
+// `zod.discriminatedUnion(key, [...])`, which gives per-branch validation
+// errors instead of the useless "no union member matched" that a plain
+// `zod.union` produces. Orval shipped this once (PR #1907) but reverted it
+// (PR #2118, issue #2085) because `zod.discriminatedUnion` only accepts
+// *object* options: an inheritance branch (`allOf`) renders as a
+// `zod.object().and(...)` intersection, which zod rejects at construction and
+// crashes the generated module.
+//
+// The fix is to only emit a discriminated union when every branch can be
+// rendered as a single `ZodObject`, and fall back to a plain union otherwise.
+// The go/no-go decision is made here (against the resolved spec, where we have
+// full type information); the render side just trusts the marker and forces
+// `allOf` branches to merge into one object.
+//
+// The property name is smuggled through the definition's function name because
+// the definition tuple only carries `[name, args]` (see PR #1907, which used
+// the same approach).
+const DISCRIMINATOR_MARK = '::discriminator::';
+
+const encodeDiscriminatorSeparator = (base: string, property: string): string =>
+  `${base}${DISCRIMINATOR_MARK}${property}`;
+
+const decodeDiscriminatorSeparator = (
+  fn: string,
+): { base: string; property: string } | null => {
+  const index = fn.indexOf(DISCRIMINATOR_MARK);
+  if (index === -1) return null;
+  return {
+    base: fn.slice(0, index),
+    property: fn.slice(index + DISCRIMINATOR_MARK.length),
+  };
+};
+
+// Follow a single `$ref` to its target; pass concrete schemas through as-is.
+const resolveUnionMemberSchema = (
+  member: OpenApiSchemaObject | OpenApiReferenceObject,
+  context: ContextSpec,
+): OpenApiSchemaObject | undefined => {
+  if (member && '$ref' in member && typeof member.$ref === 'string') {
+    return tryResolveRefSchema(member.$ref, context);
+  }
+  return member as OpenApiSchemaObject;
+};
+
+// A schema that renders to a single `zod.object({...})` — i.e. not a union,
+// not an intersection (`allOf`), and shaped like an object.
+const isPlainObjectSchema = (
+  schema: OpenApiSchemaObject | undefined,
+): boolean => {
+  if (!schema || schema.oneOf || schema.anyOf || schema.allOf) return false;
+  return (
+    schema.type === 'object' ||
+    (isObject(schema.properties) && Object.keys(schema.properties).length > 0)
+  );
+};
+
+// The branch must declare the discriminator key as a literal value — a `const`
+// or an `enum`. Both zod v3 (>=3.20) and v4 build their branch lookup by
+// reading discrete literal values off each option, and throw at construction if
+// a discriminator resolves to a non-literal (e.g. a free `string`). Requiring a
+// literal here keeps such specs on the plain-union path instead.
+const hasLiteralDiscriminator = (
+  schema: OpenApiSchemaObject | undefined,
+  property: string,
+): boolean => {
+  if (!schema || !isObject(schema.properties)) return false;
+  const propertySchema = schema.properties[property];
+  if (!isObject(propertySchema)) return false;
+  return (
+    (propertySchema as { const?: unknown }).const !== undefined ||
+    Array.isArray((propertySchema as { enum?: unknown }).enum)
+  );
+};
+
+// Read the literal discriminator value(s) a branch declares for `property`
+// (a `const` yields one value, an `enum` yields several). Resolves `$ref` and,
+// for `allOf`, honours the render-time merge semantics where a later member
+// overrides an earlier one — so the last part that declares the property wins.
+// Returns null when no literal is found. Used to reject duplicate discriminator
+// values across branches, which `zod.discriminatedUnion` throws on at
+// construction.
+const collectDiscriminatorValues = (
+  member: OpenApiSchemaObject | OpenApiReferenceObject,
+  property: string,
+  context: ContextSpec,
+): unknown[] | null => {
+  const readValues = (
+    schema: OpenApiSchemaObject | undefined,
+  ): unknown[] | null => {
+    if (!schema || !isObject(schema.properties)) return null;
+    const propertySchema = schema.properties[property];
+    if (!isObject(propertySchema)) return null;
+    const constValue = (propertySchema as { const?: unknown }).const;
+    if (constValue !== undefined) return [constValue];
+    const enumValues = (propertySchema as { enum?: unknown }).enum;
+    if (Array.isArray(enumValues)) return enumValues;
+    return null;
+  };
+
+  const resolved = resolveUnionMemberSchema(member, context);
+  if (!resolved) return null;
+
+  if (resolved.allOf) {
+    const parts = (
+      resolved.allOf as (OpenApiSchemaObject | OpenApiReferenceObject)[]
+    ).map((part) => resolveUnionMemberSchema(part, context));
+    for (let index = parts.length - 1; index >= 0; index--) {
+      const values = readValues(parts[index]);
+      if (values) return values;
+    }
+    return null;
+  }
+
+  return readValues(resolved);
+};
+
+// Can this union branch be rendered as a `ZodObject` carrying the discriminator
+// literal? If not, the whole union must stay a plain `zod.union`.
+const isDiscriminatableMember = (
+  member: OpenApiSchemaObject | OpenApiReferenceObject,
+  property: string,
+  useReusableSchemas: boolean,
+  context: ContextSpec,
+): boolean => {
+  const resolved = resolveUnionMemberSchema(member, context);
+  if (!resolved) return false;
+
+  // A nested union can't be a discriminated-union option.
+  if (resolved.oneOf || resolved.anyOf) return false;
+
+  if (resolved.allOf) {
+    // Inheritance: representable only when we can flatten the parts into one
+    // object at render time. That needs the parts inlined property-by-property.
+    // With `useReusableSchemas` the parts stay `$ref` identifiers to other
+    // consts (potentially intersections themselves), so we can't guarantee a
+    // ZodObject — leave it as a plain union.
+    if (useReusableSchemas) return false;
+    const parts = (
+      resolved.allOf as (OpenApiSchemaObject | OpenApiReferenceObject)[]
+    ).map((part) => resolveUnionMemberSchema(part, context));
+    if (!parts.every((part) => isPlainObjectSchema(part))) return false;
+    return parts.some((part) => hasLiteralDiscriminator(part, property));
+  }
+
+  if (!isPlainObjectSchema(resolved)) return false;
+  return hasLiteralDiscriminator(resolved, property);
+};
+
 export const generateZodValidationSchemaDefinition = (
   schema: OpenApiSchemaObject | OpenApiReferenceObject | undefined,
   context: ContextSpec,
@@ -503,6 +654,54 @@ export const generateZodValidationSchemaDefinition = (
       | OpenApiReferenceObject
     )[];
 
+    // Emit a discriminated union only when the opt-in flag is set AND the spec
+    // asks for one AND every branch can be rendered as a `ZodObject` (see the
+    // notes on `isDiscriminatableMember`). Otherwise keep `separator` as-is and
+    // fall back to a plain `zod.union`, which accepts any member shape.
+    const discriminatorProperty = ((): string | undefined => {
+      if (
+        !context.output?.override?.zod?.generateDiscriminatedUnion ||
+        !(schema.oneOf || schema.anyOf) ||
+        !schema.discriminator?.propertyName ||
+        schemas.length <= 1
+      ) {
+        return undefined;
+      }
+
+      const property = schema.discriminator.propertyName;
+      if (
+        !schemas.every((member) =>
+          isDiscriminatableMember(
+            member,
+            property,
+            useReusableSchemas,
+            context,
+          ),
+        )
+      ) {
+        return undefined;
+      }
+
+      // `zod.discriminatedUnion` builds a value->branch map at construction and
+      // throws if two branches share a discriminator value. Require the values
+      // to be unique across all branches; otherwise fall back to a plain union.
+      const seenValues = new Set<string>();
+      for (const member of schemas) {
+        const values = collectDiscriminatorValues(member, property, context);
+        if (!values || values.length === 0) return undefined;
+        for (const value of values) {
+          const key = JSON.stringify(value);
+          if (seenValues.has(key)) return undefined;
+          seenValues.add(key);
+        }
+      }
+
+      return property;
+    })();
+    const unionSeparator = discriminatorProperty
+      ? encodeDiscriminatorSeparator(separator, discriminatorProperty)
+      : separator;
+
     // In JSON Schema / OpenAPI 3.1 a `required` array in any `allOf` member
     // (and on the composing schema itself) applies to properties contributed by
     // any member. Collect them all so each member's own properties can be marked
@@ -582,7 +781,7 @@ export const generateZodValidationSchemaDefinition = (
         functions.push([
           'allOf',
           [
-            { functions: [[separator, baseSchemas]], consts: [] },
+            { functions: [[unionSeparator, baseSchemas]], consts: [] },
             additionalPropertiesDefinition,
           ],
         ]);
@@ -592,7 +791,7 @@ export const generateZodValidationSchemaDefinition = (
         functions.push([separator, baseSchemas]);
       }
     } else {
-      functions.push([separator, baseSchemas]);
+      functions.push([unionSeparator, baseSchemas]);
     }
     skipSwitchStatement = true;
   }
@@ -1326,6 +1525,59 @@ ${Object.entries(objectArgs)
       )}`,
     });
 
+    // Merge an `allOf` of object schemas into one set of properties, or null
+    // when a part isn't a plain object. Mirrors `mergeAllOfObjectsClassic`.
+    const mergeAllOfObjectsMini = (
+      allOfArgs: ZodValidationSchemaDefinition[],
+    ): Record<string, ZodValidationSchemaDefinition> | null => {
+      const allAreObjects =
+        allOfArgs.length > 0 &&
+        allOfArgs.every((partSchema) => {
+          if (partSchema.functions.length === 0) return false;
+          const firstFn = partSchema.functions[0][0];
+          return firstFn === 'object' || firstFn === 'strictObject';
+        });
+      if (!allAreObjects) return null;
+
+      const mergedProperties: Record<string, ZodValidationSchemaDefinition> =
+        {};
+      for (const partSchema of allOfArgs) {
+        if (partSchema.consts.length > 0) {
+          appendConstsChunk(partSchema.consts.join('\n'));
+        }
+        const objectFunctionIndex = partSchema.functions.findIndex(
+          ([fnName]) => fnName === 'object' || fnName === 'strictObject',
+        );
+        if (objectFunctionIndex !== -1) {
+          const objectArgs = partSchema.functions[objectFunctionIndex][1];
+          if (isObject(objectArgs)) {
+            Object.assign(
+              mergedProperties,
+              objectArgs as Record<string, ZodValidationSchemaDefinition>,
+            );
+          }
+        }
+      }
+      return mergedProperties;
+    };
+
+    // Render a single discriminated-union branch as a `ZodObject` (see
+    // `renderDiscriminatedUnionMember` for the classic-variant counterpart).
+    const renderDiscriminatedUnionMemberMini = (
+      member: ZodValidationSchemaDefinition,
+    ): string => {
+      if (member.functions[0]?.[0] === 'allOf') {
+        const merged = mergeAllOfObjectsMini(
+          member.functions[0][1] as ZodValidationSchemaDefinition[],
+        );
+        if (merged !== null) {
+          return renderObject(merged, getObjectFunctionName(true, strict)).expr;
+        }
+      }
+      appendConstsChunk(member.consts.join('\n'));
+      return renderMiniDefinition(member, fieldPath).expr;
+    };
+
     for (let index = 0; index < definition.functions.length; index++) {
       const [fn, args = ''] = definition.functions[index];
 
@@ -1349,39 +1601,11 @@ ${Object.entries(objectArgs)
 
       if (fn === 'allOf') {
         const allOfArgs = args as ZodValidationSchemaDefinition[];
-        const allAreObjects =
-          strict &&
-          allOfArgs.length > 0 &&
-          allOfArgs.every((partSchema) => {
-            if (partSchema.functions.length === 0) return false;
-            const firstFn = partSchema.functions[0][0];
-            return firstFn === 'object' || firstFn === 'strictObject';
-          });
+        const mergedProperties = strict
+          ? mergeAllOfObjectsMini(allOfArgs)
+          : null;
 
-        if (allAreObjects) {
-          const mergedProperties: Record<
-            string,
-            ZodValidationSchemaDefinition
-          > = {};
-          const allConsts: string[] = [];
-          for (const partSchema of allOfArgs) {
-            if (partSchema.consts.length > 0) {
-              allConsts.push(partSchema.consts.join('\n'));
-            }
-            const objectFunctionIndex = partSchema.functions.findIndex(
-              ([fnName]) => fnName === 'object' || fnName === 'strictObject',
-            );
-            if (objectFunctionIndex !== -1) {
-              const objectArgs = partSchema.functions[objectFunctionIndex][1];
-              if (isObject(objectArgs)) {
-                Object.assign(
-                  mergedProperties,
-                  objectArgs as Record<string, ZodValidationSchemaDefinition>,
-                );
-              }
-            }
-          }
-          appendConstsChunk(allConsts.join('\n'));
+        if (mergedProperties !== null) {
           current = renderObject(
             mergedProperties,
             getObjectFunctionName(true, strict),
@@ -1406,11 +1630,24 @@ ${Object.entries(objectArgs)
         continue;
       }
 
-      if (fn === 'oneOf' || fn === 'anyOf') {
+      const discriminator = decodeDiscriminatorSeparator(fn);
+      if (discriminator || fn === 'oneOf' || fn === 'anyOf') {
         const unionArgs = args as ZodValidationSchemaDefinition[];
         if (unionArgs.length === 1) {
           appendConstsChunk(unionArgs[0].consts.join('\n'));
           current = renderMiniDefinition(unionArgs[0], fieldPath);
+          continue;
+        }
+        if (discriminator) {
+          current = {
+            expr: zodMiniCall(
+              'discriminatedUnion',
+              `'${jsStringEscape(discriminator.property)}', [${unionArgs
+                .map((arg) => renderDiscriminatedUnionMemberMini(arg))
+                .join(',')}]`,
+            ),
+            kind: 'union',
+          };
           continue;
         }
         current = {
@@ -1578,6 +1815,95 @@ ${Object.entries(objectArgs)
     return current ?? { expr: '' };
   };
 
+  // Merge an `allOf` of object schemas into a single `zod.object({...})`.
+  // Returns null when a part isn't a plain object (so the caller can fall back
+  // to `.and()`). Used both for strict-mode object merging and to turn an
+  // inheritance branch of a discriminated union into a valid object option.
+  function mergeAllOfObjectsClassic(
+    allOfArgs: ZodValidationSchemaDefinition[],
+    fieldPath: readonly string[],
+  ): string | null {
+    const allAreObjects =
+      allOfArgs.length > 0 &&
+      allOfArgs.every((partSchema) => {
+        if (partSchema.functions.length === 0) return false;
+        const firstFn = partSchema.functions[0][0];
+        // Zod v3 renders a strict object as `object(...).strict()`, so the
+        // object constructor is still the first function.
+        return firstFn === 'object' || firstFn === 'strictObject';
+      });
+    if (!allAreObjects) return null;
+
+    const mergedProperties: Record<string, ZodValidationSchemaDefinition> = {};
+    let allConsts = '';
+    for (const partSchema of allOfArgs) {
+      if (partSchema.consts.length > 0) {
+        allConsts += partSchema.consts.join('\n');
+      }
+      const objectFunctionIndex = partSchema.functions.findIndex(
+        ([fnName]) => fnName === 'object' || fnName === 'strictObject',
+      );
+      if (objectFunctionIndex !== -1) {
+        const objectArgs = partSchema.functions[objectFunctionIndex][1];
+        if (isObject(objectArgs)) {
+          // Later members override earlier ones (derived over base).
+          Object.assign(
+            mergedProperties,
+            objectArgs as Record<string, ZodValidationSchemaDefinition>,
+          );
+        }
+      }
+    }
+
+    if (allConsts.length > 0) {
+      appendConstsChunk(allConsts);
+    }
+
+    const objectType = getObjectFunctionName(isZodV4, strict);
+    const mergedObjectString = `zod.${objectType}({
+${Object.entries(mergedProperties)
+  .map(([key, schema]) => {
+    const value = schema.functions
+      .map((prop) => parseProperty(prop, [...fieldPath, key]))
+      .join('');
+    appendConstsChunk(schema.consts.join('\n'));
+    return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
+  })
+  .join(',\n')}
+})`;
+
+    // Apply strict only once for Zod v3 (v4 uses strictObject above).
+    if (strict && !isZodV4) {
+      return `${mergedObjectString}.strict()`;
+    }
+    return mergedObjectString;
+  }
+
+  // Render a single discriminated-union branch as a `ZodObject`. `allOf`
+  // (inheritance) branches are merged into one object; every other branch is a
+  // plain object or a `$ref` identifier and renders as-is. Generation only
+  // marks the union as discriminated when all branches satisfy this, so the
+  // fallback here should not trigger in practice.
+  const renderDiscriminatedUnionMember = (
+    member: ZodValidationSchemaDefinition,
+    fieldPath: readonly string[],
+  ): string => {
+    if (member.functions[0]?.[0] === 'allOf') {
+      const merged = mergeAllOfObjectsClassic(
+        member.functions[0][1] as ZodValidationSchemaDefinition[],
+        fieldPath,
+      );
+      if (merged !== null) {
+        return merged;
+      }
+    }
+    appendConstsChunk(member.consts.join('\n'));
+    const value = member.functions
+      .map((prop) => parseProperty(prop, fieldPath))
+      .join('');
+    return `${value.startsWith('.') ? 'zod' : ''}${value}`;
+  };
+
   const parseProperty = (
     property: [string, unknown],
     fieldPath: readonly string[] = [],
@@ -1617,70 +1943,13 @@ ${Object.entries(objectArgs)
 
     if (fn === 'allOf') {
       const allOfArgs = args as ZodValidationSchemaDefinition[];
-      // Check if all parts are objects and we need to merge them for strict mode
-      const allAreObjects =
-        strict &&
-        allOfArgs.length > 0 &&
-        allOfArgs.every((partSchema) => {
-          if (partSchema.functions.length === 0) return false;
-          const firstFn = partSchema.functions[0][0];
-          // Check if first function is object or strictObject
-          // For Zod v3 with strict, it will be object followed by strict
-          return firstFn === 'object' || firstFn === 'strictObject';
-        });
-
-      if (allAreObjects) {
-        // Merge all object properties into a single object
-        const mergedProperties: Record<string, ZodValidationSchemaDefinition> =
-          {};
-        let allConsts = '';
-
-        for (const partSchema of allOfArgs) {
-          if (partSchema.consts.length > 0) {
-            allConsts += partSchema.consts.join('\n');
-          }
-
-          // Find the object function (might be first or second after strict)
-          const objectFunctionIndex = partSchema.functions.findIndex(
-            ([fnName]) => fnName === 'object' || fnName === 'strictObject',
-          );
-
-          if (objectFunctionIndex !== -1) {
-            const objectArgs = partSchema.functions[objectFunctionIndex][1];
-            if (isObject(objectArgs)) {
-              // Merge properties (later schemas override earlier ones)
-              Object.assign(
-                mergedProperties,
-                objectArgs as Record<string, ZodValidationSchemaDefinition>,
-              );
-            }
-          }
+      // In strict mode, merge object parts into a single object so the extra
+      // constraint applies once (rather than to each `.and()` term).
+      if (strict) {
+        const merged = mergeAllOfObjectsClassic(allOfArgs, fieldPath);
+        if (merged !== null) {
+          return merged;
         }
-
-        if (allConsts.length > 0) {
-          appendConstsChunk(allConsts);
-        }
-
-        // Generate merged object
-        const objectType = getObjectFunctionName(isZodV4, strict);
-        const mergedObjectString = `zod.${objectType}({
-${Object.entries(mergedProperties)
-  .map(([key, schema]) => {
-    const value = schema.functions
-      .map((prop) => parseProperty(prop, [...fieldPath, key]))
-      .join('');
-    appendConstsChunk(schema.consts.join('\n'));
-    return `  "${key}": ${value.startsWith('.') ? 'zod' : ''}${value}`;
-  })
-  .join(',\n')}
-})`;
-
-        // Apply strict only once for Zod v3 (v4 uses strictObject)
-        if (!isZodV4) {
-          return `${mergedObjectString}.strict()`;
-        }
-
-        return mergedObjectString;
       }
 
       // Fallback to original .and() approach for non-object or non-strict cases
@@ -1704,7 +1973,8 @@ ${Object.entries(mergedProperties)
 
       return acc;
     }
-    if (fn === 'oneOf' || fn === 'anyOf') {
+    const discriminator = decodeDiscriminatorSeparator(fn);
+    if (discriminator || fn === 'oneOf' || fn === 'anyOf') {
       const unionArgs = args as ZodValidationSchemaDefinition[];
       // Can't use zod.union() with a single item
       if (unionArgs.length === 1) {
@@ -1712,6 +1982,13 @@ ${Object.entries(mergedProperties)
         return unionArgs[0].functions
           .map((prop: [string, unknown]) => parseProperty(prop, fieldPath))
           .join('');
+      }
+
+      if (discriminator) {
+        const members = unionArgs.map((member) =>
+          renderDiscriminatedUnionMember(member, fieldPath),
+        );
+        return `.discriminatedUnion('${jsStringEscape(discriminator.property)}', [${members.join(',')}])`;
       }
 
       const union = unionArgs.map(

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -11321,3 +11321,315 @@ describe('enum/const value escaping (#3505)', () => {
     ]);
   });
 });
+
+// `oneOf`/`anyOf` + `discriminator` should map onto `zod.discriminatedUnion`,
+// which gives per-branch validation errors instead of the opaque "no union
+// member matched" a plain `zod.union` produces. Orval shipped this in PR #1907
+// and then reverted it in PR #2118 because `zod.discriminatedUnion` only
+// accepts object options and an inheritance (`allOf`) branch rendered as a
+// `.and()` intersection, crashing the generated module (issue #2085). These
+// tests lock in the safe behaviour: emit a discriminated union when every
+// branch can render as an object, and fall back to a plain union otherwise.
+describe('discriminated unions (#1907, #2085)', () => {
+  const render = (
+    schema: OpenApiSchemaObject,
+    {
+      context = createTestContextSpec(),
+      isZodV4 = false,
+      strict = false,
+      useReusableSchemas = false,
+      variant = 'classic' as 'classic' | 'mini',
+      // The feature is opt-in, so enable it by default for these tests.
+      generateDiscriminatedUnion = true,
+    } = {},
+  ) => {
+    context.output.override.zod.generateDiscriminatedUnion =
+      generateDiscriminatedUnion;
+    const definition = generateZodValidationSchemaDefinition(
+      schema,
+      context,
+      'test',
+      strict,
+      isZodV4,
+      { required: true, useReusableSchemas },
+    );
+    return parseZodValidationSchemaDefinition(
+      definition,
+      context,
+      false,
+      strict,
+      isZodV4,
+      undefined,
+      undefined,
+      variant,
+    ).zod;
+  };
+
+  const objectBranch = (type: string, extra: Record<string, unknown>) =>
+    ({
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: [type] },
+        ...extra,
+      },
+    }) as OpenApiSchemaObject;
+
+  const catDogUnion = {
+    oneOf: [
+      objectBranch('cat', { meow: { type: 'boolean' } }),
+      objectBranch('dog', { bark: { type: 'boolean' } }),
+    ],
+    discriminator: { propertyName: 'type' },
+  } as OpenApiSchemaObject;
+
+  it('emits a discriminatedUnion for object branches with a discriminator', () => {
+    const result = render(catDogUnion);
+    expect(result).toContain("zod.discriminatedUnion('type', [");
+    expect(result).not.toContain('zod.union(');
+  });
+
+  it('supports anyOf discriminators, not just oneOf', () => {
+    const result = render({
+      anyOf: catDogUnion.oneOf,
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject);
+    expect(result).toContain("zod.discriminatedUnion('type', [");
+  });
+
+  // The exact case that forced the PR #1907 revert (#2085): each branch is an
+  // `allOf` (base + own props). It must be flattened into a single object so
+  // `zod.discriminatedUnion` accepts it — never an `.and()` intersection.
+  it('flattens allOf inheritance branches into objects instead of crashing', () => {
+    const inheritance = {
+      oneOf: [
+        {
+          allOf: [
+            objectBranch('cat', {}),
+            { type: 'object', properties: { meow: { type: 'boolean' } } },
+          ],
+        },
+        {
+          allOf: [
+            objectBranch('dog', {}),
+            { type: 'object', properties: { bark: { type: 'boolean' } } },
+          ],
+        },
+      ],
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject;
+
+    const result = render(inheritance);
+    expect(result).toContain("zod.discriminatedUnion('type', [");
+    // No intersection: that is what zod rejects for a discriminated union.
+    expect(result).not.toContain('.and(');
+    // Base and own properties both survive the merge.
+    expect(result).toContain('"meow"');
+    expect(result).toContain('"bark"');
+  });
+
+  // Jolteon's setup: `generateReusableSchemas` keeps each branch as a reference
+  // to its own generated const, so the union lists identifiers.
+  it('references reusable schema branches by identifier', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Cat: objectBranch('cat', { meow: { type: 'boolean' } }),
+            Dog: objectBranch('dog', { bark: { type: 'boolean' } }),
+          },
+        },
+      } as never,
+    });
+    const result = render(
+      {
+        oneOf: [
+          { $ref: '#/components/schemas/Cat' },
+          { $ref: '#/components/schemas/Dog' },
+        ],
+        discriminator: { propertyName: 'type' },
+      } as unknown as OpenApiSchemaObject,
+      { context, useReusableSchemas: true },
+    );
+    // __REF_X__ placeholders are rewritten to the const name by the orchestrator.
+    expect(result).toBe(
+      "zod.discriminatedUnion('type', [__REF_Cat__,__REF_Dog__])",
+    );
+  });
+
+  it('wraps an optional/nullable discriminated union as union([..., null])', () => {
+    // Pydantic emits an optional discriminated union as
+    // `anyOf: [{ oneOf + discriminator }, null]` — the discriminator sits on the
+    // inner union, so only the inner half becomes a discriminatedUnion.
+    const result = render({
+      anyOf: [
+        {
+          oneOf: catDogUnion.oneOf,
+          discriminator: { propertyName: 'type' },
+        },
+        { type: 'null' },
+      ],
+    } as unknown as OpenApiSchemaObject);
+    expect(result).toContain("zod.discriminatedUnion('type', [");
+    expect(result).toContain('zod.null()');
+    expect(result.startsWith('zod.union([')).toBe(true);
+  });
+
+  it('emits a discriminatedUnion in zod v4', () => {
+    expect(render(catDogUnion, { isZodV4: true })).toContain(
+      "zod.discriminatedUnion('type', [",
+    );
+  });
+
+  it('emits a discriminatedUnion in the zod-mini variant', () => {
+    expect(render(catDogUnion, { isZodV4: true, variant: 'mini' })).toContain(
+      "zod.discriminatedUnion('type', [",
+    );
+  });
+
+  // --- Safe fallbacks: keep a plain union when a discriminated one can't be
+  // built, rather than emitting code that throws at construction. ---
+
+  it('falls back to a plain union when a branch is not an object', () => {
+    const result = render({
+      oneOf: [objectBranch('cat', {}), { type: 'string' }],
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject);
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  it('falls back to a plain union when a branch lacks the discriminator key', () => {
+    const result = render({
+      oneOf: [
+        objectBranch('cat', {}),
+        { type: 'object', properties: { bark: { type: 'boolean' } } },
+      ],
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject);
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  // zod (v3 and v4) needs discrete literal values per branch. A free-string
+  // discriminator can't be extracted, so it must stay a plain union rather than
+  // emit code that throws at construction on either version.
+  it('falls back to a plain union when the discriminator is not a literal', () => {
+    const result = render({
+      oneOf: [
+        { type: 'object', properties: { type: { type: 'string' } } },
+        { type: 'object', properties: { type: { type: 'string' } } },
+      ],
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject);
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  // Reusable schemas + inheritance: the branch const may itself be an
+  // intersection, which we can't introspect from a reference, so stay a union.
+  it('falls back to a plain union for reusable inheritance branches', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Cat: {
+              allOf: [
+                objectBranch('cat', {}),
+                { type: 'object', properties: { meow: { type: 'boolean' } } },
+              ],
+            },
+            Dog: {
+              allOf: [
+                objectBranch('dog', {}),
+                { type: 'object', properties: { bark: { type: 'boolean' } } },
+              ],
+            },
+          },
+        },
+      } as never,
+    });
+    const result = render(
+      {
+        oneOf: [
+          { $ref: '#/components/schemas/Cat' },
+          { $ref: '#/components/schemas/Dog' },
+        ],
+        discriminator: { propertyName: 'type' },
+      } as unknown as OpenApiSchemaObject,
+      { context, useReusableSchemas: true },
+    );
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  it('leaves a discriminator-less oneOf as a plain union', () => {
+    const result = render({
+      oneOf: [objectBranch('cat', {}), objectBranch('dog', {})],
+    } as OpenApiSchemaObject);
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  // The feature is off by default: without the opt-in flag, even a
+  // discriminator-carrying union stays a plain `zod.union` (unchanged output).
+  it('emits a plain union when generateDiscriminatedUnion is disabled', () => {
+    const result = render(catDogUnion, { generateDiscriminatedUnion: false });
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  // `zod.discriminatedUnion` throws at construction if two branches share a
+  // discriminator value, so a spec with a duplicate literal must stay a plain
+  // union rather than emit code that crashes the generated module.
+  it('falls back to a plain union when two branches share a discriminator value', () => {
+    const result = render({
+      oneOf: [
+        objectBranch('cat', { meow: { type: 'boolean' } }),
+        objectBranch('cat', { purr: { type: 'boolean' } }),
+      ],
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject);
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  // Overlapping `enum` values across branches collide the same way a duplicate
+  // `const` does — the combined value set must be unique.
+  it('falls back to a plain union when branch enum values overlap', () => {
+    const result = render({
+      oneOf: [
+        {
+          type: 'object',
+          properties: { type: { type: 'string', enum: ['a', 'b'] } },
+        },
+        {
+          type: 'object',
+          properties: { type: { type: 'string', enum: ['b', 'c'] } },
+        },
+      ],
+      discriminator: { propertyName: 'type' },
+    } as OpenApiSchemaObject);
+    expect(result).toContain('zod.union([');
+    expect(result).not.toContain('discriminatedUnion');
+  });
+
+  // A discriminator property name with characters that are special inside a
+  // single-quoted string literal must be escaped, or the generated call is
+  // syntactically broken.
+  it('escapes special characters in the discriminator property name', () => {
+    const result = render({
+      oneOf: [
+        {
+          type: 'object',
+          properties: { "kind'x": { type: 'string', enum: ['cat'] } },
+        },
+        {
+          type: 'object',
+          properties: { "kind'x": { type: 'string', enum: ['dog'] } },
+        },
+      ],
+      discriminator: { propertyName: "kind'x" },
+    } as OpenApiSchemaObject);
+    expect(result).toContain("zod.discriminatedUnion('kind\\'x', [");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `override.zod.generateDiscriminatedUnion` flag that emits `z.discriminatedUnion(key, [...])` for a `oneOf`/`anyOf` carrying an OpenAPI `discriminator`, instead of a plain `z.union([...])`.

This reintroduces #1907 (reverted in #2118 due to #2085) but avoids the crash
that forced the revert.

## Why the previous attempt was reverted

`z.discriminatedUnion` only accepts object options. An inheritance branch (`allOf`) was rendered as `z.object().and(...)` which zod rejects at construction, crashing the generated module (#2085).

## Approach

- Go/no-go at generation time: emit a discriminated union only when *every* branch can be represented as an object carrying a literal (`const`/`enum`) discriminator.
- `allOf` branches are flattened into a single object (reusing the existing strict-mode object-merge) so they stay valid options
- Safe fallback to `z.union` whenever a branch can't be an object: nested unions, non-object members, non-literal discriminators, or (with `generateReusableSchemas`) a branch that `$ref`s an `allOf` schema. The generator never emits code that throws at construction.
- Opt-in, default `false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `generateDiscriminatedUnion` setting for Zod output.
  * When enabled and compatible, emits `zod.discriminatedUnion` for discriminator-based `oneOf`/`anyOf`, with safe fallback to `zod.union`.
  * Supports Zod v3, Zod v4, and the Mini variant.

* **Documentation**
  * Updated `override.zod` docs with the new option and clarified that operation/tag-level usage is ignored.

* **Tests**
  * Expanded discriminated-union coverage (including inheritance, reusable schemas, and nullability).
  * Updated generator test defaults to explicitly disable the option where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->