### PR TITLE
perf: reuse collator for natural sorting

### DIFF
--- a/packages/core/src/generators/imports.ts
+++ b/packages/core/src/generators/imports.ts
@@ -7,7 +7,7 @@ import {
   GetterPropType,
   NamingConvention,
 } from '../types';
-import { conventionName } from '../utils';
+import { compareNatural, conventionName } from '../utils';
 import { escapeRegExp } from '../utils/string';
 
 interface GenerateImportsOptions {
@@ -58,7 +58,7 @@ export function generateImports({
   );
 
   return Object.entries(grouped)
-    .toSorted(([a], [b]) => a.localeCompare(b, 'en', { numeric: true }))
+    .toSorted(([a], [b]) => compareNatural(a, b))
     .map(([, group]) => {
       const sample = group[0];
       const canAggregate =

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -10,6 +10,7 @@ import {
   SchemaType,
 } from '../types';
 import {
+  compareNatural,
   isReference,
   isString,
   jsDoc,
@@ -369,9 +370,7 @@ export function getObject({
     const entries = Object.entries(itemProperties);
     if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
-        return a[0].localeCompare(b[0], 'en', {
-          numeric: true,
-        });
+        return compareNatural(a[0], b[0]);
       });
     }
     const acc: ScalarValue = {

--- a/packages/core/src/utils/sort.test.ts
+++ b/packages/core/src/utils/sort.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareNatural } from './sort';
+
+describe('compareNatural', () => {
+  it('matches existing English numeric localeCompare ordering', () => {
+    const values = [
+      'item10',
+      'item2',
+      'item1',
+      'Item2',
+      'item-2',
+      'item_2',
+      'item.2',
+      'item02',
+      'item',
+      'item20',
+      'item11',
+      'item1a',
+      'item1b',
+    ];
+
+    expect([...values].sort(compareNatural)).toEqual(
+      [...values].sort((a, b) => a.localeCompare(b, 'en', { numeric: true })),
+    );
+  });
+
+  it('returns zero for equal strings', () => {
+    expect(compareNatural('schema10', 'schema10')).toBe(0);
+  });
+});

--- a/packages/core/src/utils/sort.ts
+++ b/packages/core/src/utils/sort.ts
@@ -23,3 +23,11 @@ export const sortByPriority = <T>(
     }
     return 0;
   });
+
+let naturalCompareCollator: Intl.Collator | undefined;
+
+export function compareNatural(a: string, b: string): number {
+  naturalCompareCollator ??= new Intl.Collator('en', { numeric: true });
+
+  return naturalCompareCollator.compare(a, b);
+}

--- a/packages/core/src/writers/schemas-tags-split.ts
+++ b/packages/core/src/writers/schemas-tags-split.ts
@@ -6,7 +6,12 @@ import {
   type NamingConvention,
   type Tsconfig,
 } from '../types';
-import { conventionName, getImportExtension, upath } from '../utils';
+import {
+  compareNatural,
+  conventionName,
+  getImportExtension,
+  upath,
+} from '../utils';
 import { writeGeneratedFile } from './file';
 import { buildSchemaTagMap, SHARED_DIR } from './schema-tag-mapper';
 import { writeSchemas } from './schemas';
@@ -91,9 +96,7 @@ export async function writeSchemasTagsSplit({
 
     const tagDirs = [...groups.keys()]
       .filter((dir) => dir !== SHARED_DIR)
-      .toSorted((a: string, b: string) =>
-        a.localeCompare(b, 'en', { numeric: true }),
-      );
+      .toSorted((a: string, b: string) => compareNatural(a, b));
     const tagExports = tagDirs.map((dir) => {
       const dirPath = importExtension
         ? `./${dir}/index${importExtension}`

--- a/packages/core/src/writers/schemas.ts
+++ b/packages/core/src/writers/schemas.ts
@@ -10,7 +10,12 @@ import {
   NamingConvention,
   type Tsconfig,
 } from '../types';
-import { conventionName, getImportExtension, upath } from '../utils';
+import {
+  compareNatural,
+  conventionName,
+  getImportExtension,
+  upath,
+} from '../utils';
 import { writeGeneratedFile } from './file';
 
 type CanonicalInfo = Pick<GeneratorImport, 'importPath' | 'name'>;
@@ -623,7 +628,7 @@ export async function writeSchemas({
       ].map(([, specifier]) => `export * from '${specifier}';`);
 
       const exports = [...new Set([...existingExports, ...currentExports])]
-        .toSorted((a, b) => a.localeCompare(b, 'en', { numeric: true }))
+        .toSorted((a, b) => compareNatural(a, b))
         .join('\n');
 
       const fileContent = `${header}\n${exports}\n`;

--- a/packages/mock/src/faker/getters/object.ts
+++ b/packages/mock/src/faker/getters/object.ts
@@ -1,4 +1,5 @@
 import {
+  compareNatural,
   type ContextSpec,
   type GeneratorImport,
   getKey,
@@ -256,7 +257,7 @@ export function getMockObject({
     const entries = Object.entries(itemProperties);
     if (context.output.propertySortOrder === PropertySortOrder.ALPHABETICAL) {
       entries.sort((a, b) => {
-        return a[0].localeCompare(b[0], 'en', { numeric: true });
+        return compareNatural(a[0], b[0]);
       });
     }
     const propertyScalars = entries

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -5,6 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import {
+  compareNatural,
   type ContextSpec,
   EnumGeneration,
   type GeneratorImport,
@@ -87,7 +88,7 @@ export function getMockScalar({
     properties: {},
   };
   const sortedTags = Object.entries(safeMockOptions.tags ?? {}).toSorted(
-    (a, b) => a[0].localeCompare(b[0], 'en', { numeric: true }),
+    (a, b) => compareNatural(a[0], b[0]),
   );
   for (const [tag, options] of sortedTags) {
     if (!tags.includes(tag)) {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import {
+  compareNatural,
   type ContextSpec,
   conventionName,
   DefaultTag,
@@ -479,13 +480,11 @@ const groupSchemasByFilePath = <T extends { filePath: string }>(
   }
 
   const sortedGroups = [...grouped.values()].map((group) =>
-    [...group].toSorted((a, b) =>
-      a.filePath.localeCompare(b.filePath, 'en', { numeric: true }),
-    ),
+    [...group].toSorted((a, b) => compareNatural(a.filePath, b.filePath)),
   );
 
   return sortedGroups.toSorted((a, b) =>
-    a[0].filePath.localeCompare(b[0].filePath, 'en', { numeric: true }),
+    compareNatural(a[0].filePath, b[0].filePath),
   );
 };
 
@@ -569,7 +568,7 @@ export async function writeZodSchemaTagsSplitBarrel(
 
   const tagDirs = [...allDirs.keys()]
     .filter((dir) => dir !== ROOT_DIR)
-    .toSorted((a, b) => a.localeCompare(b, 'en', { numeric: true }));
+    .toSorted((a, b) => compareNatural(a, b));
 
   const tagExports = tagDirs.map((dir) => {
     const dirPath = indexImportExt


### PR DESCRIPTION
Reuses a lazy `Intl.Collator('en', { numeric: true })` for natural sorting instead of constructing locale comparison machinery inside hot sort comparators.

This preserves the existing English numeric ordering used by the previous `localeCompare` calls while reducing repeated comparator overhead in import generation, schema barrel exports, tag-split schema barrels, zod split output, and sorted mock/object properties.

Refs #3805

### Validation

- `vp exec tsc --noEmit -p packages/core/tsconfig.json` - passed
- `vp exec tsc --noEmit -p packages/mock/tsconfig.json` - passed
- `vp exec tsc --noEmit -p packages/orval/tsconfig.json` - passed
- `vp exec vitest run packages/core/src/utils/sort.test.ts packages/core/src/generators/imports.test.ts packages/core/src/writers/schemas.test.ts packages/core/src/writers/schemas-tags-split.test.ts packages/orval/src/write-zod-specs.test.ts packages/mock/src/faker/getters/object.test.ts packages/mock/src/faker/getters/scalar.test.ts --pool forks --reporter verbose` - passed
- `vp run -w format:check` - passed
- `vp run -w build:release` - passed
- `vp run -w lint` - passed
- `vp run -w lint:samples` - passed
- `vp run -w typecheck` - passed outside sandbox after sandbox IPC shared-memory failure
- `vp run -w test` - passed outside sandbox after sandbox IPC shared-memory failure
- `vp run -w test:snapshots` - passed outside sandbox after sandbox `spawn EPERM`
- `vp run -F orval-tests build` - passed
- `git diff --check` - passed

### Performance

Workload: temporary local Vitest benchmark exercising real `generateImports` sorting with 780 deterministic imports plus a schema-barrel-style natural export sort over 780 deterministic export strings.

Environment: Node.js v22.22.3, Bun v1.3.14, `vp` v0.2.8, local `vite-plus` v0.1.24, Vitest v4.0.18.

Iterations: 20 warm-up iterations, then 100 measured iterations.

Before:
- `generateImports`: median 23.503ms, mean 24.548ms
- schema export sort: median 21.128ms, mean 22.158ms

After:
- `generateImports`: median 3.706ms, mean 3.731ms
- schema export sort: median 1.405ms, mean 1.410ms

Change:
- `generateImports`: median improved by 19.797ms, about 84.2% lower
- schema export sort: median improved by 19.723ms, about 93.4% lower


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Generated imports, schemas, tags, properties, filenames, and directories are now sorted naturally and consistently.
  * Numeric portions of names are ordered intuitively—for example, item 2 appears before item 10.
  * Mock data generation follows the same natural ordering rules.

* **Tests**
  * Added coverage to verify natural sorting behavior across varied strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->