### PR TITLE
fix(core): preserve bound-alias name through ref hop (#3746)

### DIFF
--- a/packages/core/src/generators/dynamic-ref.test.ts
+++ b/packages/core/src/generators/dynamic-ref.test.ts
@@ -349,6 +349,70 @@ describe('generateSchemasDefinition with $dynamicRef', () => {
         );
       }
     });
+    it('references bound alias by name through a plain $ref hop (#3746)', () => {
+      const spec: OpenApiDocument = {
+        openapi: '3.1.0',
+        info: { title: 'Test', version: '0.1.0' },
+        paths: {},
+        components: {
+          schemas: {
+            SomeObject: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+            },
+            GenericArray: {
+              $id: 'https://example.com/schemas/GenericArray',
+              $defs: {
+                itemType: { $dynamicAnchor: 'itemType', not: {} },
+              },
+              type: 'object',
+              properties: {
+                items: {
+                  type: 'array',
+                  items: { $dynamicRef: '#itemType' },
+                },
+              },
+            },
+            ObjectArray: {
+              $defs: {
+                itemType: {
+                  $dynamicAnchor: 'itemType',
+                  $ref: '#/components/schemas/SomeObject',
+                },
+              },
+              $ref: '#/components/schemas/GenericArray',
+            },
+            Foo: {
+              type: 'object',
+              properties: {
+                bar: { $ref: '#/components/schemas/ObjectArray' },
+              },
+            },
+          },
+        },
+      };
+
+      const schemas = spec.components!.schemas!;
+      const result = generateSchemasDefinition(
+        schemas,
+        createContext(spec),
+        '',
+      );
+
+      // The bound alias is still emitted as its own specialized type.
+      const objectArray = result.find((s) => s.name === 'ObjectArray');
+      expect(objectArray).toBeDefined();
+      expect(objectArray!.model).toContain(
+        'type ObjectArray = GenericArray<SomeObject>',
+      );
+
+      // The plain $ref hop must reference the alias by name, not recurse
+      // through to the unspecialized template.
+      const foo = result.find((s) => s.name === 'Foo');
+      expect(foo).toBeDefined();
+      expect(foo!.model).toContain('bar?: ObjectArray');
+      expect(foo!.model).not.toContain('GenericArray');
+    });
     it('collects imports and readonly properties from allOf extra schemas', () => {
       const spec: OpenApiDocument = {
         openapi: '3.1.0',

--- a/packages/core/src/resolvers/ref.test.ts
+++ b/packages/core/src/resolvers/ref.test.ts
@@ -235,7 +235,7 @@ describe('resolveRef', () => {
     });
   });
 
-  it('fully resolves through bound-alias (generic binding) refs', () => {
+  it('stops at bound-alias (generic binding) ref, referencing it by name (#3746)', () => {
     const context = createContext({
       openapi: '3.1.0',
       components: {
@@ -284,10 +284,12 @@ describe('resolveRef', () => {
       },
     });
     expect('$ref' in result.schema).toBe(false);
-    expect(result.imports[0]).toEqual({
-      name: 'PaginatedTemplate',
-      schemaName: 'PaginatedTemplate',
-    });
+    // The bound alias must be referenced by name (not resolved through to the
+    // unspecialized template); the template is recorded as a secondary hop.
+    expect(result.imports).toEqual([
+      { name: 'PaginatedUserResponse', schemaName: 'PaginatedUserResponse' },
+      { name: 'PaginatedTemplate', schemaName: 'PaginatedTemplate' },
+    ]);
   });
 
   it('orders bound-alias type args from encoded template schema names', () => {

--- a/packages/core/src/resolvers/ref.ts
+++ b/packages/core/src/resolvers/ref.ts
@@ -321,7 +321,15 @@ function getSchema<TSchema extends object = OpenApiComponentsObject>(
       ) as OpenApiSchemaObject | OpenApiReferenceObject | undefined)
     : undefined;
 
-  if (isObject(schemaByRefPaths) && isReference(schemaByRefPaths)) {
+  // Don't tail-recurse through an intermediate that is itself a bound alias:
+  // it is emitted as its own named, specialized type (e.g. `ObjectArray`),
+  // so callers must reference it by name. Recursing drops that name and emits
+  // the unspecialized template instead (#3746).
+  if (
+    isObject(schemaByRefPaths) &&
+    isReference(schemaByRefPaths) &&
+    !isBoundAlias(schemaByRefPaths)
+  ) {
     return getSchema(schemaByRefPaths, context);
   }
 


### PR DESCRIPTION
Fixes #3746.

## Problem

A `$ref` to a schema that is itself a bound generic alias (e.g. `ObjectArray = GenericArray<SomeObject>`) resolves through the alias to the unspecialized template, emitting `bar?: GenericArray` instead of `bar?: ObjectArray`. An inline binding on the same `$ref` (`baz`) already works.

## Root cause

`getSchema` (`packages/core/src/resolvers/ref.ts`) tail-recurses through any intermediate that is itself a `$ref`. For a bound-alias intermediate this drops its name: `resolveRef` records the deepest hop (`GenericArray`) as `imports[0]`, and `resolveValue` emits that.

## Fix

Stop the tail-recursion when the intermediate is a bound alias. Such intermediates are emitted as their own named, specialized type, so callers must reference them by name rather than recurse through. The predicate reuses the existing `isBoundAlias` (a `$defs` entry with both `$dynamicAnchor` and `$ref`) — the same check `extractBoundAliasInfo` uses to detect a specialization — so the recursion guard and the emitter agree by construction.

Predicated on `isBoundAlias` rather than "any `$dynamicAnchor`" deliberately: anchor-only `$defs` entries are template parameter declarations, not bindings, and stopping there would emit an uninstantiated template.

## Tests

- New fixture in `dynamic-ref.test.ts` mirroring the issue spec; asserts `Foo.bar` emits `ObjectArray`, not `GenericArray`.
- Updated the existing `resolveRef` test that encoded the old "fully resolves through" contract.
- `samples/dynamic-ref` regenerates with no diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema resolution for generic bound aliases referenced through intermediate references.
  * Generated models now preserve and use the bound alias name instead of incorrectly resolving to the underlying generic template.
  * Corrected import generation to include both the bound alias and its underlying template when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->