### PR TITLE
fix(mock): terminate recursive $ref mocks with type-valid values

### DIFF
--- a/packages/mock/src/faker/getters/object.test.ts
+++ b/packages/mock/src/faker/getters/object.test.ts
@@ -434,6 +434,16 @@ describe('getMockObject recursive reference terminators', () => {
     expect(result.value).toContain('next: null');
   });
 
+  it('casts instead of null when nonNullable is set', () => {
+    const result = buildNode(
+      { ...nodeSchema, type: ['object', 'null'] },
+      { nonNullable: true },
+    );
+
+    expect(result.value).not.toContain('next: null');
+    expect(result.value).toContain('as unknown as Node');
+  });
+
   it('omits an optional recursive $ref', () => {
     const result = buildNode({ ...nodeSchema, required: [] });
 

--- a/packages/mock/src/faker/getters/object.test.ts
+++ b/packages/mock/src/faker/getters/object.test.ts
@@ -386,3 +386,57 @@ describe('getMockObject', () => {
     expect(result.imports.length).toBeLessThan(200);
   });
 });
+
+describe('getMockObject recursive reference terminators', () => {
+  const nodeSchema = {
+    type: 'object',
+    required: ['next'],
+    properties: { next: { $ref: '#/components/schemas/Node' } },
+  } satisfies OpenApiSchemaObject;
+
+  const buildNode = (
+    schema: Exclude<OpenApiSchemaObject, boolean>,
+    mockOptions?: MockOptions,
+  ) => {
+    const context = createTestContextSpec({
+      spec: { components: { schemas: { Node: schema } } },
+    });
+    return getMockObject({
+      item: {
+        name: 'Node',
+        ...schema,
+      } as Parameters<typeof getMockObject>[0]['item'],
+      operationId: 'Node',
+      tags: [],
+      context,
+      imports: [],
+      existingReferencedProperties: ['Node'],
+      splitMockImplementations: [],
+      mockOptions,
+    });
+  };
+
+  it('casts a required non-nullable recursive $ref that cannot be stubbed', () => {
+    const result = buildNode(nodeSchema);
+
+    expect(result.value).toBe('{next: {} as unknown as Node}');
+    expect(result.imports).toContainEqual(
+      expect.objectContaining({ name: 'Node' }),
+    );
+  });
+
+  it('keeps null when the recursive $ref targets a nullable schema', () => {
+    const result = buildNode({
+      ...nodeSchema,
+      type: ['object', 'null'],
+    });
+
+    expect(result.value).toContain('next: null');
+  });
+
+  it('omits an optional recursive $ref', () => {
+    const result = buildNode({ ...nodeSchema, required: [] });
+
+    expect(result.value).toBe('{}');
+  });
+});

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -9,7 +9,6 @@ import {
   type OpenApiSchemaObject,
   PropertySortOrder,
 } from '@orval/core';
-import { prop } from 'remeda';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
 import { DEFAULT_OBJECT_KEY_MOCK } from '../constants';
@@ -17,6 +16,7 @@ import {
   resolveMockValue,
   getNullable,
   isNullableSchema,
+  resolveRefTarget,
 } from '../resolvers/value';
 import { mergeReturnedMockImports } from '../imports';
 import { combineSchemasMock } from './combine';
@@ -47,21 +47,6 @@ function getReferenceName(
   return getRefInfo(ref, context).name;
 }
 
-function resolveRefTarget(
-  ref: string | undefined,
-  context: ContextSpec,
-): Partial<OpenApiSchemaObject> | undefined {
-  if (typeof ref !== 'string') return undefined;
-  const { refPaths } = getRefInfo(ref, context);
-  if (!Array.isArray(refPaths)) return undefined;
-
-  return prop(
-    context.spec,
-    // @ts-expect-error: [ts2556] refPaths are not guaranteed to be valid keys of the spec
-    ...refPaths,
-  ) as Partial<OpenApiSchemaObject> | undefined;
-}
-
 function isNullableRefTarget(
   ref: string | undefined,
   context: ContextSpec,
@@ -69,11 +54,9 @@ function isNullableRefTarget(
   return isNullableSchema(resolveRefTarget(ref, context));
 }
 
-// One-hop lookahead for a recursive ref about to be re-expanded: when the
-// target's own required `$ref` properties already sit on the resolution path
-// and can neither be nulled nor cut, the re-expansion is guaranteed to end in
-// casts and collapse back to one. Predicting that here skips the wasted work,
-// which otherwise dominates generation time on dense recursive specs.
+// One-hop lookahead before re-expanding a recursive ref: when the target's
+// own required refs already sit on the path and cannot be nulled, the
+// re-expansion can only end in casts, so skip the wasted work.
 function reExpansionWouldCollapse(
   ref: string | undefined,
   context: ContextSpec,
@@ -295,22 +278,16 @@ export function getMockObject({
           const refName = isReference(prop)
             ? getReferenceName(prop.$ref, context)
             : '';
-          const refVisits = refName
-            ? existingReferencedProperties.filter(
-                (existing) => existing === refName,
-              ).length
-            : 0;
+          const isRecursiveRef =
+            !!refName && existingReferencedProperties.includes(refName);
 
-          // A property `$ref` already on the resolution path is recursive.
-          // Optional: drop it. Nullable: `null` is valid. Anything else
-          // expands once more so the array/union guards a hop deeper can
-          // close the cycle with a value the type accepts. At most one such
-          // re-expansion per path (any repeated name on the path casts
-          // immediately), and a re-expansion that still needed casts inside
-          // collapses back to a single cast below: an all-required cycle has
-          // no finite value anyway, and unbounded re-expansion blows up the
-          // output on dense recursive specs.
-          if (refVisits > 0) {
+          // Recursive $ref. Optional properties are dropped, nullable ones
+          // keep null. The rest expands one more level, letting the deeper
+          // array/union guards close the cycle with a typed stub. One
+          // re-expansion per path, and none when it could only end in casts:
+          // an all-required cycle has no finite value, and unbounded
+          // re-expansion blows up on dense specs.
+          if (isRecursiveRef) {
             if (!isRequired) {
               return;
             }
@@ -326,7 +303,6 @@ export function getMockObject({
               new Set(existingReferencedProperties).size !==
               existingReferencedProperties.length;
             if (
-              refVisits >= 2 ||
               inReExpansion ||
               (isReference(prop) &&
                 reExpansionWouldCollapse(
@@ -372,9 +348,8 @@ export function getMockObject({
 
           const keyDefinition = getKey(key);
 
-          // A required `$ref` union whose variants were all recursively
-          // skipped resolves to `undefined`; cast it so the emitted literal
-          // still satisfies the type.
+          // A required $ref union whose variants were all recursively
+          // skipped resolves to undefined; cast it to satisfy the type.
           if (isRequired && refName && resolvedValue.value === 'undefined') {
             imports.push({ name: refName });
             return `${keyDefinition}: undefined as unknown as ${refName}`;
@@ -384,7 +359,7 @@ export function getMockObject({
           // casting here directly, so keep the smaller form.
           if (
             isRequired &&
-            refVisits > 0 &&
+            isRecursiveRef &&
             resolvedValue.value.includes(' as unknown as ')
           ) {
             imports.push({ name: refName });

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -9,6 +9,7 @@ import {
   type OpenApiSchemaObject,
   PropertySortOrder,
 } from '@orval/core';
+import { prop } from 'remeda';
 
 import type { MockDefinition, MockSchema, MockSchemaObject } from '../../types';
 import { DEFAULT_OBJECT_KEY_MOCK } from '../constants';
@@ -44,6 +45,59 @@ function getReferenceName(
   if (!ref) return '';
 
   return getRefInfo(ref, context).name;
+}
+
+function resolveRefTarget(
+  ref: string | undefined,
+  context: ContextSpec,
+): Partial<OpenApiSchemaObject> | undefined {
+  if (typeof ref !== 'string') return undefined;
+  const { refPaths } = getRefInfo(ref, context);
+  if (!Array.isArray(refPaths)) return undefined;
+
+  return prop(
+    context.spec,
+    // @ts-expect-error: [ts2556] refPaths are not guaranteed to be valid keys of the spec
+    ...refPaths,
+  ) as Partial<OpenApiSchemaObject> | undefined;
+}
+
+function isNullableRefTarget(
+  ref: string | undefined,
+  context: ContextSpec,
+): boolean {
+  return isNullableSchema(resolveRefTarget(ref, context));
+}
+
+// One-hop lookahead for a recursive ref about to be re-expanded: when the
+// target's own required `$ref` properties already sit on the resolution path
+// and can neither be nulled nor cut, the re-expansion is guaranteed to end in
+// casts and collapse back to one. Predicting that here skips the wasted work,
+// which otherwise dominates generation time on dense recursive specs.
+function reExpansionWouldCollapse(
+  ref: string | undefined,
+  context: ContextSpec,
+  existingReferencedProperties: string[],
+  nonNullable: boolean | undefined,
+): boolean {
+  const target = resolveRefTarget(ref, context);
+  const targetProperties = target?.properties as
+    | Record<string, OpenApiReferenceObject | OpenApiSchemaObject>
+    | undefined;
+  const targetRequired = target?.required as string[] | undefined;
+  if (!targetProperties || !Array.isArray(targetRequired)) return false;
+
+  return Object.entries(targetProperties).some(([key, property]) => {
+    if (!targetRequired.includes(key) || !isReference(property)) return false;
+    if (
+      !existingReferencedProperties.includes(
+        getReferenceName(property.$ref, context),
+      )
+    ) {
+      return false;
+    }
+    return nonNullable || !isNullableRefTarget(property.$ref, context);
+  });
 }
 
 interface GetMockObjectOptions {
@@ -238,19 +292,53 @@ export function getMockObject({
 
           const hasNullable = 'nullable' in prop && prop.nullable === true;
 
-          // Check to see if the property is a reference to an existing property
-          // Fixes issue #910
-          if (
-            isReference(prop) &&
-            existingReferencedProperties.includes(
-              getReferenceName(prop.$ref, context),
-            )
-          ) {
-            if (isRequired) {
-              const keyDefinition = getKey(key);
+          const refName = isReference(prop)
+            ? getReferenceName(prop.$ref, context)
+            : '';
+          const refVisits = refName
+            ? existingReferencedProperties.filter(
+                (existing) => existing === refName,
+              ).length
+            : 0;
+
+          // A property `$ref` already on the resolution path is recursive.
+          // Optional: drop it. Nullable: `null` is valid. Anything else
+          // expands once more so the array/union guards a hop deeper can
+          // close the cycle with a value the type accepts. At most one such
+          // re-expansion per path (any repeated name on the path casts
+          // immediately), and a re-expansion that still needed casts inside
+          // collapses back to a single cast below: an all-required cycle has
+          // no finite value anyway, and unbounded re-expansion blows up the
+          // output on dense recursive specs.
+          if (refVisits > 0) {
+            if (!isRequired) {
+              return;
+            }
+            const keyDefinition = getKey(key);
+            if (
+              !mockOptions?.nonNullable &&
+              (hasNullable ||
+                (isReference(prop) && isNullableRefTarget(prop.$ref, context)))
+            ) {
               return `${keyDefinition}: null`;
             }
-            return;
+            const inReExpansion =
+              new Set(existingReferencedProperties).size !==
+              existingReferencedProperties.length;
+            if (
+              refVisits >= 2 ||
+              inReExpansion ||
+              (isReference(prop) &&
+                reExpansionWouldCollapse(
+                  prop.$ref,
+                  context,
+                  existingReferencedProperties,
+                  mockOptions?.nonNullable,
+                ))
+            ) {
+              imports.push({ name: refName });
+              return `${keyDefinition}: {} as unknown as ${refName}`;
+            }
           }
 
           const importsBefore = imports.length;
@@ -283,6 +371,25 @@ export function getMockObject({
           includedProperties.push(key);
 
           const keyDefinition = getKey(key);
+
+          // A required `$ref` union whose variants were all recursively
+          // skipped resolves to `undefined`; cast it so the emitted literal
+          // still satisfies the type.
+          if (isRequired && refName && resolvedValue.value === 'undefined') {
+            imports.push({ name: refName });
+            return `${keyDefinition}: undefined as unknown as ${refName}`;
+          }
+
+          // A re-expansion that still needed casts gained nothing over
+          // casting here directly, so keep the smaller form.
+          if (
+            isRequired &&
+            refVisits > 0 &&
+            resolvedValue.value.includes(' as unknown as ')
+          ) {
+            imports.push({ name: refName });
+            return `${keyDefinition}: {} as unknown as ${refName}`;
+          }
 
           const hasDefault = 'default' in prop && prop.default !== undefined;
 

--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -508,6 +508,267 @@ describe('generateFakerForSchemas recursion guards', () => {
   });
 });
 
+describe('generateFakerForSchemas recursive reference terminators', () => {
+  const run = (
+    schemas: Record<string, OpenApiSchemaObject>,
+    roots: string[],
+    context = createTestContextSpec(),
+  ) => {
+    context.spec.components = { schemas };
+    return generateFakerForSchemas(
+      roots.map((root) => ({
+        name: root,
+        model: root,
+        imports: [],
+        schema: schemas[root]!,
+      })),
+      context,
+      { type: OutputMockType.FAKER, schemas: true },
+    );
+  };
+
+  const factoryBody = (implementation: string, factoryName: string) => {
+    const start = implementation.indexOf(`export const ${factoryName}`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = implementation.indexOf('export const', start + 1);
+    return implementation.slice(start, end === -1 ? undefined : end);
+  };
+
+  const levelSchema = {
+    type: 'object',
+    required: ['entityType', 'nextLevelsWithConditions'],
+    properties: {
+      entityType: { type: 'string' },
+      nextLevelsWithConditions: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/LevelWithCondition' },
+      },
+    },
+  } satisfies OpenApiSchemaObject;
+  const levelWithConditionSchema = {
+    type: 'object',
+    required: ['condition', 'level'],
+    properties: {
+      condition: { type: 'string' },
+      level: { $ref: '#/components/schemas/Level' },
+    },
+  } satisfies OpenApiSchemaObject;
+  const levelSchemas: Record<string, OpenApiSchemaObject> = {
+    Level: levelSchema,
+    LevelWithCondition: levelWithConditionSchema,
+  };
+
+  it('stubs a required non-nullable recursive $ref instead of emitting null', () => {
+    const result = run(levelSchemas, ['LevelWithCondition', 'Level']);
+
+    expect(result.implementation).not.toContain('level: null');
+    // The re-expansion terminates through the array guard one hop deeper.
+    const levelMock = factoryBody(result.implementation, 'getLevelMock');
+    expect(levelMock).toContain('level: {entityType:');
+    expect(levelMock).toContain('nextLevelsWithConditions: []');
+  });
+
+  it('picks a concrete variant for a union member referencing its parent union', () => {
+    const result = run(
+      {
+        TracingValue: {
+          oneOf: [
+            { $ref: '#/components/schemas/StringTracingValue' },
+            { $ref: '#/components/schemas/RangeTracingValue' },
+          ],
+        },
+        StringTracingValue: {
+          type: 'object',
+          required: ['value', 'type'],
+          properties: {
+            value: { type: 'string' },
+            type: { type: 'string', enum: ['StringTracingValue'] },
+          },
+        },
+        RangeTracingValue: {
+          type: 'object',
+          required: ['from', 'to', 'type'],
+          properties: {
+            from: { $ref: '#/components/schemas/TracingValue' },
+            to: { $ref: '#/components/schemas/TracingValue' },
+            type: { type: 'string', enum: ['RangeTracingValue'] },
+          },
+        },
+      },
+      ['StringTracingValue', 'RangeTracingValue', 'TracingValue'],
+    );
+
+    expect(result.implementation).not.toContain('from: null');
+    expect(result.implementation).not.toContain('to: null');
+    const helper = factoryBody(
+      result.implementation,
+      'getTracingValueResponseRangeTracingValueMock',
+    );
+    expect(helper).toContain(
+      'from: faker.helpers.arrayElement([{...getTracingValueResponseStringTracingValueMock()}',
+    );
+  });
+
+  it('keeps null for a required recursive $ref to a nullable schema', () => {
+    const schemas: Record<string, OpenApiSchemaObject> = {
+      ...levelSchemas,
+      Level: {
+        ...levelSchema,
+        type: ['object', 'null'],
+      },
+    };
+    const result = run(schemas, ['Level']);
+
+    const levelMock = factoryBody(result.implementation, 'getLevelMock');
+    expect(levelMock).toContain('level: null');
+  });
+
+  it('still omits an optional recursive $ref', () => {
+    const schemas: Record<string, OpenApiSchemaObject> = {
+      ...levelSchemas,
+      LevelWithCondition: {
+        ...levelWithConditionSchema,
+        required: ['condition'],
+      },
+    };
+    const result = run(schemas, ['Level']);
+
+    const levelMock = factoryBody(result.implementation, 'getLevelMock');
+    expect(levelMock).not.toContain('level:');
+  });
+
+  it('terminates a fully-required self cycle with a cast after one re-expansion', () => {
+    const result = run(
+      {
+        Ouro: {
+          type: 'object',
+          required: ['next'],
+          properties: { next: { $ref: '#/components/schemas/Ouro' } },
+        },
+      },
+      ['Ouro'],
+    );
+
+    expect(result.implementation).not.toContain('next: null');
+    expect(result.implementation).toContain('next: {} as unknown as Ouro');
+  });
+
+  it('terminates a fully-required mutual cycle with a cast', () => {
+    const result = run(
+      {
+        A: {
+          type: 'object',
+          required: ['b'],
+          properties: { b: { $ref: '#/components/schemas/B' } },
+        },
+        B: {
+          type: 'object',
+          required: ['a'],
+          properties: { a: { $ref: '#/components/schemas/A' } },
+        },
+      },
+      ['A', 'B'],
+    );
+
+    expect(result.implementation).not.toContain(': null');
+    expect(result.implementation).toContain('as unknown as');
+  });
+
+  it('casts undefined for a required $ref union whose variants are all recursive', () => {
+    const result = run(
+      {
+        OnlyRange: {
+          oneOf: [{ $ref: '#/components/schemas/RangeOnly' }],
+        },
+        RangeOnly: {
+          type: 'object',
+          required: ['from'],
+          properties: { from: { $ref: '#/components/schemas/OnlyRange' } },
+        },
+      },
+      ['RangeOnly'],
+    );
+
+    expect(result.implementation).not.toContain('from: undefined,');
+    expect(result.implementation).toContain(
+      'from: undefined as unknown as OnlyRange',
+    );
+  });
+
+  it('collapses a re-expansion that still needed casts inside', () => {
+    const result = run(
+      {
+        Wrap: {
+          type: 'object',
+          required: ['inner'],
+          properties: {
+            inner: {
+              type: 'object',
+              required: ['next'],
+              properties: { next: { $ref: '#/components/schemas/Wrap' } },
+            },
+          },
+        },
+      },
+      ['Wrap'],
+    );
+
+    expect(result.implementation).toContain('next: {} as unknown as Wrap');
+    expect(result.implementation).not.toContain('next: {inner:');
+  });
+
+  it('keeps output bounded on a dense cluster of mutually required refs', () => {
+    const names = ['D0', 'D1', 'D2', 'D3', 'D4', 'D5'];
+    const schemas: Record<string, OpenApiSchemaObject> = Object.fromEntries(
+      names.map((name) => [
+        name,
+        {
+          type: 'object',
+          required: names.filter((other) => other !== name),
+          properties: Object.fromEntries(
+            names
+              .filter((other) => other !== name)
+              .map((other) => [
+                other,
+                { $ref: `#/components/schemas/${other}` },
+              ]),
+          ),
+        },
+      ]),
+    );
+
+    const result = run(schemas, names);
+
+    expect(result.implementation.length).toBeLessThan(1_000_000);
+  });
+
+  it('does not delegate a recursive $ref to its own factory (runtime cycle)', () => {
+    const context = createTestContextSpec({
+      output: {
+        schemas: 'model',
+        mock: {
+          indexMockFiles: false,
+          generators: [{ type: OutputMockType.FAKER, schemas: true }],
+        },
+      },
+    });
+    const result = run(
+      {
+        TreeNode: {
+          type: 'object',
+          required: ['next'],
+          properties: { next: { $ref: '#/components/schemas/TreeNode' } },
+        },
+      },
+      ['TreeNode'],
+      context,
+    );
+
+    expect(result.implementation).not.toContain('next: { ...getTreeNodeMock()');
+    expect(result.implementation).toContain('next: {} as unknown as TreeNode');
+  });
+});
+
 describe('resolveMockValue returns one factory import per ref-property (#3606)', () => {
   // Delegation to a `get<X>Mock` factory requires output.schemas to be set and
   // the $ref to point at a components schema.

--- a/packages/mock/src/faker/index.test.ts
+++ b/packages/mock/src/faker/index.test.ts
@@ -670,7 +670,8 @@ describe('generateFakerForSchemas recursive reference terminators', () => {
       ['A', 'B'],
     );
 
-    expect(result.implementation).not.toContain(': null');
+    expect(result.implementation).not.toContain('a: null');
+    expect(result.implementation).not.toContain('b: null');
     expect(result.implementation).toContain('as unknown as');
   });
 
@@ -689,7 +690,7 @@ describe('generateFakerForSchemas recursive reference terminators', () => {
       ['RangeOnly'],
     );
 
-    expect(result.implementation).not.toContain('from: undefined,');
+    expect(result.implementation).not.toContain('from: undefined}');
     expect(result.implementation).toContain(
       'from: undefined as unknown as OnlyRange',
     );
@@ -739,7 +740,7 @@ describe('generateFakerForSchemas recursive reference terminators', () => {
 
     const result = run(schemas, names);
 
-    expect(result.implementation.length).toBeLessThan(1_000_000);
+    expect(result.implementation.length).toBeLessThan(300_000);
   });
 
   it('does not delegate a recursive $ref to its own factory (runtime cycle)', () => {

--- a/packages/mock/src/faker/resolvers/value.test.ts
+++ b/packages/mock/src/faker/resolvers/value.test.ts
@@ -1,7 +1,13 @@
 import type { OpenApiSchemaObject } from '@orval/core';
 import { describe, expect, it } from 'vitest';
 
-import { getNullable, isNullableSchema, resolveMockOverride } from './value';
+import { createTestContextSpec } from '../../../../core/src/test-utils/context';
+import {
+  getNullable,
+  isNullableSchema,
+  resolveMockOverride,
+  resolveRefTarget,
+} from './value';
 
 type Item = OpenApiSchemaObject & { name: string; path?: string };
 
@@ -16,6 +22,27 @@ describe('isNullableSchema', () => {
 
   it('returns false for non-nullable schemas', () => {
     expect(isNullableSchema({ type: 'string' })).toBe(false);
+  });
+});
+
+describe('resolveRefTarget', () => {
+  const context = createTestContextSpec({
+    spec: {
+      components: {
+        schemas: { Pet: { type: 'object', required: ['name'] } },
+      },
+    },
+  });
+
+  it('resolves a same-document fragment ref', () => {
+    expect(resolveRefTarget('#/components/schemas/Pet', context)).toEqual({
+      type: 'object',
+      required: ['name'],
+    });
+  });
+
+  it('returns undefined for a fragmentless external ref', () => {
+    expect(resolveRefTarget('./pet.yaml', context)).toBeUndefined();
   });
 });
 

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -377,6 +377,10 @@ export function resolveMockValue({
     const canDelegate =
       shouldDelegateToSchemaFactories(context) &&
       isComponentsSchemaRef(refPaths) &&
+      // A ref already on the resolution path is recursive: delegating would
+      // emit a factory call that re-enters itself at runtime. Inline it so
+      // the recursion terminators can cut the cycle instead.
+      !existingReferencedProperties.includes(name) &&
       !delegationDropsRequired &&
       !hasOverrideTouchingSchema(
         schemaRef?.properties as Record<string, unknown> | undefined,

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -100,6 +100,9 @@ export function resolveRefTarget(
   context: ContextSpec,
 ): Partial<OpenApiSchemaObject> | undefined {
   if (typeof ref !== 'string') return undefined;
+  // getRefInfo throws on refs without a '#' fragment
+  const [, fragment] = ref.split('#');
+  if (!fragment) return undefined;
   const { refPaths } = getRefInfo(ref, context);
   if (!Array.isArray(refPaths)) return undefined;
 

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -94,6 +94,22 @@ export function resolveMockOverride(
   };
 }
 
+/** Resolves a `$ref` string to its schema in the loaded spec, if any. */
+export function resolveRefTarget(
+  ref: string | undefined,
+  context: ContextSpec,
+): Partial<OpenApiSchemaObject> | undefined {
+  if (typeof ref !== 'string') return undefined;
+  const { refPaths } = getRefInfo(ref, context);
+  if (!Array.isArray(refPaths)) return undefined;
+
+  return prop(
+    context.spec,
+    // @ts-expect-error: [ts2556] refPaths are not guaranteed to be valid keys of the spec
+    ...refPaths,
+  ) as Partial<OpenApiSchemaObject> | undefined;
+}
+
 /** OpenAPI 3.0 `nullable: true` or 3.1 `type` unions that include `null`. */
 export function isNullableSchema(schema: unknown): boolean {
   if (!schema || typeof schema !== 'object') {
@@ -245,13 +261,7 @@ export function resolveMockValue({
     const schemaRefPath = typeof schema.$ref === 'string' ? schema.$ref : '';
     const { name, refPaths } = getRefInfo(schemaRefPath, context);
 
-    const schemaRef = Array.isArray(refPaths)
-      ? (prop(
-          context.spec,
-          // @ts-expect-error: [ts2556] refPaths are not guaranteed to be valid keys of the spec
-          ...refPaths,
-        ) as Partial<OpenApiSchemaObject>)
-      : undefined;
+    const schemaRef = resolveRefTarget(schemaRefPath, context);
 
     const newSchema = {
       ...schemaRef,
@@ -583,14 +593,7 @@ function resolvesToObjectLike(
       return false;
     }
     seen = new Set(seen).add(schema.$ref);
-    const { refPaths } = getRefInfo(schema.$ref, context);
-    resolved = Array.isArray(refPaths)
-      ? (prop(
-          context.spec,
-          // @ts-expect-error: refPaths are not guaranteed to be valid keys of the spec
-          ...refPaths,
-        ) as Partial<OpenApiSchemaObject>)
-      : undefined;
+    resolved = resolveRefTarget(schema.$ref, context);
   } else {
     resolved = schema as Partial<OpenApiSchemaObject>;
   }


### PR DESCRIPTION
Fixes #3802.

With `mock: { generators: [{ type: 'faker', schemas: true }] }`, required recursive `$ref`s were mocked as `null`, which doesn't compile under `tsc --strict`.

Now the ref gets expanded one more level so the existing guards can break the cycle with something valid: arrays become `[]`, unions pick a non-recursive variant, nullable schemas keep `null`. A cycle where everything is required has no valid value at all, that becomes `{} as unknown as X`. The extra expansion is capped so heavily recursive specs don't blow up generation.

Also a factory no longer delegates to itself for self-referencing schemas, that looped forever at runtime.

Tested with the spec from the issue: strict tsc passes, mocks run. Plain `mock: true` output is unchanged. Deeply recursive msw mocks change too, `null` becomes a stub or cast there as well.

Left out as separate bugs (can file issues): mutually recursive factories still call each other forever when a schemas dir is set, and without one the faker file imports `from './filename'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented infinite recursion when generating mock data from self-referencing or mutually referencing schemas.
  * Improved handling of recursive required, optional, nullable, and union fields.
  * Ensured recursive references produce bounded output through appropriate casts, null values, or omitted properties.

* **Tests**
  * Added comprehensive coverage for recursive schema references, including nested cycles and complex reference graphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->