### PR TITLE
fix(tests): invalidate in onSuccess in the custom mutation fixture

### DIFF
--- a/tests/mutators/custom-mutation.ts
+++ b/tests/mutators/custom-mutation.ts
@@ -20,8 +20,11 @@ export const useCustomMutation = <T, TError, TData, TContext>(
   // re-renders.
   return {
     ...options,
-    onSuccess: (data: T, variables: TData, context: TContext) => {
-      queryClient.invalidateQueries({ queryKey: ['/pets'] });
+    onSuccess: async (data: T, variables: TData, context: TContext) => {
+      // `onSuccess` may return a promise, and the mutation waits for it, so
+      // awaiting the invalidation keeps the mutation pending until `/pets` is
+      // refreshed instead of settling while the refetch is still in flight.
+      await queryClient.invalidateQueries({ queryKey: ['/pets'] });
       return options.onSuccess?.(data, variables, context);
     },
   };

--- a/tests/mutators/custom-mutation.ts
+++ b/tests/mutators/custom-mutation.ts
@@ -9,8 +9,20 @@ export const useCustomMutation = <T, TError, TData, TContext>(
   operation: { operationId: string; operationName: string },
 ) => {
   const queryClient = useQueryClient();
-  if (operation.operationId === 'deletePetById') {
-    queryClient.invalidateQueries({ queryKey: ['/pets'] });
+
+  if (operation.operationId !== 'deletePetById') {
+    return options;
   }
-  return options;
+
+  // Invalidate after the mutation settles, not while the hook renders. The
+  // generated options function calls this mutator on every render, so an
+  // invalidation in the body refetches `/pets` on each one, and the refetch
+  // re-renders.
+  return {
+    ...options,
+    onSuccess: (data: T, variables: TData, context: TContext) => {
+      queryClient.invalidateQueries({ queryKey: ['/pets'] });
+      return options.onSuccess?.(data, variables, context);
+    },
+  };
 };


### PR DESCRIPTION
Follow-up to #3825, where I raised this at the end and offered to send it separately.

The `useCustomMutation` fixture invalidates in the hook body:

```ts
const queryClient = useQueryClient();
if (operation.operationId === 'deletePetById') {
  queryClient.invalidateQueries({ queryKey: ['/pets'] });
}
return options;
```

`mutation-generator.ts` emits the mutator call inside the generated options function:

```ts
const customOptions = useCustomMutation({...mutationOptions, mutationFn}, ...);
```

That function runs on every render of the hook, not when the mutation settles. So the invalidation fires on each render, and since invalidating `/pets` triggers a refetch and a refetch re-renders, a component holding both hooks can loop.

The fixture works as a fixture because nothing in the test suite renders it twice. It matters because it is what people copy: it is the only `mutationOptions` example in the repo, and it is where I took the example in #3825 from. That PR is now merged, so the documented example shows the `onSuccess` shape while the fixture still shows the other one.

The invalidation moves into `onSuccess` and calls through to any `onSuccess` the caller passed, so it still composes.

## Verification

The generator emits an import and a call, never the mutator body, so no snapshot changes. I checked: `tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts` and `tests/__snapshots__/react-query/issue-2039/endpoints.ts` contain only `import { useCustomMutation } from '../../../mutators/custom-mutation'` and two call sites.

The return type does change, from the options object to a union of it and the spread with `onSuccess`, so I typechecked the consumer side rather than assume. Both generated snapshot directories plus `tests/mutators` under `strict`: 122 repo files, no errors. `tests/tsconfig.json` is clean too.

`vp fmt` skips `tests/mutators` by its ignore rules, so there is nothing to format there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pet list data now refreshes after a successful pet deletion.
  * Mutation success callbacks continue to run as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->