### PR TITLE
docs: add examples for queryKey, queryOptions and mutationOptions

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1251,6 +1251,81 @@ parameter, orval passes operation identity so the mutator can branch on it
 - `mutationOptions` mutator — `{ operationId, operationName }` (the `url`
   is supplied in the second parameter)
 
+Each option takes a mutator, so point it at a file and an exported name:
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      client: 'react-query',
+      override: {
+        query: {
+          queryKey: {
+            path: './src/mutators/custom-query-key.ts',
+            name: 'customQueryKey',
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+`queryKey` replaces the generated key factory. It receives the operation's
+query properties and a context carrying the `url`:
+
+```ts title="src/mutators/custom-query-key.ts"
+export function customQueryKey(
+  // The properties dictionary varies per operation (params, petId, ...), so
+  // type it broadly if one mutator serves every endpoint.
+  properties: Record<string, unknown>,
+  context: { url: string },
+) {
+  return ['tenant-abc', context.url, properties] as const;
+}
+```
+
+`queryOptions` wraps the options object passed to the generated hook. The
+third parameter is the operation identity described above:
+
+```ts title="src/mutators/custom-query-options.ts"
+import type { QueryKey } from '@tanstack/react-query';
+
+export function customQueryOptions<T extends { queryKey: QueryKey }>(
+  options: T,
+  _queryProperties: Record<string, unknown>,
+  operation: { url: string; operationId: string; operationName: string },
+): T {
+  return {
+    ...options,
+    queryKey: ['operation', operation.operationId, ...options.queryKey],
+  };
+}
+```
+
+`mutationOptions` works the same way for mutations, which is where branching
+on `operationId` is most useful:
+
+```ts title="src/mutators/custom-mutation.ts"
+import { type UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+
+export const useCustomMutation = <T, TError, TData, TContext>(
+  options: UseMutationOptions<T, TError, TData, TContext>,
+  _: { url: string },
+  operation: { operationId: string; operationName: string },
+) => {
+  const queryClient = useQueryClient();
+  if (operation.operationId === 'deletePetById') {
+    queryClient.invalidateQueries({ queryKey: ['/pets'] });
+  }
+  return options;
+};
+```
+
+Because the mutator receives `operationId`, one file can serve every
+operation and branch where the behaviour needs to differ, which is the usual
+alternative to a per-operation configuration option.
+
 ### shouldExportMutatorHooks
 
 **Type:** `Boolean`

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1264,6 +1264,14 @@ export default defineConfig({
             path: './src/mutators/custom-query-key.ts',
             name: 'customQueryKey',
           },
+          queryOptions: {
+            path: './src/mutators/custom-query-options.ts',
+            name: 'customQueryOptions',
+          },
+          mutationOptions: {
+            path: './src/mutators/custom-mutation.ts',
+            name: 'useCustomMutation',
+          },
         },
       },
     },
@@ -1295,7 +1303,7 @@ export function customQueryOptions<T extends { queryKey: QueryKey }>(
   options: T,
   _queryProperties: Record<string, unknown>,
   operation: { url: string; operationId: string; operationName: string },
-): T {
+): T & { queryKey: QueryKey } {
   return {
     ...options,
     queryKey: ['operation', operation.operationId, ...options.queryKey],
@@ -1304,21 +1312,32 @@ export function customQueryOptions<T extends { queryKey: QueryKey }>(
 ```
 
 `mutationOptions` works the same way for mutations, which is where branching
-on `operationId` is most useful:
+on `operationId` is most useful.
+
+The mutator runs where the options object is built, inside the hook body, so
+side effects belong in a callback rather than in the mutator itself. Calling
+`invalidateQueries()` directly would fire on every render instead of after the
+mutation succeeds:
 
 ```ts title="src/mutators/custom-mutation.ts"
 import { type UseMutationOptions, useQueryClient } from '@tanstack/react-query';
 
-export const useCustomMutation = <T, TError, TData, TContext>(
-  options: UseMutationOptions<T, TError, TData, TContext>,
+export const useCustomMutation = <TData, TError, TVariables, TContext>(
+  options: UseMutationOptions<TData, TError, TVariables, TContext>,
   _: { url: string },
   operation: { operationId: string; operationName: string },
 ) => {
   const queryClient = useQueryClient();
-  if (operation.operationId === 'deletePetById') {
-    queryClient.invalidateQueries({ queryKey: ['/pets'] });
-  }
-  return options;
+  if (operation.operationId !== 'deletePetById') return options;
+
+  return {
+    ...options,
+    onSuccess: (...args: Parameters<NonNullable<typeof options.onSuccess>>) => {
+      queryClient.invalidateQueries({ queryKey: ['/pets'] });
+      // Keep whatever the caller already passed.
+      return options.onSuccess?.(...args);
+    },
+  };
 };
 ```
 


### PR DESCRIPTION
Picks up @melloware's note on #3790 that the docs are lacking here, scoped to documentation only. No config or behaviour change.

The `queryKey / queryOptions / mutationOptions` section described the three overrides in prose and named the operation identity each mutator receives, but had no code. So the answer to "how do I actually write one" lived in the test fixtures and in old tickets, which is what the issue thread ended up doing manually.

Adds the config snippet that wires a mutator up, then one example per option. They are taken from the fixtures @wadakatu pointed at rather than written from scratch:

- `queryKey` from `tests/mutators/custom-query-key.ts`
- `queryOptions` from `tests/mutators/custom-query-options-with-operation.ts`
- `mutationOptions` from `tests/mutators/custom-mutation.ts`

I trimmed them for the page: the `queryOptions` example inlines the key prefix instead of hoisting a constant, and the `mutationOptions` one drops the `Required<Pick<..., 'mutationFn'>>` intersection, which is noise in a doc example. The parameter lists and the operation-identity shapes are unchanged from the fixtures.

The closing line points at what the issue was actually asking for: since the mutator receives `operationId`, one file can serve every operation and branch where behaviour differs. That is the alternative to the per-operation prefix option requested in the issue, and it is what the thread converged on.

`vp fmt` skips `.mdx`, so there is no formatter to run against this file. The anchors and heading levels are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring custom query and mutation behavior.
  * Documented custom key generation, callback signatures, operation context, and operation-specific examples.
  * Included instructions for connecting custom configuration files and names.
  * Explained option wrapping and recommended practices for handling callback side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->