### PR TITLE
fix(zod): infer type from `const` primitive values

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -146,8 +146,6 @@ const resolveZodType = (schema: OpenApiSchemaObject): ResolvedZodType => {
     if (isNumber(constValue)) return 'number';
     if (isBoolean(constValue)) return 'boolean';
     if (constValue === null) return 'null';
-    if (Array.isArray(constValue)) return 'array';
-    if (isObject(constValue)) return 'object';
   }
 
   switch (type) {
@@ -1001,26 +999,22 @@ export const generateZodValidationSchemaDefinition = (
         break;
       }
       case 'array': {
-        if ('const' in schema) {
-          functions.push(['literal', JSON.stringify(schema.const)]);
-        } else {
-          functions.push([
-            'array',
-            generateZodValidationSchemaDefinition(
-              schema.items as OpenApiSchemaObject | undefined,
-              context,
-              camel(`${name}-item`),
-              strict,
-              isZodV4,
-              {
-                required: true,
-                constNameRegistry,
-                useReusableSchemas,
-                urlEncoded,
-              },
-            ),
-          ]);
-        }
+        functions.push([
+          'array',
+          generateZodValidationSchemaDefinition(
+            schema.items as OpenApiSchemaObject | undefined,
+            context,
+            camel(`${name}-item`),
+            strict,
+            isZodV4,
+            {
+              required: true,
+              constNameRegistry,
+              useReusableSchemas,
+              urlEncoded,
+            },
+          ),
+        ]);
         break;
       }
       case 'string': {
@@ -1151,8 +1145,7 @@ export const generateZodValidationSchemaDefinition = (
             constValue === null
           ) {
             functions.push(['literal', constValue]);
-          } else if (isObject(constValue)) {
-            functions.push(['literal', JSON.stringify(constValue)]);
+            break;
           }
         }
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -139,6 +139,17 @@ const resolveZodType = (schema: OpenApiSchemaObject): ResolvedZodType => {
     return 'tuple';
   }
 
+  // Infer type from const value when type is not explicitly specified
+  if (!type && 'const' in schema) {
+    const constValue = schema.const;
+    if (isString(constValue)) return 'string';
+    if (isNumber(constValue)) return 'number';
+    if (isBoolean(constValue)) return 'boolean';
+    if (constValue === null) return 'null';
+    if (Array.isArray(constValue)) return 'array';
+    if (isObject(constValue)) return 'object';
+  }
+
   switch (type) {
     case 'integer': {
       return 'number';
@@ -990,22 +1001,26 @@ export const generateZodValidationSchemaDefinition = (
         break;
       }
       case 'array': {
-        functions.push([
-          'array',
-          generateZodValidationSchemaDefinition(
-            schema.items as OpenApiSchemaObject | undefined,
-            context,
-            camel(`${name}-item`),
-            strict,
-            isZodV4,
-            {
-              required: true,
-              constNameRegistry,
-              useReusableSchemas,
-              urlEncoded,
-            },
-          ),
-        ]);
+        if ('const' in schema) {
+          functions.push(['literal', JSON.stringify(schema.const)]);
+        } else {
+          functions.push([
+            'array',
+            generateZodValidationSchemaDefinition(
+              schema.items as OpenApiSchemaObject | undefined,
+              context,
+              camel(`${name}-item`),
+              strict,
+              isZodV4,
+              {
+                required: true,
+                constNameRegistry,
+                useReusableSchemas,
+                urlEncoded,
+              },
+            ),
+          ]);
+        }
         break;
       }
       case 'string': {
@@ -1127,6 +1142,20 @@ export const generateZodValidationSchemaDefinition = (
         break;
       }
       default: {
+        // Handle const for number, boolean, null, and object types
+        if ('const' in schema) {
+          const constValue = schema.const;
+          if (
+            isNumber(constValue) ||
+            isBoolean(constValue) ||
+            constValue === null
+          ) {
+            functions.push(['literal', constValue]);
+          } else if (isObject(constValue)) {
+            functions.push(['literal', JSON.stringify(constValue)]);
+          }
+        }
+
         const hasProperties = !!schema.properties;
         const properties = schema.properties ?? {};
         const hasDefinedProperties = Object.keys(properties).length > 0;

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -11486,6 +11486,33 @@ describe('enum/const value escaping (#3505)', () => {
       'export const testDateDefaultDefault = new Date("2024-01-01T00:00:00Z");',
     ]);
   });
+
+  it.each([
+    ['test', ['literal', '"test"'], 'string'],
+    [42, ['literal', 42], 'number'],
+    [true, ['literal', true], 'boolean'],
+    [null, ['literal', null], 'null'],
+    [['foo', 'bar'], ['literal', '["foo","bar"]'], 'array'],
+    [{ foo: 'bar' }, ['literal', '{"foo":"bar"}'], 'object'],
+  ] as const)(
+    'infers type from const value when type is not specified (%s)',
+    (constValue, expectedFunction, typeName) => {
+      const schema = {
+        const: constValue,
+      } as OpenApiSchemaObject;
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        `testConst${typeName}Inferred`,
+        false,
+        false,
+        { required: true },
+      );
+
+      expect(result.functions).toContainEqual(expectedFunction);
+    },
+  );
 });
 
 // `oneOf`/`anyOf` + `discriminator` should map onto `zod.discriminatedUnion`,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -11492,8 +11492,6 @@ describe('enum/const value escaping (#3505)', () => {
     [42, ['literal', 42], 'number'],
     [true, ['literal', true], 'boolean'],
     [null, ['literal', null], 'null'],
-    [['foo', 'bar'], ['literal', '["foo","bar"]'], 'array'],
-    [{ foo: 'bar' }, ['literal', '{"foo":"bar"}'], 'object'],
   ] as const)(
     'infers type from const value when type is not specified (%s)',
     (constValue, expectedFunction, typeName) => {

--- a/tests/__snapshots__/zod/typed-arrays-tuples-v3-1/typed-arrays-tuples-v3-1.ts
+++ b/tests/__snapshots__/zod/typed-arrays-tuples-v3-1/typed-arrays-tuples-v3-1.ts
@@ -23,7 +23,7 @@ export const PostApiSampleResponse = zod.object({
       zod.string().uuid(),
     ])
     .optional(),
-  example_const: zod.unknown().optional(),
+  example_const: zod.literal('this_is_a_const').optional(),
   example_string_const: zod.literal('this_is_a_string_const').optional(),
   example_enum: zod.enum(['enum1', 'enum2']).optional(),
 });


### PR DESCRIPTION
Basic example schema
```yaml
openapi: 3.1.0
info:
  version: 1.0.0
  title: Infer type from const
  license:
    name: MIT
paths:
  /foo:
    get:
      operationId: getNotHasPropertiesWithAllOfPets
      responses:
        '200':
          description: User
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Foo'

components:
  schemas:
    Foo:
      const: 'test'
```
This would correctly generate a literal `"test"` as the type when creating a query client but generating zod code would make it fallback to `z.unknown()` (Because there is no type specified). This updates zod so it can infer the type from a `const` which makes it generate `z.literal("test")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema validation generation for OpenAPI `const` values when the data type is not explicitly provided.
  * Correctly infers and emits literal validation for `const` values (string, number, boolean, null), including stopping further processing for these constant schemas.

* **Tests**
  * Added regression coverage to verify `const`-based type inference in generated validator definitions when `type` is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->