### PR TITLE
feat: support HTTP QUERY operations

### DIFF
--- a/packages/angular/src/utils.ts
+++ b/packages/angular/src/utils.ts
@@ -225,8 +225,8 @@ export function isRetrievalVerb(
   if (clientOverride === 'httpResource') return true;
   if (clientOverride === 'httpClient') return false;
 
-  // Absent a per-operation override, GET is treated as a retrieval
-  if (verb === 'get') return true;
+  // Absent a per-operation override, safe retrieval verbs stay in httpResource.
+  if (verb === 'get' || verb === 'query') return true;
 
   // POST with a retrieval-like operation name
   if (verb === 'post' && operationName) {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -21,6 +21,7 @@ export const VERBS_WITH_BODY = [
   Verbs.PUT,
   Verbs.PATCH,
   Verbs.DELETE,
+  Verbs.QUERY,
 ];
 
 export const URL_REGEX =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1310,7 +1310,8 @@ export type Verbs =
   | 'delete'
   | 'options'
   | 'head'
-  | 'patch';
+  | 'patch'
+  | 'query';
 
 export const Verbs = {
   GET: 'get' as Verbs,
@@ -1320,6 +1321,7 @@ export const Verbs = {
   OPTIONS: 'options' as Verbs,
   HEAD: 'head' as Verbs,
   PATCH: 'patch' as Verbs,
+  QUERY: 'query' as Verbs,
 };
 
 /**

--- a/packages/core/src/utils/assertion.test.ts
+++ b/packages/core/src/utils/assertion.test.ts
@@ -77,8 +77,10 @@ describe('assertion testing', () => {
     expect(isVerb(Verbs.OPTIONS)).toBeTruthy();
     expect(isVerb(Verbs.HEAD)).toBeTruthy();
     expect(isVerb(Verbs.PATCH)).toBeTruthy();
+    expect(isVerb(Verbs.QUERY)).toBeTruthy();
 
     // Negative checks: casing and unknown verbs
+    expect(isVerb('QUERY')).toBeFalsy();
     expect(isVerb('unknown')).toBeFalsy();
     expect(isVerb('')).toBeFalsy();
     expect(isVerb(undefined as unknown as string)).toBeFalsy();

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -14,6 +14,7 @@ import {
   isBinaryContentType,
   isObject,
   makeRouteSafe,
+  type OpenApiOperationObject,
   type OpenApiParameterObject,
   type OpenApiReferenceObject,
   type OpenApiSchemaObject,
@@ -22,6 +23,7 @@ import {
   type SharedTypeDeclaration,
   stringify,
   toObjectString,
+  type Verbs,
 } from '@orval/core';
 
 const WILDCARD_STATUS_CODE_REGEX = /^[1-5]XX$/i;
@@ -117,7 +119,9 @@ export const generateRequestFunction = (
     'implementation',
   );
 
-  const spec = context.spec.paths?.[pathRoute];
+  const spec = context.spec.paths?.[pathRoute] as
+    | Partial<Record<Verbs, OpenApiOperationObject>>
+    | undefined;
   const parameters = spec?.[verb]?.parameters ?? [];
   const parameterObjects = parameters.map((parameter) => {
     const { schema } = resolveRef(parameter, context);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -54,6 +54,9 @@ const getAnnotations = (verb: Verbs): string => {
     case 'head': {
       return '{ readOnlyHint: true, destructiveHint: false }';
     }
+    case 'query': {
+      return '{ readOnlyHint: true, destructiveHint: false, idempotentHint: true }';
+    }
     case 'post': {
       return '{ destructiveHint: false }';
     }

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -46,9 +46,77 @@ const PETSTORE_SPEC: OpenApiDocument = {
   },
 };
 
+const QUERY_METHOD_SPEC = {
+  openapi: '3.2.0',
+  info: { title: 'Search API', version: '1.0.0' },
+  paths: {
+    '/search': {
+      query: {
+        operationId: 'searchPets',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  term: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Search results',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: PETSTORE_SPEC.components,
+} as unknown as OpenApiDocument;
+
 const createTempWorkspace = async () => {
   return mkdtemp(path.join(os.tmpdir(), 'orval-gen-spec-'));
 };
+
+describe('generateSpec - HTTP QUERY method', () => {
+  it('generates clients for QUERY operations with request bodies', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'endpoints.ts');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: QUERY_METHOD_SPEC },
+          output: {
+            target: './endpoints.ts',
+            client: 'fetch',
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const content = await fs.readFile(targetFile, 'utf8');
+
+      expect(content).toContain('export const searchPets =');
+      expect(content).toContain("method: 'QUERY'");
+      expect(content).toContain('body: JSON.stringify(searchPetsBody)');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('generateSpec - schemas: false', () => {
   it('does not generate separate schema files when schemas is false', async () => {


### PR DESCRIPTION
## Summary
- Add `QUERY` to Orval's supported HTTP verbs
- Treat `QUERY` as a body-capable safe retrieval method where clients classify verbs
- Add a generation regression test covering an OpenAPI 3.2 `query` operation with a JSON request body

Closes #3729.

## Test plan
- `bun run vitest run packages/core/src/utils/assertion.test.ts packages/orval/src/generate-spec.test.ts --testNamePattern 'verbs|HTTP QUERY method'`\n- `bun run vitest run packages/core/src/utils/assertion.test.ts packages/orval/src/generate-spec.test.ts packages/fetch/src/index.test.ts packages/angular/src/utils.test.ts packages/mcp/src/index.test.ts --testNamePattern 'verbs|HTTP QUERY method|fetch|retrieval|annotations|query'`\n- `bun run format:check`\n- `bun run typecheck`\n- `git diff --check`\n\nThis pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the HTTP `QUERY` method, including request bodies.
  * Generated clients can now create `QUERY` requests with serialized payloads.
  * `QUERY` operations are recognized as read-only and idempotent where applicable.

* **Bug Fixes**
  * Corrected retrieval and mutation classification for `QUERY` operations.

* **Tests**
  * Added coverage for `QUERY` operations and request-body generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->