### PR TITLE
fix(core): override path parameters with operation parameters

### DIFF
--- a/packages/core/src/getters/parameters.test.ts
+++ b/packages/core/src/getters/parameters.test.ts
@@ -5,6 +5,30 @@ import type { OpenApiParameterObject, OpenApiReferenceObject } from '../types';
 import { getParameters } from './parameters';
 
 describe('getParameters', () => {
+  it('keeps the operation-level parameter when it overrides a path-level parameter (issue #3745)', () => {
+    const pathParameter: OpenApiParameterObject = {
+      name: 'name',
+      in: 'query',
+      description: 'Path-level definition',
+      schema: { type: 'string' },
+    };
+    const operationParameter: OpenApiParameterObject = {
+      name: 'name',
+      in: 'query',
+      description: 'Operation-level override',
+      schema: { type: 'integer' },
+    };
+
+    const result = getParameters({
+      parameters: [pathParameter, operationParameter],
+      context: createTestContextSpec(),
+    });
+
+    expect(result.query).toEqual([
+      { parameter: operationParameter, imports: [] },
+    ]);
+  });
+
   it('resolves a header parameter referenced via #/components/parameters/* and surfaces its named import', () => {
     // Refs that target a slot under `#/components/<NAMED_COMPONENT_SECTIONS>`
     // have a matching `export type` emitted by `generateParameterDefinition`,

--- a/packages/core/src/getters/parameters.test.ts
+++ b/packages/core/src/getters/parameters.test.ts
@@ -29,6 +29,30 @@ describe('getParameters', () => {
     ]);
   });
 
+  it('matches header parameter names case-insensitively when applying overrides', () => {
+    const pathParameter: OpenApiParameterObject = {
+      name: 'X-Trace-Id',
+      in: 'header',
+      description: 'Path-level definition',
+      schema: { type: 'string' },
+    };
+    const operationParameter: OpenApiParameterObject = {
+      name: 'x-trace-id',
+      in: 'header',
+      description: 'Operation-level override',
+      schema: { type: 'integer' },
+    };
+
+    const result = getParameters({
+      parameters: [pathParameter, operationParameter],
+      context: createTestContextSpec(),
+    });
+
+    expect(result.header).toEqual([
+      { parameter: operationParameter, imports: [] },
+    ]);
+  });
+
   it('resolves a header parameter referenced via #/components/parameters/* and surfaces its named import', () => {
     // Refs that target a slot under `#/components/<NAMED_COMPONENT_SECTIONS>`
     // have a matching `export type` emitted by `generateParameterDefinition`,

--- a/packages/core/src/getters/parameters.ts
+++ b/packages/core/src/getters/parameters.ts
@@ -43,5 +43,17 @@ export function getParameters({
       }
     }
   }
+
+  // Parameters are unique by their name and location. Callers provide
+  // path-level parameters first and operation-level parameters last, so
+  // replacing an existing entry applies the operation-level override.
+  for (const location of ['path', 'query', 'header'] as const) {
+    result[location] = [
+      ...new Map(
+        result[location].map((entry) => [entry.parameter.name, entry]),
+      ).values(),
+    ];
+  }
+
   return result;
 }

--- a/packages/core/src/getters/parameters.ts
+++ b/packages/core/src/getters/parameters.ts
@@ -46,11 +46,17 @@ export function getParameters({
 
   // Parameters are unique by their name and location. Callers provide
   // path-level parameters first and operation-level parameters last, so
-  // replacing an existing entry applies the operation-level override.
+  // replacing an existing entry applies the operation-level override. HTTP
+  // header names are case-insensitive, unlike names in the other locations.
   for (const location of ['path', 'query', 'header'] as const) {
     result[location] = [
       ...new Map(
-        result[location].map((entry) => [entry.parameter.name, entry]),
+        result[location].map((entry) => [
+          location === 'header'
+            ? entry.parameter.name?.toLowerCase()
+            : entry.parameter.name,
+          entry,
+        ]),
       ).values(),
     ];
   }


### PR DESCRIPTION
## Summary

- merge parameters by their OpenAPI identity (`in` and `name`)
- let operation-level parameters override matching path-level parameters
- add a regression test for the duplicate parameter output reported in #3745

## Root cause

Orval appended operation-level parameters after path-level parameters and passed the combined list through without deduplicating it. When both levels defined the same parameter, both definitions were emitted into the generated TypeScript type.

## Impact

Generated clients now contain a single parameter definition, using the operation-level override as required by OpenAPI, instead of duplicate TypeScript properties.

## Validation

- confirmed the regression test fails before the implementation
- `vitest run --maxWorkers=1` in `packages/core`: 54 files, 2,244 tests passed
- `tsc --noEmit` in `packages/core`
- type-aware lint for the changed files
- format check for the changed files
- regenerated the minimal reproduction and confirmed only the operation-level parameter remains

Fixes #3745


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter resolution so operation-level parameters correctly override path-level parameters when the `name` and location match.
  * Ensured header parameter overrides work case-insensitively (e.g., `X-Trace-Id` overrides `x-trace-id`).
  * Prevented duplicate parameters from appearing by enforcing uniqueness per location in the final results.
* **Tests**
  * Added unit tests covering override precedence and case-insensitive header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->