### PR TITLE
fix(core): don't delete the entire working directory when schemas has no path

### DIFF
--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -1262,6 +1262,32 @@ describe('generateSpec - schemas.splitByTags validation', () => {
   });
 });
 
+describe('generateSpec - normalizeOptions pathless schemas object', () => {
+  // Regression: a `schemas` object with no `path` (e.g. `schemas: { type: 'zod' }`)
+  // normalized to an undefined path, which `clean: true` then resolved to the
+  // current working directory and wiped.
+  it('rejects a schemas object without a path', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: { target: PETSTORE_SPEC },
+            output: {
+              target: './src/generated/api.ts',
+              schemas: { type: 'zod' } as never,
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow(/schemas\.path` is required/);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('generateSpec - returnTypesToWrite isolation across tags (#3685)', () => {
   it("each tag emits its own *Result type, not the other tag's", async () => {
     const SPEC: OpenApiDocument = {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -121,6 +121,15 @@ function normalizeSchemasOption(
     return normalizePath(schemas, workspace);
   }
 
+  if (!isString(schemas.path) || schemas.path.trim() === '') {
+    throw new Error(
+      styleText(
+        'red',
+        `\`schemas.path\` is required when \`schemas\` is an object (e.g. \`schemas: { path: './model', type: 'zod' }\`). To generate schemas alongside the target instead, omit \`schemas\` or set \`schemas: false\`.`,
+      ),
+    );
+  }
+
   validatePackageSpecifier(schemas.importPath, 'schemas.importPath');
 
   return {


### PR DESCRIPTION
Closes: #3752

<!-- A few sentences describing the overall goals of the pull request's commits. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for schema configuration.
  * Clearer error messages are now shown when a schema path is missing, invalid, or blank.
  * Schema generation now guides you toward valid configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->