### PR TITLE
fix(zod): enforce integer validation

### DIFF
--- a/packages/orval/src/reusable-schemas.test.ts
+++ b/packages/orval/src/reusable-schemas.test.ts
@@ -199,7 +199,7 @@ describe('generateReusableSchemaSet', () => {
       `zodParams({"operationId":"","location":"schema","schemaName":"Pet","fieldPath":["name"],"validator":"string"})`,
     );
     expect(entry.zod).toContain(
-      `zodParams({"operationId":"","location":"schema","schemaName":"Pet","fieldPath":["age"],"validator":"number"})`,
+      `zod.number(zodParams({"operationId":"","location":"schema","schemaName":"Pet","fieldPath":["age"],"validator":"number"})).int(zodParams({"operationId":"","location":"schema","schemaName":"Pet","fieldPath":["age"],"validator":"int"}))`,
     );
   });
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -112,8 +112,7 @@ const resolveZodType = (schema: OpenApiSchemaObject): ResolvedZodType => {
     // Filter out 'null' type as it's handled separately via nullable
     const nonNullTypes = schemaTypeValue
       .filter((t): t is string => isString(t))
-      .filter((t) => t !== 'null' && possibleSchemaTypes.has(t))
-      .map((t) => (t === 'integer' ? 'number' : t));
+      .filter((t) => t !== 'null' && possibleSchemaTypes.has(t));
 
     // If multiple types, return a special marker for union handling
     if (nonNullTypes.length > 1) {
@@ -128,7 +127,7 @@ const resolveZodType = (schema: OpenApiSchemaObject): ResolvedZodType => {
       return 'tuple';
     }
 
-    return type;
+    return type === 'integer' ? 'number' : type;
   }
 
   // Handle single type value
@@ -664,6 +663,9 @@ export const generateZodValidationSchemaDefinition = (
     isBoolean(exclusiveMaxRaw) && exclusiveMaxRaw ? max : exclusiveMaxRaw;
 
   const multipleOf = schema.multipleOf;
+  const isIntegerSchema =
+    schema.type === 'integer' ||
+    (Array.isArray(schema.type) && schema.type.includes('integer'));
   const matches = schema.pattern ?? undefined;
   // Enum-based schemas are emitted as `zod.enum(...)` or literal unions, so
   // chaining scalar constraints onto the parent schema would generate invalid
@@ -1244,6 +1246,11 @@ export const generateZodValidationSchemaDefinition = (
           break;
         }
 
+        if (isIntegerSchema) {
+          functions.push(['int', undefined]);
+          break;
+        }
+
         functions.push([type, undefined]);
 
         break;
@@ -1778,6 +1785,18 @@ ${Object.entries(objectArgs)
 
       const combinedArgs = buildCombinedArgs(fn, args, fieldPath);
 
+      if (fn === 'int' && shouldCoerce('number')) {
+        const numberArgs = buildCombinedArgs('number', undefined, fieldPath);
+        current = {
+          expr: zodMiniCall(
+            'pipe',
+            `${zodMiniCoerceCall('number', numberArgs)}, ${zodMiniCall('int', combinedArgs)}`,
+          ),
+          kind: 'number',
+        };
+        continue;
+      }
+
       if (fn === 'optional' || fn === 'nullable' || fn === 'nullish') {
         const value = requireCurrent(fn);
         current = { expr: zodMiniCall(fn, value.expr), kind: value.kind };
@@ -1843,9 +1862,11 @@ ${Object.entries(objectArgs)
       current = {
         expr: zodMiniCall(fn, combinedArgs),
         kind:
-          fn === 'enum' || fn === 'literal' || fn === 'stringFormat'
-            ? 'string'
-            : fn.split('.')[0],
+          fn === 'int'
+            ? 'number'
+            : fn === 'enum' || fn === 'literal' || fn === 'stringFormat'
+              ? 'string'
+              : fn.split('.')[0],
       };
     }
 
@@ -2159,6 +2180,19 @@ ${Object.entries(objectArgs)
         : paramsArg;
     } else {
       combinedArgs = formattedArgs;
+    }
+
+    if (fn === 'int') {
+      const shouldCoerceNumber =
+        coerceTypes &&
+        (Array.isArray(coerceTypes) ? coerceTypes.includes('number') : true);
+      const numberArgs = buildCombinedArgs('number', undefined, fieldPath);
+      if (shouldCoerceNumber) {
+        return `.coerce.number(${numberArgs}).int(${combinedArgs})`;
+      }
+      if (!isZodV4) {
+        return `.number(${numberArgs}).int(${combinedArgs})`;
+      }
     }
 
     if (

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -127,7 +127,7 @@ const resolveZodType = (schema: OpenApiSchemaObject): ResolvedZodType => {
       return 'tuple';
     }
 
-    return type === 'integer' ? 'number' : type;
+    return type;
   }
 
   // Handle single type value
@@ -147,14 +147,7 @@ const resolveZodType = (schema: OpenApiSchemaObject): ResolvedZodType => {
     if (constValue === null) return 'null';
   }
 
-  switch (type) {
-    case 'integer': {
-      return 'number';
-    }
-    default: {
-      return type ?? 'unknown';
-    }
-  }
+  return type ?? 'unknown';
 };
 
 // https://github.com/colinhacks/zod#coercion-for-primitives
@@ -196,7 +189,7 @@ export interface ZodValidationSchemaDefinition {
   consts: string[];
 }
 
-const minAndMaxTypes = new Set(['number', 'string', 'array']);
+const minAndMaxTypes = new Set(['number', 'integer', 'string', 'array']);
 
 const removeReadOnlyProperties = (
   schema: OpenApiSchemaObject,
@@ -663,9 +656,6 @@ export const generateZodValidationSchemaDefinition = (
     isBoolean(exclusiveMaxRaw) && exclusiveMaxRaw ? max : exclusiveMaxRaw;
 
   const multipleOf = schema.multipleOf;
-  const isIntegerSchema =
-    schema.type === 'integer' ||
-    (Array.isArray(schema.type) && schema.type.includes('integer'));
   const matches = schema.pattern ?? undefined;
   // Enum-based schemas are emitted as `zod.enum(...)` or literal unions, so
   // chaining scalar constraints onto the parent schema would generate invalid
@@ -1246,12 +1236,7 @@ export const generateZodValidationSchemaDefinition = (
           break;
         }
 
-        if (isIntegerSchema) {
-          functions.push(['int', undefined]);
-          break;
-        }
-
-        functions.push([type, undefined]);
+        functions.push([type === 'integer' ? 'int' : type, undefined]);
 
         break;
       }
@@ -2183,11 +2168,8 @@ ${Object.entries(objectArgs)
     }
 
     if (fn === 'int') {
-      const shouldCoerceNumber =
-        coerceTypes &&
-        (Array.isArray(coerceTypes) ? coerceTypes.includes('number') : true);
       const numberArgs = buildCombinedArgs('number', undefined, fieldPath);
-      if (shouldCoerceNumber) {
+      if (shouldCoerce('number')) {
         return `.coerce.number(${numberArgs}).int(${combinedArgs})`;
       }
       if (!isZodV4) {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -205,6 +205,38 @@ describe('parseZodValidationSchemaDefinition', () => {
     );
   });
 
+  it('renders zod mini integer bounds as numeric checks', () => {
+    const parseResult = parseZodValidationSchemaDefinition(
+      {
+        functions: [
+          ['int', undefined],
+          ['min', 'ageMin'],
+          ['max', 'ageMax'],
+          ['multipleOf', 'ageMultipleOf'],
+          ['optional', undefined],
+        ],
+        consts: [],
+      },
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      false,
+      false,
+      true,
+      undefined,
+      undefined,
+      'mini',
+    );
+
+    expect(parseResult.zod).toBe(
+      '/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.int().check(/*#__PURE__*/ zod.gte(ageMin)).check(/*#__PURE__*/ zod.lte(ageMax)).check(/*#__PURE__*/ zod.multipleOf(ageMultipleOf)))',
+    );
+  });
+
   it('renders zod mini allOf fallback as intersections', () => {
     const parseResult = parseZodValidationSchemaDefinition(
       {
@@ -461,6 +493,80 @@ describe('parseZodValidationSchemaDefinition with params injection', () => {
     );
     expect(zod).toContain(
       '.max(120, zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":["age"],"validator":"max"}))',
+    );
+  });
+
+  it('injects integer params on the int validator for every target', () => {
+    const input: ZodValidationSchemaDefinition = {
+      functions: [
+        ['int', undefined],
+        ['optional', undefined],
+      ],
+      consts: [],
+    };
+    const params =
+      'zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":[],"validator":"int"})';
+    const numberParams =
+      'zodParams({"operationId":"createUser","location":"body","schemaName":"CreateUserBody","fieldPath":[],"validator":"number"})';
+
+    expect(
+      parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        false,
+        false,
+        false,
+        undefined,
+        makeInjection(),
+      ).zod,
+    ).toBe(`zod.number(${numberParams}).int(${params}).optional()`);
+    expect(
+      parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        true,
+        false,
+        true,
+        undefined,
+        makeInjection(),
+      ).zod,
+    ).toBe(`zod.coerce.number(${numberParams}).int(${params}).optional()`);
+    expect(
+      parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        false,
+        false,
+        true,
+        undefined,
+        makeInjection(),
+      ).zod,
+    ).toBe(`zod.int(${params}).optional()`);
+    expect(
+      parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        false,
+        false,
+        true,
+        undefined,
+        makeInjection(),
+        'mini',
+      ).zod,
+    ).toBe(`/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.int(${params}))`);
+    expect(
+      parseZodValidationSchemaDefinition(
+        input,
+        ctx,
+        true,
+        false,
+        true,
+        undefined,
+        makeInjection(),
+        'mini',
+      ).zod,
+    ).toBe(
+      `/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.pipe(/*#__PURE__*/ zod.coerce.number(${numberParams}), /*#__PURE__*/ zod.int(${params})))`,
     );
   });
 
@@ -3532,6 +3638,93 @@ describe('generateZodValidationSchemaDefinition`', () => {
         false,
       );
       expect(parsed.zod).toBe('zod.number().optional()');
+    });
+    it('generates native integer schemas for each supported Zod target', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'integer',
+      };
+
+      const resultV3 = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testInteger',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(resultV3).toEqual({
+        functions: [
+          ['int', undefined],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+      expect(
+        parseZodValidationSchemaDefinition(
+          resultV3,
+          context,
+          false,
+          false,
+          false,
+        ).zod,
+      ).toBe('zod.number().int().optional()');
+
+      const resultV4 = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testInteger',
+        false,
+        true,
+        { required: false },
+      );
+
+      expect(resultV4).toEqual({
+        functions: [
+          ['int', undefined],
+          ['optional', undefined],
+        ],
+        consts: [],
+      });
+      expect(
+        parseZodValidationSchemaDefinition(
+          resultV4,
+          context,
+          false,
+          false,
+          true,
+        ).zod,
+      ).toBe('zod.int().optional()');
+      expect(
+        parseZodValidationSchemaDefinition(
+          resultV4,
+          context,
+          false,
+          false,
+          true,
+          undefined,
+          undefined,
+          'mini',
+        ).zod,
+      ).toBe('/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.int())');
+      expect(
+        parseZodValidationSchemaDefinition(resultV4, context, true, false, true)
+          .zod,
+      ).toBe('zod.coerce.number().int().optional()');
+      expect(
+        parseZodValidationSchemaDefinition(
+          resultV4,
+          context,
+          true,
+          false,
+          true,
+          undefined,
+          undefined,
+          'mini',
+        ).zod,
+      ).toBe(
+        '/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.pipe(/*#__PURE__*/ zod.coerce.number(), /*#__PURE__*/ zod.int()))',
+      );
     });
     it('generates an number with min', () => {
       const schema: OpenApiSchemaObject = {
@@ -6701,7 +6894,7 @@ describe('generateZod required defaults regression (#2987)', () => {
       /"number": zod\.number\(\)\.default\(getGizmoResponseNumberDefault\)/,
     );
     expect(result.implementation).toMatch(
-      /"integer": zod\.number\(\)\.default\(getGizmoResponseIntegerDefault\)/,
+      /"integer": zod\.int\(\)\.default\(getGizmoResponseIntegerDefault\)/,
     );
     expect(result.implementation).toMatch(
       /"nullableString": zod\.string\(\)\.nullish\(\)\.default\(getGizmoResponseNullableStringDefault\)/,
@@ -6854,9 +7047,9 @@ describe('generateZodWithMultiTypeArray', () => {
     );
 
     expect(parsed.zod).toContain('zod.union([');
-    expect(parsed.zod).toContain('zod.number()');
+    expect(parsed.zod).toContain('zod.int()');
     expect(parsed.zod).not.toMatch(
-      /zod\.number\(\)[^,\]]*\.(?:stringFormat|regex)\(/,
+      /zod\.int\(\)[^,\]]*\.(?:stringFormat|regex)\(/,
     );
     expect(parsed.zod.match(/\.stringFormat\(/g) ?? []).toHaveLength(1);
   });

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -237,6 +237,38 @@ describe('parseZodValidationSchemaDefinition', () => {
     );
   });
 
+  it('renders zod mini coerced integer bounds as checks on the pipe', () => {
+    const parseResult = parseZodValidationSchemaDefinition(
+      {
+        functions: [
+          ['int', undefined],
+          ['min', 'ageMin'],
+          ['max', 'ageMax'],
+          ['multipleOf', 'ageMultipleOf'],
+          ['optional', undefined],
+        ],
+        consts: [],
+      },
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      true,
+      false,
+      true,
+      undefined,
+      undefined,
+      'mini',
+    );
+
+    expect(parseResult.zod).toBe(
+      '/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.pipe(/*#__PURE__*/ zod.coerce.number(), /*#__PURE__*/ zod.int()).check(/*#__PURE__*/ zod.gte(ageMin)).check(/*#__PURE__*/ zod.lte(ageMax)).check(/*#__PURE__*/ zod.multipleOf(ageMultipleOf)))',
+    );
+  });
+
   it('renders zod mini allOf fallback as intersections', () => {
     const parseResult = parseZodValidationSchemaDefinition(
       {
@@ -3725,6 +3757,25 @@ describe('generateZodValidationSchemaDefinition`', () => {
       ).toBe(
         '/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.pipe(/*#__PURE__*/ zod.coerce.number(), /*#__PURE__*/ zod.int()))',
       );
+    });
+    it('coerces integer schemas on the Zod v3 target', () => {
+      const schema: OpenApiSchemaObject = {
+        type: 'integer',
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'testCoercedInteger',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(
+        parseZodValidationSchemaDefinition(result, context, true, false, false)
+          .zod,
+      ).toBe('zod.coerce.number().int().optional()');
     });
     it('generates an number with min', () => {
       const schema: OpenApiSchemaObject = {

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/error.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/error.zod.ts
@@ -11,7 +11,7 @@ export const errorCodeMax = 600;
 
 export const Error = zod.object({
   code: zod
-    .number()
+    .int()
     .min(errorCodeMin)
     .max(errorCodeMax)
     .describe('HTTP-like error code'),

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/patchPetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const patchPetByIdBodyRatingMultipleOf = 0.5;
 export const patchPetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const PatchPetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const PatchPetByIdBody = zod.object({
     .default(patchPetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(patchPetByIdBodyAgeMin)
     .max(patchPetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/pet.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/pet.zod.ts
@@ -21,7 +21,7 @@ export const petRatingMultipleOf = 0.5;
 export const petPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const Pet = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod.string().min(1).max(petNameMax).describe('Name of the pet'),
   tag: zod
     .string()
@@ -35,7 +35,7 @@ export const Pet = zod.object({
     .default(petStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(petAgeMin)
     .max(petAgeMax)
     .optional()

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/pets.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/pets.zod.ts
@@ -25,7 +25,7 @@ export const petsItemPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 export const Pets = zod
   .array(
     zod.object({
-      id: zod.number().min(1).describe('Unique identifier for the pet'),
+      id: zod.int().min(1).describe('Unique identifier for the pet'),
       name: zod
         .string()
         .min(1)
@@ -43,7 +43,7 @@ export const Pets = zod
         .default(petsItemStatusDefault)
         .describe('Current adoption status'),
       age: zod
-        .number()
+        .int()
         .min(petsItemAgeMin)
         .max(petsItemAgeMax)
         .optional()

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/searchPetsParams.zod.ts
@@ -13,7 +13,7 @@ export const SearchPetsParams = zod.object({
   requirednullableStringTwo: zod.string().nullable(),
   nonRequirednullableString: zod.string().nullish(),
   status: zod.enum(['available', 'pending', 'sold']).optional(),
-  limit: zod.number().min(1).max(searchPetsParamsLimitMax).optional(),
+  limit: zod.int().min(1).max(searchPetsParamsLimitMax).optional(),
 });
 
 export type SearchPetsParams = zod.input<typeof SearchPetsParams>;

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/updatePetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const updatePetByIdBodyRatingMultipleOf = 0.5;
 export const updatePetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const UpdatePetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const UpdatePetByIdBody = zod.object({
     .default(updatePetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(updatePetByIdBodyAgeMin)
     .max(updatePetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/error.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/error.zod.ts
@@ -11,7 +11,7 @@ export const errorCodeMax = 600;
 
 export const Error = zod.object({
   code: zod
-    .number()
+    .int()
     .min(errorCodeMin)
     .max(errorCodeMax)
     .describe('HTTP-like error code'),

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/patchPetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const patchPetByIdBodyRatingMultipleOf = 0.5;
 export const patchPetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const PatchPetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const PatchPetByIdBody = zod.object({
     .default(patchPetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(patchPetByIdBodyAgeMin)
     .max(patchPetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/pet.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/pet.zod.ts
@@ -21,7 +21,7 @@ export const petRatingMultipleOf = 0.5;
 export const petPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const Pet = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod.string().min(1).max(petNameMax).describe('Name of the pet'),
   tag: zod
     .string()
@@ -35,7 +35,7 @@ export const Pet = zod.object({
     .default(petStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(petAgeMin)
     .max(petAgeMax)
     .optional()

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/pets.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/pets.zod.ts
@@ -25,7 +25,7 @@ export const petsItemPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 export const Pets = zod
   .array(
     zod.object({
-      id: zod.number().min(1).describe('Unique identifier for the pet'),
+      id: zod.int().min(1).describe('Unique identifier for the pet'),
       name: zod
         .string()
         .min(1)
@@ -43,7 +43,7 @@ export const Pets = zod
         .default(petsItemStatusDefault)
         .describe('Current adoption status'),
       age: zod
-        .number()
+        .int()
         .min(petsItemAgeMin)
         .max(petsItemAgeMax)
         .optional()

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/searchPetsParams.zod.ts
@@ -13,7 +13,7 @@ export const SearchPetsParams = zod.object({
   requirednullableStringTwo: zod.string().nullable(),
   nonRequirednullableString: zod.string().nullish(),
   status: zod.enum(['available', 'pending', 'sold']).optional(),
-  limit: zod.number().min(1).max(searchPetsParamsLimitMax).optional(),
+  limit: zod.int().min(1).max(searchPetsParamsLimitMax).optional(),
 });
 
 export type SearchPetsParams = zod.input<typeof SearchPetsParams>;

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/updatePetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const updatePetByIdBodyRatingMultipleOf = 0.5;
 export const updatePetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const UpdatePetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const UpdatePetByIdBody = zod.object({
     .default(updatePetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(updatePetByIdBodyAgeMin)
     .max(updatePetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/src/api/endpoints-zod/model/error.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/error.zod.ts
@@ -11,7 +11,7 @@ export const errorCodeMax = 600;
 
 export const Error = zod.object({
   code: zod
-    .number()
+    .int()
     .min(errorCodeMin)
     .max(errorCodeMax)
     .describe('HTTP-like error code'),

--- a/samples/angular-app/src/api/endpoints-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/patchPetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const patchPetByIdBodyRatingMultipleOf = 0.5;
 export const patchPetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const PatchPetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const PatchPetByIdBody = zod.object({
     .default(patchPetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(patchPetByIdBodyAgeMin)
     .max(patchPetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/src/api/endpoints-zod/model/pet.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/pet.zod.ts
@@ -21,7 +21,7 @@ export const petRatingMultipleOf = 0.5;
 export const petPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const Pet = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod.string().min(1).max(petNameMax).describe('Name of the pet'),
   tag: zod
     .string()
@@ -35,7 +35,7 @@ export const Pet = zod.object({
     .default(petStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(petAgeMin)
     .max(petAgeMax)
     .optional()

--- a/samples/angular-app/src/api/endpoints-zod/model/pets.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/pets.zod.ts
@@ -25,7 +25,7 @@ export const petsItemPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 export const Pets = zod
   .array(
     zod.object({
-      id: zod.number().min(1).describe('Unique identifier for the pet'),
+      id: zod.int().min(1).describe('Unique identifier for the pet'),
       name: zod
         .string()
         .min(1)
@@ -43,7 +43,7 @@ export const Pets = zod
         .default(petsItemStatusDefault)
         .describe('Current adoption status'),
       age: zod
-        .number()
+        .int()
         .min(petsItemAgeMin)
         .max(petsItemAgeMax)
         .optional()

--- a/samples/angular-app/src/api/endpoints-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/searchPetsParams.zod.ts
@@ -13,7 +13,7 @@ export const SearchPetsParams = zod.object({
   requirednullableStringTwo: zod.string().nullable(),
   nonRequirednullableString: zod.string().nullish(),
   status: zod.enum(['available', 'pending', 'sold']).optional(),
-  limit: zod.number().min(1).max(searchPetsParamsLimitMax).optional(),
+  limit: zod.int().min(1).max(searchPetsParamsLimitMax).optional(),
 });
 
 export type SearchPetsParams = zod.input<typeof SearchPetsParams>;

--- a/samples/angular-app/src/api/endpoints-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/updatePetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const updatePetByIdBodyRatingMultipleOf = 0.5;
 export const updatePetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const UpdatePetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const UpdatePetByIdBody = zod.object({
     .default(updatePetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(updatePetByIdBodyAgeMin)
     .max(updatePetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/src/api/http-resource-zod/model/error.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/error.zod.ts
@@ -11,7 +11,7 @@ export const errorCodeMax = 600;
 
 export const Error = zod.object({
   code: zod
-    .number()
+    .int()
     .min(errorCodeMin)
     .max(errorCodeMax)
     .describe('HTTP-like error code'),

--- a/samples/angular-app/src/api/http-resource-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/patchPetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const patchPetByIdBodyRatingMultipleOf = 0.5;
 export const patchPetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const PatchPetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const PatchPetByIdBody = zod.object({
     .default(patchPetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(patchPetByIdBodyAgeMin)
     .max(patchPetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-app/src/api/http-resource-zod/model/pet.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/pet.zod.ts
@@ -21,7 +21,7 @@ export const petRatingMultipleOf = 0.5;
 export const petPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const Pet = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod.string().min(1).max(petNameMax).describe('Name of the pet'),
   tag: zod
     .string()
@@ -35,7 +35,7 @@ export const Pet = zod.object({
     .default(petStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(petAgeMin)
     .max(petAgeMax)
     .optional()

--- a/samples/angular-app/src/api/http-resource-zod/model/pets.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/pets.zod.ts
@@ -25,7 +25,7 @@ export const petsItemPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 export const Pets = zod
   .array(
     zod.object({
-      id: zod.number().min(1).describe('Unique identifier for the pet'),
+      id: zod.int().min(1).describe('Unique identifier for the pet'),
       name: zod
         .string()
         .min(1)
@@ -43,7 +43,7 @@ export const Pets = zod
         .default(petsItemStatusDefault)
         .describe('Current adoption status'),
       age: zod
-        .number()
+        .int()
         .min(petsItemAgeMin)
         .max(petsItemAgeMax)
         .optional()

--- a/samples/angular-app/src/api/http-resource-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/searchPetsParams.zod.ts
@@ -13,7 +13,7 @@ export const SearchPetsParams = zod.object({
   requirednullableStringTwo: zod.string().nullable(),
   nonRequirednullableString: zod.string().nullish(),
   status: zod.enum(['available', 'pending', 'sold']).optional(),
-  limit: zod.number().min(1).max(searchPetsParamsLimitMax).optional(),
+  limit: zod.int().min(1).max(searchPetsParamsLimitMax).optional(),
 });
 
 export type SearchPetsParams = zod.input<typeof SearchPetsParams>;

--- a/samples/angular-app/src/api/http-resource-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/updatePetByIdBody.zod.ts
@@ -21,7 +21,7 @@ export const updatePetByIdBodyRatingMultipleOf = 0.5;
 export const updatePetByIdBodyPhoneRegExp = new RegExp('^\\+?[1-9]\\d{1,14}$');
 
 export const UpdatePetByIdBody = zod.object({
-  id: zod.number().min(1).describe('Unique identifier for the pet'),
+  id: zod.int().min(1).describe('Unique identifier for the pet'),
   name: zod
     .string()
     .min(1)
@@ -39,7 +39,7 @@ export const UpdatePetByIdBody = zod.object({
     .default(updatePetByIdBodyStatusDefault)
     .describe('Current adoption status'),
   age: zod
-    .number()
+    .int()
     .min(updatePetByIdBodyAgeMin)
     .max(updatePetByIdBodyAgeMax)
     .optional()

--- a/samples/angular-query/__snapshots__/api/model-zod/cat.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/samples/angular-query/__snapshots__/api/model-zod/dachshund.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/samples/angular-query/__snapshots__/api/model-zod/dog.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/samples/angular-query/__snapshots__/api/model-zod/error.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/samples/angular-query/__snapshots__/api/model-zod/labradoodle.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/samples/angular-query/__snapshots__/api/model-zod/pet.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/samples/angular-query/__snapshots__/api/model-zod/petWithTag.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/samples/angular-query/__snapshots__/api/model-zod/pets.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/samples/angular-query/src/api/model-zod/cat.zod.ts
+++ b/samples/angular-query/src/api/model-zod/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/samples/angular-query/src/api/model-zod/dachshund.zod.ts
+++ b/samples/angular-query/src/api/model-zod/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/samples/angular-query/src/api/model-zod/dog.zod.ts
+++ b/samples/angular-query/src/api/model-zod/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/samples/angular-query/src/api/model-zod/error.zod.ts
+++ b/samples/angular-query/src/api/model-zod/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/samples/angular-query/src/api/model-zod/labradoodle.zod.ts
+++ b/samples/angular-query/src/api/model-zod/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/samples/angular-query/src/api/model-zod/pet.zod.ts
+++ b/samples/angular-query/src/api/model-zod/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/samples/angular-query/src/api/model-zod/petWithTag.zod.ts
+++ b/samples/angular-query/src/api/model-zod/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/samples/angular-query/src/api/model-zod/pets.zod.ts
+++ b/samples/angular-query/src/api/model-zod/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/pets/pets.zod.ts
+++ b/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/pets/pets.zod.ts
@@ -14,7 +14,7 @@ export const ListPetsQueryParams = zod.object({
 });
 
 export const ListPetsResponseItem = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -27,19 +27,19 @@ export const CreatePetsBodyItem = zod.object({
 export const CreatePetsBody = zod.array(CreatePetsBodyItem);
 
 export const CreatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsBody = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -49,7 +49,7 @@ export const ShowPetByIdParams = zod.object({
 });
 
 export const ShowPetByIdResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });

--- a/samples/hono/composite-routes-with-tags-split/src/endpoints/pets/pets.zod.ts
+++ b/samples/hono/composite-routes-with-tags-split/src/endpoints/pets/pets.zod.ts
@@ -14,7 +14,7 @@ export const ListPetsQueryParams = zod.object({
 });
 
 export const ListPetsResponseItem = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -27,19 +27,19 @@ export const CreatePetsBodyItem = zod.object({
 export const CreatePetsBody = zod.array(CreatePetsBodyItem);
 
 export const CreatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsBody = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -49,7 +49,7 @@ export const ShowPetByIdParams = zod.object({
 });
 
 export const ShowPetByIdResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.zod.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.zod.ts
@@ -14,7 +14,7 @@ export const ListPetsQueryParams = zod.object({
 });
 
 export const ListPetsResponseItem = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -27,19 +27,19 @@ export const CreatePetsBodyItem = zod.object({
 export const CreatePetsBody = zod.array(CreatePetsBodyItem);
 
 export const CreatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsBody = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -49,7 +49,7 @@ export const ShowPetByIdParams = zod.object({
 });
 
 export const ShowPetByIdResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.zod.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.zod.ts
@@ -14,7 +14,7 @@ export const ListPetsQueryParams = zod.object({
 });
 
 export const ListPetsResponseItem = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -27,19 +27,19 @@ export const CreatePetsBodyItem = zod.object({
 export const CreatePetsBody = zod.array(CreatePetsBodyItem);
 
 export const CreatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsBody = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
 
 export const UpdatePetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });
@@ -49,7 +49,7 @@ export const ShowPetByIdParams = zod.object({
 });
 
 export const ShowPetByIdResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string(),
 });

--- a/samples/hono/hono-with-zod/__snapshots__/petstore.zod.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/petstore.zod.ts
@@ -21,29 +21,29 @@ export const ListPetsResponseItem = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -67,29 +67,29 @@ export const CreatePetsResponse = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -104,29 +104,29 @@ export const UpdatePetsBody = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -142,29 +142,29 @@ export const UpdatePetsResponse = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -185,29 +185,29 @@ export const ShowPetByIdResponse = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/samples/hono/hono-with-zod/src/petstore.zod.ts
+++ b/samples/hono/hono-with-zod/src/petstore.zod.ts
@@ -21,29 +21,29 @@ export const ListPetsResponseItem = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -67,29 +67,29 @@ export const CreatePetsResponse = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -104,29 +104,29 @@ export const UpdatePetsBody = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -142,29 +142,29 @@ export const UpdatePetsResponse = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -185,29 +185,29 @@ export const ShowPetByIdResponse = zod.preprocess(
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/samples/mcp/custom-server/src/tool-schemas.zod.ts
+++ b/samples/mcp/custom-server/src/tool-schemas.zod.ts
@@ -22,11 +22,11 @@ export const FindPetsByStatusQueryParams = zod.object({
 });
 
 export const FindPetsByStatusResponseItem = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -34,7 +34,7 @@ export const FindPetsByStatusResponseItem = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -51,11 +51,11 @@ export const FindPetsByTagsQueryParams = zod.object({
 });
 
 export const FindPetsByTagsResponseItem = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -63,7 +63,7 @@ export const FindPetsByTagsResponseItem = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -76,15 +76,15 @@ export const FindPetsByTagsResponseItem = zod.object({
 export const FindPetsByTagsResponse = zod.array(FindPetsByTagsResponseItem);
 
 export const GetPetByIdParams = zod.object({
-  petId: zod.number().describe('ID of pet to return'),
+  petId: zod.int().describe('ID of pet to return'),
 });
 
 export const GetPetByIdResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -92,7 +92,7 @@ export const GetPetByIdResponse = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -104,7 +104,7 @@ export const GetPetByIdResponse = zod.object({
 });
 
 export const UpdatePetWithFormParams = zod.object({
-  petId: zod.number().describe('ID of pet that needs to be updated'),
+  petId: zod.int().describe('ID of pet that needs to be updated'),
 });
 
 export const UpdatePetWithFormQueryParams = zod.object({
@@ -119,11 +119,11 @@ export const UpdatePetWithFormQueryParams = zod.object({
 });
 
 export const UpdatePetWithFormResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -131,7 +131,7 @@ export const UpdatePetWithFormResponse = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -143,7 +143,7 @@ export const UpdatePetWithFormResponse = zod.object({
 });
 
 export const DeletePetParams = zod.object({
-  petId: zod.number().describe('Pet id to delete'),
+  petId: zod.int().describe('Pet id to delete'),
 });
 
 export const DeletePetHeader = zod.object({
@@ -152,16 +152,16 @@ export const DeletePetHeader = zod.object({
 
 export const DeletePetResponse = zod.unknown();
 
-export const GetInventoryResponse = zod.record(zod.string(), zod.number());
+export const GetInventoryResponse = zod.record(zod.string(), zod.int());
 
 export const GetOrderByIdParams = zod.object({
-  orderId: zod.number().describe('ID of order that needs to be fetched'),
+  orderId: zod.int().describe('ID of order that needs to be fetched'),
 });
 
 export const GetOrderByIdResponse = zod.object({
-  id: zod.number().optional(),
-  petId: zod.number().optional(),
-  quantity: zod.number().optional(),
+  id: zod.int().optional(),
+  petId: zod.int().optional(),
+  quantity: zod.int().optional(),
   shipDate: zod.iso.datetime({ offset: true }).optional(),
   status: zod
     .enum(['placed', 'approved', 'delivered'])
@@ -171,7 +171,7 @@ export const GetOrderByIdResponse = zod.object({
 });
 
 export const DeleteOrderParams = zod.object({
-  orderId: zod.number().describe('ID of the order that needs to be deleted'),
+  orderId: zod.int().describe('ID of the order that needs to be deleted'),
 });
 
 export const DeleteOrderResponse = zod.unknown();
@@ -195,14 +195,14 @@ export const GetUserByNameParams = zod.object({
 });
 
 export const GetUserByNameResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   username: zod.string().optional(),
   firstName: zod.string().optional(),
   lastName: zod.string().optional(),
   email: zod.string().optional(),
   password: zod.string().optional(),
   phone: zod.string().optional(),
-  userStatus: zod.number().optional().describe('User Status'),
+  userStatus: zod.int().optional().describe('User Status'),
 });
 
 export const DeleteUserParams = zod.object({

--- a/samples/mcp/petstore/src/tool-schemas.zod.ts
+++ b/samples/mcp/petstore/src/tool-schemas.zod.ts
@@ -21,11 +21,11 @@ export const FilterPetsByStatusQueryParams = zod.object({
 });
 
 export const FilterPetsByStatusBody = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -33,7 +33,7 @@ export const FilterPetsByStatusBody = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -45,11 +45,11 @@ export const FilterPetsByStatusBody = zod.object({
 });
 
 export const FilterPetsByStatusResponseItem = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -57,7 +57,7 @@ export const FilterPetsByStatusResponseItem = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -79,11 +79,11 @@ export const FindPetsByStatusQueryParams = zod.object({
 });
 
 export const FindPetsByStatusResponseItem = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -91,7 +91,7 @@ export const FindPetsByStatusResponseItem = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -108,11 +108,11 @@ export const FindPetsByTagsQueryParams = zod.object({
 });
 
 export const FindPetsByTagsResponseItem = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -120,7 +120,7 @@ export const FindPetsByTagsResponseItem = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -133,15 +133,15 @@ export const FindPetsByTagsResponseItem = zod.object({
 export const FindPetsByTagsResponse = zod.array(FindPetsByTagsResponseItem);
 
 export const GetPetByIdParams = zod.object({
-  petId: zod.number().describe('ID of pet to return'),
+  petId: zod.int().describe('ID of pet to return'),
 });
 
 export const GetPetByIdResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -149,7 +149,7 @@ export const GetPetByIdResponse = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -161,7 +161,7 @@ export const GetPetByIdResponse = zod.object({
 });
 
 export const UpdatePetWithFormParams = zod.object({
-  petId: zod.number().describe('ID of pet that needs to be updated'),
+  petId: zod.int().describe('ID of pet that needs to be updated'),
 });
 
 export const UpdatePetWithFormQueryParams = zod.object({
@@ -176,11 +176,11 @@ export const UpdatePetWithFormQueryParams = zod.object({
 });
 
 export const UpdatePetWithFormResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string(),
   category: zod
     .object({
-      id: zod.number().optional(),
+      id: zod.int().optional(),
       name: zod.string().optional(),
     })
     .optional(),
@@ -188,7 +188,7 @@ export const UpdatePetWithFormResponse = zod.object({
   tags: zod
     .array(
       zod.object({
-        id: zod.number().optional(),
+        id: zod.int().optional(),
         name: zod.string().optional(),
       }),
     )
@@ -200,7 +200,7 @@ export const UpdatePetWithFormResponse = zod.object({
 });
 
 export const DeletePetParams = zod.object({
-  petId: zod.number().describe('Pet id to delete'),
+  petId: zod.int().describe('Pet id to delete'),
 });
 
 export const DeletePetHeader = zod.object({
@@ -209,16 +209,16 @@ export const DeletePetHeader = zod.object({
 
 export const DeletePetResponse = zod.unknown();
 
-export const GetInventoryResponse = zod.record(zod.string(), zod.number());
+export const GetInventoryResponse = zod.record(zod.string(), zod.int());
 
 export const GetOrderByIdParams = zod.object({
-  orderId: zod.number().describe('ID of order that needs to be fetched'),
+  orderId: zod.int().describe('ID of order that needs to be fetched'),
 });
 
 export const GetOrderByIdResponse = zod.object({
-  id: zod.number().optional(),
-  petId: zod.number().optional(),
-  quantity: zod.number().optional(),
+  id: zod.int().optional(),
+  petId: zod.int().optional(),
+  quantity: zod.int().optional(),
   shipDate: zod.iso.datetime({ offset: true }).optional(),
   status: zod
     .enum(['placed', 'approved', 'delivered'])
@@ -228,7 +228,7 @@ export const GetOrderByIdResponse = zod.object({
 });
 
 export const DeleteOrderParams = zod.object({
-  orderId: zod.number().describe('ID of the order that needs to be deleted'),
+  orderId: zod.int().describe('ID of the order that needs to be deleted'),
 });
 
 export const DeleteOrderResponse = zod.unknown();
@@ -252,14 +252,14 @@ export const GetUserByNameParams = zod.object({
 });
 
 export const GetUserByNameResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   username: zod.string().optional(),
   firstName: zod.string().optional(),
   lastName: zod.string().optional(),
   email: zod.string().optional(),
   password: zod.string().optional(),
   phone: zod.string().optional(),
-  userStatus: zod.number().optional().describe('User Status'),
+  userStatus: zod.int().optional().describe('User Status'),
 });
 
 export const DeleteUserParams = zod.object({

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.zod.ts
@@ -21,29 +21,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -67,29 +67,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -106,29 +106,29 @@ export const UpdatePetsBody = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -142,29 +142,29 @@ export const UpdatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -185,29 +185,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),

--- a/samples/swr-with-zod/__snapshots__/models/cat-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/cat-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.number().int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/samples/swr-with-zod/__snapshots__/models/dachshund-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/dachshund-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.number().int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/samples/swr-with-zod/__snapshots__/models/dog-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/dog-reusable.zod.ts
@@ -10,7 +10,7 @@ import { Labradoodle } from './labradoodle-reusable.zod';
 
 export const Dog = zod.union([Labradoodle, Dachshund]).and(
   zod.object({
-    barksPerMinute: zod.number().optional(),
+    barksPerMinute: zod.number().int().optional(),
     type: zod.enum(['dog']),
   }),
 );

--- a/samples/swr-with-zod/__snapshots__/models/error-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/error-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.number().int(),
   message: zod.string(),
 });
 

--- a/samples/swr-with-zod/__snapshots__/models/labradoodle-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/labradoodle-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.number().int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/samples/swr-with-zod/__snapshots__/models/pet-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/pet-reusable.zod.ts
@@ -11,7 +11,7 @@ import { Dog } from './dog-reusable.zod';
 export const Pet = zod.union([Dog, Cat]).and(
   zod.object({
     '@id': zod.string().optional(),
-    id: zod.number(),
+    id: zod.number().int(),
     name: zod.string(),
     tag: zod.string().optional(),
     email: zod.string().email().optional(),

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.zod.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.zod.ts
@@ -21,29 +21,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -67,29 +67,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -106,29 +106,29 @@ export const UpdatePetsBody = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -142,29 +142,29 @@ export const UpdatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),
@@ -185,29 +185,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.number().int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.number().int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.number().int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.number().int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.number().int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.string().email().optional(),

--- a/samples/swr-with-zod/src/gen/models/cat-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/cat-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.number().int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/samples/swr-with-zod/src/gen/models/dachshund-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/dachshund-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.number().int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/samples/swr-with-zod/src/gen/models/dog-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/dog-reusable.zod.ts
@@ -10,7 +10,7 @@ import { Labradoodle } from './labradoodle-reusable.zod';
 
 export const Dog = zod.union([Labradoodle, Dachshund]).and(
   zod.object({
-    barksPerMinute: zod.number().optional(),
+    barksPerMinute: zod.number().int().optional(),
     type: zod.enum(['dog']),
   }),
 );

--- a/samples/swr-with-zod/src/gen/models/error-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/error-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.number().int(),
   message: zod.string(),
 });
 

--- a/samples/swr-with-zod/src/gen/models/labradoodle-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/labradoodle-reusable.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.number().int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/samples/swr-with-zod/src/gen/models/pet-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/pet-reusable.zod.ts
@@ -11,7 +11,7 @@ import { Dog } from './dog-reusable.zod';
 export const Pet = zod.union([Dog, Cat]).and(
   zod.object({
     '@id': zod.string().optional(),
-    id: zod.number(),
+    id: zod.number().int(),
     name: zod.string(),
     tag: zod.string().optional(),
     email: zod.string().email().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/cat.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/dachshund.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/dog.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/dog.zod.ts
@@ -7,13 +7,13 @@
 import { z as zod } from 'zod';
 
 export const Dog = zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 }))
 

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/error.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  "code": zod.number(),
+  "code": zod.int(),
   "message": zod.string()
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/pet.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/pet.zod.ts
@@ -7,20 +7,20 @@
 import { z as zod } from 'zod';
 
 export const Pet = zod.union([zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 })),zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })]).and(zod.object({
   "@id": zod.string().optional(),
-  "id": zod.number(),
+  "id": zod.int(),
   "name": zod.string(),
   "tag": zod.string().optional(),
   "email": zod.email().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/petWithTag.zod.ts
@@ -9,20 +9,20 @@ import { z as zod } from 'zod';
 export const PetWithTag = zod.object({
   "tag": zod.string(),
   "pet": zod.union([zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 })),zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })]).and(zod.object({
   "@id": zod.string().optional(),
-  "id": zod.number(),
+  "id": zod.int(),
   "name": zod.string(),
   "tag": zod.string().optional(),
   "email": zod.email().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/pets.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/pets.zod.ts
@@ -7,20 +7,20 @@
 import { z as zod } from 'zod';
 
 export const Pets = zod.array(zod.union([zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 })),zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })]).and(zod.object({
   "@id": zod.string().optional(),
-  "id": zod.number(),
+  "id": zod.int(),
   "name": zod.string(),
   "tag": zod.string().optional(),
   "email": zod.email().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/cat.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod/model/dachshund.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod/model/dog.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/dog.zod.ts
@@ -7,13 +7,13 @@
 import { z as zod } from 'zod';
 
 export const Dog = zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 }))
 

--- a/tests/__snapshots__/angular/http-resource-zod/model/error.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  "code": zod.number(),
+  "code": zod.int(),
   "message": zod.string()
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 })
 

--- a/tests/__snapshots__/angular/http-resource-zod/model/pet.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/pet.zod.ts
@@ -7,20 +7,20 @@
 import { z as zod } from 'zod';
 
 export const Pet = zod.union([zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 })),zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })]).and(zod.object({
   "@id": zod.string().optional(),
-  "id": zod.number(),
+  "id": zod.int(),
   "name": zod.string(),
   "tag": zod.string().optional(),
   "email": zod.email().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/petWithTag.zod.ts
@@ -9,20 +9,20 @@ import { z as zod } from 'zod';
 export const PetWithTag = zod.object({
   "tag": zod.string(),
   "pet": zod.union([zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 })),zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })]).and(zod.object({
   "@id": zod.string().optional(),
-  "id": zod.number(),
+  "id": zod.int(),
   "name": zod.string(),
   "tag": zod.string().optional(),
   "email": zod.email().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/pets.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/pets.zod.ts
@@ -7,20 +7,20 @@
 import { z as zod } from 'zod';
 
 export const Pets = zod.array(zod.union([zod.union([zod.object({
-  "cuteness": zod.number(),
+  "cuteness": zod.int(),
   "breed": zod.enum(['Labradoodle'])
 }),zod.object({
-  "length": zod.number(),
+  "length": zod.int(),
   "breed": zod.enum(['Dachshund'])
 })]).and(zod.object({
-  "barksPerMinute": zod.number().optional(),
+  "barksPerMinute": zod.int().optional(),
   "type": zod.enum(['dog'])
 })),zod.object({
-  "petsRequested": zod.number().optional(),
+  "petsRequested": zod.int().optional(),
   "type": zod.enum(['cat'])
 })]).and(zod.object({
   "@id": zod.string().optional(),
-  "id": zod.number(),
+  "id": zod.int(),
   "name": zod.string(),
   "tag": zod.string().optional(),
   "email": zod.email().optional(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/angular/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/angular/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/angular/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/angular/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/angular/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/error.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pagination.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pagination.zod.ts
@@ -7,8 +7,8 @@
 import { z as zod } from 'zod';
 
 export const Pagination = zod.object({
-  total: zod.number(),
-  page: zod.number(),
+  total: zod.int(),
+  page: zod.int(),
   hasNext: zod.boolean().optional(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/listPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/listPetsParams.zod.ts
@@ -8,7 +8,7 @@ import { z as zod } from 'zod';
 import { SortOrder } from '../sortOrder.zod';
 
 export const ListPetsParams = zod.object({
-  limit: zod.number().optional(),
+  limit: zod.int().optional(),
   sort: SortOrder.optional(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/listStoresParams.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/listStoresParams.zod.ts
@@ -8,7 +8,7 @@ import { z as zod } from 'zod';
 import { SortOrder } from '../sortOrder.zod';
 
 export const ListStoresParams = zod.object({
-  limit: zod.number().optional(),
+  limit: zod.int().optional(),
   sort: SortOrder.optional(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/pets/pets.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/pets/pets.ts
@@ -9,7 +9,7 @@ import * as zod from 'zod';
 import { CreatePetBody, Pet, PetList } from '../model';
 
 export const ListPetsQueryParams = zod.object({
-  limit: zod.number().optional(),
+  limit: zod.int().optional(),
   sort: zod.enum(['asc', 'desc']).optional(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/stores/stores.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/stores/stores.ts
@@ -9,7 +9,7 @@ import * as zod from 'zod';
 import { CreateStoreBody, Store, StoreList } from '../model';
 
 export const ListStoresQueryParams = zod.object({
-  limit: zod.number().optional(),
+  limit: zod.int().optional(),
   sort: zod.enum(['asc', 'desc']).optional(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/error.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/cat.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dachshund.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dog.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/labradoodle.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pet.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/petWithTag.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pets.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/cat.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/axios/zod-nodenext/model/dachshund.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/axios/zod-nodenext/model/dog.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/dog.zod.ts
@@ -10,7 +10,7 @@ import { Labradoodle } from './labradoodle.zod.js';
 
 export const Dog = zod.union([Labradoodle, Dachshund]).and(
   zod.object({
-    barksPerMinute: zod.number().optional(),
+    barksPerMinute: zod.int().optional(),
     type: zod.enum(['dog']),
   }),
 );

--- a/tests/__snapshots__/axios/zod-nodenext/model/error.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/axios/zod-nodenext/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/axios/zod-nodenext/model/pet.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/pet.zod.ts
@@ -11,7 +11,7 @@ import { Dog } from './dog.zod.js';
 export const Pet = zod.union([Dog, Cat]).and(
   zod.object({
     '@id': zod.string().optional(),
-    id: zod.number(),
+    id: zod.int(),
     name: zod.string(),
     tag: zod.string().optional(),
     email: zod.email().optional(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/axios/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/axios/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/axios/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/axios/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/axios/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/endpoints.ts
@@ -30,29 +30,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -91,29 +91,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -134,29 +134,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -193,29 +193,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/cat.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/default/schemas-zod-only/model/dachshund.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/default/schemas-zod-only/model/dog.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/default/schemas-zod-only/model/error.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/default/schemas-zod-only/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/default/schemas-zod-only/model/pet.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/pets.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
@@ -18,10 +18,10 @@ export const ListPetsByCountryParams = zod.object({
 export const ListPetsByCountryQueryParams = zod.object({
   q: zod.array(zod.string()).optional().describe('Filter pets by substring'),
   limit: zod
-    .number()
+    .int()
     .optional()
     .describe('How many items to return at one time (max 100)'),
-  offset: zod.number().optional().describe('How many items to skip'),
+  offset: zod.int().optional().describe('How many items to skip'),
   order: zod
     .enum(['asc', 'desc'])
     .optional()
@@ -43,10 +43,10 @@ export const listPetsByCountryResponseCountryCodeDefault = `UY`;
 
 export const ListPetsByCountryResponseItem = zod.object({
   '@id': zod.string().optional(),
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string().optional(),
-  age: zod.number().optional(),
+  age: zod.int().optional(),
   countryCode: zod
     .enum(['CN', 'UY'])
     .default(listPetsByCountryResponseCountryCodeDefault),
@@ -58,10 +58,7 @@ export const ListPetsByCountryResponse = zod.array(
 export const listPetsByAgePathAgeDefault = 5;
 
 export const ListPetsByAgeParams = zod.object({
-  age: zod
-    .number()
-    .default(listPetsByAgePathAgeDefault)
-    .describe('Filter by age'),
+  age: zod.int().default(listPetsByAgePathAgeDefault).describe('Filter by age'),
 });
 
 export const ListPetsByAgeQueryParams = zod.object({
@@ -79,10 +76,10 @@ export const listPetsByAgeResponseCountryCodeDefault = `UY`;
 
 export const ListPetsByAgeResponseItem = zod.object({
   '@id': zod.string().optional(),
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   tag: zod.string().optional(),
-  age: zod.number().optional(),
+  age: zod.int().optional(),
   countryCode: zod
     .enum(['CN', 'UY'])
     .default(listPetsByAgeResponseCountryCodeDefault),

--- a/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -173,29 +173,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/pets/pets.zod.ts
@@ -30,29 +30,29 @@ export const ListPetsResponseItem = zod.preprocess(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -91,29 +91,29 @@ export const CreatePetsResponse = zod.preprocess(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -134,29 +134,29 @@ export const ShowPetByIdResponse = zod.preprocess(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -185,29 +185,29 @@ export const ShowPetWithOwnerResponse = zod.preprocess(
         zod
           .union([
             zod.object({
-              cuteness: zod.number(),
+              cuteness: zod.int(),
               breed: zod.enum(['Labradoodle']),
             }),
             zod.object({
-              length: zod.number(),
+              length: zod.int(),
               breed: zod.enum(['Dachshund']),
             }),
           ])
           .and(
             zod.object({
-              barksPerMinute: zod.number().optional(),
+              barksPerMinute: zod.int().optional(),
               type: zod.enum(['dog']),
             }),
           ),
         zod.object({
-          petsRequested: zod.number().optional(),
+          petsRequested: zod.int().optional(),
           type: zod.enum(['cat']),
         }),
       ])
       .and(
         zod.object({
           '@id': zod.string().optional(),
-          id: zod.number(),
+          id: zod.int(),
           name: zod.string(),
           tag: zod.string().optional(),
           email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -173,29 +173,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -173,29 +173,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -173,29 +173,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/cat.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/dachshund.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/dog.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/error.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/labradoodle.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/pet.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/petWithTag.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/pets.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/cat.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dachshund.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dog.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/error.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/labradoodle.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pet.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/petWithTag.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pets.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
@@ -27,29 +27,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -85,29 +85,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -125,29 +125,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -175,29 +175,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/mock/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/mock/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/mock/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/mock/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/mock/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/react-query/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/react-query/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/react-query/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/react-query/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/react-query/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/swr/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/swr/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/swr/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/swr/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/swr/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/cat.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Cat = zod.object({
-  petsRequested: zod.number().optional(),
+  petsRequested: zod.int().optional(),
   type: zod.enum(['cat']),
 });
 

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/dachshund.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Dachshund = zod.object({
-  length: zod.number(),
+  length: zod.int(),
   breed: zod.enum(['Dachshund']),
 });
 

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/dog.zod.ts
@@ -9,17 +9,17 @@ import { z as zod } from 'zod';
 export const Dog = zod
   .union([
     zod.object({
-      cuteness: zod.number(),
+      cuteness: zod.int(),
       breed: zod.enum(['Labradoodle']),
     }),
     zod.object({
-      length: zod.number(),
+      length: zod.int(),
       breed: zod.enum(['Dachshund']),
     }),
   ])
   .and(
     zod.object({
-      barksPerMinute: zod.number().optional(),
+      barksPerMinute: zod.int().optional(),
       type: zod.enum(['dog']),
     }),
   );

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/error.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Error = zod.object({
-  code: zod.number(),
+  code: zod.int(),
   message: zod.string(),
 });
 

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/labradoodle.zod.ts
@@ -7,7 +7,7 @@
 import { z as zod } from 'zod';
 
 export const Labradoodle = zod.object({
-  cuteness: zod.number(),
+  cuteness: zod.int(),
   breed: zod.enum(['Labradoodle']),
 });
 

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/pet.zod.ts
@@ -11,29 +11,29 @@ export const Pet = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/petWithTag.zod.ts
@@ -13,29 +13,29 @@ export const PetWithTag = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/pets.zod.ts
@@ -12,29 +12,29 @@ export const Pets = zod.array(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/basic/circularReferences.ts
+++ b/tests/__snapshots__/zod/basic/circularReferences.ts
@@ -10,7 +10,7 @@ import * as zod from 'zod';
  * @summary Example
  */
 export const GetExampleResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string().optional(),
   child: zod.unknown().optional(),
 });
@@ -19,7 +19,7 @@ export const GetExampleResponse = zod.object({
  * @summary Node with required child
  */
 export const GetNodeWithRequiredChildResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   child: zod.unknown(),
 });

--- a/tests/__snapshots__/zod/branded-types/branded-types.ts
+++ b/tests/__snapshots__/zod/branded-types/branded-types.ts
@@ -36,29 +36,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -107,29 +107,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -153,29 +153,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -218,29 +218,29 @@ export const ShowPetWithOwnerResponse = zod
         zod
           .union([
             zod.object({
-              cuteness: zod.number(),
+              cuteness: zod.int(),
               breed: zod.enum(['Labradoodle']),
             }),
             zod.object({
-              length: zod.number(),
+              length: zod.int(),
               breed: zod.enum(['Dachshund']),
             }),
           ])
           .and(
             zod.object({
-              barksPerMinute: zod.number().optional(),
+              barksPerMinute: zod.int().optional(),
               type: zod.enum(['dog']),
             }),
           ),
         zod.object({
-          petsRequested: zod.number().optional(),
+          petsRequested: zod.int().optional(),
           type: zod.enum(['cat']),
         }),
       ])
       .and(
         zod.object({
           '@id': zod.string().optional(),
-          id: zod.number(),
+          id: zod.int(),
           name: zod.string(),
           tag: zod.string().optional(),
           email: zod.email().optional(),

--- a/tests/__snapshots__/zod/coerce/coerce.ts
+++ b/tests/__snapshots__/zod/coerce/coerce.ts
@@ -10,7 +10,7 @@ import * as zod from 'zod';
  * @summary Example
  */
 export const GetExampleResponse = zod.object({
-  id: zod.coerce.number().optional(),
+  id: zod.coerce.number().int().optional(),
   name: zod.coerce.string().optional(),
   child: zod.unknown().optional(),
 });
@@ -19,7 +19,7 @@ export const GetExampleResponse = zod.object({
  * @summary Node with required child
  */
 export const GetNodeWithRequiredChildResponse = zod.object({
-  id: zod.coerce.number(),
+  id: zod.coerce.number().int(),
   name: zod.coerce.string(),
   child: zod.unknown(),
 });

--- a/tests/__snapshots__/zod/date-time-options/date-time-options.ts
+++ b/tests/__snapshots__/zod/date-time-options/date-time-options.ts
@@ -14,13 +14,13 @@ export const ShowPetByIdParams = zod.object({
 });
 
 export const ShowPetByIdResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   birthDate: zod.iso.date(),
   createdAt: zod.iso.datetime({ offset: true, precision: 3 }),
-  age: zod.number().optional(),
+  age: zod.int().optional(),
   legCount: zod.number().optional(),
   weight: zod.number().optional(),
   height: zod.number().optional(),
-  chipNumbers: zod.array(zod.number()).optional(),
+  chipNumbers: zod.array(zod.int()).optional(),
   feedingTime: zod.iso.time({}).optional(),
 });

--- a/tests/__snapshots__/zod/force-version-3/force-version-3.ts
+++ b/tests/__snapshots__/zod/force-version-3/force-version-3.ts
@@ -31,13 +31,13 @@ export const ListPetsResponseItem = zod
       .union([
         zod
           .object({
-            cuteness: zod.number(),
+            cuteness: zod.number().int(),
             breed: zod.enum(['Labradoodle']),
           })
           .strict(),
         zod
           .object({
-            length: zod.number(),
+            length: zod.number().int(),
             breed: zod.enum(['Dachshund']),
           })
           .strict(),
@@ -45,14 +45,14 @@ export const ListPetsResponseItem = zod
       .and(
         zod
           .object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.number().int().optional(),
             type: zod.enum(['dog']),
           })
           .strict(),
       ),
     zod
       .object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.number().int().optional(),
         type: zod.enum(['cat']),
       })
       .strict(),
@@ -61,7 +61,7 @@ export const ListPetsResponseItem = zod
     zod
       .object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.number().int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.string().email().optional(),
@@ -104,13 +104,13 @@ export const CreatePetsResponse = zod
       .union([
         zod
           .object({
-            cuteness: zod.number(),
+            cuteness: zod.number().int(),
             breed: zod.enum(['Labradoodle']),
           })
           .strict(),
         zod
           .object({
-            length: zod.number(),
+            length: zod.number().int(),
             breed: zod.enum(['Dachshund']),
           })
           .strict(),
@@ -118,14 +118,14 @@ export const CreatePetsResponse = zod
       .and(
         zod
           .object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.number().int().optional(),
             type: zod.enum(['dog']),
           })
           .strict(),
       ),
     zod
       .object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.number().int().optional(),
         type: zod.enum(['cat']),
       })
       .strict(),
@@ -134,7 +134,7 @@ export const CreatePetsResponse = zod
     zod
       .object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.number().int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.string().email().optional(),
@@ -157,13 +157,13 @@ export const ShowPetByIdResponse = zod
       .union([
         zod
           .object({
-            cuteness: zod.number(),
+            cuteness: zod.number().int(),
             breed: zod.enum(['Labradoodle']),
           })
           .strict(),
         zod
           .object({
-            length: zod.number(),
+            length: zod.number().int(),
             breed: zod.enum(['Dachshund']),
           })
           .strict(),
@@ -171,14 +171,14 @@ export const ShowPetByIdResponse = zod
       .and(
         zod
           .object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.number().int().optional(),
             type: zod.enum(['dog']),
           })
           .strict(),
       ),
     zod
       .object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.number().int().optional(),
         type: zod.enum(['cat']),
       })
       .strict(),
@@ -187,7 +187,7 @@ export const ShowPetByIdResponse = zod
     zod
       .object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.number().int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.string().email().optional(),
@@ -227,13 +227,13 @@ export const ShowPetWithOwnerResponse = zod
           .union([
             zod
               .object({
-                cuteness: zod.number(),
+                cuteness: zod.number().int(),
                 breed: zod.enum(['Labradoodle']),
               })
               .strict(),
             zod
               .object({
-                length: zod.number(),
+                length: zod.number().int(),
                 breed: zod.enum(['Dachshund']),
               })
               .strict(),
@@ -241,14 +241,14 @@ export const ShowPetWithOwnerResponse = zod
           .and(
             zod
               .object({
-                barksPerMinute: zod.number().optional(),
+                barksPerMinute: zod.number().int().optional(),
                 type: zod.enum(['dog']),
               })
               .strict(),
           ),
         zod
           .object({
-            petsRequested: zod.number().optional(),
+            petsRequested: zod.number().int().optional(),
             type: zod.enum(['cat']),
           })
           .strict(),
@@ -257,7 +257,7 @@ export const ShowPetWithOwnerResponse = zod
         zod
           .object({
             '@id': zod.string().optional(),
-            id: zod.number(),
+            id: zod.number().int(),
             name: zod.string(),
             tag: zod.string().optional(),
             email: zod.string().email().optional(),

--- a/tests/__snapshots__/zod/force-version-4/force-version-4.ts
+++ b/tests/__snapshots__/zod/force-version-4/force-version-4.ts
@@ -30,29 +30,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.strictObject({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.strictObject({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.strictObject({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.strictObject({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.strictObject({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -91,29 +91,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.strictObject({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.strictObject({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.strictObject({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.strictObject({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.strictObject({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -134,29 +134,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.strictObject({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.strictObject({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.strictObject({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.strictObject({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.strictObject({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -193,29 +193,29 @@ export const ShowPetWithOwnerResponse = zod.strictObject({
       zod
         .union([
           zod.strictObject({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.strictObject({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.strictObject({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.strictObject({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.strictObject({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/import-from-subdirectory/import-from-subdirectory.ts
+++ b/tests/__snapshots__/zod/import-from-subdirectory/import-from-subdirectory.ts
@@ -7,14 +7,14 @@
 import * as zod from 'zod';
 
 export const PostPetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
   file: zod
     .object({
-      id: zod.number(),
+      id: zod.int(),
     })
     .optional(),
 });
 
 export const GetPetsResponse = zod.object({
-  id: zod.number(),
+  id: zod.int(),
 });

--- a/tests/__snapshots__/zod/nullable-any-of-refs/nullable-any-of-refs.ts
+++ b/tests/__snapshots__/zod/nullable-any-of-refs/nullable-any-of-refs.ts
@@ -57,12 +57,10 @@ export const GetMixedTypesResponseItem = zod.object({
     .union([
       zod.string().nullable(),
       zod.number().nullable(),
-      zod.number().nullable(),
+      zod.int().nullable(),
       zod.boolean().nullable(),
     ])
     .nullish(),
-  mixedTypesNotNull: zod
-    .union([zod.number(), zod.number(), zod.uuid()])
-    .nullish(),
+  mixedTypesNotNull: zod.union([zod.number(), zod.int(), zod.uuid()]).nullish(),
 });
 export const GetMixedTypesResponse = zod.array(GetMixedTypesResponseItem);

--- a/tests/__snapshots__/zod/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/zod/petstore-tags-split/pets/pets.ts
@@ -30,29 +30,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -91,29 +91,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -134,29 +134,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -188,29 +188,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/petstore/endpoints.ts
+++ b/tests/__snapshots__/zod/petstore/endpoints.ts
@@ -51,29 +51,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -118,29 +118,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -164,29 +164,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -235,29 +235,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/preprocess/preprocess.ts
+++ b/tests/__snapshots__/zod/preprocess/preprocess.ts
@@ -41,29 +41,29 @@ export const ListPetsResponseItem = zod.preprocess(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -116,29 +116,29 @@ export const CreatePetsResponse = zod.preprocess(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -165,29 +165,29 @@ export const ShowPetByIdResponse = zod.preprocess(
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),
@@ -233,29 +233,29 @@ export const ShowPetWithOwnerResponse = zod.preprocess(
         zod
           .union([
             zod.object({
-              cuteness: zod.number(),
+              cuteness: zod.int(),
               breed: zod.enum(['Labradoodle']),
             }),
             zod.object({
-              length: zod.number(),
+              length: zod.int(),
               breed: zod.enum(['Dachshund']),
             }),
           ])
           .and(
             zod.object({
-              barksPerMinute: zod.number().optional(),
+              barksPerMinute: zod.int().optional(),
               type: zod.enum(['dog']),
             }),
           ),
         zod.object({
-          petsRequested: zod.number().optional(),
+          petsRequested: zod.int().optional(),
           type: zod.enum(['cat']),
         }),
       ])
       .and(
         zod.object({
           '@id': zod.string().optional(),
-          id: zod.number(),
+          id: zod.int(),
           name: zod.string(),
           tag: zod.string().optional(),
           email: zod.email().optional(),

--- a/tests/__snapshots__/zod/required-default-values/required-default-values.ts
+++ b/tests/__snapshots__/zod/required-default-values/required-default-values.ts
@@ -14,7 +14,7 @@ export const getGizmoResponseNullableStringDefault = `hello`;
 export const GetGizmoResponse = zod.object({
   booleanFlag: zod.boolean().default(getGizmoResponseBooleanFlagDefault),
   number: zod.number().default(getGizmoResponseNumberDefault),
-  integer: zod.number().default(getGizmoResponseIntegerDefault),
+  integer: zod.int().default(getGizmoResponseIntegerDefault),
   nullableString: zod
     .string()
     .nullish()

--- a/tests/__snapshots__/zod/schemas-false/endpoints.ts
+++ b/tests/__snapshots__/zod/schemas-false/endpoints.ts
@@ -30,29 +30,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -91,29 +91,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -134,29 +134,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -193,29 +193,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/split/endpoints.ts
+++ b/tests/__snapshots__/zod/split/endpoints.ts
@@ -30,29 +30,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -91,29 +91,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -134,29 +134,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -193,29 +193,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/strict-mode/strict-mode.ts
+++ b/tests/__snapshots__/zod/strict-mode/strict-mode.ts
@@ -10,7 +10,7 @@ import * as zod from 'zod';
  * @summary Example
  */
 export const GetExampleResponse = zod.strictObject({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   name: zod.string().optional(),
   child: zod.unknown().optional(),
 });
@@ -19,7 +19,7 @@ export const GetExampleResponse = zod.strictObject({
  * @summary Node with required child
  */
 export const GetNodeWithRequiredChildResponse = zod.strictObject({
-  id: zod.number(),
+  id: zod.int(),
   name: zod.string(),
   child: zod.unknown(),
 });

--- a/tests/__snapshots__/zod/tags/pets.ts
+++ b/tests/__snapshots__/zod/tags/pets.ts
@@ -45,29 +45,29 @@ export const ListPetsResponseItem = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -106,29 +106,29 @@ export const CreatePetsResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -149,29 +149,29 @@ export const ShowPetByIdResponse = zod
     zod
       .union([
         zod.object({
-          cuteness: zod.number(),
+          cuteness: zod.int(),
           breed: zod.enum(['Labradoodle']),
         }),
         zod.object({
-          length: zod.number(),
+          length: zod.int(),
           breed: zod.enum(['Dachshund']),
         }),
       ])
       .and(
         zod.object({
-          barksPerMinute: zod.number().optional(),
+          barksPerMinute: zod.int().optional(),
           type: zod.enum(['dog']),
         }),
       ),
     zod.object({
-      petsRequested: zod.number().optional(),
+      petsRequested: zod.int().optional(),
       type: zod.enum(['cat']),
     }),
   ])
   .and(
     zod.object({
       '@id': zod.string().optional(),
-      id: zod.number(),
+      id: zod.int(),
       name: zod.string(),
       tag: zod.string().optional(),
       email: zod.email().optional(),
@@ -203,29 +203,29 @@ export const ShowPetWithOwnerResponse = zod.object({
       zod
         .union([
           zod.object({
-            cuteness: zod.number(),
+            cuteness: zod.int(),
             breed: zod.enum(['Labradoodle']),
           }),
           zod.object({
-            length: zod.number(),
+            length: zod.int(),
             breed: zod.enum(['Dachshund']),
           }),
         ])
         .and(
           zod.object({
-            barksPerMinute: zod.number().optional(),
+            barksPerMinute: zod.int().optional(),
             type: zod.enum(['dog']),
           }),
         ),
       zod.object({
-        petsRequested: zod.number().optional(),
+        petsRequested: zod.int().optional(),
         type: zod.enum(['cat']),
       }),
     ])
     .and(
       zod.object({
         '@id': zod.string().optional(),
-        id: zod.number(),
+        id: zod.int(),
         name: zod.string(),
         tag: zod.string().optional(),
         email: zod.email().optional(),

--- a/tests/__snapshots__/zod/time-options/time-options.ts
+++ b/tests/__snapshots__/zod/time-options/time-options.ts
@@ -14,13 +14,13 @@ export const ShowPetByIdParams = zod.object({
 });
 
 export const ShowPetByIdResponse = zod.object({
-  id: zod.number().optional(),
+  id: zod.int().optional(),
   birthDate: zod.iso.date(),
   createdAt: zod.iso.datetime({ offset: true }),
-  age: zod.number().optional(),
+  age: zod.int().optional(),
   legCount: zod.number().optional(),
   weight: zod.number().optional(),
   height: zod.number().optional(),
-  chipNumbers: zod.array(zod.number()).optional(),
+  chipNumbers: zod.array(zod.int()).optional(),
   feedingTime: zod.iso.time({ precision: -1 }).optional(),
 });


### PR DESCRIPTION
## Summary

- generate native integer validators for OpenAPI `integer` schemas
- use `z.int()` for Zod 4 and Zod Mini while preserving `z.number().int()` for Zod 3
- preserve integer validation in OpenAPI 3.1 multi-type schemas
- support integer coercion and forward custom Zod params to both the numeric input validator and the integer validator
- update generated samples and snapshots

## Behavior

Fractional values are now rejected for OpenAPI `integer` schemas. Zod 4 and Zod Mini use the native `z.int()` safe-integer semantics; Zod 3 retains its native `z.number().int()` behavior.

## Breaking behavior

- On Zod 4 and Zod Mini, `z.int()` enforces JavaScript safe integer bounds. Integer fields with `format: int64` that carry values above `Number.MAX_SAFE_INTEGER` (for example 64-bit snowflake ids) were accepted by the previous `z.number()` output and are now rejected. The Zod 3 output (`z.number().int()`) still accepts them. Note that `JSON.parse` already loses precision for such values, so rejecting them surfaces a real problem; APIs that need full 64-bit range should serialize those fields as strings or use an override.
- For `zodParams` mutator authors: integer fields now surface the new validator name `int`. On Zod 4 and Zod Mini without coercion the mutator is called with `int` instead of `number`; on Zod 3 and on coerced output it is called with both `number` and `int`.

## Test plan

- `vp lint packages/zod/src/index.ts packages/zod/src/zod.test.ts packages/orval/src/reusable-schemas.test.ts`
- `vitest run packages/zod/src packages/orval/src/reusable-schemas.test.ts`
- `tsc --noEmit -p packages/zod/tsconfig.json`
- `tsc --noEmit -p packages/orval/tsconfig.json`
- `vp run -w test:snapshots`

Fixes #3736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated Zod schemas now emit integer-specific validation (`int`) for OpenAPI `type: "integer"`, including correct min/max constraint handling and support across different Zod emission modes (including coercion and lightweight variants).
  * Parameter injection into generated schemas now applies correctly for integer validators.
* **Bug Fixes**
  * Numeric fields used for identifiers, limits, quantities, and status now reject fractional values and consistently require integers.
* **Tests**
  * Expanded assertions to cover integer rendering, constraint output, and injected parameter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
