### PR TITLE
perf(core): avoid repeated schema name scans

### DIFF
--- a/packages/core/src/getters/object.test.ts
+++ b/packages/core/src/getters/object.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTestContextSpec } from '../test-utils/context';
+import type { OpenApiSchemaObject } from '../types';
+import { getObject } from './object';
+
+describe('getObject', () => {
+  it('suffixes inline object property schema names that collide with component schemas', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            UserDetails: { type: 'object' },
+          },
+        },
+      },
+    });
+
+    const result = getObject({
+      item: {
+        type: 'object',
+        properties: {
+          details: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        },
+      },
+      name: 'User',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('details?: UserDetailsProperty');
+    expect(result.schemas).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'UserDetailsProperty' }),
+      ]),
+    );
+  });
+
+  it('uses the same PascalCase collision semantics for differently cased or separated schema names', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            'user-details': { type: 'object' },
+            user_details: { type: 'object' },
+          },
+        },
+      },
+    });
+
+    const result = getObject({
+      item: {
+        type: 'object',
+        properties: {
+          details: {
+            type: 'object',
+            properties: {
+              enabled: { type: 'boolean' },
+            },
+          },
+        },
+      } satisfies OpenApiSchemaObject,
+      name: 'User',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('details?: UserDetailsProperty');
+    expect(result.schemas).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'UserDetailsProperty' }),
+      ]),
+    );
+  });
+
+  it('keeps inline object property schema names unchanged when component schemas do not collide', () => {
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          schemas: {
+            AccountDetails: { type: 'object' },
+          },
+        },
+      },
+    });
+
+    const result = getObject({
+      item: {
+        type: 'object',
+        properties: {
+          details: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        },
+      },
+      name: 'User',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('details?: UserDetails');
+    expect(result.value).not.toContain('UserDetailsProperty');
+    expect(result.schemas).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'UserDetails' }),
+      ]),
+    );
+  });
+});

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -171,6 +171,16 @@ interface GetObjectOptions {
   formDataContext?: FormDataContext;
 }
 
+function getNormalizedComponentSchemaNames(context: ContextSpec): Set<string> {
+  context.normalizedComponentSchemaNames ??= new Set(
+    Object.keys(context.spec.components?.schemas ?? {}).map((schemaName) =>
+      pascal(schemaName),
+    ),
+  );
+
+  return context.normalizedComponentSchemaNames;
+}
+
 /**
  * Return the output type from an object
  *
@@ -398,11 +408,8 @@ export function getObject({
         );
       }
 
-      const allSpecSchemas = context.spec.components?.schemas ?? {};
-
-      const isNameAlreadyTaken = Object.keys(allSpecSchemas).some(
-        (schemaName) => pascal(schemaName) === propName,
-      );
+      const isNameAlreadyTaken =
+        getNormalizedComponentSchemaNames(context).has(propName);
 
       if (isNameAlreadyTaken) {
         propName = propName + 'Property';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1388,6 +1388,12 @@ export interface ContextSpec {
    */
   dynamicAnchorIndex?: Map<string, DynamicAnchorIndexEntry>;
   /**
+   * Lazily-built set of normalized component schema names, used while naming
+   * inline object-property schemas so component name collision checks do not
+   * rescan `components.schemas` for every property.
+   */
+  normalizedComponentSchemaNames?: Set<string>;
+  /**
    * Tracks array-item mock factory names already emitted per output file scope.
    * Populated by `@orval/mock` when `arrayItems: true` so shared `$ref` item
    * factories are not re-declared within the same file (single/split) or tag


### PR DESCRIPTION
Improves the object-generation hot path by indexing normalized component schema names once per specification instead of rebuilding and normalizing the complete schema-name list for each object property.

This preserves the existing PascalCase schema-name collision behavior, including cases where multiple raw component names normalize to the same generated name, while avoiding repeated O(properties × schemas) scans.

Refs #3805

### Validation

- `vp install --frozen-lockfile` — passed
- `vp run prepare` — passed
- `vp fmt --check packages/core/src/getters/object.ts packages/core/src/getters/object.test.ts packages/core/src/types.ts` — passed
- `vp exec vitest run packages/core/src/getters/object.test.ts --config packages/core/vitest.config.ts --pool forks --reporter verbose` — passed
- `vp exec tsc --noEmit -p packages/core/tsconfig.json` — passed
- `vp exec vitest run --config vitest.config.ts --pool forks` from `packages/core` — passed
- `vp run -w format:check` — passed
- `vp run -w build:release` — passed
- `vp run -w lint` — passed
- `vp run -w lint:samples` — passed
- `vp run -w typecheck` — passed
- `vp run -w test` — passed
- `vp run -w test:snapshots` — passed
- `vp run -w test:cli` — passed
- `git diff --cached --check` — passed

### Performance

Workload: temporary local Vitest harness calling the real `getObject` path with deterministic object schemas where schema count equals property count. Each measured iteration built a fresh `ContextSpec`; results below are warm medians over 30 iterations.

Environment: macOS arm64, `vp v0.2.8`, local `vite-plus v0.1.24`, `vitest 4.0.18`, `vp exec node v22.22.3`, Bun `1.3.14`.

Before:

- 100 schemas/properties: median `0.897ms`, mean `0.901ms`
- 800 schemas/properties: median `54.040ms`, mean `53.946ms`

After:

- 100 schemas/properties: median `0.305ms`, mean `0.306ms`
- 800 schemas/properties: median `1.714ms`, mean `1.821ms`

Change:

- 100 schemas/properties: `0.592ms` faster, about `66.0%` lower median time
- 800 schemas/properties: `52.326ms` faster, about `96.8%` lower median time


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline object property naming to prevent conflicts with component schema names.
  * Conflicting names now receive a `Property` suffix, while non-conflicting names remain unchanged.
  * Collision detection now consistently handles differences in capitalization and separators.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->