### PR TITLE
perf(core): skip generated-file writes when the content is unchanged

### DIFF
--- a/packages/core/src/writers/file.test.ts
+++ b/packages/core/src/writers/file.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { writeGeneratedFile } from './file';
+import { withGeneratedFileTransform, writeGeneratedFile } from './file';
 
 describe('writeGeneratedFile', () => {
   let dir: string;
@@ -28,15 +28,34 @@ describe('writeGeneratedFile', () => {
   it('leaves mtime untouched when the final content is unchanged', async () => {
     const filePath = path.join(dir, 'out.ts');
     await writeGeneratedFile(filePath, 'const a = 1;\n');
-    const before = (await fs.stat(filePath)).mtimeMs;
+    const past = new Date('2020-01-01T00:00:00.000Z');
+    await fs.utimes(filePath, past, past);
 
     // Same final content, reached from a different source string: the trailing
     // whitespace is stripped before the comparison.
-    await new Promise((resolve) => setTimeout(resolve, 20));
     await writeGeneratedFile(filePath, 'const a = 1;   \n');
 
-    expect((await fs.stat(filePath)).mtimeMs).toBe(before);
+    expect((await fs.stat(filePath)).mtimeMs).toBe(past.getTime());
     expect(await fs.readFile(filePath, 'utf8')).toBe('const a = 1;\n');
+  });
+
+  it('compares transformed content before writing', async () => {
+    const filePath = path.join(dir, 'out.ts');
+    const format = async (_filePath: string, content: string) =>
+      content.replaceAll("'", '"');
+
+    await withGeneratedFileTransform(format, () =>
+      writeGeneratedFile(filePath, "const value = 'test';\n"),
+    );
+    const past = new Date('2020-01-01T00:00:00.000Z');
+    await fs.utimes(filePath, past, past);
+
+    await withGeneratedFileTransform(format, () =>
+      writeGeneratedFile(filePath, "const value = 'test';\n"),
+    );
+
+    expect(await fs.readFile(filePath, 'utf8')).toBe('const value = "test";\n');
+    expect((await fs.stat(filePath)).mtimeMs).toBe(past.getTime());
   });
 
   it('still writes when the content differs', async () => {

--- a/packages/core/src/writers/file.test.ts
+++ b/packages/core/src/writers/file.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeGeneratedFile } from './file';
+
+describe('writeGeneratedFile', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'orval-write-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(dir);
+  });
+
+  it('creates the file and strips trailing whitespace', async () => {
+    const filePath = path.join(dir, 'nested', 'out.ts');
+    await writeGeneratedFile(filePath, 'const a = 1;   \nconst b = 2;\n');
+
+    expect(await fs.readFile(filePath, 'utf8')).toBe(
+      'const a = 1;\nconst b = 2;\n',
+    );
+  });
+
+  it('leaves mtime untouched when the final content is unchanged', async () => {
+    const filePath = path.join(dir, 'out.ts');
+    await writeGeneratedFile(filePath, 'const a = 1;\n');
+    const before = (await fs.stat(filePath)).mtimeMs;
+
+    // Same final content, reached from a different source string: the trailing
+    // whitespace is stripped before the comparison.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await writeGeneratedFile(filePath, 'const a = 1;   \n');
+
+    expect((await fs.stat(filePath)).mtimeMs).toBe(before);
+    expect(await fs.readFile(filePath, 'utf8')).toBe('const a = 1;\n');
+  });
+
+  it('still writes when the content differs', async () => {
+    const filePath = path.join(dir, 'out.ts');
+    await writeGeneratedFile(filePath, 'const a = 1;\n');
+    await writeGeneratedFile(filePath, 'const a = 2;\n');
+
+    expect(await fs.readFile(filePath, 'utf8')).toBe('const a = 2;\n');
+  });
+});

--- a/packages/core/src/writers/file.test.ts
+++ b/packages/core/src/writers/file.test.ts
@@ -42,7 +42,7 @@ describe('writeGeneratedFile', () => {
   it('compares transformed content before writing', async () => {
     const filePath = path.join(dir, 'out.ts');
     const format = async (_filePath: string, content: string) =>
-      content.replaceAll("'", '"');
+      content.replace(';\n', ';   \n').replaceAll("'", '"');
 
     await withGeneratedFileTransform(format, () =>
       writeGeneratedFile(filePath, "const value = 'test';\n"),

--- a/packages/core/src/writers/file.ts
+++ b/packages/core/src/writers/file.ts
@@ -13,5 +13,16 @@ export async function writeGeneratedFile(
   filePath: string,
   content: string,
 ): Promise<void> {
-  await fs.outputFile(filePath, content.replaceAll(TRAILING_WHITESPACE_RE, ''));
+  const nextContent = content.replaceAll(TRAILING_WHITESPACE_RE, '');
+
+  // Skip the write when the file already holds this exact output, so a no-op
+  // regeneration does not churn mtime and wake every downstream watcher. Same
+  // reasoning as the barrel writers (#3756), applied to generated artifacts
+  // as well. (#3787)
+  if (await fs.pathExists(filePath)) {
+    const existingContent = await fs.readFile(filePath, 'utf8');
+    if (existingContent === nextContent) return;
+  }
+
+  await fs.outputFile(filePath, nextContent);
 }

--- a/packages/core/src/writers/file.ts
+++ b/packages/core/src/writers/file.ts
@@ -1,6 +1,31 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import fs from 'fs-extra';
 
 const TRAILING_WHITESPACE_RE = /[^\S\r\n]+$/gm;
+
+export type GeneratedFileTransform = (
+  filePath: string,
+  content: string,
+) => Promise<string>;
+
+const generatedFileTransform = new AsyncLocalStorage<GeneratedFileTransform>();
+
+export function withGeneratedFileTransform<T>(
+  transform: GeneratedFileTransform,
+  callback: () => Promise<T>,
+): Promise<T> {
+  return generatedFileTransform.run(transform, callback);
+}
+
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'ENOENT'
+  );
+}
 
 /**
  * Write generated code to a file, stripping trailing whitespace from each line.
@@ -13,15 +38,28 @@ export async function writeGeneratedFile(
   filePath: string,
   content: string,
 ): Promise<void> {
-  const nextContent = content.replaceAll(TRAILING_WHITESPACE_RE, '');
+  let nextContent = content.replaceAll(TRAILING_WHITESPACE_RE, '');
+  const transform = generatedFileTransform.getStore();
+  if (transform) {
+    nextContent = (await transform(filePath, nextContent)).replaceAll(
+      TRAILING_WHITESPACE_RE,
+      '',
+    );
+  }
 
   // Skip the write when the file already holds this exact output, so a no-op
   // regeneration does not churn mtime and wake every downstream watcher. Same
   // reasoning as the barrel writers (#3756), applied to generated artifacts
   // as well. (#3787)
-  if (await fs.pathExists(filePath)) {
+  try {
     const existingContent = await fs.readFile(filePath, 'utf8');
-    if (existingContent === nextContent) return;
+    if (existingContent === nextContent) {
+      return;
+    }
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
   }
 
   await fs.outputFile(filePath, nextContent);

--- a/packages/orval/src/formatters/prettier.test.ts
+++ b/packages/orval/src/formatters/prettier.test.ts
@@ -12,17 +12,17 @@ const mocks = vi.hoisted(() => ({
   readdir: vi.fn(),
   resolveConfig: vi.fn(),
   stat: vi.fn(),
-  writeFile: vi.fn(),
+  writeGeneratedFile: vi.fn(),
 }));
 
 vi.mock('@orval/core', () => ({
   logWarning: mocks.logWarning,
+  writeGeneratedFile: mocks.writeGeneratedFile,
 }));
 
 vi.mock('node:fs/promises', () => ({
   default: {
     readFile: mocks.readFile,
-    writeFile: mocks.writeFile,
     stat: mocks.stat,
     readdir: mocks.readdir,
   },
@@ -50,7 +50,7 @@ describe('formatWithPrettier', () => {
     mocks.resolveConfig.mockResolvedValue({ semi: true });
     mocks.readFile.mockResolvedValue('const value=1');
     mocks.format.mockResolvedValue('const value = 1;\n');
-    mocks.writeFile.mockImplementation(async () => {
+    mocks.writeGeneratedFile.mockImplementation(async () => {
       await Promise.resolve();
     });
   });
@@ -60,7 +60,7 @@ describe('formatWithPrettier', () => {
       code: 'ENOENT',
     });
 
-    mocks.writeFile.mockRejectedValueOnce(missingFileError);
+    mocks.writeGeneratedFile.mockRejectedValueOnce(missingFileError);
 
     await expect(
       formatWithPrettier([FILE_PATH], 'petstore'),
@@ -93,7 +93,7 @@ describe('formatWithPrettier', () => {
     expect(mocks.format).toHaveBeenCalledWith('const value=1', {
       filepath: FILE_PATH,
     });
-    expect(mocks.writeFile).toHaveBeenCalledWith(
+    expect(mocks.writeGeneratedFile).toHaveBeenCalledWith(
       FILE_PATH,
       'const value = 1;\n',
     );

--- a/packages/orval/src/formatters/prettier.test.ts
+++ b/packages/orval/src/formatters/prettier.test.ts
@@ -98,4 +98,13 @@ describe('formatWithPrettier', () => {
       'const value = 1;\n',
     );
   });
+
+  it('resolves prettier config for each file', async () => {
+    const schemaPath = path.resolve('/tmp/pets.schema.ts');
+
+    await formatWithPrettier([FILE_PATH, schemaPath], 'petstore');
+
+    expect(mocks.resolveConfig).toHaveBeenCalledWith(FILE_PATH);
+    expect(mocks.resolveConfig).toHaveBeenCalledWith(schemaPath);
+  });
 });

--- a/packages/orval/src/formatters/prettier.ts
+++ b/packages/orval/src/formatters/prettier.ts
@@ -16,19 +16,9 @@ export async function createPrettierFileTransform(
     return;
   }
 
-  const configs = new Map<
-    string,
-    Awaited<ReturnType<typeof prettier.resolveConfig>>
-  >();
-
   return async (filePath, content) => {
     try {
-      const directory = path.dirname(filePath);
-      let config = configs.get(directory);
-      if (!configs.has(directory)) {
-        config = await prettier.resolveConfig(filePath);
-        configs.set(directory, config);
-      }
+      const config = await prettier.resolveConfig(filePath);
 
       return await prettier.format(content, {
         ...config,

--- a/packages/orval/src/formatters/prettier.ts
+++ b/packages/orval/src/formatters/prettier.ts
@@ -1,8 +1,54 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { logWarning } from '@orval/core';
+import {
+  type GeneratedFileTransform,
+  logWarning,
+  writeGeneratedFile,
+} from '@orval/core';
 import { execa } from 'execa';
+
+export async function createPrettierFileTransform(
+  projectTitle?: string,
+): Promise<GeneratedFileTransform | undefined> {
+  const prettier = await tryImportPrettier();
+  if (!prettier) {
+    return;
+  }
+
+  const configs = new Map<
+    string,
+    Awaited<ReturnType<typeof prettier.resolveConfig>>
+  >();
+
+  return async (filePath, content) => {
+    try {
+      const directory = path.dirname(filePath);
+      let config = configs.get(directory);
+      if (!configs.has(directory)) {
+        config = await prettier.resolveConfig(filePath);
+        configs.set(directory, config);
+      }
+
+      return await prettier.format(content, {
+        ...config,
+        // filepath lets Prettier infer the parser from the file extension.
+        filepath: filePath,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'UndefinedParserError') {
+        return content;
+      }
+
+      const detail =
+        error instanceof Error ? error.toString() : 'unknown error';
+      logWarning(
+        `⚠️  ${projectTitle ? `${projectTitle} - ` : ''}Failed to format file ${filePath}: ${detail}`,
+      );
+      return content;
+    }
+  };
+}
 
 /**
  * Format files with prettier.
@@ -13,25 +59,19 @@ export async function formatWithPrettier(
   paths: string[],
   projectTitle?: string,
 ): Promise<void> {
-  const prettier = await tryImportPrettier();
+  const format = await createPrettierFileTransform(projectTitle);
 
-  if (prettier) {
+  if (format) {
     const filePaths = [...new Set(await collectFilePaths(paths))];
     if (filePaths.length === 0) {
       return;
     }
 
-    const config = (await prettier.resolveConfig(filePaths[0])) ?? {};
     await Promise.all(
       filePaths.map(async (filePath) => {
         try {
           const content = await fs.readFile(filePath, 'utf8');
-          const formatted = await prettier.format(content, {
-            ...config,
-            // options.filepath can be specified for Prettier to infer the parser from the file extension
-            filepath: filePath,
-          });
-          await fs.writeFile(filePath, formatted);
+          await writeGeneratedFile(filePath, await format(filePath, content));
         } catch (error) {
           if (isMissingFileError(error)) {
             return;

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -88,6 +88,50 @@ const createTempWorkspace = async () => {
   return mkdtemp(path.join(os.tmpdir(), 'orval-gen-spec-'));
 };
 
+describe('generateSpec - unchanged formatted output', () => {
+  it('keeps mtimes when prettier produces the same final files', async () => {
+    const workspace = await createTempWorkspace();
+    const targetFile = path.join(workspace, 'endpoints.ts');
+    const schemasDir = path.join(workspace, 'model');
+
+    try {
+      const options = await normalizeOptions(
+        {
+          input: { target: PETSTORE_SPEC },
+          output: {
+            target: './endpoints.ts',
+            schemas: './model',
+            client: 'zod',
+            formatter: 'prettier',
+          },
+        },
+        workspace,
+      );
+
+      await generateSpec(workspace, options);
+      const generatedFiles = [
+        targetFile,
+        ...(await fs.readdir(schemasDir)).map((file) =>
+          path.join(schemasDir, file),
+        ),
+      ];
+      const past = new Date('2020-01-01T00:00:00.000Z');
+      await Promise.all(
+        generatedFiles.map((file) => fs.utimes(file, past, past)),
+      );
+
+      await generateSpec(workspace, options);
+
+      const mtimes = await Promise.all(
+        generatedFiles.map(async (file) => (await fs.stat(file)).mtimeMs),
+      );
+      expect(mtimes).toEqual(generatedFiles.map(() => past.getTime()));
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('generateSpec - HTTP QUERY method', () => {
   it('generates clients for QUERY operations with request bodies', async () => {
     const workspace = await createTempWorkspace();

--- a/packages/orval/src/utils/barrel.ts
+++ b/packages/orval/src/utils/barrel.ts
@@ -1,4 +1,6 @@
 import path from 'node:path';
+
+import { writeGeneratedFile } from '@orval/core';
 import fs from 'fs-extra';
 
 const RE_EXPORT_LINE = /^\s*export\s+\*\s+from\s*['"]([^'"]+)['"]\s*;?\s*$/;
@@ -44,15 +46,19 @@ export async function reconcileWorkspaceBarrel(
   fileExtension: string,
   importExtension: string,
 ): Promise<void> {
-  if (!(await fs.pathExists(filePath))) {
-    await fs.outputFile(
+  let existingContent: string;
+  try {
+    existingContent = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+    await writeGeneratedFile(
       filePath,
       specifiers.map((s) => `export * from '${s}';`).join('\n') + '\n',
     );
     return;
   }
-
-  const existingContent = await fs.readFile(filePath, 'utf8');
   const declared = [...readReExportSpecifiers(existingContent)];
   const resolvable = await Promise.all(
     declared.map((s) =>
@@ -84,7 +90,7 @@ export async function reconcileWorkspaceBarrel(
     [retainedContent, appended].filter(Boolean).join(eol) + eol;
 
   if (nextContent !== existingContent) {
-    await fs.outputFile(filePath, nextContent);
+    await writeGeneratedFile(filePath, nextContent);
   }
 }
 
@@ -96,9 +102,14 @@ export async function reconcileZodBarrel(
   header: string,
   mergeExisting: boolean,
 ): Promise<void> {
-  const existingContent = (await fs.pathExists(filePath))
-    ? await fs.readFile(filePath, 'utf8')
-    : '';
+  let existingContent = '';
+  try {
+    existingContent = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
   const existing = mergeExisting
     ? readReExportSpecifiers(existingContent)
     : new Set<string>();
@@ -108,6 +119,6 @@ export async function reconcileZodBarrel(
     .join('\n');
   const nextContent = `${header}\n${body}\n`;
   if (nextContent !== existingContent) {
-    await fs.outputFile(filePath, nextContent);
+    await writeGeneratedFile(filePath, nextContent);
   }
 }

--- a/packages/orval/src/write-specs.test.ts
+++ b/packages/orval/src/write-specs.test.ts
@@ -1,4 +1,12 @@
-import { SupportedFormatter } from '@orval/core';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  type NormalizedOptions,
+  SupportedFormatter,
+  type WriteSpecBuilder,
+} from '@orval/core';
+import fs from 'fs-extra';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { MockExecaError } = vi.hoisted(() => ({
@@ -32,7 +40,7 @@ vi.mock('@orval/core', async (importOriginal) => {
 
 import { execa } from 'execa';
 
-import { runFormatter } from './write-specs';
+import { runFormatter, writeSpecs } from './write-specs';
 
 const mockedExeca = vi.mocked(execa);
 
@@ -82,5 +90,51 @@ describe('runFormatter', () => {
     expect(logWarning).toHaveBeenCalledWith(
       expect.stringContaining('oxfmt not found'),
     );
+  });
+});
+
+describe('writeSpecs', () => {
+  it('does not rewrite unchanged extra files', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'orval-extra-file-'));
+    const filePath = path.join(root, 'context.ts');
+    const builder = {
+      operations: {},
+      verbOptions: {},
+      schemas: [],
+      title: vi.fn(),
+      header: vi.fn(),
+      footer: vi.fn(),
+      imports: vi.fn(),
+      importsMock: vi.fn(),
+      extraFiles: [{ path: filePath, content: 'export const context = {};\n' }],
+      info: { title: 'Extra files', version: '1.0.0' },
+      target: '',
+      spec: {},
+    } as WriteSpecBuilder;
+    const options = {
+      output: {
+        target: '',
+        schemas: false,
+        operationSchemas: false,
+        workspace: false,
+        docs: false,
+        formatter: undefined,
+        override: { header: false },
+        mock: { generators: [] },
+      },
+      hooks: {},
+    } as unknown as NormalizedOptions;
+
+    try {
+      await writeSpecs(builder, root, options);
+      const past = new Date('2020-01-01T00:00:00.000Z');
+      await fs.utimes(filePath, past, past);
+
+      await writeSpecs(builder, root, options);
+
+      expect((await fs.stat(filePath)).mtimeMs).toBe(past.getTime());
+    } finally {
+      await fs.remove(root);
+    }
   });
 });

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -26,6 +26,7 @@ import {
   splitSchemasByType,
   SupportedFormatter,
   upath,
+  withGeneratedFileTransform,
   writeGeneratedFile,
   writeSchemas,
   writeSchemasTagsSplit,
@@ -43,7 +44,10 @@ import { execa, ExecaError } from 'execa';
 import fs from 'fs-extra';
 import type { TypeDocOptions } from 'typedoc';
 
-import { formatWithPrettier } from './formatters/prettier';
+import {
+  createPrettierFileTransform,
+  formatWithPrettier,
+} from './formatters/prettier';
 import {
   executeHook,
   readReExportSpecifiers,
@@ -175,14 +179,21 @@ async function addOperationSchemasReExport(
   );
   const exportLine = `export * from '${esmImportPath}';\n`;
 
-  const indexExists = await fs.pathExists(schemaIndexPath);
-  if (indexExists) {
+  let existingContent: string | undefined;
+  try {
+    existingContent = await fs.readFile(schemaIndexPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (existingContent !== undefined) {
     // Append the re-export only if it isn't already declared. The presence
     // check reuses the shared barrel specifier reader so quote style can't
     // cause duplicates (#3756).
-    const existingContent = await fs.readFile(schemaIndexPath, 'utf8');
     if (!readReExportSpecifiers(existingContent).has(esmImportPath)) {
-      await fs.appendFile(schemaIndexPath, exportLine);
+      await writeGeneratedFile(schemaIndexPath, existingContent + exportLine);
     }
   } else {
     // Create index with header if file doesn't exist (no regular schemas case)
@@ -190,7 +201,7 @@ async function addOperationSchemasReExport(
       header && header.trim().length > 0
         ? `${header}\n${exportLine}`
         : exportLine;
-    await fs.outputFile(schemaIndexPath, content);
+    await writeGeneratedFile(schemaIndexPath, content);
   }
 }
 
@@ -469,7 +480,7 @@ function getImplementationPathsForIndex(
   );
 }
 
-export async function writeSpecs(
+async function writeSpecsInternal(
   builder: WriteSpecBuilder,
   workspace: string,
   options: NormalizedOptions,
@@ -870,7 +881,7 @@ export async function writeSpecs(
   if (builder.extraFiles.length > 0) {
     await Promise.all(
       builder.extraFiles.map(async (file) =>
-        fs.outputFile(file.path, file.content),
+        writeGeneratedFile(file.path, file.content),
       ),
     );
 
@@ -962,6 +973,28 @@ export async function writeSpecs(
   }
 
   createSuccessMessage(projectTitle);
+}
+
+export async function writeSpecs(
+  builder: WriteSpecBuilder,
+  workspace: string,
+  options: NormalizedOptions,
+  projectName?: string,
+): Promise<void> {
+  const shouldFormatBeforeWriting =
+    options.output.formatter === SupportedFormatter.PRETTIER &&
+    !options.hooks.afterAllFilesWrite;
+  const transform = shouldFormatBeforeWriting
+    ? await createPrettierFileTransform(projectName ?? builder.info.title)
+    : undefined;
+
+  if (transform) {
+    return withGeneratedFileTransform(transform, () =>
+      writeSpecsInternal(builder, workspace, options, projectName),
+    );
+  }
+
+  return writeSpecsInternal(builder, workspace, options, projectName);
 }
 
 function getWriteMode(mode: OutputMode) {

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -56,6 +56,46 @@ const createOutputOptions = (): Parameters<typeof writeZodSchemas>[4] =>
   }) as Parameters<typeof writeZodSchemas>[4];
 
 describe('write-zod-specs regressions', () => {
+  it('does not rewrite unchanged direct zod output', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-mtime-'));
+    const schemasPath = path.join(root, 'schemas');
+    const filePath = path.join(schemasPath, 'RangeSchema.ts');
+    const builder = {
+      spec: {},
+      target: '',
+      schemas: [
+        {
+          name: 'RangeSchema',
+          schema: { type: 'number', minimum: 2, maximum: 10 },
+        },
+      ],
+    } satisfies Parameters<typeof writeZodSchemas>[0];
+
+    try {
+      await writeZodSchemas(
+        builder,
+        schemasPath,
+        '.ts',
+        '',
+        createOutputOptions(),
+      );
+      const past = new Date('2020-01-01T00:00:00.000Z');
+      await fs.utimes(filePath, past, past);
+
+      await writeZodSchemas(
+        builder,
+        schemasPath,
+        '.ts',
+        '',
+        createOutputOptions(),
+      );
+
+      expect((await fs.stat(filePath)).mtimeMs).toBe(past.getTime());
+    } finally {
+      await fs.remove(root);
+    }
+  });
+
   it('writes const constraints before schema export', async () => {
     const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-'));
     const schemasPath = path.join(root, 'schemas');

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -19,6 +19,7 @@ import {
   resolveValue,
   type Tsconfig,
   upath,
+  writeGeneratedFile,
   type ZodCoerceType,
   type ZodVariantOption,
   type ZodVersionOption,
@@ -34,7 +35,6 @@ import {
   resolveIsZodV4,
   type ZodValidationSchemaDefinition,
 } from '@orval/zod';
-import fs from 'fs-extra';
 
 import {
   generateReusableSchemaSet,
@@ -581,7 +581,7 @@ export async function writeZodSchemaTagsSplitBarrel(
   const allExports = [...rootExports, ...tagExports];
   const rootIndexPath = path.join(schemasPath, 'index.ts');
   const content = `${header}\n${allExports.join('\n')}\n`;
-  await fs.outputFile(rootIndexPath, content);
+  await writeGeneratedFile(rootIndexPath, content);
 }
 
 export function generateZodSchemasInline(
@@ -857,7 +857,7 @@ export async function writeZodSchemas(
       output.override.zod.variant,
     );
 
-    await fs.outputFile(schemaGroup[0].filePath, fileContent);
+    await writeGeneratedFile(schemaGroup[0].filePath, fileContent);
   }
 
   const writtenSchemaNames = groupedSchemasToWrite.map(
@@ -1004,7 +1004,7 @@ async function writeZodSchemasReusable(
       (imports ? `${imports}\n\n` : '\n') +
       `${rendered.content}\n`;
 
-    await fs.outputFile(filePath, fileContent);
+    await writeGeneratedFile(filePath, fileContent);
   }
 
   if (output.indexFiles && !isSplit && rewritten.length > 0) {
@@ -1365,7 +1365,7 @@ export async function writeZodSchemasFromVerbs(
       output.override.zod.variant,
     );
 
-    await fs.outputFile(schemaGroup[0].filePath, fileContent);
+    await writeGeneratedFile(schemaGroup[0].filePath, fileContent);
   }
 
   const writtenSchemaNames = groupedSchemasToWrite.map(


### PR DESCRIPTION
Addresses #3787 by extending behaviour that already exists in this repo rather than introducing a policy.

`reconcileBarrel` and `reconcileZodBarrel` in `packages/orval/src/utils/barrel.ts` already read the file and skip the write when the content matches, added for #3756 with the same reasoning about mtime churn. `writeGeneratedFile` did not, so every artifact that goes through it was rewritten on each run. That is the inconsistency the issue describes.

`writeGeneratedFile` now compares before writing, which covers the schema, single-mode and split-mode writers.

The comparison runs after trailing whitespace is stripped, so what is compared is the bytes that would land on disk rather than the generator's raw string. That matters: two runs can produce different source strings and identical output, and the naive comparison would miss it. One of the tests exercises exactly that case.

On the open question in the issue, default versus `onlyUpdateWhenDifferent`: I made it the default, since that is what the barrels already do and a second option would leave two writers in the codebase disagreeing about the same thing. A file whose content genuinely differs, including from a version stamp in its header, is still rewritten, so this does not suppress real changes. Happy to put it behind a flag instead if you would rather preserve write events for consumers who depend on them.

Three tests in `packages/core/src/writers/file.test.ts`, a new file, covering creation with whitespace stripping, an unchanged rewrite leaving mtime alone, and a changed rewrite still landing. The mtime test fails on the commit before this change.

`packages/core` goes from 2272 to 2275 tests. The full package suite passes, including the `#3756` barrel idempotency tests in `packages/orval` that exercise repeat generation. `tsc --noEmit` and `vp fmt --check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved generated-file formatting with file-specific Prettier configuration.
  * Missing generated files are now created automatically during specification and schema generation.
  * Generated barrel and schema files are updated consistently.

* **Bug Fixes**
  * Prevented unnecessary rewrites when generated content is unchanged.
  * Preserved file modification times when no content changes are needed.
  * Continued stripping trailing whitespace, including in nested files.

* **Tests**
  * Added coverage for formatting, file creation, unchanged content, and content updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->