### PR TITLE
fix(core): sanitize numeric response schemas

### DIFF
--- a/packages/core/src/generators/component-definition.test.ts
+++ b/packages/core/src/generators/component-definition.test.ts
@@ -26,4 +26,21 @@ describe('generateComponentDefinition', () => {
     expect(result).toMatchObject([{ name: 'N401Response' }]);
     expect(result[0]?.model).toContain('export type N401Response');
   });
+
+  it('preserves leading underscore in response components like _401', () => {
+    const result = generateComponentDefinition(
+      {
+        _401: {
+          description: 'Unauthorized',
+          content: { 'application/json': { schema: { type: 'object' } } },
+        },
+      },
+      context,
+      'Response',
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result).toMatchObject([{ name: '_401Response' }]);
+    expect(result[0]?.model).toContain('export type _401Response');
+  });
 });

--- a/packages/core/src/generators/component-definition.test.ts
+++ b/packages/core/src/generators/component-definition.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContextSpec } from '../types';
+import { generateComponentDefinition } from './component-definition';
+
+const context = {
+  output: { override: { namingConvention: {} } },
+  target: 'typescript',
+  spec: {},
+} as unknown as ContextSpec;
+
+describe('generateComponentDefinition', () => {
+  it('sanitizes inline schemas from numeric response components', () => {
+    const result = generateComponentDefinition(
+      {
+        401: {
+          description: 'Unauthorized',
+          content: { 'application/json': { schema: { type: 'object' } } },
+        },
+      },
+      context,
+      'Response',
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result).toMatchObject([{ name: 'N401Response' }]);
+    expect(result[0]?.model).toContain('export type N401Response');
+  });
+});

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -16,7 +16,7 @@ import {
   type OpenApiSchemaObject,
   type ResReqTypesValue,
 } from '../types';
-import { camel } from '../utils';
+import { camel, sanitize } from '../utils';
 import { isReference } from '../utils/assertion';
 import { pascal } from '../utils/case';
 import {
@@ -245,7 +245,12 @@ export function getResReqTypes(
       if (res.content) {
         const contents = Object.entries(res.content).map(
           ([contentType, mediaType], index, arr) => {
-            let propName = key ? pascal(name) + pascal(key) : undefined;
+            let propName = key
+              ? sanitize(pascal(name) + pascal(key), {
+                  es5keyword: true,
+                  es5IdentifierName: true,
+                })
+              : undefined;
 
             if (propName && arr.length > 1) {
               propName = propName + pascal(getNumberWord(index + 1));
@@ -388,7 +393,12 @@ export function getResReqTypes(
           : undefined;
 
       if (swaggerSchema) {
-        const propName = key ? pascal(name) + pascal(key) : undefined;
+        const propName = key
+          ? sanitize(pascal(name) + pascal(key), {
+              es5keyword: true,
+              es5IdentifierName: true,
+            })
+          : undefined;
         const resolvedValue = resolveObject({
           schema: swaggerSchema,
           propName,

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -247,6 +247,9 @@ export function getResReqTypes(
           ([contentType, mediaType], index, arr) => {
             let propName = key
               ? sanitize(pascal(name) + pascal(key), {
+                  underscore: '_',
+                  whitespace: '_',
+                  dash: true,
                   es5keyword: true,
                   es5IdentifierName: true,
                 })
@@ -395,6 +398,9 @@ export function getResReqTypes(
       if (swaggerSchema) {
         const propName = key
           ? sanitize(pascal(name) + pascal(key), {
+              underscore: '_',
+              whitespace: '_',
+              dash: true,
               es5keyword: true,
               es5IdentifierName: true,
             })


### PR DESCRIPTION
Sanitizes inline model names built from numeric response component names.
Closes #3847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated request and response property names by safely handling reserved keywords, numeric keys, leading underscores, and other invalid identifier characters.
  * Preserved consistent PascalCase naming for generated types.

* **Tests**
  * Added coverage for generating component definitions from numeric and underscore-prefixed response keys, including generated type declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->