### PR TITLE
fix(core): keep integer enum+const type values as strings

### DIFF
--- a/packages/core/src/getters/enum.test.ts
+++ b/packages/core/src/getters/enum.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { NamingConvention, type OpenApiSchemaObject } from '../types';
 import {
+  EnumGeneration,
+  NamingConvention,
+  type OpenApiSchemaObject,
+} from '../types';
+import {
+  getEnum,
   getEnumDescriptions,
   getEnumImplementation,
   getEnumNames,
@@ -343,5 +348,20 @@ describe('getEnumImplementation with object-format descriptions', () => {
       l.includes("inactive: 'inactive'"),
     );
     expect(lines[inactiveLine - 1]).not.toContain('/**');
+  });
+});
+
+describe('getEnum integer const coercion (#3758)', () => {
+  it('does not throw when value is a numeric string from integer const/enum', () => {
+    // After the scalar fix, value is already a string; this guards the helper
+    // itself against non-string inputs so the crash cannot resurface.
+    const result = getEnum(
+      '1' as unknown as string,
+      'Flag',
+      undefined,
+      EnumGeneration.CONST,
+    );
+    expect(result).toContain('export type Flag');
+    expect(result).toContain('export const Flag');
   });
 });

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -141,6 +141,10 @@ const getTypeConstEnum = (
 ) => {
   let enumValue = `export type ${enumName} = typeof ${enumName}[keyof typeof ${enumName}]`;
 
+  // Coerce first: integer/number `const` used to overwrite the enum union with
+  // a raw number, so `value.endsWith` threw (#3758).
+  value = String(value);
+
   if (value.endsWith(' | null')) {
     value = value.replace(' | null', '');
     enumValue += ' | null';

--- a/packages/core/src/getters/scalar.test.ts
+++ b/packages/core/src/getters/scalar.test.ts
@@ -296,3 +296,36 @@ describe('getScalar (string const value escaping #3505)', () => {
     expect(result.value).toBe("'Asia/Tokyo'");
   });
 });
+
+describe('getScalar integer enum + const (#3758)', () => {
+  it('keeps a string type value when both enum and const are present', () => {
+    // FastAPI/Pydantic Literal[1] emits { type: integer, enum: [1], const: 1 }.
+    // The const branch used to overwrite the enum union with a raw number, which
+    // later crashed getTypeConstEnum via value.endsWith(...).
+    const schema: OpenApiSchemaObject = {
+      type: 'integer',
+      enum: [1],
+      const: 1,
+    };
+
+    const result = getScalar({ item: schema, name: 'flag', context });
+
+    expect(typeof result.value).toBe('string');
+    expect(result.value).toBe('1');
+    expect(result.isEnum).toBe(true);
+  });
+
+  it('preserves nullable suffix when const is present', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'integer',
+      enum: [1],
+      const: 1,
+      nullable: true,
+    };
+
+    const result = getScalar({ item: schema, name: 'flag', context });
+
+    expect(typeof result.value).toBe('string');
+    expect(result.value).toBe('1 | null');
+  });
+});

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -131,8 +131,12 @@ export function getScalar({
 
       value += nullable;
 
+      // Keep the type value a string. Numeric `const` values (common from
+      // FastAPI/Pydantic Literal[int] fields that also emit `enum`) must not
+      // replace the union with a raw number, or getTypeConstEnum crashes on
+      // `value.endsWith(...)` (#3758).
       if (schemaConst !== undefined) {
-        value = schemaConst;
+        value = `${schemaConst}${nullable}`;
       }
 
       return {
@@ -161,8 +165,10 @@ export function getScalar({
 
       value += nullable;
 
+      // Same string-coercion as integer/number so const never becomes a
+      // non-string type-value for downstream enum helpers (#3758).
       if (schemaConst !== undefined) {
-        value = schemaConst;
+        value = `${schemaConst}${nullable}`;
       }
 
       return {


### PR DESCRIPTION
## Summary

FastAPI / Pydantic v2 `Literal[1]` fields emit `{ "type": "integer", "enum": [1], "const": 1 }`. In `getScalar`, the `const` branch overwrote the enum union with the raw number `1`. When enum generation later called `getTypeConstEnum`, it did `value.endsWith(" | null")` on a number and crashed with:

```
value.endsWith is not a function
```

## Fix

- Keep integer/number (and boolean) `const` values as **strings** for the type-value path, preserving any `| null` suffix.
- Harden `getTypeConstEnum` with `String(value)` so a non-string input cannot resurface the crash.

## Tests

```text
bunx vitest run src/getters/scalar.test.ts src/getters/enum.test.ts
# Test Files  2 passed (2)
# Tests  49 passed (49)
```

Fixes #3758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation of integer and numeric constants when values are provided as strings.
  * Prevented errors when processing integer constants and enums.
  * Preserved nullable indicators for constant scalar values.
  * Ensured constant values remain correctly represented as strings in generated types and declarations.

* **Tests**
  * Added coverage for numeric constants, combined enum and constant schemas, and nullable constant values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->