### PR TITLE
refactor(orval): consolidate barrel logic into utils/barrel

### DIFF
--- a/packages/orval/src/utils/barrel.test.ts
+++ b/packages/orval/src/utils/barrel.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import fs from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { reExportSpecifierExists } from './barrel';
+
+describe('reExportSpecifierExists', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), 'orval-barrel-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function write(relativePath: string): Promise<void> {
+    const absolute = path.join(dir, relativePath);
+    await fs.ensureDir(path.dirname(absolute));
+    await fs.writeFile(absolute, '');
+  }
+
+  async function probe(specifier: string): Promise<boolean> {
+    const indexFile = path.join(dir, 'index.ts');
+    return reExportSpecifierExists(indexFile, specifier, '.ts', '.js');
+  }
+
+  it('resolves a direct file', async () => {
+    await write('foo.ts');
+    await expect(probe('./foo')).resolves.toBe(true);
+  });
+
+  it('resolves an index file inside a directory', async () => {
+    await write('foo/index.ts');
+    await expect(probe('./foo')).resolves.toBe(true);
+  });
+
+  it('resolves an ESM import extension swapped for the file extension', async () => {
+    await write('foo.ts');
+    await expect(probe('./foo.js')).resolves.toBe(true);
+  });
+
+  it('returns false when no candidate exists', async () => {
+    await expect(probe('./missing')).resolves.toBe(false);
+  });
+
+  it('short-circuits for bare package specifiers without a filesystem probe', async () => {
+    await expect(probe('some-external-package')).resolves.toBe(true);
+  });
+});

--- a/packages/orval/src/utils/barrel.ts
+++ b/packages/orval/src/utils/barrel.ts
@@ -1,31 +1,109 @@
+import path from 'node:path';
 import fs from 'fs-extra';
 
 const RE_EXPORT_SPECIFIER = /export\s+\*\s+from\s*['"]([^'"]+)['"]/g;
+const RE_EXPORT_LINE = /^\s*export\s+\*\s+from\s*['"]([^'"]+)['"]\s*;?\s*$/;
 
-/**
- * Extract the set of `export * from '...'` module specifiers from barrel
- * content. Quote-agnostic (matches both `'` and `"`) so it is unaffected by a
- * formatter changing quote style between generations.
- */
 export function readReExportSpecifiers(content: string): Set<string> {
   return new Set([...content.matchAll(RE_EXPORT_SPECIFIER)].map((m) => m[1]));
 }
 
-/**
- * Return the deduplicated list of specifiers for a barrel by unioning the
- * freshly generated `specifiers` with whatever re-exports already exist on
- * disk. Merging on the bare specifier (rather than the formatted line) makes
- * the barrel idempotent across regenerations regardless of how an external
- * formatter rewrites quotes, semicolons, or whitespace. On-disk order is
- * preserved and new specifiers are appended — matching the previous append
- * ordering — so callers control any sorting they want.
- */
-export async function mergeBarrelSpecifiers(
+// Bare specifiers (no leading `.`) are assumed resolvable; the workspace
+// barrel only emits relative paths, so node_modules probing is out of scope.
+export async function reExportSpecifierExists(
+  indexFile: string,
+  specifier: string,
+  fileExtension: string,
+  importExtension: string,
+): Promise<boolean> {
+  if (!specifier.startsWith('.')) return true;
+
+  const resolved = path.resolve(path.dirname(indexFile), specifier);
+  const candidates = new Set<string>([resolved]);
+  if (importExtension && specifier.endsWith(importExtension)) {
+    candidates.add(resolved.slice(0, -importExtension.length) + fileExtension);
+  }
+  candidates.add(`${resolved}${fileExtension}`);
+  candidates.add(path.join(resolved, `index${fileExtension}`));
+
+  for (const candidate of candidates) {
+    if (await fs.pathExists(candidate)) return true;
+  }
+  return false;
+}
+
+// Workspace barrel: line-preserving, prune stale exports on disk state,
+// conditional write (#3675, #3756, #3763).
+export async function reconcileWorkspaceBarrel(
   filePath: string,
   specifiers: string[],
-): Promise<string[]> {
-  const existing = (await fs.pathExists(filePath))
-    ? readReExportSpecifiers(await fs.readFile(filePath, 'utf8'))
+  fileExtension: string,
+  importExtension: string,
+): Promise<void> {
+  if (!(await fs.pathExists(filePath))) {
+    await fs.outputFile(
+      filePath,
+      specifiers.map((s) => `export * from '${s}';`).join('\n') + '\n',
+    );
+    return;
+  }
+
+  const existingContent = await fs.readFile(filePath, 'utf8');
+  const declared = [...readReExportSpecifiers(existingContent)];
+  const resolvable = await Promise.all(
+    declared.map((s) =>
+      reExportSpecifierExists(filePath, s, fileExtension, importExtension),
+    ),
+  );
+  const desired = new Set<string>(specifiers);
+  declared.forEach((s, i) => {
+    if (resolvable[i]) desired.add(s);
+  });
+
+  const seen = new Set<string>();
+  const eol = existingContent.includes('\r\n') ? '\r\n' : '\n';
+  const retained: string[] = [];
+  for (const line of existingContent.split(/\r?\n/)) {
+    const m = line.match(RE_EXPORT_LINE)?.[1];
+    if (!m) {
+      retained.push(line);
+    } else if (desired.has(m) && !seen.has(m)) {
+      retained.push(line);
+      seen.add(m);
+      desired.delete(m);
+    }
+  }
+
+  const retainedContent = retained.join(eol).trimEnd();
+  const appended = [...desired].map((s) => `export * from '${s}';`).join(eol);
+  const nextContent =
+    [retainedContent, appended].filter(Boolean).join(eol) + eol;
+
+  if (nextContent !== existingContent) {
+    await fs.outputFile(filePath, nextContent);
+  }
+}
+
+// Zod schemas barrel: header-prefixed, sorted. Skips write when content is
+// unchanged so no-op regenerations don't churn mtime (#3756).
+export async function reconcileZodBarrel(
+  filePath: string,
+  specifiers: string[],
+  header: string,
+  mergeExisting: boolean,
+): Promise<void> {
+  const existingContent = (await fs.pathExists(filePath))
+    ? await fs.readFile(filePath, 'utf8')
+    : '';
+  const existing = mergeExisting
+    ? readReExportSpecifiers(existingContent)
     : new Set<string>();
-  return [...new Set([...existing, ...specifiers])];
+  const body = [...new Set([...existing, ...specifiers])]
+    .sort()
+    .map((s) => `export * from '${s}';`)
+    .join('\n');
+  const nextContent = `${header}\n${body}\n`;
+  if (nextContent !== existingContent) {
+    await fs.outputFile(filePath, nextContent);
+  }
 }

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -44,7 +44,11 @@ import fs from 'fs-extra';
 import type { TypeDocOptions } from 'typedoc';
 
 import { formatWithPrettier } from './formatters/prettier';
-import { executeHook, readReExportSpecifiers } from './utils';
+import {
+  executeHook,
+  readReExportSpecifiers,
+  reconcileWorkspaceBarrel,
+} from './utils';
 import {
   generateZodSchemasInline,
   writeZodSchemas,
@@ -188,94 +192,6 @@ async function addOperationSchemasReExport(
         : exportLine;
     await fs.outputFile(schemaIndexPath, content);
   }
-}
-
-const RE_EXPORT_LINE = /^\s*export\s+\*\s+from\s*['"]([^'"]+)['"]\s*;?\s*$/;
-
-function getReExportLineSpecifier(line: string): string | undefined {
-  return line.match(RE_EXPORT_LINE)?.[1];
-}
-
-async function reExportSpecifierExists(
-  indexFile: string,
-  specifier: string,
-  fileExtension: string,
-  importExtension: string,
-): Promise<boolean> {
-  if (!specifier.startsWith('.')) {
-    return true;
-  }
-
-  const resolved = path.resolve(path.dirname(indexFile), specifier);
-  const candidates = new Set<string>([resolved]);
-
-  if (importExtension && specifier.endsWith(importExtension)) {
-    candidates.add(resolved.slice(0, -importExtension.length) + fileExtension);
-  }
-
-  candidates.add(`${resolved}${fileExtension}`);
-  candidates.add(path.join(resolved, `index${fileExtension}`));
-
-  for (const candidate of candidates) {
-    if (await fs.pathExists(candidate)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-async function getResolvableReExportSpecifiers(
-  indexFile: string,
-  content: string,
-  fileExtension: string,
-  importExtension: string,
-): Promise<Set<string>> {
-  const specifiers = [...readReExportSpecifiers(content)];
-  const exists = await Promise.all(
-    specifiers.map((specifier) =>
-      reExportSpecifierExists(
-        indexFile,
-        specifier,
-        fileExtension,
-        importExtension,
-      ),
-    ),
-  );
-
-  return new Set(specifiers.filter((_, index) => exists[index]));
-}
-
-function updateBarrelReExports(
-  content: string,
-  specifiers: Iterable<string>,
-): string {
-  const remaining = new Set(specifiers);
-  const seen = new Set<string>();
-  const eol = content.includes('\r\n') ? '\r\n' : '\n';
-  const retainedLines: string[] = [];
-
-  for (const line of content.split(/\r?\n/)) {
-    const specifier = getReExportLineSpecifier(line);
-
-    if (!specifier) {
-      retainedLines.push(line);
-      continue;
-    }
-
-    if (remaining.has(specifier) && !seen.has(specifier)) {
-      retainedLines.push(line);
-      seen.add(specifier);
-      remaining.delete(specifier);
-    }
-  }
-
-  const retainedContent = retainedLines.join(eol).trimEnd();
-  const appendedContent = [...remaining]
-    .map((specifier) => `export * from '${specifier}';`)
-    .join(eol);
-
-  return [retainedContent, appendedContent].filter(Boolean).join(eol) + eol;
 }
 
 /**
@@ -925,36 +841,18 @@ export async function writeSpecs(
 
     if (output.indexFiles) {
       // The workspace barrel can share its path with the implementation
-      // target (#3675: `target` === `<workspace>/index.ts`), so append rather
-      // than overwrite non-export content. Dedup on the bare specifier (not
-      // the formatted line) so a formatter changing quote style between runs
-      // can't reintroduce duplicates (#3756). Stale relative exports whose
-      // targets no longer exist are pruned so removed operations/projects do
-      // not leave dangling imports behind.
-      if (await fs.pathExists(indexFile)) {
-        const existingContent = await fs.readFile(indexFile, 'utf8');
-        const declared = await getResolvableReExportSpecifiers(
-          indexFile,
-          existingContent,
-          output.fileExtension,
-          importExtension,
-        );
-        const nextSpecifiers = [...new Set([...declared, ...imports])];
-        const nextContent = updateBarrelReExports(
-          existingContent,
-          nextSpecifiers,
-        );
-        if (nextContent !== existingContent) {
-          await fs.outputFile(indexFile, nextContent);
-        }
-      } else {
-        await fs.outputFile(
-          indexFile,
-          `${[...new Set(imports)]
-            .map((imp) => `export * from '${imp}';`)
-            .join('\n')}\n`,
-        );
-      }
+      // target (#3675: `target` === `<workspace>/index.ts`), so non-export
+      // lines are preserved rather than overwritten. Dedup on the bare
+      // specifier (not the formatted line) so a formatter changing quote
+      // style between runs can't reintroduce duplicates (#3756). Stale
+      // relative exports whose targets no longer exist are pruned so removed
+      // operations/projects do not leave dangling imports behind (#3763).
+      await reconcileWorkspaceBarrel(
+        indexFile,
+        [...new Set(imports)],
+        output.fileExtension,
+        importExtension,
+      );
 
       // Use the full (unfiltered) implementation paths here, not
       // `implementationPathsForIndex` — for tags-operations modes that list

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -44,7 +44,7 @@ import {
   rewriteReusableSchemas,
   rewriteSentinelsToDirect,
 } from './reusable-schemas';
-import { mergeBarrelSpecifiers } from './utils/barrel';
+import { reconcileZodBarrel } from './utils/barrel';
 
 interface ZodSchemaFileEntry {
   schemaName: string;
@@ -513,17 +513,12 @@ async function writeZodSchemaIndex(
   // Dedup on the bare specifier (not the formatted line) so a formatter run
   // between generations can't reintroduce duplicates via quote-style changes
   // (#3756).
-  const specifiers = (
-    shouldMergeExisting
-      ? await mergeBarrelSpecifiers(indexPath, newSpecifiers)
-      : newSpecifiers
-  ).toSorted();
-
-  const exports = specifiers
-    .map((specifier) => `export * from '${specifier}';`)
-    .join('\n');
-
-  await fs.outputFile(indexPath, `${header}\n${exports}\n`);
+  await reconcileZodBarrel(
+    indexPath,
+    newSpecifiers,
+    header,
+    shouldMergeExisting,
+  );
 }
 
 export async function writeZodSchemaTagsSplitBarrel(


### PR DESCRIPTION
Follow-up to #3770 (the workspace barrel prune fix). Three concerns were scattered across `write-specs.ts`, `write-zod-specs.ts`, and `utils/barrel.ts`: the `export * from` line regex, the resolve-and-prune logic, and the fresh-vs-reconcile write paths. This PR consolidates all of it in `utils/barrel.ts` behind two purpose-specific entry points.

## What changes

- **`reconcileWorkspaceBarrel`** (replaces the workspace if/else block in `write-specs.ts`): line-preserving, prunes stale relative exports whose targets no longer resolve on disk, conditional write. Preserves #3675 (shared path with implementation target), #3756 (dedup on bare specifier), #3763 (prune stale exports).
- **`reconcileZodBarrel`** (replaces `mergeBarrelSpecifiers` + manual sort/write in `write-zod-specs.ts`): header-prefixed, sorted, unconditional merge semantics preserved.
- **`reExportSpecifierExists`** is now exported and unit-tested directly (`barrel.test.ts`, 5 cases covering direct file, dir `index.ts`, `.js`→`.ts` ESM-extension swap, missing target, package-specifier short-circuit).
- One `export * from` regex (was duplicated: unanchored/global in `barrel.ts`, anchored in `write-specs.ts`).

## Behavior change

`reconcileZodBarrel` now skips `fs.outputFile` when the produced barrel is byte-identical to what is already on disk. Before, every zod regen wrote the file unconditionally. This brings zod consistent with `reconcileWorkspaceBarrel`, which has had this guard since #3770.

Observable effects:
- File `mtime`/`ctime` no longer updates on a no-op zod regen. File watchers (`tsc --watch`, `vite`, `next dev`) and mtime-keyed build tools (`nx`, `turbo`) no longer fire spurious rebuilds.
- `git status` output is identical in all cases — git keys on content hash, not mtime.
- The heartbeat signal "the regenerator touched this file" goes away. The workspace barrel already lost this signal in #3770; this just makes zod consistent.

## Verification

All CI checks from `.github/workflows/pr-checks.yaml` pass locally:

| Check | Result |
|---|---|
| `vp fmt --check` | clean |
| `vp run -w typecheck` | clean |
| `vp run -w test` (orval) | 217/217 |
| `vp run -w lint` | clean |
| `vp run -w lint:samples` | clean |
| `vp run -w build:release` | clean |
| `vp run -w test:snapshots` | 5525/5525 (incl. 5524 in orval-tests snapshot suite) |
| `vp run -F orval-tests build` | 16/16 client builds pass |

Byte-identity for the zod path confirmed by all 23 tests in `write-zod-specs.test.ts` passing unchanged.

Refs: #3763.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved generated index files to keep valid existing exports, remove outdated references, and add newly available exports.
  - Added support for resolving file extensions and directory index files when validating exports.
  - Generated schema indexes now provide consistent, sorted, deduplicated exports.
  - Preserved existing line endings and avoided unnecessary file rewrites when content is unchanged.

- **Tests**
  - Added coverage for export resolution across files, directories, extensions, missing targets, and package specifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->