### PR TITLE
docs: distinguish output.headers from output.override.header

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -839,8 +839,24 @@ export default defineConfig({
 ## headers
 
 **Type:** `Boolean`
+**Default:** `false`
 
-Enable generation of headers.
+Generate typed parameters for the HTTP request headers an operation declares in
+the specification. When disabled, header parameters are omitted from the
+generated function signatures.
+
+This is unrelated to [`override.header`](#header), which controls the comment
+block written at the top of each generated file.
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      headers: true,
+    },
+  },
+});
+```
 
 ## tsconfig
 
@@ -969,9 +985,15 @@ export default defineConfig({
 ### header
 
 **Type:** `Boolean | Function`
-**Default:** `true`
+**Default:** the built-in header function
 
-Customize or disable the generated file header:
+Customize or disable the comment block written at the top of each generated
+file. This is unrelated to [`output.headers`](#headers), which controls HTTP
+request header parameters.
+
+Pass `false` to omit the comment block, or a function to replace it. Passing
+`true` produces the same output as omitting the option, since any value that is
+neither `false` nor a function falls back to the built-in header.
 
 ```ts title="orval.config.ts"
 export default defineConfig({


### PR DESCRIPTION
Documentation half of #3789. No config or type changes.

`output.headers` and `output.override.header` are unrelated but read as if they were the same setting. The reference said only "Enable generation of headers" for the first and gave no default, and described the second as the "generated file header" without distinguishing it. Both entries now say which one they are and link to each other.

Two facts I checked against the code rather than taking from the issue:

`output.headers` gates `getQueryParams({ queryParams: parameters.header, suffix: 'headers' })` in `packages/core/src/generators/verbs-options.ts`, so it is the operation's HTTP header parameters. Its default is `false` in `packages/orval/src/utils/options.ts`, which the reference did not mention.

`output.override.header` was documented with a default of `true`. The normalizer is:

```ts
header:
  outputOptions.override?.header === false
    ? false
    : isFunction(outputOptions.override?.header)
      ? outputOptions.override.header
      : getDefaultFilesHeader,
```

Anything that is neither `false` nor a function falls through to `getDefaultFilesHeader`, so `true` behaves exactly like omitting the option, and the effective default is that function rather than `true`. The page now says so.

I left the type narrowing from `boolean | function` to `false | function` out, since #3789 puts it in a major.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded configuration guidance for output headers.
  * Clarified default behavior, customization options, disabling headers, and fallback behavior.
  * Added configuration examples and explained the distinction between related header settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->