### PR TITLE
feat: add throwOnError global option

### DIFF
--- a/docs/content/docs/reference/integration.mdx
+++ b/docs/content/docs/reference/integration.mdx
@@ -84,6 +84,9 @@ const globalOptions: GlobalOptions = {
   // Package configuration
   packageJson: './package.json',
   input: './api-spec.yaml',
+
+  // Error handling
+  throwOnError: true, // Throw generation errors instead of only logging them
 };
 
 await generate('./orval.config.js', process.cwd(), globalOptions);
@@ -114,6 +117,25 @@ function generate(
 - `optionsExport`: Path to config file or configuration object
 - `workspace`: Working directory (defaults to `process.cwd()`)
 - `options`: Global options to override config settings
+
+## Error Handling
+
+By default, `generate()` logs generation errors and resolves after processing the configured project or projects. Set `throwOnError` when a script needs to catch failures and decide how to handle them:
+
+```ts
+import { generate, logError } from 'orval';
+
+try {
+  await generate('./orval.config.js', process.cwd(), {
+    throwOnError: true,
+  });
+} catch (error) {
+  logError(error);
+  process.exit(1);
+}
+```
+
+When a config file contains multiple projects, `throwOnError` stops on the first generation error instead of continuing with later projects.
 
 ## Watch Mode
 

--- a/docs/content/docs/reference/integration.mdx
+++ b/docs/content/docs/reference/integration.mdx
@@ -86,7 +86,7 @@ const globalOptions: GlobalOptions = {
   input: './api-spec.yaml',
 
   // Error handling
-  throwOnError: true, // Throw generation errors instead of only logging them
+  throwOnError: true, // Throw initial generation errors instead of only logging them
 };
 
 await generate('./orval.config.js', process.cwd(), globalOptions);
@@ -120,7 +120,7 @@ function generate(
 
 ## Error Handling
 
-By default, `generate()` logs generation errors and resolves after processing the configured project or projects. Set `throwOnError` when a script needs to catch failures and decide how to handle them:
+By default, `generate()` logs initial generation errors and resolves after processing the configured project or projects. Set `throwOnError` when a script needs to catch initial generation failures and decide how to handle them:
 
 ```ts
 import { generate, logError } from 'orval';
@@ -135,7 +135,7 @@ try {
 }
 ```
 
-When a config file contains multiple projects, `throwOnError` stops on the first generation error instead of continuing with later projects.
+When a config file contains multiple projects, `throwOnError` stops on the first generation error during the initial run instead of continuing with later projects. Watch mode generation errors are still logged after the watcher has started.
 
 ## Watch Mode
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1431,6 +1431,7 @@ export interface GlobalOptions {
   input?: string | string[];
   output?: string;
   failOnWarnings?: boolean;
+  throwOnError?: boolean;
 }
 
 export interface Tsconfig {

--- a/packages/orval/src/generate.test.ts
+++ b/packages/orval/src/generate.test.ts
@@ -1,8 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const watcherMock = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => void>();
+  const watcher = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.set(event, handler);
+      return watcher;
+    }),
+  };
+
+  return {
+    handlers,
+    watch: vi.fn(() => watcher),
+    watcher,
+  };
+});
+
 vi.mock('@orval/core', () => ({
   getWarningCount: vi.fn().mockReturnValue(0),
+  isBoolean: (value: unknown) => typeof value === 'boolean',
   isString: (value: unknown) => typeof value === 'string',
+  log: vi.fn(),
   logError: vi.fn(),
   resetWarnings: vi.fn(),
   setVerbose: vi.fn(),
@@ -23,15 +41,18 @@ vi.mock('./utils/options', () => ({
   }),
 }));
 
-vi.mock('./utils/watcher', () => ({
-  startWatcher: vi.fn(),
+vi.mock('chokidar', () => ({
+  watch: watcherMock.watch,
 }));
 
 import { getWarningCount, logError, setVerbose } from '@orval/core';
 
 import { generate } from './generate';
 import { generateSpec } from './generate-spec';
-import { startWatcher } from './utils/watcher';
+
+beforeEach(() => {
+  watcherMock.handlers.clear();
+});
 
 describe('generate - verbose handling', () => {
   beforeEach(() => {
@@ -120,18 +141,24 @@ describe('generate - throwOnError', () => {
     expect(logError).not.toHaveBeenCalled();
   });
 
-  it('throws watch callback errors when throwOnError is enabled', async () => {
+  it('logs watch event generation errors when throwOnError is enabled', async () => {
     const error = new Error('watch generation failed');
     await generate({ input: 'spec.yaml', output: 'out.ts' }, '/workspace', {
       throwOnError: true,
       watch: true,
     });
 
-    const callback = vi.mocked(startWatcher).mock.calls[0][1];
+    const readyHandler = watcherMock.handlers.get('ready');
+    expect(readyHandler).toBeDefined();
+    readyHandler?.();
+
     vi.mocked(generateSpec).mockRejectedValueOnce(error);
 
-    await expect(callback()).rejects.toThrow(error);
+    const changeHandler = watcherMock.handlers.get('all');
+    expect(changeHandler).toBeDefined();
+    changeHandler?.('change', 'spec.yaml');
 
-    expect(logError).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(logError).toHaveBeenCalledWith(error);
   });
 });

--- a/packages/orval/src/generate.test.ts
+++ b/packages/orval/src/generate.test.ts
@@ -27,9 +27,11 @@ vi.mock('./utils/watcher', () => ({
   startWatcher: vi.fn(),
 }));
 
-import { getWarningCount, setVerbose } from '@orval/core';
+import { getWarningCount, logError, setVerbose } from '@orval/core';
 
 import { generate } from './generate';
+import { generateSpec } from './generate-spec';
+import { startWatcher } from './utils/watcher';
 
 describe('generate - verbose handling', () => {
   beforeEach(() => {
@@ -86,5 +88,50 @@ describe('generate - failOnWarnings', () => {
     await expect(
       generate({ input: 'spec.yaml', output: 'out.ts' }, '/workspace'),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('generate - throwOnError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs and resolves generation errors by default', async () => {
+    const error = new Error('generation failed');
+    vi.mocked(generateSpec).mockRejectedValueOnce(error);
+
+    await expect(
+      generate({ input: 'spec.yaml', output: 'out.ts' }, '/workspace'),
+    ).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalledWith(error);
+  });
+
+  it('throws generation errors when throwOnError is enabled', async () => {
+    const error = new Error('generation failed');
+    vi.mocked(generateSpec).mockRejectedValueOnce(error);
+
+    await expect(
+      generate({ input: 'spec.yaml', output: 'out.ts' }, '/workspace', {
+        throwOnError: true,
+      }),
+    ).rejects.toThrow(error);
+
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it('throws watch callback errors when throwOnError is enabled', async () => {
+    const error = new Error('watch generation failed');
+    await generate({ input: 'spec.yaml', output: 'out.ts' }, '/workspace', {
+      throwOnError: true,
+      watch: true,
+    });
+
+    const callback = vi.mocked(startWatcher).mock.calls[0][1];
+    vi.mocked(generateSpec).mockRejectedValueOnce(error);
+
+    await expect(callback()).rejects.toThrow(error);
+
+    expect(logError).not.toHaveBeenCalled();
   });
 });

--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -38,6 +38,9 @@ export async function generate(
       try {
         await generateSpec(workspace, normalizedOptions, projectName);
       } catch (error) {
+        if (options?.throwOnError) {
+          throw error;
+        }
         hasErrors = true;
         logError(error, projectName);
       }
@@ -54,6 +57,9 @@ export async function generate(
             try {
               await generateSpec(workspace, normalizedOptions, projectName);
             } catch (error) {
+              if (options.throwOnError) {
+                throw error;
+              }
               logError(error, projectName);
             }
             if (options.failOnWarnings && getWarningCount() > 0) {
@@ -88,6 +94,9 @@ export async function generate(
   try {
     await generateSpec(workspace, normalizedOptions);
   } catch (error) {
+    if (options?.throwOnError) {
+      throw error;
+    }
     logError(error);
   }
 
@@ -99,6 +108,9 @@ export async function generate(
         try {
           await generateSpec(workspace, normalizedOptions);
         } catch (error) {
+          if (options.throwOnError) {
+            throw error;
+          }
           logError(error);
         }
         if (options.failOnWarnings && getWarningCount() > 0) {

--- a/packages/orval/src/generate.ts
+++ b/packages/orval/src/generate.ts
@@ -57,9 +57,6 @@ export async function generate(
             try {
               await generateSpec(workspace, normalizedOptions, projectName);
             } catch (error) {
-              if (options.throwOnError) {
-                throw error;
-              }
               logError(error, projectName);
             }
             if (options.failOnWarnings && getWarningCount() > 0) {
@@ -108,9 +105,6 @@ export async function generate(
         try {
           await generateSpec(workspace, normalizedOptions);
         } catch (error) {
-          if (options.throwOnError) {
-            throw error;
-          }
           logError(error);
         }
         if (options.failOnWarnings && getWarningCount() > 0) {


### PR DESCRIPTION
## Summary

- Add `throwOnError` to `GlobalOptions` for programmatic `generate()` usage.
- Re-throw generation errors in normal and watch-mode paths when the option is enabled, while preserving the existing log-and-resolve behavior by default.
- Document the option and add focused tests for default/error-throwing behavior.

Closes #2290
Closes #3364

## Checks

- `bun run build`
- `bun run vitest run packages/orval/src/generate.test.ts`
- `bun run typecheck`
- `bun run format:check`

## AI assistance disclosure

OpenAI Codex helped inspect the existing generate flow, make this scoped implementation/test/docs change, and draft this PR body. I reviewed the change and ran the checks above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `throwOnError` option to control whether generation errors are thrown or logged.
  * When enabled, generation stops sooner by surfacing the first initial generation error instead of only logging it.
  * Updated watch-mode error handling to match the new throwing behavior in applicable cases.
* **Documentation**
  * Expanded the “Error Handling” reference with new examples and clearer descriptions of default vs `throwOnError: true` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->