### PR TITLE
fix(zod): add u flag to RegExp with Unicode property escapes

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -177,7 +177,8 @@ const zodMiniCoerceCall = (fn: string, args = '') =>
 // match the literal characters `p{...}`, so the generated validator silently
 // rejects valid input (#3841). Only patterns that use them get the flag,
 // leaving existing outputs unchanged.
-const hasUnicodePropertyEscape = (pattern: string) => /\\[pP]\{/.test(pattern);
+const hasUnicodePropertyEscape = (pattern: string) =>
+  /(^|[^\\])(?:\\\\)*\\[pP]\{/.test(pattern);
 
 const buildRegExpLiteral = (pattern: string) => {
   const innerPattern = pattern.slice(

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -173,6 +173,21 @@ const zodMiniCall = (fn: string, args = '') =>
 const zodMiniCoerceCall = (fn: string, args = '') =>
   `${PURE_COMMENT}zod.coerce.${fn}(${args})`;
 
+// Unicode property escapes (`\p{...}`) require the `u` flag; without it they
+// match the literal characters `p{...}`, so the generated validator silently
+// rejects valid input (#3841). Only patterns that use them get the flag,
+// leaving existing outputs unchanged.
+const hasUnicodePropertyEscape = (pattern: string) => /\\[pP]\{/.test(pattern);
+
+const buildRegExpLiteral = (pattern: string) => {
+  const innerPattern = pattern.slice(
+    pattern.startsWith('/') ? 1 : 0,
+    pattern.endsWith('/') ? -1 : undefined,
+  );
+  const unicodeFlag = hasUnicodePropertyEscape(innerPattern) ? ", 'u'" : '';
+  return `new RegExp('${jsStringLiteralEscape(innerPattern)}'${unicodeFlag})`;
+};
+
 /** Escapes string defaults for safe embedding in template literals. */
 function formatDefaultValue(value: unknown): string {
   if (isString(value)) {
@@ -1208,14 +1223,7 @@ export const generateZodValidationSchemaDefinition = (
             if ('const' in schema) {
               functions.push(['literal', JSON.stringify(String(schema.const))]);
             } else if (schema.pattern && schema.format) {
-              const isStartWithSlash = schema.pattern.startsWith('/');
-              const isEndWithSlash = schema.pattern.endsWith('/');
-              const regexp = `new RegExp('${jsStringLiteralEscape(
-                schema.pattern.slice(
-                  isStartWithSlash ? 1 : 0,
-                  isEndWithSlash ? -1 : undefined,
-                ),
-              )}')`;
+              const regexp = buildRegExpLiteral(schema.pattern);
               consts.push(
                 `export const ${name}RegExp${constsCounterValue} = ${regexp};\n`,
               );
@@ -1477,12 +1485,7 @@ export const generateZodValidationSchemaDefinition = (
     type === 'string' &&
     !stringFormatAlreadyEmitted
   ) {
-    const isStartWithSlash = matches.startsWith('/');
-    const isEndWithSlash = matches.endsWith('/');
-
-    const regexp = `new RegExp('${jsStringLiteralEscape(
-      matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined),
-    )}')`;
+    const regexp = buildRegExpLiteral(matches);
 
     consts.push(
       `export const ${name}RegExp${constsCounterValue} = ${regexp};\n`,

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4668,6 +4668,88 @@ describe('generateZodValidationSchemaDefinition`', () => {
     expect(regexpConst).toContain(String.raw`new RegExp('^(0|[1-9]\\d*)$')`);
   });
 
+  it('adds the u flag when a pattern uses a Unicode property escape (#3841)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      pattern: String.raw`^[\p{L}][\p{L}\p{M}'’. -]{0,99}$`,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schema,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'firstName',
+      false,
+      true,
+      { required: true },
+    );
+
+    const regexpConst = result.consts.find((c) => c.includes('RegExp'));
+    expect(regexpConst).toBeDefined();
+    expect(regexpConst).toContain(String.raw`^[\\p{L}][\\p{L}\\p{M}`);
+    expect(regexpConst).toContain(", 'u'");
+  });
+
+  it('adds the u flag for custom format+pattern with property escapes in v4 (#3841)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      format: 'name',
+      pattern: String.raw`^[\p{L}]+$`,
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schema,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'displayName',
+      false,
+      true,
+      { required: true },
+    );
+
+    const regexpConst = result.consts.find((c) => c.includes('RegExp'));
+    expect(regexpConst).toBeDefined();
+    expect(regexpConst).toContain(String.raw`^[\\p{L}]+$`);
+    expect(regexpConst).toContain(", 'u'");
+  });
+
+  it('leaves patterns without property escapes flagless (#3841)', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'string',
+      pattern: '^[a-z0-9-]+$',
+    };
+
+    const result = generateZodValidationSchemaDefinition(
+      schema,
+      {
+        output: {
+          override: {
+            useDates: false,
+          },
+        },
+      } as ContextSpec,
+      'slug',
+      false,
+      true,
+      { required: true },
+    );
+
+    const regexpConst = result.consts.find((c) => c.includes('RegExp'));
+    expect(regexpConst).toBeDefined();
+    expect(regexpConst).toContain(String.raw`new RegExp('^[a-z0-9-]+$')`);
+    expect(regexpConst).not.toContain("'u'");
+  });
+
   it('does not emit stringFormat for custom format+pattern in v3', () => {
     const schemaFormatPattern: OpenApiSchemaObject = {
       type: 'string',

--- a/tests/__snapshots__/swr/pattern/endpoints.ts
+++ b/tests/__snapshots__/swr/pattern/endpoints.ts
@@ -98,6 +98,7 @@ export const getGetVversionExampleResponseMock = (
   guid: faker.helpers.fromRegExp(
     '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
   ),
+  name: faker.helpers.fromRegExp("^[\\p{L}][\\p{L}\\p{M}'’. -]{0,99}$"),
   ...overrideResponse,
 });
 

--- a/tests/__snapshots__/swr/pattern/model/node.ts
+++ b/tests/__snapshots__/swr/pattern/model/node.ts
@@ -8,4 +8,6 @@
 export interface Node {
   /** @pattern ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ */
   guid: string;
+  /** @pattern ^[\p{L}][\p{L}\p{M}'’. -]{0,99}$ */
+  name: string;
 }

--- a/tests/__snapshots__/zod/pattern/pattern.ts
+++ b/tests/__snapshots__/zod/pattern/pattern.ts
@@ -12,7 +12,12 @@ import * as zod from 'zod';
 export const getExampleResponseGuidRegExp = new RegExp(
   '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
 );
+export const getExampleResponseNameRegExp = new RegExp(
+  "^[\\p{L}][\\p{L}\\p{M}'’. -]{0,99}$",
+  'u',
+);
 
 export const GetExampleResponse = zod.object({
   guid: zod.string().regex(getExampleResponseGuidRegExp),
+  name: zod.string().regex(getExampleResponseNameRegExp),
 });

--- a/tests/specifications/pattern.yaml
+++ b/tests/specifications/pattern.yaml
@@ -19,7 +19,12 @@ components:
       type: object
       required:
         - guid
+        - name
       properties:
         guid:
           type: string
           pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        name:
+          type: string
+          # Unicode property escapes need the `u` flag (#3841).
+          pattern: '^[\p{L}][\p{L}\p{M}''’. -]{0,99}$'


### PR DESCRIPTION
## What

OpenAPI declares `pattern` to be an ECMA 262 regular expression, and
Unicode property escapes (`\p{...}`) are the standard way to express
"letters in any script" — common for name/address fields from .NET/Java
backends. Without the `u` flag, `\p{L}` parses as the literal characters
`p{L}`: the generated `RegExp` is syntactically valid, nothing throws, and
the zod validator silently rejects valid input (`"Anna"`, `"Müller"`).

## Fix

Emit `new RegExp('<pattern>', 'u')` when the pattern uses a Unicode
property escape (`\p{` or `\P{`), matching ECMA-262 semantics. Patterns
without property escapes are unchanged (no new flags, no risk from `u`'s
stricter escaping rules). Both RegExp emission sites (plain `pattern` and
v4 custom `format`+`pattern`) use the same helper.

## Tests

- Unit tests: flagged emission for plain patterns and for custom
  format+pattern in v4, plus a flagless negative case.
- `tests/specifications/pattern.yaml` gains a `name` property with a
  `\p{L}` pattern; the generated output now shows
  `new RegExp("^[\\p{L}][\\p{L}\\p{M}'’. -]{0,99}$", 'u')`.

## Validation

- `bunx vitest run src/zod.test.ts` — 307 passed
- `bunx vitest run --config vitest.snapshots.ts` — 6094 passed
- `node tests/scripts/typecheck-generated.mjs` — all 18 clients pass

Closes #3841


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular-expression validation for Unicode property escapes by correctly applying Unicode support when generating patterns.
  * Preserved existing behavior for standard regular expressions without Unicode property escapes.

* **Validation**
  * Updated pattern validation to support names beginning with a Unicode letter and allowing letters, marks, apostrophes, periods, spaces, and hyphens.

* **Documentation**
  * Updated the OpenAPI specification to require the `Node` name field and document its Unicode-aware validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->