### PR TITLE
fix(core): don't read the pascal cache off Object.prototype

### DIFF
--- a/packages/core/src/utils/case.test.ts
+++ b/packages/core/src/utils/case.test.ts
@@ -71,3 +71,39 @@ describe('kebab-case a few examples', () => {
     });
   }
 });
+
+describe('property names inherited from Object.prototype', () => {
+  // A schema is free to name a property `toString` or `constructor`. The
+  // pascal cache is keyed by that name, so on an object literal the lookup
+  // read the inherited member back instead of a cached string.
+  for (const name of [
+    'toString',
+    'valueOf',
+    'constructor',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'toLocaleString',
+    'propertyIsEnumerable',
+  ]) {
+    it(`pascal('${name}') returns a string`, () => {
+      const result = pascal(name);
+      expect(typeof result).toBe('string');
+      expect(result).toBe(name.charAt(0).toUpperCase() + name.slice(1));
+    });
+
+    it(`camel('${name}') returns a string`, () => {
+      expect(camel(name)).toBe(name);
+    });
+  }
+
+  it('shapes __proto__ by the same word rules as any other name', () => {
+    expect(pascal('__proto__')).toBe('_Proto');
+    expect(camel('__proto__')).toBe('_proto');
+  });
+
+  it('returns the same value on a second call', () => {
+    expect(pascal('toString')).toBe(pascal('toString'));
+    expect(pascal('petTag')).toBe('PetTag');
+    expect(pascal('petTag')).toBe('PetTag');
+  });
+});

--- a/packages/core/src/utils/case.ts
+++ b/packages/core/src/utils/case.ts
@@ -91,12 +91,17 @@ const lower = (s: string, fillWith: string, isDeapostrophe: boolean) => {
   return fill(low(prep(s, !!fillWith)), fillWith, isDeapostrophe);
 };
 
-// Caches the previously converted strings to improve performance
-const pascalMemory: Record<string, string> = {};
+// Caches the previously converted strings to improve performance.
+// A Map, not an object literal: the keys are names taken from the OpenAPI
+// document, and a schema is free to call a property `toString` or
+// `constructor`. On an object those read back off `Object.prototype`, so the
+// lookup would return a function instead of a string.
+const pascalMemory = new Map<string, string>();
 
 export function pascal(s = '') {
-  if (pascalMemory[s]) {
-    return pascalMemory[s];
+  const cached = pascalMemory.get(s);
+  if (cached !== undefined) {
+    return cached;
   }
 
   const isStartWithUnderscore = s.startsWith('_');
@@ -114,7 +119,7 @@ export function pascal(s = '') {
     ? `_${pascalString}`
     : pascalString;
 
-  pascalMemory[cacheKey] = pascalWithUnderscore;
+  pascalMemory.set(cacheKey, pascalWithUnderscore);
 
   return pascalWithUnderscore;
 }


### PR DESCRIPTION
﻿`pascal` memoizes into an object literal keyed by the name being converted:

```ts
const pascalMemory: Record<string, string> = {};

export function pascal(s = '') {
  if (pascalMemory[s]) {
    return pascalMemory[s];
  }
```

Those keys come from the OpenAPI document, and a schema is free to name a property `toString` or `constructor`. For those the lookup finds the member inherited from `Object.prototype`, which is truthy, so the cache "hits" and hands back a function:

```js
pascal('toString')   // function toString() { [native code] }
camel('toString')    // TypeError: s.charAt is not a function
```

`camel` passes the result to `decap`, which calls `.charAt` on it, so generation stops on a `TypeError` that names neither the schema nor the property. Seven ordinary names reach it: `toString`, `valueOf`, `constructor`, `hasOwnProperty`, `isPrototypeOf`, `toLocaleString`, `propertyIsEnumerable`.

The write side is broken in the same place: `pascalMemory['__proto__'] = ...` goes through the `Object.prototype` setter and stores nothing, so that key never caches.

## The change

A `Map`. Reading with `get` and comparing against `undefined` rather than truthiness also lets an empty result stay cached, which the old check could never do.

## Tests

Added a block to `case.test.ts`: for each of the seven names, `pascal` returns a string with the expected shape and `camel` round-trips it. Plus `__proto__`, which the word rules shape to `_Proto` / `_proto` like any other name, and a second-call check so the cache is still exercised.

Fifteen of the twenty-nine cases in `case.test.ts` fail on `master` and all twenty-nine pass here.

`bunx vitest run packages/core`: 2285 passed. The three failures in `resolve-version.test.ts` are already there on a clean checkout of `master` on this machine and are untouched by this change. `bunx vp fmt --check` is clean on both files.

## How I got here

Reading the file rather than from an issue, so there is nothing to link. Happy to open one first if you would rather have it tracked that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name conversion reliability for special names, including `__proto__`.
  * Ensured repeated PascalCase conversions return consistent results.
  * Prevented conflicts with inherited object property names during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->