### PR TITLE
fix(mock): report a misplaced boolean `required` instead of crashing

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -16,6 +16,7 @@ export * from './logger';
 export * from './merge-deep';
 export * from './occurrence';
 export * as upath from './path';
+export * from './required';
 export * from './resolve-version';
 export * from './schemas-options';
 export * from './sort';

--- a/packages/core/src/utils/required.ts
+++ b/packages/core/src/utils/required.ts
@@ -1,0 +1,27 @@
+import type { OpenApiSchemaObject } from '../types';
+
+/**
+ * Read a schema object's `required` keyword.
+ *
+ * Some generators emit `required: true` on a schema that carries a `$ref`,
+ * borrowing the boolean that belongs on the request body object. Spreading that
+ * boolean fails with `required ?? [] is not iterable`, which says nothing about
+ * the document. Report the offending schema and the expected shape instead. The
+ * document is not rewritten: a boolean carries no property names, so there is
+ * nothing to recover from it. (#3719)
+ *
+ * @param schema - Schema whose `required` keyword to read.
+ * @param name - Label for the offending schema, used in the error message.
+ */
+export function getRequiredKeys(schema: OpenApiSchemaObject, name: string) {
+  const required = schema.required as unknown;
+
+  if (required === undefined) return [];
+  if (Array.isArray(required)) return required;
+
+  throw new Error(
+    `Invalid OpenAPI document: schema "${name}" has \`required: ${JSON.stringify(
+      required,
+    )}\`, but a schema object's \`required\` must be an array of property names. A boolean \`required\` belongs on the request body object or on a parameter, not on the schema it references.`,
+  );
+}

--- a/packages/mock/src/faker/resolvers/value.test.ts
+++ b/packages/mock/src/faker/resolvers/value.test.ts
@@ -2,10 +2,12 @@ import type { OpenApiSchemaObject } from '@orval/core';
 import { describe, expect, it } from 'vitest';
 
 import { createTestContextSpec } from '../../../../core/src/test-utils/context';
+import type { MockSchema } from '../../types';
 import {
   getNullable,
   isNullableSchema,
   resolveMockOverride,
+  resolveMockValue,
   resolveRefTarget,
 } from './value';
 
@@ -225,5 +227,49 @@ describe('resolveMockOverride (#3470 — nested transparency precedence)', () =>
     const result = resolveMockOverride({ 'country.name': "'France'" }, item);
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('misplaced boolean `required` (#3719)', () => {
+  const context = createTestContextSpec({
+    spec: {
+      components: {
+        schemas: {
+          Item: {
+            type: 'object',
+            required: ['name'],
+            properties: { name: { type: 'string' } },
+          },
+        },
+      },
+    },
+  });
+
+  const resolve = (schema: unknown) =>
+    resolveMockValue({
+      schema: schema as MockSchema,
+      operationId: 'listItems',
+      tags: [],
+      context,
+      imports: [],
+      existingReferencedProperties: [],
+      splitMockImplementations: [],
+    });
+
+  it('names the offending schema instead of failing on the spread', () => {
+    // A property that is a `$ref` with a sibling `required: true` used to reach
+    // the spread in `resolveMockValue` and fail with
+    // `(schemaReference.required ?? []) is not iterable`, which names neither
+    // the schema nor the expected shape. The same document generates fine with
+    // `mock: false`.
+    expect(() =>
+      resolve({ $ref: '#/components/schemas/Item', required: true }),
+    ).toThrowError(/schema "Item" has `required: true`/);
+  });
+
+  it('still resolves a valid required array on the reference', () => {
+    expect(() =>
+      resolve({ $ref: '#/components/schemas/Item', required: ['name'] }),
+    ).not.toThrow();
   });
 });

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -2,6 +2,7 @@ import {
   type ContextSpec,
   type GeneratorImport,
   getRefInfo,
+  getRequiredKeys,
   isFunction,
   isReference,
   type MockOptions,
@@ -273,7 +274,7 @@ export function resolveMockValue({
       isRef: true,
       required: [
         ...((schemaRef?.required as string[] | undefined) ?? []),
-        ...(schemaReference.required ?? []),
+        ...getRequiredKeys(schemaReference, name),
       ],
       ...(schemaReference.nullable === undefined
         ? {}

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -17,6 +17,7 @@ import {
   getFormDataFieldFileType,
   getNumberWord,
   getRefInfo,
+  getRequiredKeys,
   isBoolean,
   isDynamicReference,
   isNumber,
@@ -419,29 +420,6 @@ const isDiscriminatableMember = (
 
   if (!isPlainObjectSchema(resolved)) return false;
   return hasLiteralDiscriminator(resolved, property);
-};
-
-/**
- * Read a schema object's `required` keyword.
- *
- * Some generators emit `required: true` on the schema referenced by a request
- * body, borrowing the boolean that belongs on the request body object. Spreading
- * that boolean fails with `(schema.required ?? []) is not iterable`, which says
- * nothing about the document. Report the offending schema and the expected shape
- * instead. The document is not rewritten: a boolean carries no property names,
- * so there is nothing to recover from it. (#3719)
- */
-const getRequiredKeys = (schema: OpenApiSchemaObject, name: string) => {
-  const required = schema.required as unknown;
-
-  if (required === undefined) return [];
-  if (Array.isArray(required)) return required;
-
-  throw new Error(
-    `Invalid OpenAPI document: schema "${name}" has \`required: ${JSON.stringify(
-      required,
-    )}\`, but a schema object's \`required\` must be an array of property names. A boolean \`required\` belongs on the request body object or on a parameter, not on the schema it references.`,
-  );
 };
 
 export const generateZodValidationSchemaDefinition = (


### PR DESCRIPTION
Follow-up to the scope note at the end of #3822, covering the same document shape in the mock generator.

One correction to the table in #3719 first. It records the mock client as "generates fine", and that holds for the position it was tested in, but not for another one. Checked against orval 8.24.0 from npm:

| where `required: true` sits | result |
| --- | --- |
| beside `$ref` in a request body schema | generates fine |
| on the component schema itself | rejected before generation: `type must be array` at `/components/schemas/Item/required` |
| beside `$ref` in a property of a component schema | `(schemaReference.required ?? []) is not iterable` |

The last row is this PR. The same spec with `mock: false` generates fine, so the failure belongs to the mock generator.

```yaml
openapi: 3.0.3
info: { title: Example API, version: 1.0.0 }
paths:
  /items:
    get:
      operationId: listItems
      responses:
        '200':
          description: ok
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Wrapper'
components:
  schemas:
    Item:
      type: object
      required: [name]
      properties:
        name: { type: string }
    Wrapper:
      type: object
      properties:
        item:
          $ref: '#/components/schemas/Item'
          required: true
```

Before, with `mock: true`:

```
🛑 mockapi - (schemaReference.required ?? []) is not iterable
```

After:

```
🛑 mockapi - Invalid OpenAPI document: schema "Item" has `required: true`, but a schema
object's `required` must be an array of property names. A boolean `required` belongs on
the request body object or on a parameter, not on the schema it references.
```

The reader you merged in #3822 moves to `@orval/core` so both generators say the same thing. The zod side is an import swap: its 340 tests pass unchanged, and running the zod client on the #3719 repro still produces the same message it did before.

I left the spread on the line above alone. That one reads `required` off the referenced component, and the shape that would reach it is already rejected by the spec validator, as the second table row shows.

Two tests in `packages/mock/src/faker/resolvers/value.test.ts`. The first fails on master with the `is not iterable` message and passes after the change. The second is a control with a valid `required` array that passes on both sides. The package goes from 342 to 344 tests. `tsc --noEmit`, `vp lint --type-aware --type-check` and `vp fmt --check` are clean.

If you would rather keep this PR out of `packages/zod`, say the word and I will inline a local copy in `packages/mock` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of required properties in referenced schemas.
  * Added clear validation errors when `required` is configured with an invalid value.
  * Preserved support for valid required-property arrays.
* **Consistency**
  * Standardized required-property processing across schema-based generation and mock value resolution.
* **Tests**
  * Added regression coverage for invalid boolean configurations and valid required-property handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->