### PR TITLE
fix(fetch): infer request options type from mutator

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -66,11 +66,11 @@ const getRequestOptionsType = (mutator?: GeneratorMutator) => {
   }
 
   if (mutator.hasSecondArg && !mutator.isHook) {
-    return `options?: SecondParameter<typeof ${mutator.name}>`;
+    return `options?: Parameters<typeof ${mutator.name}>[1]`;
   }
 
   if (mutator.hasSecondArg && mutator.isHook) {
-    return `options?: SecondParameter<ReturnType<typeof ${mutator.name}>>`;
+    return `options?: Parameters<ReturnType<typeof ${mutator.name}>>[1]`;
   }
 
   return '';

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -9,6 +9,7 @@ import {
   type GeneratorDependency,
   type GeneratorOptions,
   type GeneratorVerbOptions,
+  type GeneratorMutator,
   GetterPropType,
   isBinaryContentType,
   isObject,
@@ -58,6 +59,22 @@ export const getFetchDependencies = () => FETCH_DEPENDENCIES;
 
 const isRawRequestBodyContentType = (contentType: string) =>
   contentType === 'text/plain' || isBinaryContentType(contentType);
+
+const getRequestOptionsType = (mutator?: GeneratorMutator) => {
+  if (!mutator) {
+    return 'options?: RequestInit';
+  }
+
+  if (mutator.hasSecondArg && !mutator.isHook) {
+    return `options?: SecondParameter<typeof ${mutator.name}>`;
+  }
+
+  if (mutator.hasSecondArg && mutator.isHook) {
+    return `options?: SecondParameter<ReturnType<typeof ${mutator.name}>>`;
+  }
+
+  return '';
+};
 
 /**
  * Generates the URL helper function and the fetch request function for a single
@@ -444,7 +461,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
     useRuntimeFetcher && isRequestOptions && !mutator
       ? ', fetchFn?: typeof globalThis.fetch'
       : '';
-  const args = `${toObjectString(props, 'implementation')} ${isRequestOptions ? `options?: RequestInit` : ''}${fetchFnParam}`;
+  const args = `${toObjectString(props, 'implementation')} ${isRequestOptions ? getRequestOptionsType(mutator) : ''}${fetchFnParam}`;
   const returnType =
     override.fetch.forceSuccessResponse && hasSuccess
       ? `Promise<${successName}>`

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -61,19 +61,13 @@ const isRawRequestBodyContentType = (contentType: string) =>
   contentType === 'text/plain' || isBinaryContentType(contentType);
 
 const getRequestOptionsType = (mutator?: GeneratorMutator) => {
-  if (!mutator) {
+  if (!mutator || !mutator.hasSecondArg) {
     return 'options?: RequestInit';
   }
 
-  if (mutator.hasSecondArg && !mutator.isHook) {
-    return `options?: Parameters<typeof ${mutator.name}>[1]`;
-  }
-
-  if (mutator.hasSecondArg && mutator.isHook) {
-    return `options?: Parameters<ReturnType<typeof ${mutator.name}>>[1]`;
-  }
-
-  return '';
+  return mutator.isHook
+    ? `options?: Parameters<ReturnType<typeof ${mutator.name}>>[1]`
+    : `options?: Parameters<typeof ${mutator.name}>[1]`;
 };
 
 /**

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -115,7 +115,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -153,7 +153,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -193,7 +193,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -233,7 +233,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -115,7 +115,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -153,7 +153,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -193,7 +193,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -233,7 +233,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -108,7 +108,7 @@ export const getListPetsUrl = (
 export const listPets = async (
   params?: ListPetsParams,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customInstance>[1],
 ): Promise<listPetsResponse> => {
   return customInstance<listPetsResponse>(getListPetsUrl(params, version), {
     ...options,
@@ -229,7 +229,7 @@ export const getCreatePetsUrl = (version: number = 1) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customInstance>[1],
 ): Promise<createPetsResponse> => {
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {
     ...options,
@@ -314,7 +314,7 @@ export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
 export const showPetById = async (
   petId: string,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customInstance>[1],
 ): Promise<showPetByIdResponse> => {
   return customInstance<showPetByIdResponse>(
     getShowPetByIdUrl(petId, version),

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -108,7 +108,7 @@ export const getListPetsUrl = (
 export const listPets = async (
   params?: ListPetsParams,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customInstance>[1],
 ): Promise<listPetsResponse> => {
   return customInstance<listPetsResponse>(getListPetsUrl(params, version), {
     ...options,
@@ -229,7 +229,7 @@ export const getCreatePetsUrl = (version: number = 1) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customInstance>[1],
 ): Promise<createPetsResponse> => {
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {
     ...options,
@@ -314,7 +314,7 @@ export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
 export const showPetById = async (
   petId: string,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customInstance>[1],
 ): Promise<showPetByIdResponse> => {
   return customInstance<showPetByIdResponse>(
     getShowPetByIdUrl(petId, version),

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -151,7 +151,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -315,7 +315,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -421,7 +421,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -527,7 +527,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -151,7 +151,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -315,7 +315,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -421,7 +421,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -527,7 +527,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -130,10 +130,13 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const useListPetsHook = (): ((
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<listPetsResponse>) => {
   const customFetcher = useCustomFetch();
-  return (params?: ListPetsParams, options?: RequestInit) => {
+  return (
+    params?: ListPetsParams,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getListPetsUrl(params), {
       ...options,
       method: 'GET',
@@ -238,10 +241,13 @@ export const getCreatePetsUrl = () => {
  */
 export const useCreatePetsHook = (): ((
   createPetsBody: CreatePetsBody,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<createPetsResponse>) => {
   const customFetcher = useCustomFetch();
-  return (createPetsBody: CreatePetsBody, options?: RequestInit) => {
+  return (
+    createPetsBody: CreatePetsBody,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getCreatePetsUrl(), {
       ...options,
       method: 'POST',
@@ -363,10 +369,13 @@ export const getListPetsNestedArrayUrl = (
  */
 export const useListPetsNestedArrayHook = (): ((
   params?: ListPetsNestedArrayParams,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<listPetsNestedArrayResponse>) => {
   const customFetcher = useCustomFetch();
-  return (params?: ListPetsNestedArrayParams, options?: RequestInit) => {
+  return (
+    params?: ListPetsNestedArrayParams,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getListPetsNestedArrayUrl(params), {
       ...options,
       method: 'GET',
@@ -475,10 +484,13 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const useShowPetByIdHook = (): ((
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<showPetByIdResponse>) => {
   const customFetcher = useCustomFetch();
-  return (petId: string, options?: RequestInit) => {
+  return (
+    petId: string,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getShowPetByIdUrl(petId), {
       ...options,
       method: 'GET',

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -130,10 +130,13 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const useListPetsHook = (): ((
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<listPetsResponse>) => {
   const customFetcher = useCustomFetch();
-  return (params?: ListPetsParams, options?: RequestInit) => {
+  return (
+    params?: ListPetsParams,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getListPetsUrl(params), {
       ...options,
       method: 'GET',
@@ -238,10 +241,13 @@ export const getCreatePetsUrl = () => {
  */
 export const useCreatePetsHook = (): ((
   createPetsBody: CreatePetsBody,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<createPetsResponse>) => {
   const customFetcher = useCustomFetch();
-  return (createPetsBody: CreatePetsBody, options?: RequestInit) => {
+  return (
+    createPetsBody: CreatePetsBody,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getCreatePetsUrl(), {
       ...options,
       method: 'POST',
@@ -363,10 +369,13 @@ export const getListPetsNestedArrayUrl = (
  */
 export const useListPetsNestedArrayHook = (): ((
   params?: ListPetsNestedArrayParams,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<listPetsNestedArrayResponse>) => {
   const customFetcher = useCustomFetch();
-  return (params?: ListPetsNestedArrayParams, options?: RequestInit) => {
+  return (
+    params?: ListPetsNestedArrayParams,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getListPetsNestedArrayUrl(params), {
       ...options,
       method: 'GET',
@@ -475,10 +484,13 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const useShowPetByIdHook = (): ((
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<showPetByIdResponse>) => {
   const customFetcher = useCustomFetch();
-  return (petId: string, options?: RequestInit) => {
+  return (
+    petId: string,
+    options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
+  ) => {
     return customFetcher(getShowPetByIdUrl(petId), {
       ...options,
       method: 'GET',

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -133,7 +133,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -239,7 +239,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -364,7 +364,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -467,7 +467,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -133,7 +133,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -239,7 +239,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -364,7 +364,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -467,7 +467,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -135,7 +135,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -261,7 +261,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -388,7 +388,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -497,7 +497,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -135,7 +135,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -261,7 +261,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -388,7 +388,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -497,7 +497,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -133,7 +133,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -249,7 +249,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -355,7 +355,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -461,7 +461,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -133,7 +133,7 @@ export const getListPetsUrl = (params?: ListPetsParams) => {
  */
 export const listPets = async (
   params?: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -249,7 +249,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -355,7 +355,7 @@ export const getUpdatePetsUrl = () => {
  */
 export const updatePets = async (
   pet: NonReadonly<Pet>,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
@@ -461,7 +461,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,

--- a/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-data-with-custom-fetch/endpoints.ts
@@ -87,7 +87,7 @@ export const getCreatePetsUrl = (version: number = 1) => {
 export const createPets = async (
   pet?: Pet,
   version: number = 1,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   const formData = new FormData();
   Object.entries(pet ?? {}).forEach(([key, value]) => {

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -90,7 +90,7 @@ export const getCreatePetsUrl = () => {
  */
 export const createPets = async (
   createPetsBody: CreatePetsBody,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   const formUrlEncoded = new URLSearchParams();
   formUrlEncoded.append(`name`, createPetsBody.name);
@@ -137,7 +137,7 @@ export const getUploadPetContentUrl = () => {
  */
 export const uploadPetContent = async (
   uploadPetContentBody: UploadPetContentBody,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<uploadPetContentResponse> => {
   const formUrlEncoded = new URLSearchParams();
   formUrlEncoded.append(`name`, uploadPetContentBody.name);
@@ -188,7 +188,7 @@ export const getUploadPetContentRefUrl = () => {
  */
 export const uploadPetContentRef = async (
   uploadPetContentRefBody: UploadPetContentRefBody,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<uploadPetContentRefResponse> => {
   const formUrlEncoded = new URLSearchParams();
   formUrlEncoded.append(`name`, uploadPetContentRefBody.name);

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -95,7 +95,7 @@ export const getListPetsUrl = (params: ListPetsParams) => {
  */
 export const listPets = async (
   params: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<listPetsResponse> => {
   return customFetchWithScss<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -144,7 +144,7 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<createPetsResponse> => {
   return customFetchWithScss<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
@@ -184,7 +184,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetchWithScss<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
@@ -222,7 +222,7 @@ export const getDeletePetByIdUrl = (petId: string) => {
  */
 export const deletePetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<deletePetByIdResponse> => {
   return customFetchWithScss<deletePetByIdResponse>(
     getDeletePetByIdUrl(petId),
@@ -262,7 +262,7 @@ export const getHealthCheckUrl = () => {
  * @summary health check
  */
 export const healthCheck = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<healthCheckResponse> => {
   return customFetchWithScss<healthCheckResponse>(getHealthCheckUrl(), {
     ...options,
@@ -300,7 +300,7 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
  */
 export const showPetWithOwner = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<showPetWithOwnerResponse> => {
   return customFetchWithScss<showPetWithOwnerResponse>(
     getShowPetWithOwnerUrl(petId),

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -100,7 +100,7 @@ export const getListPetsUrl = (params: ListPetsParams) => {
  */
 export const listPets = async (
   params: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponseSuccess> => {
   return customFetch<listPetsResponseSuccess>(getListPetsUrl(params), {
     ...options,
@@ -145,7 +145,7 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponseSuccess> => {
   return customFetch<createPetsResponseSuccess>(getCreatePetsUrl(params), {
     ...options,
@@ -181,7 +181,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponseSuccess> => {
   return customFetch<showPetByIdResponseSuccess>(getShowPetByIdUrl(petId), {
     ...options,
@@ -215,7 +215,7 @@ export const getDeletePetByIdUrl = (petId: string) => {
  */
 export const deletePetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<deletePetByIdResponseSuccess> => {
   return customFetch<deletePetByIdResponseSuccess>(getDeletePetByIdUrl(petId), {
     ...options,
@@ -248,7 +248,7 @@ export const getHealthCheckUrl = () => {
  * @summary health check
  */
 export const healthCheck = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<healthCheckResponseSuccess> => {
   return customFetch<healthCheckResponseSuccess>(getHealthCheckUrl(), {
     ...options,
@@ -282,7 +282,7 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
  */
 export const showPetWithOwner = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetWithOwnerResponseSuccess> => {
   return customFetch<showPetWithOwnerResponseSuccess>(
     getShowPetWithOwnerUrl(petId),

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -138,7 +138,7 @@ export const getListPetsUrl = (params: ListPetsParams) => {
  */
 export const listPets = async (
   params: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -313,7 +313,7 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
@@ -420,7 +420,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
@@ -589,7 +589,7 @@ export const getDeletePetByIdUrl = (petId: string) => {
  */
 export const deletePetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<deletePetByIdResponse> => {
   return customFetch<deletePetByIdResponse>(getDeletePetByIdUrl(petId), {
     ...options,
@@ -693,7 +693,7 @@ export const getHealthCheckUrl = () => {
  * @summary health check
  */
 export const healthCheck = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<healthCheckResponse> => {
   return customFetch<healthCheckResponse>(getHealthCheckUrl(), {
     ...options,
@@ -850,7 +850,7 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
  */
 export const showPetWithOwner = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetWithOwnerResponse> => {
   return customFetch<showPetWithOwnerResponse>(getShowPetWithOwnerUrl(petId), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -53,7 +53,7 @@ export const getMusclesControllerFindAllUrl = () => {
  * @summary Return all muscles
  */
 export const musclesControllerFindAll = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle[]> => {
   return customFetch<Muscle[]>(getMusclesControllerFindAllUrl(), {
     ...options,
@@ -434,7 +434,7 @@ export const getMusclesControllerCreateUrl = () => {
  */
 export const musclesControllerCreate = async (
   createMuscleDto: CreateMuscleDto,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle> => {
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {
     ...options,
@@ -653,7 +653,7 @@ export const getMusclesControllerFindOneUrl = (id: string) => {
  */
 export const musclesControllerFindOne = async (
   id: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle> => {
   return customFetch<Muscle>(getMusclesControllerFindOneUrl(id), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -49,7 +49,7 @@ export const getMusclesControllerFindAllUrl = () => {
  * @summary Return all muscles
  */
 export const musclesControllerFindAll = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle[]> => {
   return customFetch<Muscle[]>(getMusclesControllerFindAllUrl(), {
     ...options,
@@ -247,7 +247,7 @@ export const getMusclesControllerCreateUrl = () => {
  */
 export const musclesControllerCreate = async (
   createMuscleDto: CreateMuscleDto,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle> => {
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {
     ...options,
@@ -466,7 +466,7 @@ export const getMusclesControllerFindOneUrl = (id: string) => {
  */
 export const musclesControllerFindOne = async (
   id: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle> => {
   return customFetch<Muscle>(getMusclesControllerFindOneUrl(id), {
     ...options,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -115,7 +115,7 @@ export const getListPetsUrl = (params: ListPetsParams) => {
  */
 export const listPets = async (
   params: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -232,7 +232,7 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
@@ -336,7 +336,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
@@ -447,7 +447,7 @@ export const getDeletePetByIdUrl = (petId: string) => {
  */
 export const deletePetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<deletePetByIdResponse> => {
   return customFetch<deletePetByIdResponse>(getDeletePetByIdUrl(petId), {
     ...options,
@@ -551,7 +551,7 @@ export const getHealthCheckUrl = () => {
  * @summary health check
  */
 export const healthCheck = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<healthCheckResponse> => {
   return customFetch<healthCheckResponse>(getHealthCheckUrl(), {
     ...options,
@@ -651,7 +651,7 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
  */
 export const showPetWithOwner = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetWithOwnerResponse> => {
   return customFetch<showPetWithOwnerResponse>(getShowPetWithOwnerUrl(petId), {
     ...options,

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -110,7 +110,7 @@ export const getListPetsUrl = (params: ListPetsParams) => {
  */
 export const listPets = async (
   params: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -198,7 +198,7 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
@@ -282,7 +282,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
@@ -359,7 +359,7 @@ export const getDeletePetByIdUrl = (petId: string) => {
  */
 export const deletePetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<deletePetByIdResponse> => {
   return customFetch<deletePetByIdResponse>(getDeletePetByIdUrl(petId), {
     ...options,
@@ -440,7 +440,7 @@ export const getHealthCheckUrl = () => {
  * @summary health check
  */
 export const healthCheck = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<healthCheckResponse> => {
   return customFetch<healthCheckResponse>(getHealthCheckUrl(), {
     ...options,
@@ -513,7 +513,7 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
  */
 export const showPetWithOwner = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetWithOwnerResponse> => {
   return customFetch<showPetWithOwnerResponse>(getShowPetWithOwnerUrl(petId), {
     ...options,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -120,7 +120,7 @@ export const getListPetsUrl = (params: ListPetsParams) => {
  */
 export const listPets = async (
   params: ListPetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<listPetsResponse> => {
   return customFetch<listPetsResponse>(getListPetsUrl(params), {
     ...options,
@@ -242,7 +242,7 @@ export const getCreatePetsUrl = (params: CreatePetsParams) => {
 export const createPets = async (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
@@ -349,7 +349,7 @@ export const getShowPetByIdUrl = (petId: string) => {
  */
 export const showPetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetByIdResponse> => {
   return customFetch<showPetByIdResponse>(getShowPetByIdUrl(petId), {
     ...options,
@@ -461,7 +461,7 @@ export const getDeletePetByIdUrl = (petId: string) => {
  */
 export const deletePetById = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<deletePetByIdResponse> => {
   return customFetch<deletePetByIdResponse>(getDeletePetByIdUrl(petId), {
     ...options,
@@ -565,7 +565,7 @@ export const getHealthCheckUrl = () => {
  * @summary health check
  */
 export const healthCheck = async (
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<healthCheckResponse> => {
   return customFetch<healthCheckResponse>(getHealthCheckUrl(), {
     ...options,
@@ -670,7 +670,7 @@ export const getShowPetWithOwnerUrl = (petId: string) => {
  */
 export const showPetWithOwner = async (
   petId: string,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<showPetWithOwnerResponse> => {
   return customFetch<showPetWithOwnerResponse>(getShowPetWithOwnerUrl(petId), {
     ...options,

--- a/tests/__snapshots__/vue-query/infinite-query-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/infinite-query-with-custom-fetch/endpoints.ts
@@ -67,7 +67,7 @@ export const getGetUsersUserIdOrdersUrl = (
 export const getUsersUserIdOrders = async (
   userId: number,
   params?: GetUsersUserIdOrdersParams,
-  options?: RequestInit,
+  options?: Parameters<typeof customFetch>[1],
 ): Promise<getUsersUserIdOrdersResponse> => {
   return customFetch<getUsersUserIdOrdersResponse>(
     getGetUsersUserIdOrdersUrl(userId, params),


### PR DESCRIPTION
When a mutator is used with `fetch` client, the generated `options` parameter now infers its type from the mutator's second argument instead of always using `RequestInit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript typings for generated request functions so the `options` parameter is inferred from the configured request handler rather than defaulting to `RequestInit`.
  * Updated sample request and hook factory signatures so `options` aligns with the second parameter type expected by the underlying fetch utilities (including hook-based mutators).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->