### PR TITLE
fix(docs): make the Fetch playground example generate fetch code

### DIFF
--- a/docs/content/docs/guides/basics.mdx
+++ b/docs/content/docs/guides/basics.mdx
@@ -18,6 +18,8 @@ export default defineConfig({
       mode: 'single',
       target: './src/petstore.ts',
       schemas: './src/model',
+      client: 'react-query',
+      httpClient: 'fetch',
       mock: true,
     },
     input: {
@@ -36,8 +38,14 @@ The output options configure how and where you want to write the generated code.
 | `mode` | Specifies how files are generated. Default: `single` (one file with everything) |
 | `target` | Specifies where the generated file(s) will be written |
 | `schemas` | Specifies where the models will be written |
-| `client` | Specifies the HTTP client to generate (`axios`, `react-query`, `vue-query`, etc.) |
+| `client` | Selects the generated client: `angular`, `angular-query`, `axios`, `axios-functions`, `react-query`, `solid-start`, `solid-query`, `svelte-query`, `vue-query`, `swr`, `zod`, `effect`, `hono`, `fetch`, or `mcp` |
+| `httpClient` | Selects the request transport: `fetch` (default), `axios`, or `angular`. The available transport depends on the selected `client`. |
 | `mock` | Generates mocks with MSW. See the [MSW guide](/docs/guides/msw) |
+
+`client` and `httpClient` control different parts of the generated output. The
+`client` selects the generated API style, while `httpClient` selects the
+request implementation used by compatible clients. For example, the
+configuration above generates React Query hooks backed by the Fetch API.
 
 ## Input Options
 

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -25,7 +25,7 @@ export default defineConfig({
 
 **Type:** `String | Function`
 **Default:** `'axios-functions'`
-**Options:** `angular`, `axios`, `axios-functions`, `react-query`, `svelte-query`, `vue-query`, `swr`, `zod`, `effect`, `hono`, `fetch`, `mcp`
+**Options:** `angular`, `angular-query`, `axios`, `axios-functions`, `react-query`, `solid-start`, `solid-query`, `svelte-query`, `vue-query`, `swr`, `zod`, `effect`, `hono`, `fetch`, `mcp`
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -61,10 +61,11 @@ const api = getPetsApi(customAxios);
 
 ## httpClient
 
-**Type:** `'fetch' | 'axios'`
+**Type:** `'fetch' | 'axios' | 'angular'`
 **Default:** `'fetch'`
 
-HTTP client used for `swr`, `react-query`, `vue-query`, and `svelte-query` clients.
+HTTP transport used by compatible generated clients. Use `fetch` or `axios` for
+query clients, and `angular` for `angular` and `angular-query` output.
 
 ```ts title="orval.config.ts"
 export default defineConfig({

--- a/docs/src/lib/playground/examples.ts
+++ b/docs/src/lib/playground/examples.ts
@@ -178,7 +178,7 @@ export const EXAMPLES: Record<string, Example[]> = {
       tags: [],
       config: dedent(/* JSON */ `{
         "output": {
-          "httpClient": "fetch",
+          "client": "fetch",
           "target": "./src/generated/endpoints.ts"
         },
         "input": {


### PR DESCRIPTION
Fixes #3818\n\n### Summary\nThe Fetch > Basic playground config used output.httpClient, which left the client generator at its default and produced Axios output. This selects the Fetch client explicitly with output.client.\n\n### Validation\n- bun run types:check (docs) passed\n- bun run build (docs) passed\n- Static assertion confirms the Fetch example uses client=fetch\n- bun run lint remains blocked by pre-existing Biome configuration and formatting diagnostics across the docs tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration examples by explicitly specifying generated clients and request transports.
  * Expanded the list of supported client options, including Solid and Effect integrations.
  * Documented Angular transport support and clarified compatibility between clients and transports.
  * Updated the Fetch playground example to use the correct configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->