### PR TITLE
fix(angular): keep httpResource idle for absent optional request body (#3700)

### DIFF
--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -632,7 +632,12 @@ describe('angular httpResource generator', () => {
       expect(header).toContain('body: searchPetsBody()');
     });
 
-    it('uses optional chaining for optional retrieval POST bodies', () => {
+    // Regression for #3700: an optional retrieval POST body maps to an optional
+    // Signal parameter. When the caller omits it, the request factory must
+    // return `undefined` so the resource stays idle, instead of firing a request
+    // with an undefined body. Past the guard the signal is known to be defined,
+    // so it is invoked directly (no optional chaining).
+    it('guards optional retrieval POST bodies and keeps the resource idle (#3700)', () => {
       const verbOption = createVerbOption({
         operationId: 'searchPets',
         operationName: 'searchPets',
@@ -677,7 +682,12 @@ describe('angular httpResource generator', () => {
       } as never);
 
       expect(header).toContain('searchPetsBody?: Signal<SearchPetsBody>');
-      expect(header).toContain('body: searchPetsBody?.()');
+      // Idle guard is emitted at the top of the request factory.
+      expect(header).toContain('if (!searchPetsBody) return undefined;');
+      // The body signal is invoked directly once past the guard.
+      expect(header).toContain('body: searchPetsBody()');
+      // The unconditional optional-call form must no longer be emitted.
+      expect(header).not.toContain('body: searchPetsBody?.()');
     });
 
     it('keeps mutations in HttpClient service methods', () => {

--- a/packages/angular/src/http-resource.ts
+++ b/packages/angular/src/http-resource.ts
@@ -441,6 +441,7 @@ interface ResourceRequest {
   readonly bodyForm: string;
   readonly request: string;
   readonly isUrlOnly: boolean;
+  readonly bodyGuard?: string;
 }
 
 const buildResourceRequest = (
@@ -456,6 +457,7 @@ const buildResourceRequest = (
     formUrlEncoded,
   }: GeneratorVerbOptions,
   route: string,
+  { supportsIdleGuard }: { readonly supportsIdleGuard: boolean },
 ): ResourceRequest => {
   const isFormData = !override.formData.disabled;
   const isFormUrlEncoded = override.formUrlEncoded !== false;
@@ -471,8 +473,24 @@ const buildResourceRequest = (
   const hasFormData = isFormData && body.formData;
   const hasFormUrlEncoded = isFormUrlEncoded && body.formUrlEncoded;
 
+  // An optional request body is exposed as an optional `Signal` parameter. When
+  // the caller omits it, the `httpResource` request factory must return
+  // `undefined` so the resource stays idle, rather than firing a request with an
+  // undefined body. This mirrors Angular's `undefined`-request contract (#3700).
+  //
+  // The guard is only emitted where the request is built lazily inside the
+  // factory (single response content-type). The multi-content path builds the
+  // request eagerly at the function-body level, where returning `undefined`
+  // would violate the function's `HttpResourceRef` return type — there we keep
+  // the optional-call (`?.()`) form, which is already runtime-safe.
+  const isDirectBody = !!body.definition && !hasFormData && !hasFormUrlEncoded;
+  const bodyGuard =
+    supportsIdleGuard && isDirectBody && body.isOptional
+      ? `if (!${body.implementation}) return undefined;`
+      : undefined;
+
   const bodyAccess = body.definition
-    ? body.isOptional
+    ? body.isOptional && !bodyGuard
       ? `${body.implementation}?.()`
       : `${body.implementation}()`
     : undefined;
@@ -527,6 +545,7 @@ const buildResourceRequest = (
     bodyForm,
     request,
     isUrlOnly,
+    bodyGuard,
   };
 };
 
@@ -873,9 +892,10 @@ const buildHttpResourceFunction = (
   const signalProps = buildSignalProps(props, params);
   const args = toObjectString(signalProps, 'implementation');
 
-  const { bodyForm, request, isUrlOnly } = buildResourceRequest(
+  const { bodyForm, request, isUrlOnly, bodyGuard } = buildResourceRequest(
     verbOption,
     encodedRoute,
+    { supportsIdleGuard: uniqueContentTypes.length <= 1 },
   );
 
   if (uniqueContentTypes.length > 1) {
@@ -1137,13 +1157,20 @@ export function ${resourceName}(${implementationArgs}): HttpResourceRef<${resour
 `;
   }
 
+  // Statements emitted at the top of the request factory, before the request
+  // object is assembled: the optional-body idle guard (when present) followed by
+  // any form-data/url-encoded body construction.
+  const factoryPrelude = [bodyGuard, bodyForm ? `${bodyForm};` : undefined]
+    .filter(Boolean)
+    .join('\n    ');
+
   return `/**
  * @experimental httpResource is experimental (Angular v19.2+)
  */
 ${functionSignatures};
 export function ${resourceName}(${implementationArgs}): HttpResourceRef<${resourceValueType}> {
   return ${resourceFactory}<${parsedDataType}>(() => {
-    ${bodyForm ? `${bodyForm};` : ''}
+    ${factoryPrelude}
     const request = ${request};
     return ${returnExpression};
   }${resourceCallOptions});

--- a/tests/__snapshots__/angular/http-resource-both-tags-split/pets/pets.resource.ts
+++ b/tests/__snapshots__/angular/http-resource-both-tags-split/pets/pets.resource.ts
@@ -39,10 +39,11 @@ export function searchPetsResource(
   options?: OrvalHttpResourceOptions<Pets, unknown>,
 ): HttpResourceRef<Pets | undefined> {
   return httpResource<Pets>(() => {
+    if (!searchPetsBody) return undefined;
     const request = {
       url: `/search`,
       method: 'POST',
-      body: searchPetsBody?.(),
+      body: searchPetsBody(),
     };
     return request;
   }, options);


### PR DESCRIPTION
## Summary

Fixes #3700.

An optional OpenAPI request body (`requestBody.required: false`) generated as an Angular `httpResource` retrieval maps to an **optional** `Signal` parameter. The generated factory accessed it unconditionally as `body: bodySignal?.()`. The optional call avoided the crash reported against 8.20.0, but the resource still **eagerly fired a request with an undefined body** when the caller omitted the signal, instead of staying idle — violating Angular's `undefined`-request contract (a factory returning `undefined` means "no request").

## Fix

Emit an idle guard at the top of the request factory for optional direct request bodies:

```ts
return httpResource<Pets>(() => {
    if (!searchPetsBody) return undefined;   // stay idle until a body signal is supplied
    const request = { url: `/search`, method: 'POST', body: searchPetsBody() };
    return request;
  }, options);
```

Past the guard the signal is known to be defined, so it is invoked directly (`body: searchPetsBody()` rather than `?.()`).

Two usage patterns are now both supported cleanly:
- omit the signal entirely → resource stays **idle**;
- pass `signal(undefined)` → request fires with an empty body.

### Scope / safety

The guard is only emitted on the **single response content-type** path, where the request is assembled lazily inside the factory. The multi-content path builds the request eagerly at the function-body level — where `return undefined` would violate the function's `HttpResourceRef` return type — so it keeps the already runtime-safe `?.()` form. No behavior change for required bodies (direct call, no guard), form-data / url-encoded bodies, or GET.

## Tests

- Reproduced with the issue's minimal spec (before: fires with undefined body; after: idle guard emitted).
- Updated the optional-body unit test into a `#3700` regression test asserting the guard + direct call and the absence of `body: ...?.()`.
- `packages/angular`: 222/222 tests pass; `tsc --noEmit` clean.
- Generation snapshots: exactly one committed fixture changed (`http-resource-both-tags-split/pets/pets.resource.ts`), regenerated via `test:snapshots:update`; 5299/5299 snapshot tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retrieval-style POST requests with optional bodies so they are not sent when no body is provided.
  * Added regression coverage to ensure request generation stops early when an optional body is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->