### PR TITLE
test(orval): resolve tmp symlinks so mutator path test passes on macOS

### DIFF
--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -19,7 +19,7 @@ vi.mock('@orval/core', async (importOriginal) => {
 import { normalizeOptions } from './options';
 
 const createTempWorkspace = async () => {
-  return mkdtemp(path.join(os.tmpdir(), 'orval-options-'));
+  return realpath(await mkdtemp(path.join(os.tmpdir(), 'orval-options-')));
 };
 
 describe('normalizeOptions', () => {


### PR DESCRIPTION
Resolves tmp symlinks so mutator path tests passes on macOS

Without fix tests fail like this:
<img width="3764" height="2422" alt="lpSEcAyJ" src="https://github.com/user-attachments/assets/937c76c4-76d0-4457-ac94-e131b9e54efe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary workspace handling in automated tests by resolving filesystem paths consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->