### PR TITLE
fix(zod): avoid duplicate parameter constants

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -2933,6 +2933,8 @@ export const parseParameters = ({
     params: {},
   };
 
+  const constNameRegistry: Record<string, number> = {};
+
   const defintionsByParameters = data.reduce((acc, val) => {
     const { schema: parameter }: { schema: OpenApiParameterObject } =
       resolveRef(val, context);
@@ -2990,6 +2992,7 @@ export const parseParameters = ({
       {
         required: parameter.required,
         useReusableSchemas,
+        constNameRegistry,
       },
     );
 


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits. -->


## Description

Fixes an issue where different OpenAPI parameter names can normalize to the same TypeScript identifier, causing duplicate constants to be generated.

For example:

- `includeInternals`
- `include_internals`

Both were generating:

```ts
export const testQueryIncludeInternalsDefault = false;
```
This change shares the existing constNameRegistry between parameters so collisions are automatically disambiguated:

```ts
export const testQueryIncludeInternalsDefault = false;
export const testQueryIncludeInternalsDefaultOne = false;
```

The original OpenAPI parameter names are preserved.

Fixes #3850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated validation schemas to ensure constant names remain unique across all parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->