### PR TITLE
fix(core): merge shared schema barrel exports

### DIFF
--- a/packages/core/src/writers/schemas.test.ts
+++ b/packages/core/src/writers/schemas.test.ts
@@ -616,7 +616,7 @@ describe('fixRegularSchemaImports', () => {
 });
 
 describe('writeSchemas indexFiles', () => {
-  it('replaces index exports with the current run when re-generating the same schema path', async () => {
+  it('merges index exports across projects that share a schema path (#2842)', async () => {
     const tempDir = await fs.mkdtemp(
       path.join(os.tmpdir(), 'orval-schema-index-'),
     );
@@ -652,10 +652,10 @@ describe('writeSchemas indexFiles', () => {
       const indexPath = path.join(schemaPath, 'index.ts');
       const content = await fs.readFile(indexPath, 'utf8');
 
+      expect(content).toContain("export * from './createUserRequest';");
+      expect(content).toContain("export * from './createUserResponse';");
       expect(content).toContain("export * from './userDto';");
       expect(content).toContain("export * from './userListResponse';");
-      expect(content).not.toContain("export * from './createUserRequest';");
-      expect(content).not.toContain("export * from './createUserResponse';");
     } finally {
       await fs.remove(tempDir);
     }

--- a/packages/core/src/writers/schemas.test.ts
+++ b/packages/core/src/writers/schemas.test.ts
@@ -652,10 +652,15 @@ describe('writeSchemas indexFiles', () => {
       const indexPath = path.join(schemaPath, 'index.ts');
       const content = await fs.readFile(indexPath, 'utf8');
 
-      expect(content).toContain("export * from './createUserRequest';");
-      expect(content).toContain("export * from './createUserResponse';");
-      expect(content).toContain("export * from './userDto';");
-      expect(content).toContain("export * from './userListResponse';");
+      const exportLines = content
+        .split('\n')
+        .filter((line) => line.startsWith('export * from'));
+      expect(exportLines).toEqual([
+        "export * from './createUserRequest';",
+        "export * from './createUserResponse';",
+        "export * from './userDto';",
+        "export * from './userListResponse';",
+      ]);
     } finally {
       await fs.remove(tempDir);
     }

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -615,7 +615,14 @@ export async function writeSchemas({
         }
       }
 
-      const exports = [...new Set(currentExports)]
+      const existingContent = await fs.readFile(schemaFilePath, 'utf8');
+      const existingExports = [
+        ...existingContent.matchAll(
+          /^\s*export\s+\*\s+from\s+['"]([^'"]+)['"]\s*;?\s*$/gm,
+        ),
+      ].map(([, specifier]) => `export * from '${specifier}';`);
+
+      const exports = [...new Set([...existingExports, ...currentExports])]
         .toSorted((a, b) => a.localeCompare(b, 'en', { numeric: true }))
         .join('\n');
 


### PR DESCRIPTION
## Summary

- preserve exports already present in a shared schema barrel when another project writes to the same schema directory
- deduplicate and deterministically sort the combined exports
- restore regression coverage for multiple projects sharing `output.schemas`

This restores the cumulative behavior added in #2843 and unintentionally removed in #3080.

Fixes #2842

## Test plan

- `bun x vitest run packages/core/src/writers/schemas.test.ts` (35 tests)
- `bun x vp run -F @orval/core test` (2,272 tests)
- `bun x vp run -F @orval/core typecheck`
- `bun x vp fmt --check packages/core/src/writers/schemas.ts packages/core/src/writers/schemas.test.ts`
- `bun run build:release`
- generated the issue reproduction with the locally built CLI and verified all seven command/query models are exported from the shared barrel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema index generation so exports from multiple writes are preserved and merged instead of being overwritten.
  * Added deduplication and consistent sorting when combining schema exports.
  * Ensured existing schema exports remain available when new schemas are added, providing a complete and predictable index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->