### PR TITLE
fix(fetch): preserve HeadersInit forms when merging request headers

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -513,7 +513,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   }
   const fetchHeadersOption =
     headersToAdd.length > 0
-      ? `headers: { ${headersToAdd.join(',')}, ...options?.headers }`
+      ? `headers: mergeOrvalHeaders({ ${headersToAdd.join(',')} }, options?.headers)`
       : '';
   const requestBodyParams = generateBodyOptions(
     body,
@@ -793,11 +793,28 @@ export const generateFetchHeader: ClientHeaderBuilder = ({
   const needsStatusCodeTypes = /HTTPStatusCode[1-5]xx|<HTTPStatusCodes,/.test(
     clientImplementation,
   );
-  if (!needsStatusCodeTypes) return '';
+  const needsMergeHeaders = clientImplementation.includes('mergeOrvalHeaders(');
+  if (!needsStatusCodeTypes && !needsMergeHeaders) return '';
 
   return {
-    implementation: '',
-    sharedTypes: HTTP_STATUS_CODE_SHARED_TYPES,
+    implementation: needsMergeHeaders
+      ? `function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}`
+      : '',
+    sharedTypes: needsStatusCodeTypes
+      ? HTTP_STATUS_CODE_SHARED_TYPES
+      : undefined,
   };
 };
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -512,7 +512,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
   }
   const fetchHeadersOption =
     headersToAdd.length > 0
-      ? `headers: { ${headersToAdd.join(',')}, ...options?.headers }`
+      ? `headers: mergeOrvalHeaders({ ${headersToAdd.join(',')} }, options?.headers)`
       : '';
   const requestBodyParams = generateBodyOptions(
     body,
@@ -793,11 +793,28 @@ export const generateFetchHeader: ClientHeaderBuilder = ({
   const needsStatusCodeTypes = /HTTPStatusCode[1-5]xx|<HTTPStatusCodes,/.test(
     clientImplementation,
   );
-  if (!needsStatusCodeTypes) return '';
+  const needsMergeHeaders = clientImplementation.includes('mergeOrvalHeaders(');
+  if (!needsStatusCodeTypes && !needsMergeHeaders) return '';
 
   return {
-    implementation: '',
-    sharedTypes: HTTP_STATUS_CODE_SHARED_TYPES,
+    implementation: needsMergeHeaders
+      ? `function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}`
+      : '',
+    sharedTypes: needsStatusCodeTypes
+      ? HTTP_STATUS_CODE_SHARED_TYPES
+      : undefined,
   };
 };
 

--- a/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
@@ -54,6 +54,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -133,7 +146,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 
@@ -182,7 +198,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -54,6 +54,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -133,7 +146,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 
@@ -182,7 +198,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -24,7 +24,19 @@ import {
   LoginUserParams,
   User,
 } from './http-schemas';
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
 
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
 export type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;
@@ -126,7 +138,10 @@ export const filterPetsByStatus = async (
   const res = await fetch(getFilterPetsByStatusUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -84,6 +84,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -158,7 +171,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -198,7 +214,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -84,6 +84,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -158,7 +171,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -198,7 +214,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -64,6 +64,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -234,7 +247,10 @@ export const createPets = async (
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -64,6 +64,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -234,7 +247,10 @@ export const createPets = async (
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -18,6 +18,19 @@ import type {
   Pets,
 } from '../models';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -105,7 +118,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -18,6 +18,19 @@ import type {
   Pets,
 } from '../models';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export const getListPetsUrl = (params?: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -105,7 +118,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -102,6 +102,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -320,7 +333,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -426,7 +442,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -102,6 +102,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -320,7 +333,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -426,7 +442,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -72,6 +72,19 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -234,7 +247,10 @@ export const createPets = async (
   return customInstance<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -72,6 +72,19 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -234,7 +247,10 @@ export const createPets = async (
   return customInstance<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -74,6 +74,19 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -251,7 +264,10 @@ export const useCreatePetsHook = (): ((
     return customFetcher(getCreatePetsUrl(), {
       ...options,
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      headers: mergeOrvalHeaders(
+        { 'Content-Type': 'application/json' },
+        options?.headers,
+      ),
       body: JSON.stringify(createPetsBody),
     });
   };

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -74,6 +74,19 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -251,7 +264,10 @@ export const useCreatePetsHook = (): ((
     return customFetcher(getCreatePetsUrl(), {
       ...options,
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...options?.headers },
+      headers: mergeOrvalHeaders(
+        { 'Content-Type': 'application/json' },
+        options?.headers,
+      ),
       body: JSON.stringify(createPetsBody),
     });
   };

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -102,6 +102,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -244,7 +257,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -369,7 +385,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -102,6 +102,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -244,7 +257,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -369,7 +385,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -104,6 +104,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -266,7 +279,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -393,7 +409,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -104,6 +104,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -266,7 +279,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -393,7 +409,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
@@ -88,6 +88,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -205,7 +218,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 
@@ -291,7 +307,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
@@ -88,6 +88,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -205,7 +218,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 
@@ -291,7 +307,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -88,6 +88,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -205,7 +218,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 
@@ -291,7 +307,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -88,6 +88,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -205,7 +218,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 
@@ -291,7 +307,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -102,6 +102,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -254,7 +267,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -360,7 +376,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -102,6 +102,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -254,7 +267,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBodyItem),
   });
 };
@@ -360,7 +376,10 @@ export const updatePets = async (
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(pet),
   });
 };

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
+++ b/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -153,7 +166,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/default/index-mock-file/pets/pets.ts
+++ b/tests/__snapshots__/default/index-mock-file/pets/pets.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -153,7 +166,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/default/no-index-files/endpoints.ts
+++ b/tests/__snapshots__/default/no-index-files/endpoints.ts
@@ -60,6 +60,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -157,7 +170,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -153,7 +166,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
+++ b/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
@@ -5,6 +5,19 @@
  * Raw binary request bodies
  * OpenAPI spec version: 1.0.0
  */
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type replaceLotteryLogoResponse204 = {
   data: void;
   status: 204;
@@ -32,7 +45,10 @@ export const replaceLotteryLogo = async (
   const res = await fetch(getReplaceLotteryLogoUrl(id), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'image/png', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'image/png' },
+      options?.headers,
+    ),
     body: replaceLotteryLogoBody,
   });
 

--- a/tests/__snapshots__/fetch/empty-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/empty-response/endpoints.ts
@@ -6,6 +6,19 @@
  */
 import type { Form } from './model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type addResponseDefault = {
   data: unknown;
   status: number;
@@ -27,7 +40,10 @@ export const add = async (
   const res = await fetch(getAddUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(form),
   });
 

--- a/tests/__snapshots__/fetch/force-success-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response/endpoints.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -160,7 +173,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -60,6 +60,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -99,10 +112,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 };
@@ -148,10 +161,10 @@ export const uploadPetContent = async (
   return customFetch<uploadPetContentResponse>(getUploadPetContentUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 };
@@ -199,10 +212,10 @@ export const uploadPetContentRef = async (
   return customFetch<uploadPetContentRefResponse>(getUploadPetContentRefUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 };

--- a/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
@@ -59,6 +59,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type createPetsResponse200 = {
   data: Pet;
   status: 200;
@@ -98,10 +111,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 
@@ -156,10 +169,10 @@ export const uploadPetContent = async (
   const res = await fetch(getUploadPetContentUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 
@@ -216,10 +229,10 @@ export const uploadPetContentRef = async (
   const res = await fetch(getUploadPetContentRefUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 

--- a/tests/__snapshots__/fetch/headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/headers/endpoints.ts
@@ -58,6 +58,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -102,7 +115,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -158,11 +171,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
@@ -20,6 +20,19 @@ import type { RequestHandlerOptions } from 'msw';
 
 import type { Cat, Dachshund, Dog, Labradoodle } from './model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -77,7 +90,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/issue-1879/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-1879/endpoints.ts
@@ -11,6 +11,19 @@ import type {
   RequestBHeaders,
 } from './model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type requestAResponse200 = {
   data: void;
   status: 200;
@@ -36,11 +49,10 @@ export const requestA = async (
   const res = await fetch(getRequestAUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(requestABody),
   });
 
@@ -75,11 +87,10 @@ export const requestB = async (
   const res = await fetch(getRequestBUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(requestBBody),
   });
 

--- a/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
@@ -6,6 +6,19 @@
  */
 import type { UploadNullableBinaryBody } from './model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type uploadNullableBinaryResponse204 = {
   data: void;
   status: 204;
@@ -37,10 +50,10 @@ export const uploadNullableBinary = async (
   const res = await fetch(getUploadNullableBinaryUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 

--- a/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
@@ -63,6 +63,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -160,7 +173,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -57,6 +57,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -149,7 +162,10 @@ export const createPets = async (
   return customFetchWithScss<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -64,6 +64,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -150,7 +163,10 @@ export const createPets = async (
   return customFetch<createPetsResponseSuccess>(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
@@ -59,6 +59,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -156,7 +169,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters/endpoints.ts
@@ -59,6 +59,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -156,7 +169,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
@@ -22,6 +22,19 @@ import type {
   Pets,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -119,7 +132,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -153,7 +166,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/petstore/endpoints.ts
+++ b/tests/__snapshots__/fetch/petstore/endpoints.ts
@@ -63,6 +63,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -160,7 +173,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -99,11 +112,13 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
-      'X-Static-Header': `static-value`,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      {
+        Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
+        'X-Static-Header': `static-value`,
+      },
+      options?.headers,
+    ),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -158,12 +173,14 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
-      'X-Static-Header': `static-value`,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
+        'X-Static-Header': `static-value`,
+      },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 
@@ -212,11 +229,13 @@ export const showPetById = async (
   const res = await fetch(getShowPetByIdUrl(petId), {
     ...options,
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
-      'X-Static-Header': `static-value`,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      {
+        Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
+        'X-Static-Header': `static-value`,
+      },
+      options?.headers,
+    ),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -264,11 +283,13 @@ export const deletePetById = async (
   const res = await fetch(getDeletePetByIdUrl(petId), {
     ...options,
     method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
-      'X-Static-Header': `static-value`,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      {
+        Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
+        'X-Static-Header': `static-value`,
+      },
+      options?.headers,
+    ),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -317,11 +338,13 @@ export const healthCheck = async (
   const res = await fetch(getHealthCheckUrl(), {
     ...options,
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
-      'X-Static-Header': `static-value`,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      {
+        Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
+        'X-Static-Header': `static-value`,
+      },
+      options?.headers,
+    ),
   });
 
   const contentType = (res.headers.get('content-type') ?? '').toLowerCase();
@@ -374,11 +397,13 @@ export const showPetWithOwner = async (
   const res = await fetch(getShowPetWithOwnerUrl(petId), {
     ...options,
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
-      'X-Static-Header': `static-value`,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      {
+        Authorization: `Bearer ${process.env.API_TOKEN || ''}`,
+        'X-Static-Header': `static-value`,
+      },
+      options?.headers,
+    ),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();

--- a/tests/__snapshots__/fetch/reviver/pets/pets.ts
+++ b/tests/__snapshots__/fetch/reviver/pets/pets.ts
@@ -58,6 +58,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -157,7 +170,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
@@ -10,6 +10,19 @@ interface TypedResponse<T> extends Response {
   json(): Promise<T>;
 }
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type streamResponse200 = {
   stream: TypedResponse<StreamEntry>;
   status: 200;
@@ -33,7 +46,10 @@ export const stream = async (
   const stream = await fetch(getStreamUrl(), {
     ...options,
     method: 'GET',
-    headers: { Accept: 'application/x-ndjson', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { Accept: 'application/x-ndjson' },
+      options?.headers,
+    ),
   });
 
   return {

--- a/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -159,7 +172,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/split/endpoints.ts
+++ b/tests/__snapshots__/fetch/split/endpoints.ts
@@ -56,6 +56,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -153,7 +166,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/stream/endpoints.ts
@@ -10,6 +10,19 @@ interface TypedResponse<T> extends Response {
   json(): Promise<T>;
 }
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type streamResponse200 = {
   stream: TypedResponse<StreamEntry>;
   status: 200;
@@ -33,7 +46,10 @@ export const stream = async (
   const stream = await fetch(getStreamUrl(), {
     ...options,
     method: 'GET',
-    headers: { Accept: 'application/x-ndjson', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { Accept: 'application/x-ndjson' },
+      options?.headers,
+    ),
   });
 
   return {

--- a/tests/__snapshots__/fetch/tags/pets.ts
+++ b/tests/__snapshots__/fetch/tags/pets.ts
@@ -63,6 +63,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -160,7 +173,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
@@ -192,6 +192,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -289,7 +302,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -54,6 +54,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -159,7 +172,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -60,6 +60,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -165,7 +178,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -54,6 +54,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -159,7 +172,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -54,6 +54,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -159,7 +172,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -14,7 +14,19 @@ import {
   CreatePetsParams,
   PetWithTag,
 } from './http-schemas';
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
 
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
 export type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;
@@ -153,7 +165,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -14,7 +14,19 @@ import {
   CreatePetsParams,
   PetWithTag,
 } from './http-schemas';
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
 
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
 export type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;
@@ -153,7 +165,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -14,7 +14,19 @@ import {
   CreatePetsParams,
   PetWithTag,
 } from './http-schemas';
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
 
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
 export type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;
@@ -153,7 +165,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -75,6 +75,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -131,7 +144,10 @@ export const updateProfileWithJson = async (
   const res = await fetch(getUpdateProfileWithJsonUrl(id), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(updateProfileBody),
   });
 
@@ -514,10 +530,10 @@ export const uploadAvatarWithBlob = async (
   const res = await fetch(getUploadAvatarWithBlobUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/octet-stream',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/octet-stream' },
+      options?.headers,
+    ),
     body: uploadAvatarBody,
   });
 

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -81,6 +81,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -143,7 +156,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -330,11 +343,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
+++ b/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
@@ -19,6 +19,19 @@ import type {
 
 import type { CreateItem, Item, UploadItem } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -58,7 +71,10 @@ export const createItem = async (
   const res = await fetch(getCreateItemUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createItemBody),
   });
 

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -73,6 +73,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -314,7 +327,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -141,7 +154,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -534,11 +547,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -74,6 +74,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -343,7 +356,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
@@ -69,6 +69,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -310,7 +323,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
@@ -69,6 +69,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -310,7 +323,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -64,6 +64,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -161,7 +174,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -82,6 +82,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -318,7 +331,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -30,6 +30,19 @@ import type {
   Pets,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -231,7 +244,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -323,7 +336,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -317,7 +330,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -317,7 +330,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -317,7 +330,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -317,7 +330,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -317,7 +330,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -74,6 +74,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -315,7 +328,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -81,6 +81,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -143,7 +156,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -330,11 +343,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -15,6 +15,19 @@ import type {
 import type { CreateEntity200, CreateEntityBody } from './model';
 
 import { useCustomMutation } from '../../../mutators/custom-mutation';
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type createEntityResponse200 = {
   data: CreateEntity200;
   status: 200;
@@ -38,7 +51,10 @@ export const createEntity = async (
   const res = await fetch(getCreateEntityUrl(version, entityId), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createEntityBody),
   });
 

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -27,6 +27,19 @@ import type { CreateMuscleDto, Muscle } from './model';
 import { customFetch } from '../../../mutators/custom-fetch';
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -439,7 +452,10 @@ export const musclesControllerCreate = async (
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createMuscleDto),
   });
 };

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -23,6 +23,19 @@ import type { CreateMuscleDto, Muscle } from './model';
 import { customFetch } from '../../../mutators/custom-fetch';
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -252,7 +265,10 @@ export const musclesControllerCreate = async (
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createMuscleDto),
   });
 };

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -19,6 +19,19 @@ import type {
   PostApiAppOssIdentityUserSignInBody,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type postApiAppOssIdentityUserImportUsersFromFileResponse200 = {
   data: ImportUsersFromFileOutput;
   status: 200;
@@ -206,10 +219,10 @@ export const postApiAppOssIdentityUserSignIn = async (
   const res = await fetch(getPostApiAppOssIdentityUserSignInUrl(), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/x-www-form-urlencoded' },
+      options?.headers,
+    ),
     body: formUrlEncoded,
   });
 

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -22,6 +22,19 @@ import type {
 
 import type { Widget } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -209,7 +222,10 @@ export const createWidget = async (
   const res = await fetch(getCreateWidgetUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(widgetNull),
   });
 

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -320,7 +333,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -320,7 +333,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -78,6 +78,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -343,7 +356,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -38,6 +38,19 @@ import type {
   Pets,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -279,7 +292,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -74,6 +74,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -472,7 +485,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -77,6 +77,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -307,7 +320,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -313,7 +326,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -320,7 +333,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -324,7 +337,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -74,6 +74,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -340,7 +353,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -73,6 +73,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -330,7 +343,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -336,7 +349,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -81,6 +81,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -569,7 +582,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -78,6 +78,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -365,7 +378,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -334,7 +347,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 const withQueryKey = <T extends object, K>(
   query: T,
   queryKey: K,
@@ -320,7 +333,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -77,6 +77,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -237,7 +250,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -25,6 +25,19 @@ import type {
   Pets,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -150,7 +163,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -67,6 +67,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -232,7 +245,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -83,6 +83,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -127,7 +140,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -253,11 +266,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -81,6 +81,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -125,7 +138,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -251,11 +264,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -353,7 +366,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -67,6 +67,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -232,7 +245,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -73,6 +73,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -350,7 +363,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params, version), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -67,6 +67,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -232,7 +245,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -74,6 +74,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -239,7 +252,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -74,6 +74,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -239,7 +252,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
@@ -12,6 +12,19 @@ import type { SWRMutationConfiguration } from 'swr/mutation';
 
 import type { RequiredPetBodyBody } from './model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type createPetResponse204 = {
   data: void;
   status: 204;
@@ -33,7 +46,10 @@ export const createPet = async (
   const res = await fetch(getCreatePetUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(requiredPetBodyBody),
   });
 

--- a/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
@@ -12,6 +12,19 @@ import type { SWRMutationConfiguration } from 'swr/mutation';
 
 import type { RequiredPetBodyBody } from './model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type createPetResponse204 = {
   data: void;
   status: 204;
@@ -33,7 +46,10 @@ export const createPet = async (
   const res = await fetch(getCreatePetUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(requiredPetBodyBody),
   });
 

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -203,7 +216,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -20,6 +20,19 @@ import type {
   Pets,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -115,7 +128,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -62,6 +62,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -204,7 +217,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -68,6 +68,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -221,7 +234,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/optional-request-body/endpoints.ts
+++ b/tests/__snapshots__/swr/optional-request-body/endpoints.ts
@@ -14,6 +14,19 @@ import type { Cookie, OptionalPetBodyBody, RequiredPetBodyBody } from './model';
 import { HttpResponse, http } from 'msw';
 import type { RequestHandlerOptions } from 'msw';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type createPetsResponse204 = {
   data: void;
   status: 204;
@@ -35,7 +48,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(requiredPetBodyBody),
   });
 
@@ -104,7 +120,10 @@ export const updatePets = async (
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(optionalPetBodyBody),
   });
 
@@ -173,7 +192,10 @@ export const createCookies = async (
   const res = await fetch(getCreateCookiesUrl(), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(cookie),
   });
 
@@ -244,7 +266,10 @@ export const updateCookies = async (
   const res = await fetch(getUpdateCookiesUrl(), {
     ...options,
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(cookie),
   });
 

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -68,6 +68,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -324,7 +337,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -62,6 +62,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -197,7 +210,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -70,6 +70,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -114,7 +127,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -280,11 +293,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -69,6 +69,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -217,7 +230,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params, version), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -62,6 +62,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -198,7 +211,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -62,6 +62,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -235,7 +248,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -62,6 +62,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -199,7 +212,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -69,6 +69,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -204,7 +217,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -69,6 +69,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -205,7 +218,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -249,7 +262,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -249,7 +262,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -82,6 +82,19 @@ export type HTTPStatusCodes =
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -247,7 +260,10 @@ export const createPets = async (
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 };

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -30,6 +30,19 @@ import type {
   Pets,
 } from '../model';
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export const getListPetsUrl = (params: ListPetsParams) => {
   const normalizedParams = new URLSearchParams();
 
@@ -160,7 +173,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -242,7 +255,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -84,6 +84,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -128,7 +141,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -260,11 +273,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -82,6 +82,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -126,7 +139,7 @@ export const listPets = async (
   const res = await fetch(getListPetsUrl(params), {
     ...options,
     method: 'GET',
-    headers: { ...headers, ...options?.headers },
+    headers: mergeOrvalHeaders({ ...headers }, options?.headers),
   });
 
   const body = [204, 205, 304].includes(res.status) ? null : await res.text();
@@ -258,11 +271,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-      ...options?.headers,
-    },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json', ...headers },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -79,6 +79,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -249,7 +262,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -72,6 +72,19 @@ export type HTTPStatusCodes =
   | HTTPStatusCode4xx
   | HTTPStatusCode5xx;
 
+function mergeOrvalHeaders(
+  ...headers: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const mergedHeaders: Record<string, string> = {};
+
+  for (const header of headers) {
+    new Headers(header).forEach((value, key) => {
+      mergedHeaders[key] = value;
+    });
+  }
+
+  return mergedHeaders;
+}
 export type listPetsResponse200 = {
   data: Pets;
   status: 200;
@@ -261,7 +274,10 @@ export const createPets = async (
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    headers: mergeOrvalHeaders(
+      { 'Content-Type': 'application/json' },
+      options?.headers,
+    ),
     body: JSON.stringify(createPetsBody),
   });
 

--- a/tests/request-headers.spec.ts
+++ b/tests/request-headers.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { createPets as createPetsWithMutator } from './generated/fetch/mutator/endpoints';
+import { createPets } from './generated/fetch/request-options-headers/endpoints';
+
+const { customFetchMock } = vi.hoisted(() => ({
+  customFetchMock: vi.fn(),
+}));
+
+vi.mock('./mutators/custom-fetch', () => ({
+  customFetch: customFetchMock,
+}));
+
+afterEach(() => {
+  customFetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+const headerCases: Array<{
+  name: string;
+  headers: HeadersInit;
+  traceValue: string;
+}> = [
+  {
+    name: 'Headers',
+    headers: new Headers({
+      authorization: 'runtime-token',
+      'content-type': 'application/custom+json',
+      'x-trace': 'headers',
+    }),
+    traceValue: 'headers',
+  },
+  {
+    name: 'tuple array',
+    headers: [
+      ['authorization', 'runtime-token'],
+      ['content-type', 'application/custom+json'],
+      ['x-trace', 'tuples'],
+    ],
+    traceValue: 'tuples',
+  },
+  {
+    name: 'record',
+    headers: {
+      authorization: 'runtime-token',
+      'content-type': 'application/custom+json',
+      'x-trace': 'record',
+    },
+    traceValue: 'record',
+  },
+];
+
+test.each(headerCases)(
+  'merges $name request headers over generated headers',
+  async ({ headers, traceValue }) => {
+    let requestHeaders: Headers | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestHeaders = new Headers(init?.headers);
+        return new Response('{}', { status: 200 });
+      }),
+    );
+
+    await createPets(
+      { name: 'Fluffy', tag: 'cat' },
+      { sort: 'name' },
+      { headers },
+    );
+
+    expect(requestHeaders?.get('authorization')).toBe('runtime-token');
+    expect(requestHeaders?.get('content-type')).toBe(
+      'application/custom+json',
+    );
+    expect(requestHeaders?.get('x-trace')).toBe(traceValue);
+    expect(requestHeaders?.get('x-static-header')).toBe('static-value');
+  },
+);
+
+test('passes merged headers as a record to a custom mutator', async () => {
+  customFetchMock.mockResolvedValue({ data: {}, status: 200 });
+
+  await createPetsWithMutator(
+    { name: 'Fluffy', tag: 'cat' },
+    { sort: 'name' },
+    { headers: new Headers({ 'x-trace': 'headers' }) },
+  );
+
+  const requestOptions = customFetchMock.mock.calls[0]?.[1] as
+    | RequestInit
+    | undefined;
+  expect(requestOptions?.headers).not.toBeInstanceOf(Headers);
+  expect(requestOptions?.headers).toMatchObject({
+    'content-type': 'application/json',
+    'x-trace': 'headers',
+  });
+});

--- a/tests/vitest.snapshots.ts
+++ b/tests/vitest.snapshots.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'api-generation.spec.ts',
       'handler-preservation.spec.ts',
       'query-key-mutator.spec.ts',
+      'request-headers.spec.ts',
       'serialize-response-headers.spec.ts',
     ],
     silent: 'passed-only',


### PR DESCRIPTION
- fixes #2375

Generated fetch clients currently merge generated headers with `options.headers` using object spread. Because entries in a `Headers` instance are not enumerable, passing one silently drops the caller-provided header values.

This change normalizes every `HeadersInit` form (`Headers`, tuple arrays, and records), applies caller-provided headers last, and returns a plain record to remain compatible with custom mutators that spread `RequestInit.headers`.

This implementation was created with an AI coding agent under direct human instruction and approval. I defined the bug-fix scope, directed and reviewed the design and implementation, reviewed the generated changes, and explicitly approved the final commits. It is not an unattended issue-to-agent submission.

## Verification

- `vp run format:check`
- `vp run lint`
- `vp run lint:samples`
- `vp run typecheck`
- `vp run test`
- `vp run test:snapshots:update` — 5 test files and 5,639 tests passed
- `vp run test:cli` — all 16 generated clients passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request headers are now merged consistently across generated clients.
  * Supports header records, `Headers` objects, and tuple arrays.
  * Caller-provided headers correctly override defaults while required headers remain intact.
  * Custom request handlers receive normalized header records for improved compatibility.
  * Header utilities are generated when needed, independently of response status types.

* **Tests**
  * Added coverage for supported header formats, precedence, normalization, and custom request handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->