### PR TITLE
fix(zod): report a misplaced boolean `required` instead of crashing

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -784,18 +784,23 @@ export const generateZodValidationSchemaDefinition = (
       ? [
           ...new Set([
             ...getRequiredKeys(schema, name),
-            ...schemas.flatMap((member) => {
+            ...schemas.flatMap((member, index) => {
               // Only the member's top-level `required` is needed. For `$ref`
               // members resolve shallowly (no deep property dereference) and
               // tolerate unresolvable refs — they simply contribute no keys.
-              const resolved =
-                '$ref' in member && typeof member.$ref === 'string'
-                  ? tryResolveRefSchema(member.$ref, context)
-                  : (member as OpenApiSchemaObject);
-              const memberRequired = resolved?.required;
-              return Array.isArray(memberRequired)
-                ? (memberRequired as string[])
-                : [];
+              const isRef = '$ref' in member && typeof member.$ref === 'string';
+              const resolved = isRef
+                ? tryResolveRefSchema(member.$ref as string, context)
+                : (member as OpenApiSchemaObject);
+              if (!resolved) return [];
+              // A constraint-only member never reaches the object path below,
+              // so a misplaced boolean here would otherwise pass unreported.
+              // Name the member, not the composing schema, or the message
+              // points at the wrong place in the document.
+              return getRequiredKeys(
+                resolved,
+                isRef ? (member.$ref as string) : `${name}.allOf[${index}]`,
+              );
             }),
           ]),
         ]

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -416,6 +416,29 @@ const isDiscriminatableMember = (
   return hasLiteralDiscriminator(resolved, property);
 };
 
+/**
+ * Read a schema object's `required` keyword.
+ *
+ * Some generators emit `required: true` on the schema referenced by a request
+ * body, borrowing the boolean that belongs on the request body object. Spreading
+ * that boolean fails with `(schema.required ?? []) is not iterable`, which says
+ * nothing about the document. Report the offending schema and the expected shape
+ * instead. The document is not rewritten: a boolean carries no property names,
+ * so there is nothing to recover from it. (#3719)
+ */
+const getRequiredKeys = (schema: OpenApiSchemaObject, name: string) => {
+  const required = schema.required as unknown;
+
+  if (required === undefined) return [];
+  if (Array.isArray(required)) return required;
+
+  throw new Error(
+    `Invalid OpenAPI document: schema "${name}" has \`required: ${JSON.stringify(
+      required,
+    )}\`, but a schema object's \`required\` must be an array of property names. A boolean \`required\` belongs on the request body object or on a parameter, not on the schema it references.`,
+  );
+};
+
 export const generateZodValidationSchemaDefinition = (
   schema: OpenApiSchemaObject | OpenApiReferenceObject | undefined,
   context: ContextSpec,
@@ -760,7 +783,7 @@ export const generateZodValidationSchemaDefinition = (
     const allOfRequired = schema.allOf
       ? [
           ...new Set([
-            ...(schema.required ?? []),
+            ...getRequiredKeys(schema, name),
             ...schemas.flatMap((member) => {
               // Only the member's top-level `required` is needed. For `$ref`
               // members resolve shallowly (no deep property dereference) and
@@ -1230,7 +1253,7 @@ export const generateZodValidationSchemaDefinition = (
           // A property is required when this schema requires it OR when a
           // sibling `allOf` member requires it (propagated via additionalRequired). (#3171)
           const requiredKeys = new Set<string>([
-            ...(schema.required ?? []),
+            ...getRequiredKeys(schema, name),
             ...(rules?.additionalRequired ?? []),
           ]);
 

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -12376,6 +12376,27 @@ describe('misplaced boolean `required` (#3719)', () => {
     ).toThrowError(/schema "Composed" has `required: true`/);
   });
 
+  it('names the offending allOf member, not the composing schema', () => {
+    // A constraint-only member has no properties, so it never reaches the
+    // object path that validates `required`. Without a check here the same
+    // malformed keyword is reported in one position and ignored in another.
+    expect(() =>
+      generateZodValidationSchemaDefinition(
+        {
+          allOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { required: true },
+          ],
+        } as unknown as OpenApiSchemaObject,
+        { output: { override: {} } } as ContextSpec,
+        'Member',
+        true,
+        false,
+        { required: true },
+      ),
+    ).toThrowError(/schema "Member\.allOf\[1\]" has `required: true`/);
+  });
+
   it('still accepts a valid required array', () => {
     expect(() =>
       generateZodValidationSchemaDefinition(
@@ -12386,6 +12407,24 @@ describe('misplaced boolean `required` (#3719)', () => {
         } as OpenApiSchemaObject,
         { output: { override: {} } } as ContextSpec,
         'Valid',
+        true,
+        false,
+        { required: true },
+      ),
+    ).not.toThrow();
+  });
+
+  it('still accepts a valid required array on an allOf member', () => {
+    expect(() =>
+      generateZodValidationSchemaDefinition(
+        {
+          allOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { required: ['a'] },
+          ],
+        } as unknown as OpenApiSchemaObject,
+        { output: { override: {} } } as ContextSpec,
+        'ValidMember',
         true,
         false,
         { required: true },

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -12333,3 +12333,63 @@ describe('constraint-only oneOf/anyOf branches (#3780)', () => {
     expect(zod).toContain('"B": zod.number().int().optional()');
   });
 });
+
+describe('misplaced boolean `required` (#3719)', () => {
+  // Some generators put `required: true` on the schema a request body
+  // references, borrowing the boolean that belongs on the request body object.
+  // That used to surface as `(schema.required ?? []) is not iterable`, which
+  // names neither the schema nor the expected shape.
+  const schema = {
+    type: 'object',
+    required: true,
+    properties: { name: { type: 'string' } },
+  } as unknown as OpenApiSchemaObject;
+
+  it('names the schema and the expected shape', () => {
+    expect(() =>
+      generateZodValidationSchemaDefinition(
+        schema,
+        { output: { override: {} } } as ContextSpec,
+        'Item',
+        true,
+        false,
+        { required: true },
+      ),
+    ).toThrowError(
+      /schema "Item" has `required: true`, but a schema object's `required` must be an array of property names/,
+    );
+  });
+
+  it('reports it on the allOf path too', () => {
+    expect(() =>
+      generateZodValidationSchemaDefinition(
+        {
+          allOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
+          required: true,
+        } as unknown as OpenApiSchemaObject,
+        { output: { override: {} } } as ContextSpec,
+        'Composed',
+        true,
+        false,
+        { required: true },
+      ),
+    ).toThrowError(/schema "Composed" has `required: true`/);
+  });
+
+  it('still accepts a valid required array', () => {
+    expect(() =>
+      generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          required: ['name'],
+          properties: { name: { type: 'string' } },
+        } as OpenApiSchemaObject,
+        { output: { override: {} } } as ContextSpec,
+        'Valid',
+        true,
+        false,
+        { required: true },
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Implements option 2 from #3719, the one @snebjorn voted for and @melloware agreed with: report the invalid document rather than normalize it.

Reproduced first. A schema carrying `required: true` reaches the two spread sites in `packages/zod/src/index.ts` and fails with:

```
TypeError: (schema.required ?? []) is not iterable
```

That message names neither the schema nor what the keyword should hold, and generation of the whole client stops.

Both sites now read `required` through a small helper that returns the array when the document is valid and otherwise throws:

```
Invalid OpenAPI document: schema "Item" has `required: true`, but a schema
object's `required` must be an array of property names. A boolean `required`
belongs on the request body object or on a parameter, not on the schema it
references.
```

I did not normalize the value. A boolean carries no property names, so there is nothing to recover from it, and picking a set of required keys would change validation without the user knowing. That is the ambiguity @snebjorn raised.

Five tests, in `packages/zod/src/zod.test.ts`: the plain object path, the `allOf` path, the `allOf` member one level down, and two controls asserting a valid `required` array still generates, one on a schema and one on a member. Run against the commit before the fix, the first three fail and both controls pass on either side, so they are not asserting something that was already true. The three fail in two different ways, which is the point of the third one:

```
names the schema and the expected shape          got '(schema.required ?? []) is not iterable'
reports it on the allOf path too                got '(schema.required ?? []) is not iterable'
names the offending allOf member                expected [Function] to throw an error
```

The member one level down never threw at all. It rendered as `zod.unknown()` and said nothing.

`packages/zod` goes from 320 to 325 tests, all passing. `tsc --noEmit` and `vp fmt --check` are clean.

Scope note: `packages/mock/src/faker/resolvers/value.ts` spreads `schemaReference.required` the same way, so the same document shape would fail there too. I left it out to keep this focused on the reported path, and can send it separately if you want it covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for schema `required` values.
  * Invalid non-array values now produce clear, descriptive errors identifying the affected schema.
  * Validation now works consistently across objects, combined schemas, and referenced schemas.
  * Valid required-field arrays continue to work correctly.

* **Tests**
  * Added regression coverage for invalid and valid `required` configurations, including combined and referenced schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
