### PR TITLE
fix(zod): keep required on constraint-only oneOf/anyOf branches

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -784,19 +784,36 @@ export const generateZodValidationSchemaDefinition = (
     // `additionalRequired` above. (#3780)
     const withSiblingProperties = (
       member: OpenApiSchemaObject | OpenApiReferenceObject,
-    ) =>
-      (schema.oneOf || schema.anyOf) &&
-      isObject(schema.properties) &&
-      Object.keys(schema.properties).length > 0 &&
-      isConstraintOnlyMember(member)
-        ? ({
-            type: 'object',
-            properties: schema.properties,
-            required: (member as OpenApiSchemaObject).required,
-            // carried over so the branch keeps its `.describe(...)`
-            description: (member as OpenApiSchemaObject).description,
-          } as OpenApiSchemaObject)
-        : (member as OpenApiSchemaObject);
+    ) => {
+      const properties = schema.properties;
+      if (
+        !(schema.oneOf || schema.anyOf) ||
+        !isObject(properties) ||
+        Object.keys(properties).length === 0 ||
+        !isConstraintOnlyMember(member)
+      ) {
+        return member as OpenApiSchemaObject;
+      }
+
+      const required = (member as OpenApiSchemaObject).required as string[];
+
+      // Every key the branch requires needs a sibling schema to attach to. A key
+      // with none cannot be made required in zod — both `unknown` and `any` are
+      // treated as optional inside an object, so `{}` would still match — and
+      // rewriting would silently drop it. Leave the whole branch as-is rather
+      // than emit an object that only looks like it enforces the constraint.
+      if (!required.every((key) => Object.hasOwn(properties, key))) {
+        return member as OpenApiSchemaObject;
+      }
+
+      return {
+        type: 'object',
+        properties,
+        required,
+        // carried over so the branch keeps its `.describe(...)`
+        description: (member as OpenApiSchemaObject).description,
+      } as OpenApiSchemaObject;
+    };
 
     // Use index-based naming to ensure uniqueness when processing multiple schemas
     // This prevents duplicate schema names when nullable refs are used

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -294,6 +294,36 @@ const isPlainObjectSchema = (
   );
 };
 
+// Keywords a member may carry while still describing no shape of its own:
+// `title` and `description` only annotate, and `not` is not translated into
+// anything by this generator today, so a branch carrying one renders as bare
+// `zod.unknown()` either way. Anything outside this set — `enum`, `const`,
+// `additionalProperties`, `nullable`, `default`, … — already renders to
+// something meaningful on its own and must be left alone.
+const SHAPELESS_MEMBER_KEYS = new Set([
+  'required',
+  'title',
+  'description',
+  'not',
+]);
+
+// A `oneOf`/`anyOf` member that declares no shape of its own and only narrows
+// which of the sibling properties must be present — e.g. two branches that each
+// `required` a different pair of keys. JSON Schema applies every branch to the
+// same instance, so the property types live on the composing schema rather than
+// on the branch. Rendered in isolation such a member has no type to resolve and
+// falls through to `zod.unknown()`, silently dropping its `required`. (#3780)
+const isConstraintOnlyMember = (
+  member: OpenApiSchemaObject | OpenApiReferenceObject,
+): boolean => {
+  if ('$ref' in member) return false;
+  const schema = member as OpenApiSchemaObject;
+  if (!Array.isArray(schema.required) || schema.required.length === 0) {
+    return false;
+  }
+  return Object.keys(schema).every((key) => SHAPELESS_MEMBER_KEYS.has(key));
+};
+
 // The branch must declare the discriminator key as a literal value — a `const`
 // or an `enum`. Both zod v3 (>=3.20) and v4 build their branch lookup by
 // reading discrete literal values off each option, and throw at construction if
@@ -748,11 +778,31 @@ export const generateZodValidationSchemaDefinition = (
         ]
       : undefined;
 
+    // Constraint-only branches have to be rendered against the composing
+    // schema's `properties`, otherwise their `required` is lost. Only for
+    // `oneOf`/`anyOf` — an `allOf` member already gets the same effect through
+    // `additionalRequired` above. (#3780)
+    const withSiblingProperties = (
+      member: OpenApiSchemaObject | OpenApiReferenceObject,
+    ) =>
+      (schema.oneOf || schema.anyOf) &&
+      isObject(schema.properties) &&
+      Object.keys(schema.properties).length > 0 &&
+      isConstraintOnlyMember(member)
+        ? ({
+            type: 'object',
+            properties: schema.properties,
+            required: (member as OpenApiSchemaObject).required,
+            // carried over so the branch keeps its `.describe(...)`
+            description: (member as OpenApiSchemaObject).description,
+          } as OpenApiSchemaObject)
+        : (member as OpenApiSchemaObject);
+
     // Use index-based naming to ensure uniqueness when processing multiple schemas
     // This prevents duplicate schema names when nullable refs are used
     const baseSchemas = schemas.map((schema, index) =>
       generateZodValidationSchemaDefinition(
-        schema as OpenApiSchemaObject,
+        withSiblingProperties(schema),
         context,
         `${camel(name)}${pascal(getNumberWord(index + 1))}`,
         strict,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -12188,13 +12188,13 @@ describe('constraint-only oneOf/anyOf branches (#3780)', () => {
     const zod = render(constraintOnlyOneOf);
 
     expect(zod).not.toContain('zod.unknown()');
-    // AB branch: A and B required, X and Y left optional
+    // pin both branches whole, so a key that goes missing or flips its
+    // requiredness cannot slip through
     expect(zod).toContain(
-      '"A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.string().optional(),',
+      'zod.object({\n  "A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.string().optional(),\n  "Y": zod.number().int().optional()\n})',
     );
-    // XY branch: the other way round
     expect(zod).toContain(
-      '"A": zod.string().optional(),\n  "B": zod.number().int().optional(),\n  "X": zod.string(),',
+      'zod.object({\n  "A": zod.string().optional(),\n  "B": zod.number().int().optional(),\n  "X": zod.string(),\n  "Y": zod.number().int()\n})',
     );
   });
 
@@ -12206,7 +12206,12 @@ describe('constraint-only oneOf/anyOf branches (#3780)', () => {
     } as OpenApiSchemaObject);
 
     expect(zod).not.toContain('zod.unknown()');
-    expect(zod).toContain('"A": zod.string(),\n  "B": zod.number().int(),');
+    expect(zod).toContain(
+      'zod.object({\n  "A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.string().optional(),\n  "Y": zod.number().int().optional()\n})',
+    );
+    expect(zod).toContain(
+      'zod.object({\n  "A": zod.string().optional(),\n  "B": zod.number().int().optional(),\n  "X": zod.string(),\n  "Y": zod.number().int()\n})',
+    );
   });
 
   it('leaves branches that declare their own shape untouched', () => {
@@ -12268,6 +12273,13 @@ describe('constraint-only oneOf/anyOf branches (#3780)', () => {
     } as OpenApiSchemaObject);
 
     expect(zod).not.toContain('zod.unknown()');
+    // the `not` branch is still the AB shape, not an all-optional object
+    expect(zod).toContain(
+      'zod.object({\n  "A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.string().optional(),\n  "Y": zod.number().int().optional()\n})',
+    );
+    expect(zod).toContain(
+      'zod.object({\n  "A": zod.string().optional(),\n  "B": zod.number().int().optional(),\n  "X": zod.string(),\n  "Y": zod.number().int()\n})',
+    );
   });
 
   it('keeps the description of a rewritten branch', () => {
@@ -12279,6 +12291,20 @@ describe('constraint-only oneOf/anyOf branches (#3780)', () => {
 
     expect(zod).not.toContain('zod.unknown()');
     expect(zod).toContain(".describe('the A case')");
+  });
+
+  it('leaves a branch alone when a required key has no sibling property', () => {
+    const zod = render({
+      type: 'object',
+      oneOf: [{ required: ['kind'] }, { required: ['A'] }],
+      properties: { A: { type: 'string' } },
+    } as OpenApiSchemaObject);
+
+    // `kind` has no schema to attach to and zod cannot require an untyped key,
+    // so that branch keeps the existing behaviour instead of pretending to
+    // enforce it; the representable branch is still rewritten
+    expect(zod).toContain('zod.union([zod.unknown(),zod.object({');
+    expect(zod).toContain('"A": zod.string()');
   });
 
   it('leaves the branches alone when there are no sibling properties to apply', () => {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -12146,3 +12146,164 @@ describe('exactOptional (opt-in)', () => {
     );
   });
 });
+
+describe('constraint-only oneOf/anyOf branches (#3780)', () => {
+  const context = {
+    output: { override: { useDates: false } },
+  } as unknown as ContextSpec;
+
+  const render = (schema: OpenApiSchemaObject) =>
+    parseZodValidationSchemaDefinition(
+      generateZodValidationSchemaDefinition(
+        schema,
+        context,
+        'createExample',
+        false,
+        false,
+        { required: true },
+      ),
+      context,
+      false,
+      false,
+      false,
+    ).zod;
+
+  // Property types live on the composing schema; each branch only says which of
+  // them must be present.
+  const constraintOnlyOneOf: OpenApiSchemaObject = {
+    type: 'object',
+    oneOf: [
+      { title: 'AB', required: ['A', 'B'] },
+      { title: 'XY', required: ['X', 'Y'] },
+    ],
+    properties: {
+      A: { type: 'string' },
+      B: { type: 'integer' },
+      X: { type: 'string' },
+      Y: { type: 'integer' },
+    },
+  };
+
+  it('applies each branch required to the sibling properties', () => {
+    const zod = render(constraintOnlyOneOf);
+
+    expect(zod).not.toContain('zod.unknown()');
+    // AB branch: A and B required, X and Y left optional
+    expect(zod).toContain(
+      '"A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.string().optional(),',
+    );
+    // XY branch: the other way round
+    expect(zod).toContain(
+      '"A": zod.string().optional(),\n  "B": zod.number().int().optional(),\n  "X": zod.string(),',
+    );
+  });
+
+  it('treats anyOf the same way', () => {
+    const zod = render({
+      ...constraintOnlyOneOf,
+      oneOf: undefined,
+      anyOf: constraintOnlyOneOf.oneOf,
+    } as OpenApiSchemaObject);
+
+    expect(zod).not.toContain('zod.unknown()');
+    expect(zod).toContain('"A": zod.string(),\n  "B": zod.number().int(),');
+  });
+
+  it('leaves branches that declare their own shape untouched', () => {
+    const zod = render({
+      type: 'object',
+      oneOf: [
+        { type: 'object', properties: { A: { type: 'string' } } },
+        { type: 'string' },
+      ],
+      properties: { B: { type: 'integer' } },
+    });
+
+    // the object branch keeps only its own property — the sibling `B` is not
+    // pulled in — and the scalar branch stays a scalar
+    expect(zod).toContain(
+      'zod.union([zod.object({\n  "A": zod.string().optional()\n}),zod.string()])',
+    );
+  });
+
+  it.each([
+    [
+      'additionalProperties',
+      { additionalProperties: { type: 'string' } },
+      'zod.record(',
+    ],
+    ['enum', { enum: ['x', 'y'] }, "zod.enum(['x', 'y'])"],
+    ['const', { const: 'x' }, 'zod.literal("x")'],
+    ['nullable', { nullable: true }, 'zod.unknown().nullable()'],
+  ])('leaves a member carrying %s alone', (_label, extra, expected) => {
+    const zod = render({
+      type: 'object',
+      oneOf: [{ required: ['A'], ...extra }, { required: ['B'] }],
+      properties: { A: { type: 'string' }, B: { type: 'integer' } },
+    } as OpenApiSchemaObject);
+
+    // the member renders on its own terms, not as the sibling properties
+    expect(zod).toContain(expected);
+  });
+
+  // The schema in #3780 pairs `required` with a `not`, which this generator does
+  // not translate at all, so it must not stop the branch from being rewritten.
+  it('rewrites a branch that also carries not', () => {
+    const zod = render({
+      type: 'object',
+      oneOf: [
+        {
+          title: 'AB',
+          required: ['A', 'B'],
+          not: { anyOf: [{ required: ['X'] }, { required: ['Y'] }] },
+        },
+        { title: 'XY', required: ['X', 'Y'] },
+      ],
+      properties: {
+        A: { type: 'string' },
+        B: { type: 'integer' },
+        X: { type: 'string' },
+        Y: { type: 'integer' },
+      },
+    } as OpenApiSchemaObject);
+
+    expect(zod).not.toContain('zod.unknown()');
+  });
+
+  it('keeps the description of a rewritten branch', () => {
+    const zod = render({
+      type: 'object',
+      oneOf: [{ required: ['A'], description: 'the A case' }],
+      properties: { A: { type: 'string' }, B: { type: 'integer' } },
+    });
+
+    expect(zod).not.toContain('zod.unknown()');
+    expect(zod).toContain(".describe('the A case')");
+  });
+
+  it('leaves the branches alone when there are no sibling properties to apply', () => {
+    const zod = render({
+      type: 'object',
+      oneOf: [{ required: ['A'] }, { required: ['B'] }],
+      properties: {},
+    } as OpenApiSchemaObject);
+
+    // nothing to mark required, so rewriting would only narrow the branch from
+    // "anything" to "any object" without expressing the constraint
+    expect(zod).toContain('zod.union([zod.unknown(),zod.unknown()])');
+  });
+
+  it('does not change allOf, which already collects required across members', () => {
+    const zod = render({
+      type: 'object',
+      allOf: [{ required: ['A'] }],
+      properties: { A: { type: 'string' }, B: { type: 'integer' } },
+    });
+
+    // the member itself is untouched and `A` is still marked required through
+    // the existing `additionalRequired` path, while `B` stays optional
+    expect(zod).toContain('zod.unknown().and(');
+    expect(zod).toContain('"A": zod.string(),');
+    expect(zod).toContain('"B": zod.number().int().optional()');
+  });
+});


### PR DESCRIPTION
Addresses the `zod.unknown()` half of #3780.

A `oneOf`/`anyOf` branch is allowed to declare no shape of its own and only list
`required`, leaving the property types on the composing schema — the two branches
in #3780 are exactly that. Each branch is rendered on its own, where there is no
`type` to resolve, so it falls through to `zod.unknown()` and its `required` is
dropped. The result is `zod.union([zod.unknown(), zod.unknown()]).and(...)`, which
accepts everything the union was supposed to constrain.

Since JSON Schema applies every branch to the same instance, those branches are
now rendered against the composing schema's `properties`. The `allOf` path already
gets the same effect via `additionalRequired` (#3171); this is the `oneOf`/`anyOf`
counterpart. Branches that describe a shape of their own are untouched.

A member only counts as shape-less when `required` is all it says, aside from
`title`/`description` (annotations, carried over so `.describe()` survives) and
`not`, which this generator does not translate into anything today. Members
carrying `enum`, `const`, `additionalProperties`, `nullable` or `default` already
render to something meaningful and are left untouched — I compared every such
keyword against `master` to make sure nothing else changes.

Against the repro spec, `empty` and `incompleteXY` now fail as they should, and
the two valid payloads still pass. `invalidMixed` still passes, because that one
needs the `not` in the AB branch — orval has no `not` support anywhere today, so
that felt like a separate change rather than something to fold in here.

`tests/specifications/one-of-required.yaml` already has this schema shape, but it
is only wired into `default.config.ts`, so no generated output changes. I checked
the other 349 specs in the repo for the pattern; none are affected. Verified end to end by
running the CLI over the spec from the issue and parsing the five payloads with
zod: 4 of 5 now match, against 2 of 5 before. Regression tests added, full suite
and typecheck pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zod schema generation for OpenAPI `oneOf`/`anyOf` branches that specify only `required` constraints, applying them to sibling properties instead of producing fallback `unknown` branches.
  * Preserves branch `description` and supports branches that include `not`, while treating `$ref` branches as non-constraint-only.
  * Maintains existing behavior when required keys can’t be matched to sibling schemas and keeps `allOf` behavior unchanged.
* **Tests**
  * Added regression coverage for constraint-only `oneOf`/`anyOf` cases, including required/description handling, sibling-absence behavior, and constraint-carrying members within branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->