### PR TITLE
ci: disable eslint tool in CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,3 +3,7 @@ reviews:
   path_filters:
     # Exclude generated test snapshots from review (noise, not human-authored)
     - "!**/__snapshots__/**"
+  tools:
+    eslint:
+      enabled: false
+


### PR DESCRIPTION
Disable the `eslint` tool in CodeRabbit reviews. The repository's own lint pipeline already covers this, so the duplicate run from CodeRabbit adds noise without value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review configuration to disable ESLint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->