### PR TITLE
refactor(orval): unify readReExportSpecifiers on RE_EXPORT_LINE

### DIFF
--- a/packages/orval/src/utils/barrel.ts
+++ b/packages/orval/src/utils/barrel.ts
@@ -1,11 +1,15 @@
 import path from 'node:path';
 import fs from 'fs-extra';
 
-const RE_EXPORT_SPECIFIER = /export\s+\*\s+from\s*['"]([^'"]+)['"]/g;
 const RE_EXPORT_LINE = /^\s*export\s+\*\s+from\s*['"]([^'"]+)['"]\s*;?\s*$/;
 
 export function readReExportSpecifiers(content: string): Set<string> {
-  return new Set([...content.matchAll(RE_EXPORT_SPECIFIER)].map((m) => m[1]));
+  const specifiers = new Set<string>();
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(RE_EXPORT_LINE)?.[1];
+    if (m) specifiers.add(m);
+  }
+  return specifiers;
 }
 
 // Bare specifiers (no leading `.`) are assumed resolvable; the workspace


### PR DESCRIPTION
Follow-up to #3777. While consolidating the barrel helpers, `utils/barrel.ts` ended up with two `export * from` regexes:

- `RE_EXPORT_SPECIFIER` — global, unanchored; used by `readReExportSpecifiers` to scan a whole barrel.
- `RE_EXPORT_LINE` — anchored to a single line; used by `reconcileWorkspaceBarrel` to classify lines during the retention walk.

This PR drops `RE_EXPORT_SPECIFIER` and rewrites `readReExportSpecifiers` to walk lines via `RE_EXPORT_LINE`. One regex owns the syntactic shape, and the scan path now matches how the retention path classifies lines.

Net effect: comments or strings containing `export * from` mid-line no longer get picked up by the scan. No generated barrel has ever produced those, so all 5525 sample-suite snapshots and the 217-test orval project suite pass unchanged.

Verified: format, typecheck, test (217/217), test:snapshots (5525/5525).

Refs: #3763.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of re-export statements across different formatting styles.
  * Added support for surrounding whitespace and optional trailing semicolons when identifying re-exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->