### PR TITLE
feat: add exactOptional option for zod and effect generators

### DIFF
--- a/docs/content/docs/guides/zod.mdx
+++ b/docs/content/docs/guides/zod.mdx
@@ -189,7 +189,7 @@ export default defineConfig({
 
 Per-operation and per-tag overrides accept the settings that apply to an individual schema: `strict`, `generate`, `coerce`, `preprocess`, `params`, and `useBrandedTypes`.
 
-Output-wide settings — `variant`, `version`, `dateTimeOptions`, `timeOptions`, `generateEachHttpStatus`, `generateReusableSchemas`, `generateMeta`, and `generateDiscriminatedUnion` — only make sense for the whole output and must stay on `override.zod`. If you place one on an operation or tag it is ignored — the value from `override.zod` still applies — and Orval prints a build warning:
+Output-wide settings — `variant`, `version`, `dateTimeOptions`, `timeOptions`, `generateEachHttpStatus`, `generateReusableSchemas`, `generateMeta`, `generateDiscriminatedUnion`, and `exactOptional` — only make sense for the whole output and must stay on `override.zod`. If you place one on an operation or tag it is ignored — the value from `override.zod` still applies — and Orval prints a build warning:
 
 ```
 ⚠️  override.operations.listPets.zod only supports strict, generate, coerce, preprocess, params, and useBrandedTypes. Ignoring unsupported field: zod.version.

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1601,6 +1601,25 @@ Behavior:
 - **Inheritance (`allOf`).** Branches composed with `allOf` are flattened into a single object so they remain valid discriminated-union options — this is the case that previously forced the feature to be reverted ([#2085](https://github.com/orval-labs/orval/issues/2085)). With [`generateReusableSchemas`](#generatereusableschemas), a branch that references an `allOf` schema stays a plain union (the referenced schema can't be guaranteed to be an object from the reference alone).
 - Works with both Zod v3 (>= 3.20) and v4, and with the [`mini`](#variant) variant.
 
+### exactOptional
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+Emit optional object properties with `.exactOptional()` (classic) / `zod.exactOptional()` (mini) instead of `.optional()`, so consumers compiling with [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) infer `{ x?: T }` rather than `{ x?: T | undefined }`.
+
+```ts
+// override: { zod: { exactOptional: true } }
+export const Pet = zod.object({ name: zod.string().exactOptional() });
+```
+
+Behavior:
+
+- **Opt-in.** Left `false`, optional properties emit `.optional()` as before, so existing output is unchanged.
+- **zod v4 only.** zod v3 has no `.exactOptional()`, so the option is a no-op there and `.optional()` is emitted.
+- Applies to optional properties in both the classic and [`mini`](#variant) variants.
+
 ---
 
 ## override.effect
@@ -1655,6 +1674,14 @@ Control which schemas are generated.
 **Default:** `false`
 
 Append `S.brand()` to generated Effect schemas using the schema name as the brand identifier. For array request/response bodies, only the top-level array wrapper schema is branded.
+
+### exactOptional
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+Emit optional Struct properties with `S.optionalWith(schema, { exact: true })` instead of `S.optional(schema)`, so consumers compiling with [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) infer `{ x?: T }` rather than `{ x?: T | undefined }`.
 
 ---
 

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -103,6 +103,7 @@ const createOutput = (
         generateReusableSchemas: false,
         generateMeta: false,
         generateDiscriminatedUnion: false,
+        exactOptional: false,
         useBrandedTypes: false,
         dateTimeOptions: {},
         timeOptions: {},
@@ -124,6 +125,7 @@ const createOutput = (
         },
         generateEachHttpStatus: false,
         useBrandedTypes: false,
+        exactOptional: false,
       },
       fetch: {
         includeHttpResponseReturnType: true,

--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -114,6 +114,7 @@ const createOutput = (
         generateReusableSchemas: false,
         generateMeta: false,
         generateDiscriminatedUnion: false,
+        exactOptional: false,
         dateTimeOptions: {},
         timeOptions: {},
       },
@@ -134,6 +135,7 @@ const createOutput = (
         },
         generateEachHttpStatus: false,
         useBrandedTypes: false,
+        exactOptional: false,
       },
       fetch: {
         includeHttpResponseReturnType: true,

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -134,6 +134,7 @@ export function createTestContextSpec({
         generateReusableSchemas: false,
         generateMeta: false,
         generateDiscriminatedUnion: false,
+        exactOptional: false,
         dateTimeOptions: {},
         timeOptions: { precision: 3 },
       },
@@ -154,6 +155,7 @@ export function createTestContextSpec({
         },
         generateEachHttpStatus: false,
         useBrandedTypes: false,
+        exactOptional: false,
       },
       fetch: {
         includeHttpResponseReturnType: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -918,6 +918,15 @@ export interface ZodOptions extends BaseZodOptions {
    * Default `false` (opt-in), so existing output is unchanged.
    */
   generateDiscriminatedUnion?: boolean;
+  /**
+   * When true (zod v4 only), emits optional object properties with
+   * `.exactOptional()` (classic) / `zod.exactOptional()` (mini) instead of
+   * `.optional()`, so consumers with `exactOptionalPropertyTypes` infer
+   * `{ x?: T }` rather than `{ x?: T | undefined }`. On zod v3 (which has no
+   * `.exactOptional()`) this is a no-op and `.optional()` is emitted. Default
+   * `false` (opt-in), so existing output is unchanged.
+   */
+  exactOptional?: boolean;
 }
 
 /**
@@ -933,6 +942,12 @@ export interface EffectOptions {
   generate?: ZodOptions['generate'];
   generateEachHttpStatus?: boolean;
   useBrandedTypes?: boolean;
+  /**
+   * When true, emits optional Struct properties with
+   * `S.optionalWith(schema, { exact: true })` instead of `S.optional(schema)`,
+   * so `exactOptionalPropertyTypes` consumers infer `{ x?: T }`. Default `false`.
+   */
+  exactOptional?: boolean;
 }
 
 export type ZodCoerceType =
@@ -983,6 +998,7 @@ export interface NormalizedZodOptions {
   generateReusableSchemas: boolean;
   generateMeta: boolean;
   generateDiscriminatedUnion: boolean;
+  exactOptional: boolean;
   dateTimeOptions: ZodDateTimeOptions;
   timeOptions: ZodTimeOptions;
 }
@@ -997,6 +1013,7 @@ export interface NormalizedEffectOptions {
   generate: NormalizedZodOptions['generate'];
   generateEachHttpStatus: boolean;
   useBrandedTypes: boolean;
+  exactOptional: boolean;
 }
 
 /**

--- a/packages/effect/src/effect.test.ts
+++ b/packages/effect/src/effect.test.ts
@@ -13,7 +13,7 @@ function makeContext(): ContextSpec {
 
 function gen(
   schema: OpenApiSchemaObject,
-  options?: { required?: boolean; strict?: boolean },
+  options?: { required?: boolean; strict?: boolean; exactOptional?: boolean },
 ) {
   const context = makeContext();
   const definition = generateEffectValidationSchemaDefinition(
@@ -27,6 +27,8 @@ function gen(
     definition,
     context,
     options?.strict ?? false,
+    undefined,
+    options?.exactOptional ?? false,
   );
   return { effect, consts };
 }
@@ -205,6 +207,27 @@ describe('nullable and optional', () => {
       // not required => optional
     });
     expect(effect).toContain('"name": S.optional(S.String)');
+  });
+
+  it('wraps with S.optionalWith exact when exactOptional is set', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    expect(gen(schema, { exactOptional: true }).effect).toContain(
+      '"name": S.optionalWith(S.String, { exact: true })',
+    );
+    expect(gen(schema).effect).toContain('"name": S.optional(S.String)');
+  });
+
+  it('leaves a nullish property as S.optional even with exactOptional (nullish admits undefined; only .optional() narrows)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      properties: { name: { type: 'string', nullable: true } },
+    };
+    expect(gen(schema, { exactOptional: true }).effect).toContain(
+      '"name": S.optional(S.NullOr(S.String))',
+    );
   });
 });
 

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -757,6 +757,7 @@ export const parseEffectValidationSchemaDefinition = (
   context: ContextSpec,
   strict: boolean,
   brandName?: string,
+  exactOptional = false,
 ): { effect: string; consts: string } => {
   if (input.functions.length === 0) {
     return { effect: '', consts: '' };
@@ -866,7 +867,15 @@ export const parseEffectValidationSchemaDefinition = (
       if (hasDefault) {
         out = `S.optionalWith(${out}, { default: () => ${defaultValue as string} })`;
       } else if (isOptional || isNullish) {
-        out = `S.optional(${out})`;
+        // `{ exact: true }` narrows a plain optional property to `{ x?: T }` for
+        // `exactOptionalPropertyTypes` consumers instead of `{ x?: T | undefined }`.
+        // Only `.optional()` is narrowed (matching the zod generator): a nullish
+        // field intentionally admits `undefined`, which is legal under the flag, so
+        // it keeps `S.optional`.
+        out =
+          exactOptional && isOptional
+            ? `S.optionalWith(${out}, { exact: true })`
+            : `S.optional(${out})`;
       }
     } else {
       if (isNullish) {
@@ -1455,24 +1464,28 @@ const generateEffectRoute = (
     context,
     effectOptions.strict.param,
     brand(`${pascalTypeName}Params`),
+    effectOptions.exactOptional,
   );
   const inputQueryParams = parseEffectValidationSchemaDefinition(
     parsedParameters.queryParams,
     context,
     effectOptions.strict.query,
     brand(`${pascalTypeName}QueryParams`),
+    effectOptions.exactOptional,
   );
   const inputHeaders = parseEffectValidationSchemaDefinition(
     parsedParameters.headers,
     context,
     effectOptions.strict.header,
     brand(`${pascalTypeName}Header`),
+    effectOptions.exactOptional,
   );
   const inputBody = parseEffectValidationSchemaDefinition(
     parsedBody.input,
     context,
     effectOptions.strict.body,
     brand(`${pascalTypeName}Body`),
+    effectOptions.exactOptional,
   );
   const inputResponses = parsedResponses.map((parsedResponse, idx) =>
     parseEffectValidationSchemaDefinition(
@@ -1480,6 +1493,7 @@ const generateEffectRoute = (
       context,
       effectOptions.strict.response,
       brand(pascal(`${typeName}-${responses[idx][0]}-response`)),
+      effectOptions.exactOptional,
     ),
   );
 

--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -130,6 +130,7 @@ function createMockContext(): ContextSpec {
           generateReusableSchemas: false,
           generateMeta: false,
           generateDiscriminatedUnion: false,
+          exactOptional: false,
           dateTimeOptions: {},
           timeOptions: { precision: 3 },
         },
@@ -150,6 +151,7 @@ function createMockContext(): ContextSpec {
           },
           generateEachHttpStatus: false,
           useBrandedTypes: false,
+          exactOptional: false,
         },
         fetch: {
           includeHttpResponseReturnType: false,

--- a/packages/orval/src/reusable-schemas.test.ts
+++ b/packages/orval/src/reusable-schemas.test.ts
@@ -227,6 +227,41 @@ describe('generateReusableSchemaSet', () => {
     expect(entry.zod).not.toContain('zodParams(');
   });
 
+  it('emits .exactOptional() for optional properties when exactOptional is enabled (zod v4)', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            Pet: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                nickname: { type: 'string' },
+              },
+              required: ['name'],
+            },
+          },
+        },
+      },
+    });
+
+    const [withExact] = generateReusableSchemaSet(
+      ['#/components/schemas/Pet'],
+      context,
+      { strict: false, isZodV4: true, exactOptional: true },
+    );
+    expect(withExact.zod).toContain('"nickname": zod.string().exactOptional()');
+    expect(withExact.zod).not.toContain('.optional()');
+
+    const [withoutExact] = generateReusableSchemaSet(
+      ['#/components/schemas/Pet'],
+      context,
+      { strict: false, isZodV4: true },
+    );
+    expect(withoutExact.zod).toContain('"nickname": zod.string().optional()');
+    expect(withoutExact.zod).not.toContain('.exactOptional()');
+  });
+
   it('expands to the transitive closure of component-schema refs', () => {
     const context = createTestContextSpec({
       spec: {

--- a/packages/orval/src/reusable-schemas.ts
+++ b/packages/orval/src/reusable-schemas.ts
@@ -147,6 +147,8 @@ export interface GenerateReusableSchemaSetOptions {
   coerce?: boolean | ZodCoerceType[];
   /** Emit `.meta({ id, ... })` on each schema (zod v4). See `ZodOptions.generateMeta`. */
   generateMeta?: boolean;
+  /** Emit `.exactOptional()` for optional properties (zod v4). See `ZodOptions.exactOptional`. */
+  exactOptional?: boolean;
   /**
    * When set, the user's `override.zod.params` mutator is invoked for every
    * leaf validator inside each emitted component schema with a `'schema'`
@@ -232,6 +234,7 @@ export const generateReusableSchemaSet = (
           }
         : undefined,
       options.variant,
+      options.exactOptional,
     );
 
     entries.push({

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -787,6 +787,45 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it('normalizes zod/effect exactOptional (default false, opt-in true)', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const input = {
+        target: {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1.0.0' },
+          paths: {},
+        },
+      };
+
+      const defaults = await normalizeOptions(
+        { input, output: { target: './generated.ts' } },
+        workspace,
+      );
+      expect(defaults.output.override.zod.exactOptional).toBe(false);
+      expect(defaults.output.override.effect.exactOptional).toBe(false);
+
+      const enabled = await normalizeOptions(
+        {
+          input,
+          output: {
+            target: './generated.ts',
+            override: {
+              zod: { exactOptional: true },
+              effect: { exactOptional: true },
+            },
+          },
+        },
+        workspace,
+      );
+      expect(enabled.output.override.zod.exactOptional).toBe(true);
+      expect(enabled.output.override.effect.exactOptional).toBe(true);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('defaults schemas.type to typescript when omitted', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -260,6 +260,7 @@ function normalizeEffectOptions(
     },
     generateEachHttpStatus: effect?.generateEachHttpStatus ?? false,
     useBrandedTypes: effect?.useBrandedTypes ?? false,
+    exactOptional: effect?.exactOptional ?? false,
   };
 }
 
@@ -659,6 +660,7 @@ export async function normalizeOptions(
           generateMeta: outputOptions.override?.zod?.generateMeta ?? false,
           generateDiscriminatedUnion:
             outputOptions.override?.zod?.generateDiscriminatedUnion ?? false,
+          exactOptional: outputOptions.override?.zod?.exactOptional ?? false,
           dateTimeOptions: outputOptions.override?.zod?.dateTimeOptions ?? {
             offset: true,
           },

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -87,6 +87,7 @@ interface WriteZodOutputOptions {
       };
       generateReusableSchemas?: boolean;
       generateMeta?: boolean;
+      exactOptional?: boolean;
     };
   };
 }
@@ -660,6 +661,7 @@ export function generateZodSchemasInline(
       undefined,
       undefined,
       output.override.zod.variant,
+      output.override.zod.exactOptional,
     );
 
     schemas.push({
@@ -726,6 +728,7 @@ function generateZodSchemasInlineReusable(
     coerce,
     variant: output.override.zod.variant,
     generateMeta: output.override.zod.generateMeta,
+    exactOptional: output.override.zod.exactOptional,
     paramsMutator,
   });
 
@@ -841,6 +844,7 @@ export async function writeZodSchemas(
       undefined,
       undefined,
       output.override.zod.variant,
+      output.override.zod.exactOptional,
     );
 
     schemasToWrite.push({
@@ -942,6 +946,7 @@ async function writeZodSchemasReusable(
     coerce,
     variant: output.override.zod.variant,
     generateMeta: output.override.zod.generateMeta,
+    exactOptional: output.override.zod.exactOptional,
     paramsMutator,
   });
 
@@ -1319,6 +1324,7 @@ export async function writeZodSchemasFromVerbs(
       undefined,
       undefined,
       output.override.zod.variant,
+      output.override.zod.exactOptional,
     );
 
     // Operation schemas sit at the top of the dependency graph, so any

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -135,6 +135,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         generateReusableSchemas: false,
         generateMeta: false,
         generateDiscriminatedUnion: false,
+        exactOptional: false,
         dateTimeOptions: {},
         timeOptions: { precision: 3 },
       },
@@ -155,6 +156,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         },
         generateEachHttpStatus: false,
         useBrandedTypes: false,
+        exactOptional: false,
       },
       fetch: {
         includeHttpResponseReturnType: false,

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1442,6 +1442,7 @@ export const parseZodValidationSchemaDefinition = (
   preprocess?: GeneratorMutator,
   paramsInjection?: ZodParamsInjection,
   variant: ZodVariantOption = 'classic',
+  exactOptional = false,
 ): { zod: string; consts: string; usedRefs: Set<string> } => {
   if (input.functions.length === 0) {
     return { zod: '', consts: '', usedRefs: new Set() };
@@ -1780,7 +1781,9 @@ ${Object.entries(objectArgs)
 
       if (fn === 'optional' || fn === 'nullable' || fn === 'nullish') {
         const value = requireCurrent(fn);
-        current = { expr: zodMiniCall(fn, value.expr), kind: value.kind };
+        const miniFn =
+          exactOptional && isZodV4 && fn === 'optional' ? 'exactOptional' : fn;
+        current = { expr: zodMiniCall(miniFn, value.expr), kind: value.kind };
         continue;
       }
 
@@ -2166,6 +2169,13 @@ ${Object.entries(objectArgs)
       (fn === 'date' && shouldCoerceType && context.output.override.useDates)
     ) {
       return `.coerce.${fn}(${combinedArgs})`;
+    }
+
+    // `.exactOptional()` (zod v4 only) narrows an optional property to `{ x?: T }`
+    // for `exactOptionalPropertyTypes` consumers. Zod v3 has no such method, so
+    // the flag no-ops there and a plain `.optional()` is emitted.
+    if (exactOptional && isZodV4 && fn === 'optional') {
+      return '.exactOptional()';
     }
 
     return `.${fn}(${combinedArgs})`;
@@ -3050,6 +3060,7 @@ const generateZodRoute = async (
     preprocessParams,
     makeParamsInjection('param', 'Params'),
     zodVariant,
+    override.zod.exactOptional,
   );
 
   const preprocessQueryParams = override.zod.preprocess?.query
@@ -3071,6 +3082,7 @@ const generateZodRoute = async (
     preprocessQueryParams,
     makeParamsInjection('query', 'QueryParams'),
     zodVariant,
+    override.zod.exactOptional,
   );
 
   const preprocessHeader = override.zod.preprocess?.header
@@ -3092,6 +3104,7 @@ const generateZodRoute = async (
     preprocessHeader,
     makeParamsInjection('header', 'Header'),
     zodVariant,
+    override.zod.exactOptional,
   );
 
   const preprocessBody = override.zod.preprocess?.body
@@ -3113,6 +3126,7 @@ const generateZodRoute = async (
     preprocessBody,
     makeParamsInjection('body', 'Body'),
     zodVariant,
+    override.zod.exactOptional,
   );
 
   const preprocessResponse = override.zod.preprocess?.response
@@ -3138,6 +3152,7 @@ const generateZodRoute = async (
         responses[index][0] ? `${responses[index][0]}Response` : 'Response',
       ),
       zodVariant,
+      override.zod.exactOptional,
     ),
   );
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -11824,3 +11824,81 @@ describe('discriminated unions (#1907, #2085)', () => {
     expect(result).toContain("zod.discriminatedUnion('kind\\'x', [");
   });
 });
+
+// `exactOptional` swaps `.optional()` for zod v4's `.exactOptional()` (classic)
+// / `zod.exactOptional()` (mini) so optional properties infer `{ x?: T }` under
+// `exactOptionalPropertyTypes`. Opt-in and zod v4 only; v3 has no such method.
+describe('exactOptional (opt-in)', () => {
+  const context = {
+    output: { override: { useDates: false } },
+  } as ContextSpec;
+
+  const optionalString: ZodValidationSchemaDefinition = {
+    functions: [
+      ['string', undefined],
+      ['optional', undefined],
+    ],
+    consts: [],
+  };
+
+  const parse = (
+    definition: ZodValidationSchemaDefinition,
+    {
+      isZodV4 = true,
+      variant = 'classic' as 'classic' | 'mini',
+      exactOptional = false,
+    } = {},
+  ) =>
+    parseZodValidationSchemaDefinition(
+      definition,
+      context,
+      false,
+      false,
+      isZodV4,
+      undefined,
+      undefined,
+      variant,
+      exactOptional,
+    ).zod;
+
+  it('emits .exactOptional() on zod v4 classic when enabled', () => {
+    expect(parse(optionalString, { exactOptional: true })).toBe(
+      'zod.string().exactOptional()',
+    );
+  });
+
+  it('emits .optional() on classic by default', () => {
+    expect(parse(optionalString)).toBe('zod.string().optional()');
+  });
+
+  it('emits zod.exactOptional() on zod mini when enabled', () => {
+    expect(
+      parse(optionalString, { variant: 'mini', exactOptional: true }),
+    ).toBe('/*#__PURE__*/ zod.exactOptional(/*#__PURE__*/ zod.string())');
+  });
+
+  it('emits zod.optional() on mini by default', () => {
+    expect(parse(optionalString, { variant: 'mini' })).toBe(
+      '/*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.string())',
+    );
+  });
+
+  it('no-ops on zod v3, emitting .optional()', () => {
+    expect(parse(optionalString, { isZodV4: false, exactOptional: true })).toBe(
+      'zod.string().optional()',
+    );
+  });
+
+  it('narrows only optional, leaving .nullish() untouched', () => {
+    const nullishString: ZodValidationSchemaDefinition = {
+      functions: [
+        ['string', undefined],
+        ['nullish', undefined],
+      ],
+      consts: [],
+    };
+    expect(parse(nullishString, { exactOptional: true })).toBe(
+      'zod.string().nullish()',
+    );
+  });
+});


### PR DESCRIPTION
Closes #3738.

Optional object properties emit `.optional()` (zod) / `S.optional()` (effect), inferring `{ x?: T | undefined }`, which `TS2375`s against an exact-optional interface under `exactOptionalPropertyTypes`.

Adds an opt-in `override.zod.exactOptional` / `override.effect.exactOptional` (default `false`, so existing output is unchanged), mirroring `generateMeta`:

- zod v4 classic -> `.exactOptional()`, mini -> `zod.exactOptional()`
- effect -> `S.optionalWith(schema, { exact: true })`
- zod v3 -> no-op (`.exactOptional()` does not exist there)
- only `.optional()` is narrowed; `.nullish()` (which admits `undefined`, legal under the flag) is left unchanged in both generators

Threaded through the reusable-schema / standalone-zod paths so it also applies in `generateReusableSchemas` mode. Tests cover classic/mini/v3/nullish, the reusable-schema path, and the normalizer. Default-off output is byte-identical; the full typecheck and the zod/effect/orval package suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in `exactOptional` setting for Zod v4 and Effect schema generation.
  - Optional properties can now preserve exact TypeScript optional-property semantics.
  - Applies consistently to request parameters, request bodies, responses, and reusable schemas.
  - Zod Mini is supported; Zod v3 remains unchanged.

- **Documentation**
  - Expanded configuration guidance and clarified that these settings are valid only under the appropriate output overrides.
  - Documented ignored settings and build warnings when configured at unsupported levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->