### PR TITLE
fix(orval): keep generated barrels idempotent across formatter runs (#3756)

### DIFF
--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -1596,3 +1596,140 @@ describe('generateSpec - operationName tuple [methodName, typeName]', () => {
     }
   });
 });
+
+const ACTIVITY_SPEC: OpenApiDocument = {
+  openapi: '3.1.0',
+  info: { title: 'Activity', version: '1.0.0' },
+  paths: {
+    '/activities': {
+      get: {
+        operationId: 'getActivities',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Activity' },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Activity: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+      },
+      ActivityDto: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      },
+    },
+  },
+};
+
+const MASTER_SPEC: OpenApiDocument = {
+  openapi: '3.1.0',
+  info: { title: 'Master', version: '1.0.0' },
+  paths: {
+    '/masters': {
+      get: {
+        operationId: 'getMasters',
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/Master' },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Master: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+      },
+      MasterDto: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      },
+    },
+  },
+};
+
+describe('generateSpec - workspace barrel idempotency (#3756)', () => {
+  // Regression for #3756: the shared workspace barrel (`<workspace>/index.ts`)
+  // is appended to once per project. The dedup used a single-quote literal
+  // substring check, so an `afterAllFilesWrite` formatter flipping quotes
+  // (single -> double) caused every export to be re-appended on each run.
+  it('does not accumulate duplicate exports when a formatter changes quote style', async () => {
+    const workspace = await createTempWorkspace();
+    const barrel = path.join(workspace, 'gen', 'index.ts');
+
+    const countExports = async () => {
+      const content = await fs.readFile(barrel, 'utf8');
+      return (content.match(/export \*/g) ?? []).length;
+    };
+
+    try {
+      const baseOptions = await normalizeOptions(
+        {
+          input: { target: ACTIVITY_SPEC },
+          output: {
+            workspace: './gen',
+            target: './gen/api/base/endpoints.ts',
+            schemas: './gen/api/base/model',
+            client: 'axios',
+          },
+        },
+        workspace,
+      );
+      const masterOptions = await normalizeOptions(
+        {
+          input: { target: MASTER_SPEC },
+          output: {
+            workspace: './gen',
+            target: './gen/api/master/endpoints.ts',
+            schemas: './gen/api/master/model',
+            client: 'axios',
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, baseOptions, 'base');
+      await generateSpec(workspace, masterOptions, 'master');
+      const afterCycle1 = await countExports();
+      expect(afterCycle1).toBeGreaterThan(0);
+
+      // Simulate prettier flipping single -> double quotes between runs.
+      const flipped = (await fs.readFile(barrel, 'utf8')).replace(
+        /export \* from '([^']+)';/g,
+        'export * from "$1";',
+      );
+      await fs.writeFile(barrel, flipped);
+
+      await generateSpec(workspace, baseOptions, 'base');
+      await generateSpec(workspace, masterOptions, 'master');
+      const afterCycle2 = await countExports();
+
+      expect(afterCycle2).toBe(afterCycle1);
+
+      const finalContent = await fs.readFile(barrel, 'utf8');
+      const specifiers = [
+        ...finalContent.matchAll(/export \* from ['"]([^'"]+)['"]/g),
+      ].map((m) => m[1]);
+      expect(new Set(specifiers).size).toBe(specifiers.length);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/orval/src/utils/barrel.ts
+++ b/packages/orval/src/utils/barrel.ts
@@ -1,0 +1,31 @@
+import fs from 'fs-extra';
+
+const RE_EXPORT_SPECIFIER = /export\s+\*\s+from\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Extract the set of `export * from '...'` module specifiers from barrel
+ * content. Quote-agnostic (matches both `'` and `"`) so it is unaffected by a
+ * formatter changing quote style between generations.
+ */
+export function readReExportSpecifiers(content: string): Set<string> {
+  return new Set([...content.matchAll(RE_EXPORT_SPECIFIER)].map((m) => m[1]));
+}
+
+/**
+ * Return the deduplicated list of specifiers for a barrel by unioning the
+ * freshly generated `specifiers` with whatever re-exports already exist on
+ * disk. Merging on the bare specifier (rather than the formatted line) makes
+ * the barrel idempotent across regenerations regardless of how an external
+ * formatter rewrites quotes, semicolons, or whitespace. On-disk order is
+ * preserved and new specifiers are appended — matching the previous append
+ * ordering — so callers control any sorting they want.
+ */
+export async function mergeBarrelSpecifiers(
+  filePath: string,
+  specifiers: string[],
+): Promise<string[]> {
+  const existing = (await fs.pathExists(filePath))
+    ? readReExportSpecifiers(await fs.readFile(filePath, 'utf8'))
+    : new Set<string>();
+  return [...new Set([...existing, ...specifiers])];
+}

--- a/packages/orval/src/utils/index.ts
+++ b/packages/orval/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './barrel';
 export * from './execute-hook';
 export * from './options';
 export * from './package-json';

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -39,11 +39,10 @@ import {
 import { generateFakerForSchemas } from '@orval/mock';
 import { execa, ExecaError } from 'execa';
 import fs from 'fs-extra';
-import { unique } from 'remeda';
 import type { TypeDocOptions } from 'typedoc';
 
 import { formatWithPrettier } from './formatters/prettier';
-import { executeHook } from './utils';
+import { executeHook, readReExportSpecifiers } from './utils';
 import {
   generateZodSchemasInline,
   writeZodSchemas,
@@ -172,13 +171,11 @@ async function addOperationSchemasReExport(
 
   const indexExists = await fs.pathExists(schemaIndexPath);
   if (indexExists) {
-    // Check if export already exists to prevent duplicates on re-runs
-    // Use regex to handle both single and double quotes
+    // Append the re-export only if it isn't already declared. The presence
+    // check reuses the shared barrel specifier reader so quote style can't
+    // cause duplicates (#3756).
     const existingContent = await fs.readFile(schemaIndexPath, 'utf8');
-    const exportPattern = new RegExp(
-      String.raw`export\s*\*\s*from\s*['"]${esmImportPath.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)}['"]`,
-    );
-    if (!exportPattern.test(existingContent)) {
+    if (!readReExportSpecifiers(existingContent).has(esmImportPath)) {
       await fs.appendFile(schemaIndexPath, exportLine);
     }
   } else {
@@ -806,23 +803,28 @@ export async function writeSpecs(
     }
 
     if (output.indexFiles) {
+      // The workspace barrel can share its path with the implementation
+      // target (#3675: `target` === `<workspace>/index.ts`), so append rather
+      // than overwrite to avoid clobbering non-export content. Dedup on the
+      // bare specifier (not the formatted line) so a formatter changing quote
+      // style between runs can't reintroduce duplicates (#3756).
       if (await fs.pathExists(indexFile)) {
-        const data = await fs.readFile(indexFile, 'utf8');
-        const importsNotDeclared = imports.filter(
-          (imp) => !data.includes(`export * from '${imp}'`),
+        const declared = readReExportSpecifiers(
+          await fs.readFile(indexFile, 'utf8'),
         );
-        await fs.appendFile(
-          indexFile,
-          unique(importsNotDeclared)
-            .map((imp) => `export * from '${imp}';\n`)
-            .join(''),
-        );
+        const toAdd = [...new Set(imports.filter((imp) => !declared.has(imp)))];
+        if (toAdd.length > 0) {
+          await fs.appendFile(
+            indexFile,
+            toAdd.map((imp) => `export * from '${imp}';\n`).join(''),
+          );
+        }
       } else {
         await fs.outputFile(
           indexFile,
-          unique(imports)
+          `${[...new Set(imports)]
             .map((imp) => `export * from '${imp}';`)
-            .join('\n') + '\n',
+            .join('\n')}\n`,
         );
       }
 

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -44,6 +44,7 @@ import {
   rewriteReusableSchemas,
   rewriteSentinelsToDirect,
 } from './reusable-schemas';
+import { mergeBarrelSpecifiers } from './utils/barrel';
 
 interface ZodSchemaFileEntry {
   schemaName: string;
@@ -500,32 +501,29 @@ async function writeZodSchemaIndex(
   const importFileExtension = getImportExtension(fileExtension, tsconfig);
   const indexPath = path.join(schemasPath, `index.ts`);
 
-  let existingExports = '';
-  if (shouldMergeExisting && (await fs.pathExists(indexPath))) {
-    const existingContent = await fs.readFile(indexPath, 'utf8');
-    const headerMatch = /^(\/\*\*[\s\S]*?\*\/\n)?/.exec(existingContent);
-    const headerPart = headerMatch ? headerMatch[0] : '';
-    existingExports = existingContent.slice(headerPart.length).trim();
-  }
+  const newSpecifiers = [
+    ...new Set(
+      schemaNames.map((schemaName) => {
+        const fileName = conventionName(schemaName, namingConvention);
+        return `./${fileName}${importFileExtension}`;
+      }),
+    ),
+  ];
 
-  const newExports = schemaNames
-    .map((schemaName) => {
-      const fileName = conventionName(schemaName, namingConvention);
-      return `export * from './${fileName}${importFileExtension}';`;
-    })
-    .toSorted()
+  // Dedup on the bare specifier (not the formatted line) so a formatter run
+  // between generations can't reintroduce duplicates via quote-style changes
+  // (#3756).
+  const specifiers = (
+    shouldMergeExisting
+      ? await mergeBarrelSpecifiers(indexPath, newSpecifiers)
+      : newSpecifiers
+  ).toSorted();
+
+  const exports = specifiers
+    .map((specifier) => `export * from '${specifier}';`)
     .join('\n');
 
-  const allExports = existingExports
-    ? `${existingExports}\n${newExports}`
-    : newExports;
-
-  const uniqueExports = [...new Set(allExports.split('\n'))]
-    .filter((line) => line.trim())
-    .toSorted()
-    .join('\n');
-
-  await fs.outputFile(indexPath, `${header}\n${uniqueExports}\n`);
+  await fs.outputFile(indexPath, `${header}\n${exports}\n`);
 }
 
 export async function writeZodSchemaTagsSplitBarrel(


### PR DESCRIPTION
Fixes #3756.

## Problem
The shared workspace barrel (`<workspace>/index.ts`) and the zod verb-schema index accumulated duplicate `export *` lines on every regeneration when an `afterAllFilesWrite` formatter (e.g. prettier) ran between generations. Each run re-appended the full export set instead of being a no-op.

## Root cause
Both barrels deduped re-exports by matching a **single-quote formatted line** (`data.includes(`export * from '${imp}'`)`). orval writes single quotes; a formatter flips them to double quotes; the next run's substring check no longer matches → every export is re-appended. Unbounded growth.

## Fix
Dedup on the **bare module specifier** (not the formatted line) via a shared quote-agnostic `readReExportSpecifiers` helper (`packages/orval/src/utils/barrel.ts`):
- the **workspace barrel** and **operationSchemas re-export** append only specifiers not already present — append (not overwrite) is required because the barrel can share its path with the implementation target (#3675: `target === <workspace>/index.ts`);
- the **zod verb-schema index** rebuilds the pure barrel from the on-disk ∪ new union (a `mergeBarrelSpecifiers` helper backs this).

All three barrel re-export sites now share the one extractor; the operationSchemas site's duplicated inline regex is removed.

## Verification
- New regression test (`generate-spec.test.ts`): two projects sharing a workspace barrel, regenerate with a simulated quote flip between runs → asserts no accumulation. Fails on master, passes with the fix.
- All 5525 snapshot tests pass with **no output changes** — `issue-3675-index-target` (barrel sharing the target path) confirmed preserved.
- Full local CI gate green: fmt, build, lint, lint:samples, typecheck, test, test:snapshots, orval-tests build (16 clients).
- Reproduced end-to-end with the reporter's config (tags-split, react-query, `workspace`, `afterAllFilesWrite: prettier`, 2 projects): `src/index.ts` went 4 → 8 → 12 lines across 3 runs, now stable at 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate exports in generated workspace and schema barrel files across repeated code generation runs.
  * Preserved existing exports reliably despite formatting or quote-style changes.
  * Improved merging and ordering of generated barrel exports for consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->