### PR TITLE
fix(orval): bump js-yaml to 4.3.0 to fix DoS vulnerability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -180,7 +180,7 @@
         "fs-extra": "^11.3.2",
         "get-tsconfig": "^4.14.0",
         "jiti": "^2.6.1",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "remeda": "^2.33.6",
         "string-argv": "^0.3.2",
         "typedoc": "^0.28.19",
@@ -3031,7 +3031,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -77,7 +77,7 @@
     "fs-extra": "^11.3.2",
     "get-tsconfig": "^4.14.0",
     "jiti": "^2.6.1",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "remeda": "^2.33.6",
     "string-argv": "^0.3.2",
     "typedoc": "^0.28.19",


### PR DESCRIPTION
  ## Description

Bump `js-yaml` from `4.2.0` to `4.3.0` in `packages/orval` to fix a high-severity Denial-of-Service vulnerability, and update `bun.lock` accordingly.

  ## Why

  Dependabot flagged this transitive dependency (via a project that depends on
  orval) as vulnerable to **CVE-2026-59869** / [GHSA-52cp-r559-cp3m](https://github.com/nodeca/js-yaml/security/advisories/GHSA-52cp-r559-cp3m):

  - **Severity:** High (CVSS 3.1: 7.5)
  - **Type:** Uncontrolled Resource Consumption (CWE-400 / CWE-407)
  - A YAML document containing a chain of merge-key (`<<`) references forces
  `js-yaml` to spend quadratic CPU time relative to input size, so a small
  (~100KB) crafted document can block the event loop for seconds or more.
  - Since orval parses arbitrary OpenAPI/Swagger YAML specs, this is a realistic
  DoS vector wherever spec files come from an untrusted or semi-trusted source.
  - Fixed upstream in `js-yaml@4.3.0` (dependencies and CLI bin entry are
  unchanged from `4.2.0`).

  ## How

  - `packages/orval/package.json`: `js-yaml` `4.2.0` → `4.3.0`
  - `bun.lock`: updated resolved version and integrity hash for `js-yaml`
