### PR TITLE
fix: generate markdown docs output

### DIFF
--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -952,7 +952,7 @@ export async function writeSpecs(
       const project = await app.convert();
       if (project) {
         const outputPath = app.options.getValue('out');
-        await app.generateDocs(project, outputPath);
+        await app.generateOutputs(project);
 
         await runFormatter(output.formatter, [outputPath], projectTitle);
       } else {

--- a/samples/react-app/docs-markdown/.nojekyll
+++ b/samples/react-app/docs-markdown/.nojekyll
@@ -1,1 +1,0 @@
-TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/samples/react-app/docs-markdown/README.md
+++ b/samples/react-app/docs-markdown/README.md
@@ -1,0 +1,25 @@
+**react-app**
+
+---
+
+# react-app
+
+## Interfaces
+
+- [Error](interfaces/Error.md)
+- [Pet](interfaces/Pet.md)
+
+## Type Aliases
+
+- [CreatePetsBody](type-aliases/CreatePetsBody.md)
+- [CreatePetsResult](type-aliases/CreatePetsResult.md)
+- [ListPetsParams](type-aliases/ListPetsParams.md)
+- [ListPetsResult](type-aliases/ListPetsResult.md)
+- [Pets](type-aliases/Pets.md)
+- [ShowPetByIdResult](type-aliases/ShowPetByIdResult.md)
+
+## Functions
+
+- [createPets](functions/createPets.md)
+- [listPets](functions/listPets.md)
+- [showPetById](functions/showPetById.md)

--- a/samples/react-app/docs-markdown/functions/createPets.html
+++ b/samples/react-app/docs-markdown/functions/createPets.html
@@ -1,6 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / createPets #
-Function: createPets() > **createPets**(`createPetsBody`, `options?`):
-`Promise`\<`AxiosResponse`\<`void`, `any`, \{ \}\>\> ## Parameters ###
-createPetsBody [`CreatePetsBody`](../types/CreatePetsBody.html) ### options?
-`AxiosRequestConfig`\<`any`\> ## Returns `Promise`\<`AxiosResponse`\<`void`,
-`any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/functions/createPets.md
+++ b/samples/react-app/docs-markdown/functions/createPets.md
@@ -1,0 +1,23 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / createPets
+
+# Function: createPets()
+
+> **createPets**(`createPetsBody`, `options?`): `Promise`\<`AxiosResponse`\<`void`, `any`, \{ \}\>\>
+
+## Parameters
+
+### createPetsBody
+
+[`CreatePetsBody`](../type-aliases/CreatePetsBody.md)
+
+### options?
+
+`AxiosRequestConfig`\<`any`\>
+
+## Returns
+
+`Promise`\<`AxiosResponse`\<`void`, `any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/functions/listPets.html
+++ b/samples/react-app/docs-markdown/functions/listPets.html
@@ -1,6 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / listPets #
-Function: listPets() > **listPets**(`params?`, `options?`):
-`Promise`\<`AxiosResponse`\<[`Pets`](../types/Pets.html), `any`, \{ \}\>\> ##
-Parameters ### params? [`ListPetsParams`](../types/ListPetsParams.html) ###
-options? `AxiosRequestConfig`\<`any`\> ## Returns
-`Promise`\<`AxiosResponse`\<[`Pets`](../types/Pets.html), `any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/functions/listPets.md
+++ b/samples/react-app/docs-markdown/functions/listPets.md
@@ -1,0 +1,23 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / listPets
+
+# Function: listPets()
+
+> **listPets**(`params?`, `options?`): `Promise`\<`AxiosResponse`\<[`Pets`](../type-aliases/Pets.md), `any`, \{ \}\>\>
+
+## Parameters
+
+### params?
+
+[`ListPetsParams`](../type-aliases/ListPetsParams.md)
+
+### options?
+
+`AxiosRequestConfig`\<`any`\>
+
+## Returns
+
+`Promise`\<`AxiosResponse`\<[`Pets`](../type-aliases/Pets.md), `any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/functions/showPetById.html
+++ b/samples/react-app/docs-markdown/functions/showPetById.html
@@ -1,6 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / showPetById #
-Function: showPetById() > **showPetById**(`petId`, `options?`):
-`Promise`\<`AxiosResponse`\<[`Pet`](../interfaces/Pet.html), `any`, \{ \}\>\> ##
-Parameters ### petId `string` ### options? `AxiosRequestConfig`\<`any`\> ##
-Returns `Promise`\<`AxiosResponse`\<[`Pet`](../interfaces/Pet.html), `any`, \{
-\}\>\>

--- a/samples/react-app/docs-markdown/functions/showPetById.md
+++ b/samples/react-app/docs-markdown/functions/showPetById.md
@@ -1,0 +1,23 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / showPetById
+
+# Function: showPetById()
+
+> **showPetById**(`petId`, `options?`): `Promise`\<`AxiosResponse`\<[`Pet`](../interfaces/Pet.md), `any`, \{ \}\>\>
+
+## Parameters
+
+### petId
+
+`string`
+
+### options?
+
+`AxiosRequestConfig`\<`any`\>
+
+## Returns
+
+`Promise`\<`AxiosResponse`\<[`Pet`](../interfaces/Pet.md), `any`, \{ \}\>\>

--- a/samples/react-app/docs-markdown/hierarchy.html
+++ b/samples/react-app/docs-markdown/hierarchy.html
@@ -1,1 +1,0 @@
-[**react-app**](README.md) *** # react-app ## Hierarchy Summary

--- a/samples/react-app/docs-markdown/index.html
+++ b/samples/react-app/docs-markdown/index.html
@@ -1,9 +1,0 @@
-[**react-app**](README.md) *** # react-app ## Interfaces -
-[Error](interfaces/Error.html) - [Pet](interfaces/Pet.html) ## Type Aliases -
-[CreatePetsBody](types/CreatePetsBody.html) -
-[CreatePetsResult](types/CreatePetsResult.html) -
-[ListPetsParams](types/ListPetsParams.html) -
-[ListPetsResult](types/ListPetsResult.html) - [Pets](types/Pets.html) -
-[ShowPetByIdResult](types/ShowPetByIdResult.html) ## Functions -
-[createPets](functions/createPets.html) - [listPets](functions/listPets.html) -
-[showPetById](functions/showPetById.html)

--- a/samples/react-app/docs-markdown/interfaces/Error.html
+++ b/samples/react-app/docs-markdown/interfaces/Error.html
@@ -1,3 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / Error #
-Interface: Error ## Properties ### code > **code**: `number` *** ### message >
-**message**: `string`

--- a/samples/react-app/docs-markdown/interfaces/Error.md
+++ b/samples/react-app/docs-markdown/interfaces/Error.md
@@ -1,0 +1,19 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / Error
+
+# Interface: Error
+
+## Properties
+
+### code
+
+> **code**: `number`
+
+---
+
+### message
+
+> **message**: `string`

--- a/samples/react-app/docs-markdown/interfaces/Pet.html
+++ b/samples/react-app/docs-markdown/interfaces/Pet.html
@@ -1,3 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / Pet # Interface:
-Pet ## Properties ### id > **id**: `number` *** ### name > **name**: `string`
-*** ### tag? > `optional` **tag?**: `string`

--- a/samples/react-app/docs-markdown/interfaces/Pet.md
+++ b/samples/react-app/docs-markdown/interfaces/Pet.md
@@ -1,0 +1,25 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / Pet
+
+# Interface: Pet
+
+## Properties
+
+### id
+
+> **id**: `number`
+
+---
+
+### name
+
+> **name**: `string`
+
+---
+
+### tag?
+
+> `optional` **tag?**: `string`

--- a/samples/react-app/docs-markdown/type-aliases/CreatePetsBody.md
+++ b/samples/react-app/docs-markdown/type-aliases/CreatePetsBody.md
@@ -1,0 +1,21 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / CreatePetsBody
+
+# Type Alias: CreatePetsBody
+
+> **CreatePetsBody** = `object`
+
+## Properties
+
+### name
+
+> **name**: `string`
+
+---
+
+### tag
+
+> **tag**: `string`

--- a/samples/react-app/docs-markdown/type-aliases/CreatePetsResult.md
+++ b/samples/react-app/docs-markdown/type-aliases/CreatePetsResult.md
@@ -1,0 +1,9 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / CreatePetsResult
+
+# Type Alias: CreatePetsResult
+
+> **CreatePetsResult** = `AxiosResponse`\<`void`\>

--- a/samples/react-app/docs-markdown/type-aliases/ListPetsParams.md
+++ b/samples/react-app/docs-markdown/type-aliases/ListPetsParams.md
@@ -1,0 +1,17 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / ListPetsParams
+
+# Type Alias: ListPetsParams
+
+> **ListPetsParams** = `object`
+
+## Properties
+
+### limit?
+
+> `optional` **limit?**: `string`
+
+How many items to return at one time (max 100)

--- a/samples/react-app/docs-markdown/type-aliases/ListPetsResult.md
+++ b/samples/react-app/docs-markdown/type-aliases/ListPetsResult.md
@@ -1,0 +1,9 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / ListPetsResult
+
+# Type Alias: ListPetsResult
+
+> **ListPetsResult** = `AxiosResponse`\<[`Pets`](Pets.md)\>

--- a/samples/react-app/docs-markdown/type-aliases/Pets.md
+++ b/samples/react-app/docs-markdown/type-aliases/Pets.md
@@ -1,0 +1,9 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / Pets
+
+# Type Alias: Pets
+
+> **Pets** = [`Pet`](../interfaces/Pet.md)[]

--- a/samples/react-app/docs-markdown/type-aliases/ShowPetByIdResult.md
+++ b/samples/react-app/docs-markdown/type-aliases/ShowPetByIdResult.md
@@ -1,0 +1,9 @@
+[**react-app**](../README.md)
+
+---
+
+[react-app](../README.md) / ShowPetByIdResult
+
+# Type Alias: ShowPetByIdResult
+
+> **ShowPetByIdResult** = `AxiosResponse`\<[`Pet`](../interfaces/Pet.md)\>

--- a/samples/react-app/docs-markdown/types/CreatePetsBody.html
+++ b/samples/react-app/docs-markdown/types/CreatePetsBody.html
@@ -1,3 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / CreatePetsBody #
-Type Alias: CreatePetsBody > **CreatePetsBody** = `object` ## Properties ###
-name > **name**: `string` *** ### tag > **tag**: `string`

--- a/samples/react-app/docs-markdown/types/CreatePetsResult.html
+++ b/samples/react-app/docs-markdown/types/CreatePetsResult.html
@@ -1,3 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / CreatePetsResult
-# Type Alias: CreatePetsResult > **CreatePetsResult** =
-`AxiosResponse`\<`void`\>

--- a/samples/react-app/docs-markdown/types/ListPetsParams.html
+++ b/samples/react-app/docs-markdown/types/ListPetsParams.html
@@ -1,4 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / ListPetsParams #
-Type Alias: ListPetsParams > **ListPetsParams** = `object` ## Properties ###
-limit? > `optional` **limit?**: `string` How many items to return at one time
-(max 100)

--- a/samples/react-app/docs-markdown/types/ListPetsResult.html
+++ b/samples/react-app/docs-markdown/types/ListPetsResult.html
@@ -1,3 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / ListPetsResult #
-Type Alias: ListPetsResult > **ListPetsResult** =
-`AxiosResponse`\<[`Pets`](Pets.html)\>

--- a/samples/react-app/docs-markdown/types/Pets.html
+++ b/samples/react-app/docs-markdown/types/Pets.html
@@ -1,2 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / Pets # Type
-Alias: Pets > **Pets** = [`Pet`](../interfaces/Pet.html)[]

--- a/samples/react-app/docs-markdown/types/ShowPetByIdResult.html
+++ b/samples/react-app/docs-markdown/types/ShowPetByIdResult.html
@@ -1,3 +1,0 @@
-[**react-app**](../README.md) *** [react-app](../index.html) / ShowPetByIdResult
-# Type Alias: ShowPetByIdResult > **ShowPetByIdResult** =
-`AxiosResponse`\<[`Pet`](../interfaces/Pet.html)\>


### PR DESCRIPTION
## Summary
- Use TypeDoc's output pipeline so `typedoc-plugin-markdown` handles docs generation
- Regenerate the react-app markdown docs sample as `.md` files instead of markdown content in `.html` files

Fixes #3054.

## Test plan
- `bun run vp run -F './packages/orval' build:debug`\n- `bun run generate-api --project petstore-file-with-docs-markdown` from `samples/react-app`\n- `bun run format:check`\n- `bun run typecheck`\n- `git diff --check`\n\nThis pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refreshed the React app sample documentation with a Markdown index and pages for interfaces, type aliases, and functions.
  - Added detailed reference pages for pet models, request parameters, response types, and available API operations.
  - Replaced outdated generated HTML documentation content with the updated Markdown documentation format.
- **Bug Fixes**
  - Improved documentation generation so outputs are written and formatted consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->