### PR TITLE
Fix/zod namespace import

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -43,12 +43,12 @@ import {
 } from './handler-merge';
 import { getRoute } from './route';
 
+// Always a namespace import: `import { z as zod }` pulls in zod's assembled `z` object,
+// which transitively references every locale table and cannot be tree-shaken. Matches
+// what `@orval/zod` and `@orval/effect` already emit via `namespaceImport`.
 const getZodSchemaImportStatement = (
   variant: NormalizedOutputOptions['override']['zod']['variant'],
-) =>
-  variant === 'mini'
-    ? `import * as zod from '${getZodImportSource(variant)}';`
-    : `import { z as zod } from '${getZodImportSource(variant)}';`;
+) => `import * as zod from '${getZodImportSource(variant)}';`;
 
 // Warn at most once per run when the optional `typescript` peer is missing and a
 // non-`skip` strategy was requested, so the degraded behavior is never silent.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,12 +28,12 @@ import {
 import { generateClient, generateFetchHeader } from '@orval/fetch';
 import { generateZod, getZodImportSource } from '@orval/zod';
 
+// Always a namespace import: `import { z as zod }` pulls in zod's assembled `z` object,
+// which transitively references every locale table and cannot be tree-shaken. Matches
+// what `@orval/zod` and `@orval/effect` already emit via `namespaceImport`.
 const getZodSchemaImportStatement = (
   variant: NormalizedOutputOptions['override']['zod']['variant'],
-) =>
-  variant === 'mini'
-    ? `import * as zod from '${getZodImportSource(variant)}';`
-    : `import { z as zod } from '${getZodImportSource(variant)}';`;
+) => `import * as zod from '${getZodImportSource(variant)}';`;
 
 const getHeader = (
   option: false | ((info: OpenApiInfoObject) => string | string[]),

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -58,10 +58,11 @@ type ZodSchemaFileToWrite = ZodSchemaFileEntry & {
   filePath: string;
 };
 
+// Always a namespace import: `import { z as zod }` pulls in zod's assembled `z` object,
+// which transitively references every locale table and cannot be tree-shaken. Matches
+// what `@orval/zod` and `@orval/effect` already emit via `namespaceImport`.
 const getZodSchemaImportStatement = (variant: ZodVariantOption) =>
-  variant === 'mini'
-    ? `import * as zod from '${getZodImportSource(variant)}';`
-    : `import { z as zod } from '${getZodImportSource(variant)}';`;
+  `import * as zod from '${getZodImportSource(variant)}';`;
 
 interface WriteZodOutputOptions {
   namingConvention: NamingConvention;
@@ -218,9 +219,8 @@ function generateZodSchemaFileContent(
   header: string,
   schemas: ZodSchemaFileEntry[],
   zodVariant: ZodVariantOption,
-  // Omit the `import { z as zod }` line when the content is concatenated into a
-  // file that already imports zod (e.g. inline single-mode output, where the
-  // zod client already emits `import * as zod from 'zod'`).
+  // Omit the zod import when the content is concatenated into a file that already
+  // imports zod (e.g. inline single-mode output, where the zod client emits its own).
   includeZodImport = true,
 ): string {
   // Group the zod import with any reusable-schema imports (deduped across the

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/createPetsBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const createPetsBodyNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/error.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const errorCodeMin = 100;
 export const errorCodeMax = 600;

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/listPetsParams.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/patchPetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const patchPetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/pet.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const petNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/pets.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetsMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/searchPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const searchPetsParamsLimitMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/model/updatePetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const updatePetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/createPetsBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const createPetsBodyNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/error.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const errorCodeMin = 100;
 export const errorCodeMax = 600;

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/listPetsParams.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/patchPetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const patchPetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/pet.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const petNameMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/pets.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetsMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/searchPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const searchPetsParamsLimitMax = 100;
 

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/model/updatePetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const updatePetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/src/api/endpoints-zod/model/createPetsBody.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const createPetsBodyNameMax = 100;
 

--- a/samples/angular-app/src/api/endpoints-zod/model/error.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const errorCodeMin = 100;
 export const errorCodeMax = 600;

--- a/samples/angular-app/src/api/endpoints-zod/model/listPetsParams.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-app/src/api/endpoints-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/patchPetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const patchPetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/src/api/endpoints-zod/model/pet.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const petNameMax = 100;
 

--- a/samples/angular-app/src/api/endpoints-zod/model/pets.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetsMax = 100;
 

--- a/samples/angular-app/src/api/endpoints-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/searchPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const searchPetsParamsLimitMax = 100;
 

--- a/samples/angular-app/src/api/endpoints-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/endpoints-zod/model/updatePetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const updatePetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/src/api/http-resource-zod/model/createPetsBody.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const createPetsBodyNameMax = 100;
 

--- a/samples/angular-app/src/api/http-resource-zod/model/error.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const errorCodeMin = 100;
 export const errorCodeMax = 600;

--- a/samples/angular-app/src/api/http-resource-zod/model/listPetsParams.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-app/src/api/http-resource-zod/model/patchPetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/patchPetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const patchPetByIdBodyNameMax = 100;
 

--- a/samples/angular-app/src/api/http-resource-zod/model/pet.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const petNameMax = 100;
 

--- a/samples/angular-app/src/api/http-resource-zod/model/pets.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetsMax = 100;
 

--- a/samples/angular-app/src/api/http-resource-zod/model/searchPetsParams.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/searchPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const searchPetsParamsLimitMax = 100;
 

--- a/samples/angular-app/src/api/http-resource-zod/model/updatePetByIdBody.zod.ts
+++ b/samples/angular-app/src/api/http-resource-zod/model/updatePetByIdBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const updatePetByIdBodyNameMax = 100;
 

--- a/samples/angular-query/__snapshots__/api/model-zod/cat.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/samples/angular-query/__snapshots__/api/model-zod/createPetsBody.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/samples/angular-query/__snapshots__/api/model-zod/createPetsHeaders.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/samples/angular-query/__snapshots__/api/model-zod/createPetsParams.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-query/__snapshots__/api/model-zod/dachshund.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/samples/angular-query/__snapshots__/api/model-zod/dog.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/samples/angular-query/__snapshots__/api/model-zod/error.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/samples/angular-query/__snapshots__/api/model-zod/labradoodle.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/samples/angular-query/__snapshots__/api/model-zod/listPetsHeaders.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/samples/angular-query/__snapshots__/api/model-zod/listPetsParams.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-query/__snapshots__/api/model-zod/pet.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/samples/angular-query/__snapshots__/api/model-zod/petWithTag.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/samples/angular-query/__snapshots__/api/model-zod/pets.zod.ts
+++ b/samples/angular-query/__snapshots__/api/model-zod/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/samples/angular-query/src/api/model-zod/cat.zod.ts
+++ b/samples/angular-query/src/api/model-zod/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/samples/angular-query/src/api/model-zod/createPetsBody.zod.ts
+++ b/samples/angular-query/src/api/model-zod/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/samples/angular-query/src/api/model-zod/createPetsHeaders.zod.ts
+++ b/samples/angular-query/src/api/model-zod/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/samples/angular-query/src/api/model-zod/createPetsParams.zod.ts
+++ b/samples/angular-query/src/api/model-zod/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-query/src/api/model-zod/dachshund.zod.ts
+++ b/samples/angular-query/src/api/model-zod/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/samples/angular-query/src/api/model-zod/dog.zod.ts
+++ b/samples/angular-query/src/api/model-zod/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/samples/angular-query/src/api/model-zod/error.zod.ts
+++ b/samples/angular-query/src/api/model-zod/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/samples/angular-query/src/api/model-zod/labradoodle.zod.ts
+++ b/samples/angular-query/src/api/model-zod/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/samples/angular-query/src/api/model-zod/listPetsHeaders.zod.ts
+++ b/samples/angular-query/src/api/model-zod/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/samples/angular-query/src/api/model-zod/listPetsParams.zod.ts
+++ b/samples/angular-query/src/api/model-zod/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/angular-query/src/api/model-zod/pet.zod.ts
+++ b/samples/angular-query/src/api/model-zod/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/samples/angular-query/src/api/model-zod/petWithTag.zod.ts
+++ b/samples/angular-query/src/api/model-zod/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/samples/angular-query/src/api/model-zod/pets.zod.ts
+++ b/samples/angular-query/src/api/model-zod/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/pets/pets.zod.ts
+++ b/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/pets/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/samples/hono/composite-routes-with-tags-split/src/endpoints/pets/pets.zod.ts
+++ b/samples/hono/composite-routes-with-tags-split/src/endpoints/pets/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.zod.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.zod.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/samples/hono/hono-with-zod/__snapshots__/petstore.zod.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/petstore.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { stripNill } from './mutators';
 
 export const ListPetsQueryParams = zod.object({

--- a/samples/hono/hono-with-zod/src/petstore.zod.ts
+++ b/samples/hono/hono-with-zod/src/petstore.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { stripNill } from './mutators';
 
 export const ListPetsQueryParams = zod.object({

--- a/samples/mcp/custom-server/src/tool-schemas.zod.ts
+++ b/samples/mcp/custom-server/src/tool-schemas.zod.ts
@@ -12,7 +12,7 @@
  * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const FindPetsByStatusQueryParams = zod.object({
   status: zod

--- a/samples/mcp/petstore/src/tool-schemas.zod.ts
+++ b/samples/mcp/petstore/src/tool-schemas.zod.ts
@@ -12,7 +12,7 @@
  * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const FilterPetsByStatusQueryParams = zod.object({
   status: zod

--- a/samples/swr-with-zod/__snapshots__/models/cat-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/cat-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.number().int().optional(),

--- a/samples/swr-with-zod/__snapshots__/models/createPetsBody-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/createPetsBody-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.array(
   zod.object({

--- a/samples/swr-with-zod/__snapshots__/models/dachshund-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/dachshund-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.number().int(),

--- a/samples/swr-with-zod/__snapshots__/models/dog-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/dog-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Dachshund } from './dachshund-reusable.zod';
 import { Labradoodle } from './labradoodle-reusable.zod';
 

--- a/samples/swr-with-zod/__snapshots__/models/error-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/error-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.number().int(),

--- a/samples/swr-with-zod/__snapshots__/models/labradoodle-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/labradoodle-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.number().int(),

--- a/samples/swr-with-zod/__snapshots__/models/listPetsParams-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/listPetsParams-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/swr-with-zod/__snapshots__/models/pet-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/pet-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Cat } from './cat-reusable.zod';
 import { Dog } from './dog-reusable.zod';
 

--- a/samples/swr-with-zod/__snapshots__/models/pets-reusable.zod.ts
+++ b/samples/swr-with-zod/__snapshots__/models/pets-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Pet } from './pet-reusable.zod';
 
 export const Pets = zod.array(Pet);

--- a/samples/swr-with-zod/src/gen/models/cat-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/cat-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.number().int().optional(),

--- a/samples/swr-with-zod/src/gen/models/createPetsBody-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/createPetsBody-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.array(
   zod.object({

--- a/samples/swr-with-zod/src/gen/models/dachshund-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/dachshund-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.number().int(),

--- a/samples/swr-with-zod/src/gen/models/dog-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/dog-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Dachshund } from './dachshund-reusable.zod';
 import { Labradoodle } from './labradoodle-reusable.zod';
 

--- a/samples/swr-with-zod/src/gen/models/error-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/error-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.number().int(),

--- a/samples/swr-with-zod/src/gen/models/labradoodle-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/labradoodle-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.number().int(),

--- a/samples/swr-with-zod/src/gen/models/listPetsParams-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/listPetsParams-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/samples/swr-with-zod/src/gen/models/pet-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/pet-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Cat } from './cat-reusable.zod';
 import { Dog } from './dog-reusable.zod';
 

--- a/samples/swr-with-zod/src/gen/models/pets-reusable.zod.ts
+++ b/samples/swr-with-zod/src/gen/models/pets-reusable.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Pet } from './pet-reusable.zod';
 
 export const Pets = zod.array(Pet);

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/cat.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   "petsRequested": zod.int().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   "name": zod.string(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   "X-EXAMPLE": zod.enum(['ONE', 'TWO', 'THREE'])

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   "limit": zod.string().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/dachshund.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   "length": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/dog.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod.union([zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/error.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   "code": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   "X-EXAMPLE": zod.enum(['ONE', 'TWO', 'THREE'])

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   "limit": zod.string().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/pet.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod.union([zod.union([zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   "tag": zod.string(),

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/model/pets.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(zod.union([zod.union([zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/cat.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   "petsRequested": zod.int().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   "name": zod.string(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   "X-EXAMPLE": zod.enum(['ONE', 'TWO', 'THREE'])

--- a/tests/__snapshots__/angular/http-resource-zod/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   "limit": zod.string().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/dachshund.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   "length": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/dog.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod.union([zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/error.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   "code": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   "X-EXAMPLE": zod.enum(['ONE', 'TWO', 'THREE'])

--- a/tests/__snapshots__/angular/http-resource-zod/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   "limit": zod.string().optional(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/pet.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod.union([zod.union([zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   "tag": zod.string(),

--- a/tests/__snapshots__/angular/http-resource-zod/model/pets.zod.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(zod.union([zod.union([zod.object({
   "cuteness": zod.int(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/angular/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/angular/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/angular/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/angular/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/angular/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/error.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pagination.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pagination.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pagination = zod.object({
   total: zod.int(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/createPetBody.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/createPetBody.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/listPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { SortOrder } from '../sortOrder.zod';
 
 export const ListPetsParams = zod.object({

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/pet.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/pet.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/petList.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/pets/petList.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Pagination } from '../pagination.zod';
 import { Pet } from './pet.zod';
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/sortOrder.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/sortOrder.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const SortOrder = zod.enum(['asc', 'desc']);
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/createStoreBody.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/createStoreBody.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreateStoreBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/listStoresParams.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/listStoresParams.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { SortOrder } from '../sortOrder.zod';
 
 export const ListStoresParams = zod.object({

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/store.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/store.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Store = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/storeList.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-reusable/model/stores/storeList.zod.ts
@@ -4,7 +4,7 @@
  * Tags Split Shared Models
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Pagination } from '../pagination.zod';
 import { Store } from './store.zod';
 

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/error.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/cat.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/createPetsBody.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/createPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dachshund.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dog.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/labradoodle.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/listPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pet.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/petWithTag.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pets.zod.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/model/pets/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/axios/zod-nodenext/model/cat.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/axios/zod-nodenext/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/dachshund.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/dog.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Dachshund } from './dachshund.zod.js';
 import { Labradoodle } from './labradoodle.zod.js';
 

--- a/tests/__snapshots__/axios/zod-nodenext/model/error.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/axios/zod-nodenext/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/axios/zod-nodenext/model/pet.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Cat } from './cat.zod.js';
 import { Dog } from './dog.zod.js';
 

--- a/tests/__snapshots__/axios/zod-nodenext/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Pet } from './pet.zod.js';
 
 export const PetWithTag = zod.object({

--- a/tests/__snapshots__/axios/zod-nodenext/model/pets.zod.ts
+++ b/tests/__snapshots__/axios/zod-nodenext/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { Pet } from './pet.zod.js';
 
 export const Pets = zod.array(Pet);

--- a/tests/__snapshots__/axios/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/axios/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/axios/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/axios/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/axios/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/axios/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/default/schemas-zod-only/model/cat.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/default/schemas-zod-only/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/dachshund.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/dog.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/default/schemas-zod-only/model/error.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/default/schemas-zod-only/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/pet.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/default/schemas-zod-only/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/default/schemas-zod-only/model/pets.zod.ts
+++ b/tests/__snapshots__/default/schemas-zod-only/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/deletePetByIdPathParameters.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/deletePetByIdPathParameters.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const DeletePetByIdPathParameters = zod.object({
   petId: zod.string(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/showPetByIdPathParameters.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/showPetByIdPathParameters.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ShowPetByIdPathParameters = zod.object({
   petId: zod.string(),

--- a/tests/__snapshots__/fetch/named-parameters-zod/model/showPetWithOwnerPathParameters.zod.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/model/showPetWithOwnerPathParameters.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ShowPetWithOwnerPathParameters = zod.object({
   petId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-single/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-split/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single-no-runtime-validation/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split-no-runtime-validation/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-no-runtime-validation/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split-no-runtime-validation/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/anyChoicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/anyChoicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const AnyChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/baseEnvelopeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/baseEnvelopeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const BaseEnvelopeSchema = zod.object({
   traceId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/choicePositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/choicePositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ChoicePositionSchema = zod.union([
   zod.object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/composedPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/composedPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ComposedPositionSchema = zod
   .object({

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/externalHolderSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/externalHolderSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalHolderSchema = zod.object({
   holderId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/externalPositionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/externalPositionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ExternalPositionSchema = zod.object({
   externalId: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/nullablePositionWrapperSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/nullablePositionWrapperSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const NullablePositionWrapperSchema = zod.object({
   position: zod

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/portfolioResponseSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/portfolioResponseSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PortfolioResponseSchema = zod.object({
   positions: zod.array(

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/positionAliasSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/positionAliasSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionAliasSchema = zod.object({
   alias: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/positionMapSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/positionMapSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionMapSchema = zod.record(
   zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/positionSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/positionSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PositionSchema = zod.object({
   id: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/treeNodeSchema.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/model/treeNodeSchema.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3027 - zod suffix ref regression
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const TreeNodeSchema = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/cat.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/dachshund.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/dog.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/error.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/pet.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/model/pets.zod.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const listPetsByCountryPathCountryDefault = `UY`;
 

--- a/tests/__snapshots__/hono/issue-3634/src/ab-widget/ab-widget.zod.ts
+++ b/tests/__snapshots__/hono/issue-3634/src/ab-widget/ab-widget.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3634 - tag normalization for multi-word / acronym tags
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListAbWidgetsQueryParams = zod.object({
   search: zod.string().optional(),

--- a/tests/__snapshots__/hono/issue-3634/src/widget/widget.zod.ts
+++ b/tests/__snapshots__/hono/issue-3634/src/widget/widget.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3634 - tag normalization for multi-word / acronym tags
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListWidgetsQueryParams = zod.object({
   search: zod.string().optional(),

--- a/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/health/health.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/health/health.zod.ts
@@ -4,6 +4,6 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const HealthCheckResponse = zod.string();

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/pets/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/health/health.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/health/health.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { stripNill } from '../../../../mutators/zod-preprocess';
 
 export const HealthCheckResponse = zod.preprocess(stripNill, zod.string());

--- a/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/pets/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 import { stripNill } from '../../../../mutators/zod-preprocess';
 
 export const ListPetsQueryParams = zod.object({

--- a/tests/__snapshots__/hono/petstore-tags-split/health/health.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/health/health.zod.ts
@@ -4,6 +4,6 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const HealthCheckResponse = zod.string();

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/health.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/health.zod.ts
@@ -4,6 +4,6 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const HealthCheckResponse = zod.string();

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/petstore-tags/health.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags/health.zod.ts
@@ -4,6 +4,6 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const HealthCheckResponse = zod.string();

--- a/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/cat.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/createPetsBody.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/createPetsParams.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/dachshund.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/dog.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/error.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/labradoodle.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/listPetsParams.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/pet.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/petWithTag.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/hono/zod-schema-response/schemas/pets.zod.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/schemas/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/custom-server/tool-schemas.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/single/tool-schemas.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/cat.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/createPetsBody.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/createPetsParams.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dachshund.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dog.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/error.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/labradoodle.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/listPetsParams.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pet.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/petWithTag.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pets.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-schemas/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/tool-schemas.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsQueryParams = zod.object({
   limit: zod

--- a/tests/__snapshots__/mock/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/mock/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/mock/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/mock/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/mock/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/mock/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/react-query/issue-3066/model/importUsersFromFileOutput.zod.ts
+++ b/tests/__snapshots__/react-query/issue-3066/model/importUsersFromFileOutput.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3066
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ImportUsersFromFileOutput = zod.object({
   success: zod.boolean().optional(),

--- a/tests/__snapshots__/react-query/issue-3066/model/importUsersFromFileType.zod.ts
+++ b/tests/__snapshots__/react-query/issue-3066/model/importUsersFromFileType.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3066
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ImportUsersFromFileType = zod.enum(['Csv', 'Excel']);
 

--- a/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserImportUsersFromFileBody.zod.ts
+++ b/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserImportUsersFromFileBody.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3066
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PostApiAppOssIdentityUserImportUsersFromFileBody = zod.object({
   File: zod.instanceof(File).optional(),

--- a/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserImportUsersFromFileParams.zod.ts
+++ b/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserImportUsersFromFileParams.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3066
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PostApiAppOssIdentityUserImportUsersFromFileParams = zod.object({
   FileType: zod.enum(['Csv', 'Excel']).optional(),

--- a/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserSignInBody.zod.ts
+++ b/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserSignInBody.zod.ts
@@ -4,7 +4,7 @@
  * Issue 3066
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PostApiAppOssIdentityUserSignInBody = zod.object({
   username: zod.string(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/react-query/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/react-query/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/react-query/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/svelte-query/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/swr/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/swr/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/swr/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/swr/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/swr/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/swr/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/cat.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/cat.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Cat = zod.object({
   petsRequested: zod.int().optional(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/createPetsBody.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/createPetsBody.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsBody = zod.object({
   name: zod.string(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/createPetsHeaders.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/createPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/createPetsParams.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/createPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const CreatePetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/dachshund.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/dachshund.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dachshund = zod.object({
   length: zod.int(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/dog.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/dog.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Dog = zod
   .union([

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/error.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/error.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Error = zod.object({
   code: zod.int(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/labradoodle.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/labradoodle.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Labradoodle = zod.object({
   cuteness: zod.int(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/listPetsHeaders.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/listPetsHeaders.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsHeaders = zod.object({
   'X-EXAMPLE': zod.enum(['ONE', 'TWO', 'THREE']),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/listPetsParams.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/listPetsParams.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const ListPetsParams = zod.object({
   limit: zod.string().optional(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/pet.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/pet.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pet = zod
   .union([

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/petWithTag.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/petWithTag.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const PetWithTag = zod.object({
   tag: zod.string(),

--- a/tests/__snapshots__/vue-query/zod-schema-response/model/pets.zod.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/model/pets.zod.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const Pets = zod.array(
   zod

--- a/tests/__snapshots__/zod/components-only/components-only.ts
+++ b/tests/__snapshots__/zod/components-only/components-only.ts
@@ -4,7 +4,7 @@
  * Components Only
  * OpenAPI spec version: 1.0.0
  */
-import { z as zod } from 'zod';
+import * as zod from 'zod';
 
 export const User = zod.object({
   email: zod.string(),

--- a/tests/api-generation.spec.ts
+++ b/tests/api-generation.spec.ts
@@ -1266,9 +1266,8 @@ test('fetch issue-3663 combines required from a constraint-only allOf overlay', 
 });
 
 test('fetch issue-3695 does not import zod for a path parameter named `z`', async () => {
-  // The fetch client imports zod as `import { z as zod } from 'zod'`. A path
-  // parameter named exactly `z` must not be mistaken for a zod usage and pull
-  // the (otherwise unused) zod import into the client. See #3695.
+  // A path parameter named exactly `z` must not be mistaken for a zod usage and
+  // pull the (otherwise unused) zod import into the client. See #3695.
   const content = await readFile(
     generated('fetch', 'issue-3695', 'endpoints.ts'),
     'utf8',


### PR DESCRIPTION
Fixes #3792.

Generated zod schema files used `import { z as zod } from 'zod'`, which pulls in zod's
assembled `z` object. That transitively references every locale table, and neither bun nor
esbuild can tree-shake it — so ~194K of translated error messages ship in every bundle.

`import * as zod` is a drop-in swap, since orval already writes every call site as `zod.*`.

### Changes

- Always emit the namespace form, dropping the `variant === 'mini'` special case in:
  - `packages/hono/src/index.ts`
  - `packages/mcp/src/index.ts`
  - `packages/orval/src/write-zod-specs.ts`
- Regenerated samples and snapshots (one import line each)
- Removed two comments describing the old form

### Impact

Bundling a single `zod.object({ name: zod.string() })`, minified:

| import | bundle | locale strings |
|---|---|---|
| `{ z as zod }` | 328K | 1503 |
| `* as zod` | 68K | 0 |

Same runtime behaviour — validation and error messages are unaffected. On a real
Hono-on-Bun service this took the production bundle from 356K to 104K.

### Notes

- This aligns the three generators with `@orval/zod` and `@orval/effect`, which already emit
  the namespace form via `namespaceImport`.
- It also removes the reason for the workaround noted at `write-zod-specs.ts:221`, where the
  two differing forms had to be reconciled when concatenated.
- The issue is titled `hono:`, but the same helper is duplicated in `mcp` and
  `write-zod-specs`. I fixed all three since it is one bug.
- I have split it into 2 commits: fix and test adjust for easier CR.

`build`, `test` (220), `test:snapshots` (5588), `typecheck`, `lint` and `format:check` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized generated Zod schemas to use consistent namespace imports.
  * Preserved existing schema behavior and exported types across supported integrations.
  * Prevented unnecessary Zod imports when a path parameter is named `z`.

* **Tests**
  * Clarified coverage for import generation in this edge case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->