### PR TITLE
fix: generate valid faker schema mocks

### DIFF
--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -7,7 +7,12 @@ import {
   OutputClient,
   type WriteSpecBuilder,
 } from '../types';
-import { getOperationTagKey, isOperationInTagBucket, pascal } from '../utils';
+import {
+  escapeRegExp,
+  getOperationTagKey,
+  isOperationInTagBucket,
+  pascal,
+} from '../utils';
 import { flattenMockOutput } from './mock-outputs';
 import type { GeneratorTargetWithFull } from './target';
 import { hasTypeScriptAwaitedType } from './typescript-version';
@@ -32,6 +37,57 @@ function emptyMockOutputFull(
     type,
     implementation: { function: '', handler: '', handlerName: '' },
     imports: [],
+  };
+}
+
+function aliasConflictingSchemaFactory(
+  mockOutput: GeneratorMockOutputFull,
+  localMockName: string,
+): GeneratorMockOutputFull {
+  if (!mockOutput.implementation.handlerName) {
+    return mockOutput;
+  }
+
+  const hasCollision = mockOutput.imports.some(
+    (imp) => imp.schemaFactory && (imp.alias ?? imp.name) === localMockName,
+  );
+  if (!hasCollision) {
+    return mockOutput;
+  }
+
+  const implementation = Object.values(mockOutput.implementation).join('\n');
+  const usedBindings = new Set(
+    mockOutput.imports.map((imp) => imp.alias ?? imp.name),
+  );
+  let alias = `${localMockName}SchemaFactory`;
+  let suffix = 2;
+  while (
+    usedBindings.has(alias) ||
+    new RegExp(String.raw`\b${escapeRegExp(alias)}\b`).test(implementation)
+  ) {
+    alias = `${localMockName}SchemaFactory${suffix}`;
+    suffix += 1;
+  }
+
+  const bindingPattern = new RegExp(
+    String.raw`\b${escapeRegExp(localMockName)}\b`,
+    'g',
+  );
+  const replaceBinding = (value: string) =>
+    value.replaceAll(bindingPattern, alias);
+
+  return {
+    ...mockOutput,
+    implementation: {
+      function: replaceBinding(mockOutput.implementation.function),
+      handler: replaceBinding(mockOutput.implementation.handler),
+      handlerName: replaceBinding(mockOutput.implementation.handlerName),
+    },
+    imports: mockOutput.imports.map((imp) =>
+      imp.schemaFactory && (imp.alias ?? imp.name) === localMockName
+        ? { ...imp, alias }
+        : imp,
+    ),
   };
 }
 
@@ -252,22 +308,26 @@ export function generateTargetForTags(
         // accumulated handler entries. Mock outputs without a handler (faker
         // only) skip the wrap.
         const wrappedMockOutputs: GeneratorMockOutputFull[] =
-          target.mockOutputs.map((m) => ({
-            type: m.type,
-            implementation: {
-              function: m.implementation.function,
-              handler: m.implementation.handlerName
-                ? m.implementation.handler +
-                  header.implementationMock +
-                  m.implementation.handlerName +
-                  footer.implementationMock
-                : m.implementation.handler,
-              handlerName: m.implementation.handlerName,
-            },
-            imports: m.imports,
-            strictMockSchemaTypeNames: m.strictMockSchemaTypeNames,
-            strictMockSchemaKinds: m.strictMockSchemaKinds,
-          }));
+          target.mockOutputs.map((mockOutput) => {
+            const collisionSafeMockOutput = aliasConflictingSchemaFactory(
+              mockOutput,
+              titles.implementationMock,
+            );
+
+            return {
+              ...collisionSafeMockOutput,
+              implementation: {
+                function: collisionSafeMockOutput.implementation.function,
+                handler: collisionSafeMockOutput.implementation.handlerName
+                  ? collisionSafeMockOutput.implementation.handler +
+                    header.implementationMock +
+                    collisionSafeMockOutput.implementation.handlerName +
+                    footer.implementationMock
+                  : collisionSafeMockOutput.implementation.handler,
+                handlerName: collisionSafeMockOutput.implementation.handlerName,
+              },
+            };
+          });
 
         transformed[tag] = {
           implementation:

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -654,7 +654,13 @@ function getEnum(
 
   let enumValue = `[${joinedEnumValues}]`;
   if (context.output.override.enumGenerationType === EnumGeneration.ENUM) {
-    if (item.isRef || existingReferencedProperties.length === 0) {
+    const isRootSchema =
+      !item.parentName && existingReferencedProperties.at(-1) === item.name;
+    if (
+      item.isRef ||
+      existingReferencedProperties.length === 0 ||
+      isRootSchema
+    ) {
       enumValue += ` as ${item.name}${item.name.endsWith('[]') ? '' : '[]'}`;
       imports.push({ name: item.name });
     } else {

--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -233,6 +233,35 @@ describe('generateFakerForSchemas property overrides (schemas: true)', () => {
   });
 });
 
+describe('generateFakerForSchemas enum factories (#3747)', () => {
+  it('casts a top-level enum to its own array type', () => {
+    const context = createTestContextSpec({
+      override: { enumGenerationType: EnumGeneration.ENUM },
+    });
+
+    const result = generateFakerForSchemas(
+      [
+        {
+          name: 'PetStatus',
+          model: 'PetStatus',
+          imports: [],
+          schema: {
+            type: 'string',
+            enum: ['available', 'pending', 'sold'],
+          },
+        },
+      ],
+      context,
+      { type: OutputMockType.FAKER, schemas: true },
+    );
+
+    expect(result.implementation).toContain(
+      "faker.helpers.arrayElement(['available','pending','sold'] as PetStatus[])",
+    );
+    expect(result.implementation).not.toContain("PetStatus['PetStatus']");
+  });
+});
+
 describe('generateFakerForSchemas schema-scoped overrides (override.mock.schemas)', () => {
   const appleColor = () => `'red'`;
   const carColor = () => `'midnight black'`;

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -1733,3 +1733,99 @@ describe('generateSpec - workspace barrel idempotency (#3756)', () => {
     }
   });
 });
+
+describe('generateSpec - faker schemas with tags-split MSW (#3747)', () => {
+  it('emits valid enum factories without colliding with tag mock aggregates', async () => {
+    const workspace = await createTempWorkspace();
+    const schemasDir = path.join(workspace, 'types');
+    const mswFile = path.join(workspace, 'sdk', 'pet', 'pet.msw.ts');
+
+    const spec: OpenApiDocument = {
+      openapi: '3.1.0',
+      info: { title: 'Faker MSW collision', version: '1.0.0' },
+      paths: {
+        '/pets': {
+          get: {
+            operationId: 'listPets',
+            tags: ['Pet'],
+            responses: {
+              '200': {
+                description: 'A list of pets',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Pet' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          PetStatus: {
+            type: 'string',
+            enum: ['available', 'pending', 'sold'],
+          },
+          Pet: {
+            type: 'object',
+            required: ['id', 'status'],
+            properties: {
+              id: { type: 'integer' },
+              status: { $ref: '#/components/schemas/PetStatus' },
+            },
+          },
+        },
+      },
+    };
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: spec },
+          output: {
+            target: './sdk/index.ts',
+            schemas: './types',
+            mode: 'tags-split',
+            client: 'react-query',
+            httpClient: 'axios',
+            mock: {
+              indexMockFiles: true,
+              generators: [
+                { type: 'msw' },
+                {
+                  type: 'faker',
+                  operationResponses: false,
+                  schemas: true,
+                },
+              ],
+            },
+            override: { enumGenerationType: 'enum' },
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+
+      const fakerSchemas = await fs.readFile(
+        path.join(schemasDir, 'index.faker.ts'),
+        'utf8',
+      );
+      expect(fakerSchemas).toContain(
+        "faker.helpers.arrayElement(['available','pending','sold'] as PetStatus[])",
+      );
+      expect(fakerSchemas).not.toContain("PetStatus['PetStatus']");
+
+      const mswContent = await fs.readFile(mswFile, 'utf8');
+      expect(mswContent).toContain('getPetMock as getPetMockSchemaFactory');
+      expect(mswContent).toContain('getPetMockSchemaFactory()');
+      expect(mswContent).toContain('export const getPetMock = () => [');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3747

## Summary
- cast top-level enum schema factories to their own enum array type
- alias schema factory imports when they collide with a per-tag MSW aggregate
- cover the combined tags-split, MSW, faker schemas, and enum configuration end to end

## Validation
- bun run vitest run packages/core/src/writers/split-tags-mode.test.ts packages/core/src/writers/tags-mode.test.ts packages/core/src/writers/mock-outputs.test.ts packages/mock/src/faker/index.test.ts packages/mock/src/faker/getters/scalar.test.ts packages/orval/src/generate-spec.test.ts
- bun run typecheck
- bun run lint
- bun run format:check

This pull request was prepared and submitted by OpenAI Codex acting as an AI agent through the contributor account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed enum faker generation to produce correct TypeScript casts for top-level schemas.
  * Prevented naming collisions in generated MSW mocks by assigning safe aliases to conflicting schema factories.

* **Tests**
  * Added coverage for enum-based faker generation.
  * Added regression tests for tagged MSW generation, including schema factory aliasing and mock output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->