### PR TITLE
fix(core): gate external $ref resolution behind explicit allow-list

### DIFF
--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -306,23 +306,14 @@ export default defineConfig({
 });
 ```
 
-Use `['*']` to allow all external refs (previous behavior). Orval will emit a warning listing all resolved external documents:
+Use `['*']` to allow all external refs (previous behavior). Orval will emit a warning listing external documents referenced by the top-level spec:
 
-```ts title="orval.config.ts"
-import { defineConfig } from 'orval';
-
-export default defineConfig({
-  petstore: {
-    input: {
-      target: './openapi.yaml',
-      parserOptions: {
-        externalRefs: {
-          allow: ['*'],
-        },
-      },
-    },
+```ts
+parserOptions: {
+  externalRefs: {
+    allow: ['*'],
   },
-});
+}
 ```
 
 <Callout type="warn">

--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -325,22 +325,6 @@ export default defineConfig({
 });
 ```
 
-#### suppressWarning
-
-**Type:** `boolean`
-**Default:** `false`
-
-Suppress the warning block that lists resolved external documents when `allow` includes `['*']`.
-
-```ts
-parserOptions: {
-  externalRefs: {
-    allow: ['*'],
-    suppressWarning: true,
-  },
-}
-```
-
 <Callout type="warn">
   **Security:** External `$ref` values come from the spec being processed, which may
   be untrusted. Allowing all external refs (`['*']`) means orval will read arbitrary

--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -272,6 +272,82 @@ export default defineConfig({
 });
 ```
 
+### externalRefs
+
+Control how external `$ref` targets (local files or remote URLs) are resolved.
+
+By default, orval refuses to resolve any external `$ref` and prints a config snippet you can paste into your `parserOptions`.
+
+#### allow
+
+**Type:** `string[]`
+**Default:** `[]`
+
+External `$ref` document targets to allow. Each entry should be the document part of the `$ref` (without the `#/...` fragment). File paths are relative to the spec file.
+
+```ts title="orval.config.ts"
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './openapi.yaml',
+      parserOptions: {
+        externalRefs: {
+          allow: [
+            './schemas/pet.yaml',
+            './schemas/user.yaml',
+            'https://example.com/schemas/shared.json',
+          ],
+        },
+      },
+    },
+  },
+});
+```
+
+Use `['*']` to allow all external refs (previous behavior). Orval will emit a warning listing all resolved external documents:
+
+```ts title="orval.config.ts"
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './openapi.yaml',
+      parserOptions: {
+        externalRefs: {
+          allow: ['*'],
+        },
+      },
+    },
+  },
+});
+```
+
+#### suppressWarning
+
+**Type:** `boolean`
+**Default:** `false`
+
+Suppress the warning block that lists resolved external documents when `allow` includes `['*']`.
+
+```ts
+parserOptions: {
+  externalRefs: {
+    allow: ['*'],
+    suppressWarning: true,
+  },
+}
+```
+
+<Callout type="warn">
+  **Security:** External `$ref` values come from the spec being processed, which may
+  be untrusted. Allowing all external refs (`['*']`) means orval will read arbitrary
+  local files and fetch arbitrary URLs referenced by the spec. Prefer listing
+  specific documents you trust.
+</Callout>
+
 ## unsafeDisableValidation
 
 Disable OpenAPI spec validation during code generation.

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -642,7 +642,9 @@ function filterParams(
       expect(result).toContain(
         `const objectParamStrategies: Readonly<Record<string, 'flatten' | 'comma' | 'deepObject'>> = {"arg0":"flatten"};`,
       );
-      expect(result).toContain('Object.hasOwn(objectParamStrategies, key)');
+      expect(result).toContain(
+        'Object.prototype.hasOwnProperty.call(objectParamStrategies, key)',
+      );
     });
   });
 

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -58,7 +58,7 @@ export const getAngularFilteredParamsExpression = (
       value != null &&
       typeof value === 'object' &&
       !Array.isArray(value) &&
-      Object.hasOwn(objectParamStrategies, key)
+      Object.prototype.hasOwnProperty.call(objectParamStrategies, key)
     ) {
       const objectStrategy = objectParamStrategies[key];
       const entries = Object.entries(value as Record<string, unknown>);
@@ -306,7 +306,7 @@ function filterParams(
       value != null &&
       typeof value === 'object' &&
       !Array.isArray(value) &&
-      Object.hasOwn(objectParamStrategies, key)
+      Object.prototype.hasOwnProperty.call(objectParamStrategies, key)
     ) {
       const objectStrategy = objectParamStrategies[key];
       const entries = Object.entries(value as Record<string, unknown>);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,8 +232,6 @@ export interface NormalizedInputOptions {
     }[];
     externalRefs?: {
       allow?: string[];
-      /** @default false */
-      suppressWarning?: boolean;
       // TODO: add `deny?: string[]` when users need "allow all except X"
     };
   };
@@ -434,13 +432,6 @@ export interface InputOptions {
        * @default []
        */
       allow?: string[];
-      /**
-       * Suppress the warning block that lists resolved external documents when
-       * `allow` includes `['*']`.
-       *
-       * @default false
-       */
-      suppressWarning?: boolean;
       // TODO: add `deny?: string[]` when users need "allow all except X"
     };
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -230,6 +230,12 @@ export interface NormalizedInputOptions {
       domains: string[];
       headers: Record<string, string>;
     }[];
+    externalRefs?: {
+      allow?: string[];
+      /** @default false */
+      suppressWarning?: boolean;
+      // TODO: add `deny?: string[]` when users need "allow all except X"
+    };
   };
 }
 
@@ -412,6 +418,31 @@ export interface InputOptions {
       domains: string[];
       headers: Record<string, string>;
     }[];
+    /**
+     * Control how external `$ref` targets (local files or remote URLs) are
+     * resolved.
+     *
+     * By default, orval refuses to resolve any external `$ref` and prints a
+     * config snippet you can paste into your `parserOptions`.
+     */
+    externalRefs?: {
+      /**
+       * External `$ref` document targets to allow. Each entry should be the
+       * document part of the `$ref` (without the `#/...` fragment). File paths
+       * are relative to the spec file. Use `['*']` to allow all external refs.
+       *
+       * @default []
+       */
+      allow?: string[];
+      /**
+       * Suppress the warning block that lists resolved external documents when
+       * `allow` includes `['*']`.
+       *
+       * @default false
+       */
+      suppressWarning?: boolean;
+      // TODO: add `deny?: string[]` when users need "allow all except X"
+    };
   };
 }
 

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -522,6 +522,115 @@ describe('externalRefs', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  it('should use configured headers when loading a remote top-level spec', async () => {
+    const remoteTarget = 'https://api.example.com/openapi.json';
+    const spec = {
+      openapi: '3.0.2',
+      info: { title: 'remote', version: '1.0' },
+      paths: {},
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(new Headers(init?.headers).get('Authorization')).toBe(
+        'Bearer token',
+      );
+      if (init?.method === 'HEAD') {
+        return new Response(undefined, { status: 200 });
+      }
+      return new Response(JSON.stringify(spec), { status: 200 });
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: [remoteTarget],
+            parserOptions: {
+              headers: [
+                {
+                  domains: ['api.example.com'],
+                  headers: { Authorization: 'Bearer token' },
+                },
+              ],
+            },
+          },
+        },
+        'test',
+        {},
+      );
+
+      const specBuilder = await importSpecs('test', normalizedOptions);
+
+      expect(specBuilder.spec.info?.title).toBe('remote');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('should allow remote relative refs when listed relative to the remote spec', async () => {
+    const remoteTarget = 'https://api.example.com/openapi.json';
+    const spec = {
+      openapi: '3.0.2',
+      info: { title: 'remote', version: '1.0' },
+      paths: {
+        '/x': {
+          get: {
+            operationId: 'getX',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: './common.yaml#/components/schemas/Foo' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const external = {
+      openapi: '3.0.2',
+      info: { title: 'external', version: '1.0' },
+      paths: {},
+      components: { schemas: { Foo: { type: 'string' } } },
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      if (init?.method === 'HEAD') {
+        return new Response(undefined, { status: 200 });
+      }
+      const url = input instanceof Request ? input.url : String(input);
+      return new Response(
+        JSON.stringify(url.endsWith('/common.yaml') ? external : spec),
+        { status: 200 },
+      );
+    });
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: [remoteTarget],
+            parserOptions: { externalRefs: { allow: ['./common.yaml'] } },
+          },
+        },
+        'test',
+        {},
+      );
+
+      const specBuilder = await importSpecs('test', normalizedOptions);
+
+      expect(specBuilder.verbOptions).toHaveProperty('getX');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe('optionsParamRequired', () => {

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -377,6 +377,7 @@ describe('validation', () => {
           output: { target: '' },
           input: {
             target: specPath,
+            parserOptions: { externalRefs: { allow: ['refs.yaml'] } },
             override: {
               transformer: (input: OpenApiDocument) => {
                 const next = structuredClone(input);
@@ -414,6 +415,142 @@ describe('validation', () => {
       expect(field?.model).toContain('LineString');
       expect(field?.model).not.toContain('refs.yaml');
     } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('externalRefs', () => {
+  async function createExternalRefWorkspace() {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-allow-'));
+    const specPath = path.join(workspace, 'spec.yaml');
+    const externalPath = path.join(workspace, 'external.yaml');
+    const external = {
+      openapi: '3.0.2',
+      info: { title: 'ext', version: '1.0' },
+      paths: {},
+      components: { schemas: { Foo: { type: 'string' } } },
+    };
+    const spec = {
+      openapi: '3.0.2',
+      info: { title: 'main', version: '1.0' },
+      paths: {
+        '/x': {
+          get: {
+            operationId: 'getX',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: 'external.yaml#/components/schemas/Foo' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await writeFile(externalPath, JSON.stringify(external), 'utf8');
+    await writeFile(specPath, JSON.stringify(spec), 'utf8');
+    return { workspace, specPath };
+  }
+
+  it('should block external $ref by default and print a config snippet', async () => {
+    const { workspace, specPath } = await createExternalRefWorkspace();
+    try {
+      const normalizedOptions = await normalizeOptions(
+        { output: { target: '' }, input: { target: specPath } },
+        workspace,
+        {},
+      );
+      await expect(importSpecs(workspace, normalizedOptions)).rejects.toThrow(
+        /External \$ref targets are not allowed by default/,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('should resolve external $ref when explicitly allowed', async () => {
+    const { workspace, specPath } = await createExternalRefWorkspace();
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: { externalRefs: { allow: ['external.yaml'] } },
+          },
+        },
+        workspace,
+        {},
+      );
+      const spec = await importSpecs(workspace, normalizedOptions);
+      expect(spec.verbOptions).toHaveProperty('getX');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('should resolve all external $refs with wildcard and emit warnings', async () => {
+    const { workspace, specPath } = await createExternalRefWorkspace();
+    const warnSpy = vi
+      .spyOn(orvalCore, 'logWarning')
+      .mockImplementation(() => {});
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: { externalRefs: { allow: ['*'] } },
+          },
+        },
+        workspace,
+        {},
+      );
+      const spec = await importSpecs(workspace, normalizedOptions);
+      expect(spec.verbOptions).toHaveProperty('getX');
+
+      const warnings = warnSpy.mock.calls.map(([msg]) => msg).join('\n');
+      expect(warnings).toContain('External $ref documents being resolved');
+      expect(warnings).toContain('external.yaml');
+    } finally {
+      warnSpy.mockRestore();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('should suppress warnings when externalRefs.suppressWarning is true', async () => {
+    const { workspace, specPath } = await createExternalRefWorkspace();
+    const warnSpy = vi
+      .spyOn(orvalCore, 'logWarning')
+      .mockImplementation(() => {});
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              externalRefs: { allow: ['*'], suppressWarning: true },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+      const spec = await importSpecs(workspace, normalizedOptions);
+      expect(spec.verbOptions).toHaveProperty('getX');
+
+      const externalRefWarnings = warnSpy.mock.calls
+        .map(([msg]) => msg)
+        .filter((msg) => msg.includes('External $ref'));
+      expect(externalRefWarnings).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
       await rm(workspace, { recursive: true, force: true });
     }
   });

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -522,38 +522,6 @@ describe('externalRefs', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
-
-  it('should suppress warnings when externalRefs.suppressWarning is true', async () => {
-    const { workspace, specPath } = await createExternalRefWorkspace();
-    const warnSpy = vi
-      .spyOn(orvalCore, 'logWarning')
-      .mockImplementation(() => {});
-    try {
-      const normalizedOptions = await normalizeOptions(
-        {
-          output: { target: '' },
-          input: {
-            target: specPath,
-            parserOptions: {
-              externalRefs: { allow: ['*'], suppressWarning: true },
-            },
-          },
-        },
-        workspace,
-        {},
-      );
-      const spec = await importSpecs(workspace, normalizedOptions);
-      expect(spec.verbOptions).toHaveProperty('getX');
-
-      const externalRefWarnings = warnSpy.mock.calls
-        .map(([msg]) => msg)
-        .filter((msg) => msg.includes('External $ref'));
-      expect(externalRefWarnings).toHaveLength(0);
-    } finally {
-      warnSpy.mockRestore();
-      await rm(workspace, { recursive: true, force: true });
-    }
-  });
 });
 
 describe('optionsParamRequired', () => {

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -25,15 +25,7 @@ import jsYaml from 'js-yaml';
 import { importOpenApi } from './import-open-api';
 
 interface ResolveSpecOptions {
-  parserOptions?: {
-    headers?: {
-      domains: string[];
-      headers: Record<string, string>;
-    }[];
-    externalRefs?: {
-      allow?: string[];
-    };
-  };
+  parserOptions?: NormalizedOptions['input']['parserOptions'];
   transformer?: OverrideInput['transformer'];
   workspace: string;
   unsafeDisableValidation?: boolean;

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -2,6 +2,7 @@ import {
   dynamicImport,
   isObject,
   isString,
+  isUrl,
   logWarning,
   type NormalizedOptions,
   type OpenApiDocument,
@@ -16,7 +17,10 @@ import {
   readFiles,
 } from '@scalar/json-magic/bundle/plugins/node';
 import { upgrade, validate as validateSpec } from '@scalar/openapi-parser';
+import { readFile } from 'node:fs/promises';
+import nodePath from 'node:path';
 import { isNullish } from 'remeda';
+import jsYaml from 'js-yaml';
 
 import { importOpenApi } from './import-open-api';
 
@@ -26,6 +30,10 @@ interface ResolveSpecOptions {
       domains: string[];
       headers: Record<string, string>;
     }[];
+    externalRefs?: {
+      allow?: string[];
+      suppressWarning?: boolean;
+    };
   };
   transformer?: OverrideInput['transformer'];
   workspace: string;
@@ -41,9 +49,43 @@ async function resolveSpec(
     unsafeDisableValidation = false,
   }: ResolveSpecOptions,
 ): Promise<OpenApiDocument> {
+  const allowedRefs = parserOptions?.externalRefs?.allow ?? [];
+  const isWildcard = allowedRefs.includes('*');
+  const suppressWarning = parserOptions?.externalRefs?.suppressWarning ?? false;
+
+  // Load the top-level spec so we can scan for external $refs before
+  // bundle() resolves them. The top-level target is trusted (user-configured
+  // input.target); only the $ref values inside the spec are untrusted.
+  const { data: specData, origin } = await loadSpec(input);
+
+  // Enforce the allow-list on refs found in the top-level spec.
+  // Transitive refs (inside external docs) are enforced by the loader wrappers.
+  if (!isWildcard) {
+    const refs = collectExternalRefs(specData);
+    const disallowed = refs.filter(
+      (ref) => !isAllowedRef(ref, allowedRefs, origin),
+    );
+    if (disallowed.length > 0) {
+      throw new Error(formatDisallowedRefsError(disallowed, allowedRefs));
+    }
+  } else if (!suppressWarning) {
+    const docs = [
+      ...new Set(collectExternalRefs(specData).map(getRefDocument)),
+    ];
+    if (docs.length > 0) {
+      logWarning(
+        `External $ref documents being resolved:\n` +
+          docs.map((d) => `  - ${d}`).join('\n'),
+      );
+    }
+  }
+
   const dereferencedData = await bundleAndDereferenceExternalRefs(
-    input,
+    specData,
     parserOptions,
+    origin,
+    isWildcard,
+    allowedRefs,
   );
 
   // Apply user-provided transformer before validation so users can repair
@@ -67,7 +109,9 @@ async function resolveSpec(
       ? await bundleAndDereferenceExternalRefs(
           applied,
           parserOptions,
-          isString(input) ? input : undefined,
+          origin,
+          isWildcard,
+          allowedRefs,
         )
       : applied;
   }
@@ -128,13 +172,17 @@ async function bundleAndDereferenceExternalRefs(
   input: string | Record<string, unknown>,
   parserOptions: ResolveSpecOptions['parserOptions'],
   origin?: string,
+  isWildcard = false,
+  allowedExternalRefs: string[] = [],
 ): Promise<Record<string, unknown>> {
   const data = await bundle(input, {
     plugins: [
-      readFiles(),
-      fetchUrls({
-        headers: parserOptions?.headers,
-      }),
+      createSafeFileLoader(origin, isWildcard, allowedExternalRefs),
+      createSafeUrlLoader(
+        isWildcard,
+        allowedExternalRefs,
+        parserOptions?.headers,
+      ),
       parseJson(),
       parseYaml(),
     ],
@@ -162,6 +210,189 @@ function hasExternalRef(obj: unknown): boolean {
     return Object.values(obj).some((value) => hasExternalRef(value));
   }
   return false;
+}
+
+// ─── External ref allow-list enforcement (GHSA-cxq5-97v7-87j8) ─────────────
+
+/**
+ * Load the top-level spec into an inline object so we can scan it for external
+ * `$ref`s before `bundle()` resolves them. The top-level target is trusted
+ * (user-configured `input.target`); only `$ref` values inside the spec are
+ * untrusted.
+ */
+async function loadSpec(
+  input: string | Record<string, unknown>,
+): Promise<{ data: Record<string, unknown>; origin?: string }> {
+  if (!isString(input)) {
+    return { data: input };
+  }
+  const text = isUrl(input)
+    ? await (await fetch(input)).text()
+    : await readFile(input, 'utf-8');
+  const result = jsYaml.load(text);
+  if (!isObject(result)) {
+    throw new Error('OpenAPI spec must be a valid JSON/YAML object.');
+  }
+  return { data: result as Record<string, unknown>, origin: input };
+}
+
+/**
+ * Strip the JSON pointer fragment (`#/...`) from a `$ref` value, leaving only
+ * the document target (file path or URL).
+ */
+function getRefDocument(ref: string): string {
+  const hashIndex = ref.indexOf('#');
+  return hashIndex === -1 ? ref : ref.slice(0, hashIndex);
+}
+
+/**
+ * Collect all external `$ref` document targets from a spec object. Returns
+ * deduplicated ref strings in their raw form (before fragment stripping).
+ */
+function collectExternalRefs(obj: unknown): string[] {
+  const refs = new Set<string>();
+  function walk(val: unknown) {
+    if (Array.isArray(val)) {
+      val.forEach(walk);
+      return;
+    }
+    if (isObject(val)) {
+      if ('$ref' in val && isString(val.$ref) && !val.$ref.startsWith('#')) {
+        refs.add(val.$ref);
+      }
+      Object.values(val).forEach(walk);
+    }
+  }
+  walk(obj);
+  return [...refs];
+}
+
+/**
+ * Resolve a ref document target (the part before `#`) to a canonical path or
+ * URL, so it can be compared against allow-list entries that were resolved the
+ * same way.
+ */
+function resolveRefTarget(ref: string, origin?: string): string {
+  const doc = getRefDocument(ref);
+  if (isUrl(doc)) return doc;
+  if (origin && isUrl(origin)) {
+    return new URL(doc, origin).href;
+  }
+  if (origin) {
+    return nodePath.resolve(nodePath.dirname(origin), doc);
+  }
+  return nodePath.resolve(doc);
+}
+
+/**
+ * Check whether a `$ref` is allowed by the user's allow-list. Both the ref and
+ * the allow-list entries are resolved against the spec origin so that
+ * `./schemas/pet.yaml` in the spec matches `./schemas/pet.yaml` in the config.
+ */
+function isAllowedRef(
+  ref: string,
+  allowedExternalRefs: string[],
+  origin?: string,
+): boolean {
+  const resolved = resolveRefTarget(ref, origin);
+  return allowedExternalRefs.some(
+    (entry) => resolveRefTarget(entry, origin) === resolved,
+  );
+}
+
+function formatDisallowedRefsError(
+  disallowed: string[],
+  currentAllowed: string[],
+): string {
+  const docs = [...new Set(disallowed.map(getRefDocument))];
+  const all = [...new Set([...currentAllowed, ...docs])];
+  const configSnippet = JSON.stringify(
+    {
+      input: {
+        parserOptions: { externalRefs: { allow: all } },
+      },
+    },
+    null,
+    2,
+  );
+  return (
+    `External $ref targets are not allowed by default.\n` +
+    `Add them to your config, or use externalRefs.allow: ['*'] to allow all.\n\n` +
+    `Disallowed refs:\n${disallowed.map((r) => `  - ${r}`).join('\n')}\n\n` +
+    `Suggested config:\n${configSnippet}`
+  );
+}
+
+/**
+ * Wrap `readFiles()` so every file read is checked against the allow-list.
+ * The top-level spec file (matching `origin`) is always allowed; subsequent
+ * reads must match an explicit entry or the wildcard.
+ */
+function createSafeFileLoader(
+  origin: string | undefined,
+  isWildcard: boolean,
+  allowedExternalRefs: string[],
+) {
+  const base = readFiles();
+  return {
+    type: 'loader' as const,
+    validate: base.validate,
+    async exec(value: string) {
+      if (isWildcard) {
+        return base.exec(value);
+      }
+      if (origin && nodePath.resolve(value) === nodePath.resolve(origin)) {
+        return base.exec(value);
+      }
+      const isAllowed = allowedExternalRefs.some(
+        (entry) => resolveRefTarget(entry, origin) === nodePath.resolve(value),
+      );
+      if (!isAllowed) {
+        throw new Error(
+          `Refused to read external file: ${value}\n` +
+            `Add it to externalRefs.allow or use ['*'] to allow all.`,
+        );
+      }
+      return base.exec(value);
+    },
+  };
+}
+
+/**
+ * Wrap `fetchUrls()` so every URL fetch is checked against the allow-list.
+ * The top-level spec URL (matching `origin`) is always allowed; subsequent
+ * fetches must match an explicit entry or the wildcard.
+ */
+function createSafeUrlLoader(
+  isWildcard: boolean,
+  allowedExternalRefs: string[],
+  headers?: { domains: string[]; headers: Record<string, string> }[],
+) {
+  const base = fetchUrls({ headers });
+  return {
+    type: 'loader' as const,
+    validate: base.validate,
+    async exec(value: string) {
+      if (isWildcard) {
+        return base.exec(value);
+      }
+      const isAllowed = allowedExternalRefs.some((entry) => {
+        if (!isUrl(entry)) return false;
+        try {
+          return new URL(value).href === new URL(entry).href;
+        } catch {
+          return false;
+        }
+      });
+      if (!isAllowed) {
+        throw new Error(
+          `Refused to fetch external URL: ${value}\n` +
+            `Add it to externalRefs.allow or use ['*'] to allow all.`,
+        );
+      }
+      return base.exec(value);
+    },
+  };
 }
 
 export async function importSpecs(

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -95,15 +95,16 @@ async function resolveSpec(
     // those refs are resolved too (#3327). External refs resolve relative to
     // the original spec file, so reuse the string target as the bundle origin;
     // an object input has no file base and cannot introduce relative refs.
-    transformedData = hasExternalRef(applied)
-      ? await bundleAndDereferenceExternalRefs(
-          applied,
-          parserOptions,
-          origin,
-          isWildcard,
-          allowedRefs,
-        )
-      : applied;
+    transformedData =
+      collectExternalRefs(applied).length > 0
+        ? await bundleAndDereferenceExternalRefs(
+            applied,
+            parserOptions,
+            origin,
+            isWildcard,
+            allowedRefs,
+          )
+        : applied;
   }
 
   if (unsafeDisableValidation) {
@@ -180,26 +181,6 @@ async function bundleAndDereferenceExternalRefs(
     ...(origin ? { origin } : {}),
   });
   return dereferenceExternalRef(data as Record<string, unknown>);
-}
-
-/**
- * Report whether any `$ref` in the document points to an external document.
- * Per the JSON Reference rules a ref is external when it does not start with
- * `#` (an in-document pointer). Used to decide whether a transformer introduced
- * new external refs that need a second bundle pass (#3327) — when it did not,
- * the already-bundled spec is returned untouched.
- */
-function hasExternalRef(obj: unknown): boolean {
-  if (Array.isArray(obj)) {
-    return obj.some((item) => hasExternalRef(item));
-  }
-  if (isObject(obj)) {
-    if ('$ref' in obj && isString(obj.$ref) && !obj.$ref.startsWith('#')) {
-      return true;
-    }
-    return Object.values(obj).some((value) => hasExternalRef(value));
-  }
-  return false;
 }
 
 // ─── External ref allow-list enforcement (GHSA-cxq5-97v7-87j8) ─────────────

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -32,7 +32,6 @@ interface ResolveSpecOptions {
     }[];
     externalRefs?: {
       allow?: string[];
-      suppressWarning?: boolean;
     };
   };
   transformer?: OverrideInput['transformer'];
@@ -51,7 +50,6 @@ async function resolveSpec(
 ): Promise<OpenApiDocument> {
   const allowedRefs = parserOptions?.externalRefs?.allow ?? [];
   const isWildcard = allowedRefs.includes('*');
-  const suppressWarning = parserOptions?.externalRefs?.suppressWarning ?? false;
 
   // Load the top-level spec so we can scan for external $refs before
   // bundle() resolves them. The top-level target is trusted (user-configured
@@ -68,7 +66,7 @@ async function resolveSpec(
     if (disallowed.length > 0) {
       throw new Error(formatDisallowedRefsError(disallowed, allowedRefs));
     }
-  } else if (!suppressWarning) {
+  } else {
     const docs = [
       ...new Set(collectExternalRefs(specData).map(getRefDocument)),
     ];

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -23,6 +23,7 @@ import { isNullish } from 'remeda';
 import jsYaml from 'js-yaml';
 
 import { importOpenApi } from './import-open-api';
+import { getHeadersForUrl } from './utils/options';
 
 interface ResolveSpecOptions {
   parserOptions?: NormalizedOptions['input']['parserOptions'];
@@ -46,7 +47,10 @@ async function resolveSpec(
   // Load the top-level spec so we can scan for external $refs before
   // bundle() resolves them. The top-level target is trusted (user-configured
   // input.target); only the $ref values inside the spec are untrusted.
-  const { data: specData, origin } = await loadSpec(input);
+  const { data: specData, origin } = await loadSpec(
+    input,
+    parserOptions?.headers,
+  );
 
   // Enforce the allow-list on refs found in the top-level spec.
   // Transitive refs (inside external docs) are enforced by the loader wrappers.
@@ -170,6 +174,7 @@ async function bundleAndDereferenceExternalRefs(
     plugins: [
       createSafeFileLoader(origin, isWildcard, allowedExternalRefs),
       createSafeUrlLoader(
+        origin,
         isWildcard,
         allowedExternalRefs,
         parserOptions?.headers,
@@ -193,12 +198,15 @@ async function bundleAndDereferenceExternalRefs(
  */
 async function loadSpec(
   input: string | Record<string, unknown>,
+  headers?: NonNullable<ResolveSpecOptions['parserOptions']>['headers'],
 ): Promise<{ data: Record<string, unknown>; origin?: string }> {
   if (!isString(input)) {
     return { data: input };
   }
   const text = isUrl(input)
-    ? await (await fetch(input)).text()
+    ? await (
+        await fetch(input, { headers: getHeadersForUrl(input, headers) })
+      ).text()
     : await readFile(input, 'utf-8');
   const result = jsYaml.load(text);
   if (!isObject(result)) {
@@ -335,6 +343,7 @@ function createSafeFileLoader(
  * fetches must match an explicit entry or the wildcard.
  */
 function createSafeUrlLoader(
+  origin: string | undefined,
   isWildcard: boolean,
   allowedExternalRefs: string[],
   headers?: { domains: string[]; headers: Record<string, string> }[],
@@ -347,9 +356,12 @@ function createSafeUrlLoader(
       if (isWildcard) {
         return base.exec(value);
       }
-      const resolved = resolveRefTarget(value);
+      const resolved = resolveRefTarget(value, origin);
+      if (origin && resolved === resolveRefTarget(origin)) {
+        return base.exec(value);
+      }
       const isAllowed = allowedExternalRefs.some(
-        (entry) => isUrl(entry) && resolveRefTarget(entry) === resolved,
+        (entry) => resolveRefTarget(entry, origin) === resolved,
       );
       if (!isAllowed) {
         throw new Error(

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -196,6 +196,14 @@ async function bundleAndDereferenceExternalRefs(
  * (user-configured `input.target`); only `$ref` values inside the spec are
  * untrusted.
  */
+function parseSpec(text: string): Record<string, unknown> {
+  const result = jsYaml.load(text);
+  if (!isObject(result)) {
+    throw new Error('OpenAPI spec must be a valid JSON/YAML object.');
+  }
+  return result as Record<string, unknown>;
+}
+
 async function loadSpec(
   input: string | Record<string, unknown>,
   headers?: NonNullable<ResolveSpecOptions['parserOptions']>['headers'],
@@ -203,16 +211,18 @@ async function loadSpec(
   if (!isString(input)) {
     return { data: input };
   }
-  const text = isUrl(input)
-    ? await (
-        await fetch(input, { headers: getHeadersForUrl(input, headers) })
-      ).text()
-    : await readFile(input, 'utf-8');
-  const result = jsYaml.load(text);
-  if (!isObject(result)) {
-    throw new Error('OpenAPI spec must be a valid JSON/YAML object.');
+  if (isUrl(input)) {
+    const response = await fetch(input, {
+      headers: getHeadersForUrl(input, headers),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch OpenAPI spec from ${input}: ${response.status} ${response.statusText}`,
+      );
+    }
+    return { data: parseSpec(await response.text()), origin: input };
   }
-  return { data: result as Record<string, unknown>, origin: input };
+  return { data: parseSpec(await readFile(input, 'utf-8')), origin: input };
 }
 
 /**
@@ -323,9 +333,7 @@ function createSafeFileLoader(
       if (origin && nodePath.resolve(value) === nodePath.resolve(origin)) {
         return base.exec(value);
       }
-      const isAllowed = allowedExternalRefs.some(
-        (entry) => resolveRefTarget(entry, origin) === nodePath.resolve(value),
-      );
+      const isAllowed = isAllowedRef(value, allowedExternalRefs, origin);
       if (!isAllowed) {
         throw new Error(
           `Refused to read external file: ${value}\n` +
@@ -360,9 +368,7 @@ function createSafeUrlLoader(
       if (origin && resolved === resolveRefTarget(origin)) {
         return base.exec(value);
       }
-      const isAllowed = allowedExternalRefs.some(
-        (entry) => resolveRefTarget(entry, origin) === resolved,
-      );
+      const isAllowed = isAllowedRef(value, allowedExternalRefs, origin);
       if (!isAllowed) {
         throw new Error(
           `Refused to fetch external URL: ${value}\n` +

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -245,7 +245,7 @@ function collectExternalRefs(obj: unknown): string[] {
  */
 function resolveRefTarget(ref: string, origin?: string): string {
   const doc = getRefDocument(ref);
-  if (isUrl(doc)) return doc;
+  if (isUrl(doc)) return new URL(doc).href;
   if (origin && isUrl(origin)) {
     return new URL(doc, origin).href;
   }
@@ -347,14 +347,10 @@ function createSafeUrlLoader(
       if (isWildcard) {
         return base.exec(value);
       }
-      const isAllowed = allowedExternalRefs.some((entry) => {
-        if (!isUrl(entry)) return false;
-        try {
-          return new URL(value).href === new URL(entry).href;
-        } catch {
-          return false;
-        }
-      });
+      const resolved = resolveRefTarget(value);
+      const isAllowed = allowedExternalRefs.some(
+        (entry) => isUrl(entry) && resolveRefTarget(entry) === resolved,
+      );
       if (!isAllowed) {
         throw new Error(
           `Refused to fetch external URL: ${value}\n` +

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -925,7 +925,7 @@ async function resolveFirstValidTarget(
   );
 }
 
-function getHeadersForUrl(
+export function getHeadersForUrl(
   url: string,
   headersConfig?: NonNullable<InputOptions['parserOptions']>['headers'],
 ): Record<string, string> {

--- a/tests/__snapshots__/angular/issue-3326/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326/endpoints.ts
@@ -121,7 +121,7 @@ function filterParams(
       value != null &&
       typeof value === 'object' &&
       !Array.isArray(value) &&
-      Object.hasOwn(objectParamStrategies, key)
+      Object.prototype.hasOwnProperty.call(objectParamStrategies, key)
     ) {
       const objectStrategy = objectParamStrategies[key];
       const entries = Object.entries(value as Record<string, unknown>);

--- a/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
@@ -172,7 +172,7 @@ function filterParams(
       value != null &&
       typeof value === 'object' &&
       !Array.isArray(value) &&
-      Object.hasOwn(objectParamStrategies, key)
+      Object.prototype.hasOwnProperty.call(objectParamStrategies, key)
     ) {
       const objectStrategy = objectParamStrategies[key];
       const entries = Object.entries(value as Record<string, unknown>);

--- a/tests/__snapshots__/angular/issue-3705/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705/endpoints.ts
@@ -126,7 +126,7 @@ function filterParams(
       value != null &&
       typeof value === 'object' &&
       !Array.isArray(value) &&
-      Object.hasOwn(objectParamStrategies, key)
+      Object.prototype.hasOwnProperty.call(objectParamStrategies, key)
     ) {
       const objectStrategy = objectParamStrategies[key];
       const entries = Object.entries(value as Record<string, unknown>);

--- a/tests/configs/default.config.ts
+++ b/tests/configs/default.config.ts
@@ -631,11 +631,15 @@ export default defineConfig({
       clean: true,
       formatter: 'prettier',
     },
-    input: '../specifications/multi-files-with-same-import-names/api.yaml',
+    input: {
+      target: '../specifications/multi-files-with-same-import-names/api.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
+    },
   },
   'external-ref': {
     input: {
       target: '../specifications/external-ref.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
     output: {
       target: '../generated/default/external-ref/endpoints.ts',
@@ -731,6 +735,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-1107/issue-1107.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   'issue-3380-external-path-ref': {
@@ -741,6 +746,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3380/issue-3380.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   'issue-1935-double-linked-ref': {
@@ -752,6 +758,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-1935/issue-1935.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   'issue-2206-msw-info-typing': {

--- a/tests/configs/fetch.config.ts
+++ b/tests/configs/fetch.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3327/spec.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
       override: {
         transformer: '../transformers/issue-3327-inject-external-ref.js',
       },
@@ -339,7 +340,10 @@ export default defineConfig({
       clean: true,
       formatter: 'prettier',
     },
-    input: '../specifications/import-from-subdirectory/petstore.yaml',
+    input: {
+      target: '../specifications/import-from-subdirectory/petstore.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
+    },
   },
   defaultOnlyResponse: {
     output: {
@@ -584,6 +588,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixSplit: {
@@ -612,6 +617,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixTags: {
@@ -638,6 +644,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixTagsSplit: {
@@ -665,6 +672,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixSingleNoRuntimeValidation: {
@@ -691,6 +699,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixSplitNoRuntimeValidation: {
@@ -719,6 +728,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixTagsNoRuntimeValidation: {
@@ -746,6 +756,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   zodSchemaResponseSuffixTagsSplitNoRuntimeValidation: {
@@ -773,6 +784,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   wildcardResponses: {

--- a/tests/configs/multi-file.config.ts
+++ b/tests/configs/multi-file.config.ts
@@ -10,7 +10,10 @@ export { MY_CONST, ANOTHER_CONST };
 
 export default defineConfig({
   api: {
-    input: '../specifications/multi-files/api.yaml',
+    input: {
+      target: '../specifications/multi-files/api.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
+    },
     output: {
       target: '../generated/multi-files/api/endpoints.ts',
       clean: true,

--- a/tests/configs/react-query.config.ts
+++ b/tests/configs/react-query.config.ts
@@ -94,6 +94,7 @@ export default defineConfig({
     },
     input: {
       target: '../specifications/issue-2540/issue-2540.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
     },
   },
   issue2039: {
@@ -1237,7 +1238,10 @@ export default defineConfig({
       clean: true,
       formatter: 'prettier',
     },
-    input: '../specifications/import-from-subdirectory/petstore.yaml',
+    input: {
+      target: '../specifications/import-from-subdirectory/petstore.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
+    },
   },
   deprecated: {
     output: {

--- a/tests/configs/zod.config.ts
+++ b/tests/configs/zod.config.ts
@@ -193,7 +193,10 @@ export default defineConfig({
       clean: true,
       formatter: 'prettier',
     },
-    input: '../specifications/import-from-subdirectory/petstore.yaml',
+    input: {
+      target: '../specifications/import-from-subdirectory/petstore.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
+    },
   },
   dateTimeOptions: {
     output: {
@@ -353,7 +356,10 @@ export default defineConfig({
       clean: true,
       formatter: 'prettier',
     },
-    input: '../specifications/issue-3027/issue-3027.yaml',
+    input: {
+      target: '../specifications/issue-3027/issue-3027.yaml',
+      parserOptions: { externalRefs: { allow: ['*'] } },
+    },
   },
   'issue-3171': {
     output: {


### PR DESCRIPTION
## Summary

Adds an explicit allow-list for external OpenAPI `$ref` resolution.

External refs are now blocked by default. Users can opt in with `input.parserOptions.externalRefs.allow`, including `['*']` for the previous allow-all behavior. Wildcard mode emits a warning for external documents referenced by the top-level spec.

## Changes

- Gate external file and URL `$ref` resolution behind `externalRefs.allow`
- Preserve existing header handling for protected remote specs
- Support relative allow-list entries for remote specs
- Update test configs that intentionally use external refs
- Document the new `input.parserOptions.externalRefs.allow` option

## Validation

- `bun vitest run packages/orval/src/import-specs.test.ts`
- `bun run lint`
- `bun run vp run -F orval-tests generate-api`

`bun run test` currently fails on an existing macOS `/tmp` vs `/private/tmp` path assertion in `packages/orval/src/utils/options.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `parserOptions.externalRefs.allow` to control which external OpenAPI `$ref` documents/URLs may be resolved (blocked by default).
  * When allowing all external refs, orval warns and documents the security implications; remote refs honor configured request headers.
  * Exported URL request header helper for public use.
* **Bug Fixes**
  * Improved Angular query-parameter filtering by using a safer property-existence check.
* **Documentation**
  * Documented external `$ref` allow-list behavior and warning/security callouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->