### PR TITLE
fix: prune stale workspace barrel exports

### DIFF
--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -1732,4 +1732,57 @@ describe('generateSpec - workspace barrel idempotency (#3756)', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  it('removes stale exports whose generated targets no longer exist', async () => {
+    const workspace = await createTempWorkspace();
+    const barrel = path.join(workspace, 'gen', 'index.ts');
+    const baseDir = path.join(path.dirname(barrel), 'gen', 'api', 'base');
+    const masterDir = path.join(path.dirname(barrel), 'gen', 'api', 'master');
+
+    try {
+      const baseOptions = await normalizeOptions(
+        {
+          input: { target: ACTIVITY_SPEC },
+          output: {
+            workspace: './gen',
+            target: './gen/api/base/endpoints.ts',
+            schemas: './gen/api/base/model',
+            client: 'axios',
+          },
+        },
+        workspace,
+      );
+      const masterOptions = await normalizeOptions(
+        {
+          input: { target: MASTER_SPEC },
+          output: {
+            workspace: './gen',
+            target: './gen/api/master/endpoints.ts',
+            schemas: './gen/api/master/model',
+            client: 'axios',
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, baseOptions, 'base');
+      await generateSpec(workspace, masterOptions, 'master');
+
+      const beforeRemoval = await fs.readFile(barrel, 'utf8');
+      expect(beforeRemoval).toContain('./gen/api/base/endpoints');
+      expect(beforeRemoval).toContain('./gen/api/master/endpoints');
+
+      await fs.remove(masterDir);
+      await generateSpec(workspace, baseOptions, 'base');
+
+      const afterRemoval = await fs.readFile(barrel, 'utf8');
+      expect(await fs.pathExists(baseDir)).toBe(true);
+      expect(await fs.pathExists(masterDir)).toBe(false);
+      expect(afterRemoval).toContain('./gen/api/base/endpoints');
+      expect(afterRemoval).not.toContain('./gen/api/master/endpoints');
+      expect(afterRemoval).not.toContain('./gen/api/master/model');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -190,6 +190,98 @@ async function addOperationSchemasReExport(
   }
 }
 
+const RE_EXPORT_LINE = /^\s*export\s+\*\s+from\s*['"]([^'"]+)['"]\s*;?\s*$/;
+
+function getReExportLineSpecifier(line: string): string | undefined {
+  return line.match(RE_EXPORT_LINE)?.[1];
+}
+
+async function reExportSpecifierExists(
+  indexFile: string,
+  specifier: string,
+  fileExtension: string,
+  importExtension: string,
+): Promise<boolean> {
+  if (!specifier.startsWith('.')) {
+    return true;
+  }
+
+  const resolved = path.resolve(path.dirname(indexFile), specifier);
+  const candidates = new Set<string>([resolved]);
+
+  if (importExtension && specifier.endsWith(importExtension)) {
+    candidates.add(resolved.slice(0, -importExtension.length) + fileExtension);
+  }
+
+  candidates.add(`${resolved}${fileExtension}`);
+  candidates.add(path.join(resolved, `index${fileExtension}`));
+
+  for (const candidate of candidates) {
+    if (await fs.pathExists(candidate)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function getResolvableReExportSpecifiers(
+  indexFile: string,
+  content: string,
+  fileExtension: string,
+  importExtension: string,
+): Promise<Set<string>> {
+  const specifiers = readReExportSpecifiers(content);
+  const resolvable = new Set<string>();
+
+  for (const specifier of specifiers) {
+    if (
+      await reExportSpecifierExists(
+        indexFile,
+        specifier,
+        fileExtension,
+        importExtension,
+      )
+    ) {
+      resolvable.add(specifier);
+    }
+  }
+
+  return resolvable;
+}
+
+function updateBarrelReExports(
+  content: string,
+  specifiers: Iterable<string>,
+): string {
+  const remaining = new Set(specifiers);
+  const seen = new Set<string>();
+  const eol = content.includes('\r\n') ? '\r\n' : '\n';
+  const retainedLines: string[] = [];
+
+  for (const line of content.split(/\r?\n/)) {
+    const specifier = getReExportLineSpecifier(line);
+
+    if (!specifier) {
+      retainedLines.push(line);
+      continue;
+    }
+
+    if (remaining.has(specifier) && !seen.has(specifier)) {
+      retainedLines.push(line);
+      seen.add(specifier);
+      remaining.delete(specifier);
+    }
+  }
+
+  const retainedContent = retainedLines.join(eol).trimEnd();
+  const appendedContent = [...remaining]
+    .map((specifier) => `export * from '${specifier}';`)
+    .join(eol);
+
+  return [retainedContent, appendedContent].filter(Boolean).join(eol) + eol;
+}
+
 /**
  * Emit `<schemas-dir>/index.faker.ts` (or `<output-root>/schemas.faker.ts`
  * when `output.schemas` is not configured) when a faker generator entry has
@@ -838,19 +930,26 @@ export async function writeSpecs(
     if (output.indexFiles) {
       // The workspace barrel can share its path with the implementation
       // target (#3675: `target` === `<workspace>/index.ts`), so append rather
-      // than overwrite to avoid clobbering non-export content. Dedup on the
-      // bare specifier (not the formatted line) so a formatter changing quote
-      // style between runs can't reintroduce duplicates (#3756).
+      // than overwrite non-export content. Dedup on the bare specifier (not
+      // the formatted line) so a formatter changing quote style between runs
+      // can't reintroduce duplicates (#3756). Stale relative exports whose
+      // targets no longer exist are pruned so removed operations/projects do
+      // not leave dangling imports behind.
       if (await fs.pathExists(indexFile)) {
-        const declared = readReExportSpecifiers(
-          await fs.readFile(indexFile, 'utf8'),
+        const existingContent = await fs.readFile(indexFile, 'utf8');
+        const declared = await getResolvableReExportSpecifiers(
+          indexFile,
+          existingContent,
+          output.fileExtension,
+          importExtension,
         );
-        const toAdd = [...new Set(imports.filter((imp) => !declared.has(imp)))];
-        if (toAdd.length > 0) {
-          await fs.appendFile(
-            indexFile,
-            toAdd.map((imp) => `export * from '${imp}';\n`).join(''),
-          );
+        const nextSpecifiers = [...new Set([...declared, ...imports])];
+        const nextContent = updateBarrelReExports(
+          existingContent,
+          nextSpecifiers,
+        );
+        if (nextContent !== existingContent) {
+          await fs.outputFile(indexFile, nextContent);
         }
       } else {
         await fs.outputFile(

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -231,23 +231,19 @@ async function getResolvableReExportSpecifiers(
   fileExtension: string,
   importExtension: string,
 ): Promise<Set<string>> {
-  const specifiers = readReExportSpecifiers(content);
-  const resolvable = new Set<string>();
-
-  for (const specifier of specifiers) {
-    if (
-      await reExportSpecifierExists(
+  const specifiers = [...readReExportSpecifiers(content)];
+  const exists = await Promise.all(
+    specifiers.map((specifier) =>
+      reExportSpecifierExists(
         indexFile,
         specifier,
         fileExtension,
         importExtension,
-      )
-    ) {
-      resolvable.add(specifier);
-    }
-  }
+      ),
+    ),
+  );
 
-  return resolvable;
+  return new Set(specifiers.filter((_, index) => exists[index]));
 }
 
 function updateBarrelReExports(


### PR DESCRIPTION
## Summary
- Reconcile existing workspace barrel re-exports against files/directories that still exist
- Preserve partial generation by keeping resolvable exports from other projects
- Add a regression test for removing stale workspace exports after a generated target disappears

Fixes #3763.

## Test plan
- `bun run vitest run packages/orval/src/generate-spec.test.ts --testNamePattern 'workspace barrel idempotency'`\n- `bun run format:check`\n- `bun run typecheck`\n- `git diff --check`\n\nThis pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace-generated barrel files now remove exports for API endpoints and models that have been deleted.
  * Existing `export * from ...` entries are revalidated against available generated output to prevent stale references.
  * Barrel contents are rebuilt with a de-duplicated, up-to-date set of exports, combining retained and newly generated specifiers.
* **Tests**
  * Added regression coverage to verify workspace barrel cleanup after an output directory is removed and generation is rerun.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->