### PR TITLE
fix(orval): keep items on Swagger 2.0 formData array parameters (#3857)

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -525,6 +525,122 @@ describe('swagger2FormData', () => {
     expect(body?.model).not.toContain('unknown[]');
   });
 
+  it('keeps items on path-level inline formData array parameters (#3857)', async () => {
+    // Swagger 2.0 allows parameters on a Path Item Object; they apply to every
+    // operation under the path. The capture must merge them in.
+    const spec = {
+      swagger: '2.0',
+      info: { title: 'Path-level form data', version: '1.0.0' },
+      paths: {
+        '/submit': {
+          parameters: [
+            {
+              name: 'tags',
+              in: 'formData',
+              required: true,
+              type: 'array',
+              items: { type: 'string' },
+            },
+          ],
+          post: {
+            operationId: 'submitForm',
+            consumes: ['application/x-www-form-urlencoded'],
+            responses: { '200': { description: 'Success' } },
+          },
+        },
+      },
+    };
+    const normalizedOptions = await normalizeOptions(
+      { output: { target: '' }, input: { target: spec } },
+      'test',
+      {},
+    );
+    const result = await importSpecs('test', normalizedOptions);
+    const body = result.schemas.find((s) => s.name === 'SubmitFormBody');
+    expect(body?.model).toContain('tags: string[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+
+  it('keeps items on path-level reusable formData parameters (#3857)', async () => {
+    const spec = {
+      swagger: '2.0',
+      info: { title: 'Path-level reusable form data', version: '1.0.0' },
+      parameters: {
+        tagList: {
+          name: 'tags',
+          in: 'formData',
+          required: true,
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+      paths: {
+        '/submit': {
+          parameters: [{ $ref: '#/parameters/tagList' }],
+          post: {
+            operationId: 'submitForm',
+            consumes: ['multipart/form-data'],
+            responses: { '200': { description: 'Success' } },
+          },
+        },
+      },
+    };
+    const normalizedOptions = await normalizeOptions(
+      { output: { target: '' }, input: { target: spec } },
+      'test',
+      {},
+    );
+    const result = await importSpecs('test', normalizedOptions);
+    // Reusable formData parameters are promoted to a requestBody component, so
+    // the generated body type takes its name from the reusable parameter key.
+    const body = result.schemas.find((s) => s.name === 'TagListBody');
+    expect(body?.model).toContain('tags: string[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+
+  it('lets operation-level parameters override path-level ones (#3857)', async () => {
+    const spec = {
+      swagger: '2.0',
+      info: { title: 'Path-level override', version: '1.0.0' },
+      paths: {
+        '/submit': {
+          parameters: [
+            {
+              name: 'tags',
+              in: 'formData',
+              required: true,
+              type: 'array',
+              items: { type: 'string' },
+            },
+          ],
+          post: {
+            operationId: 'submitForm',
+            consumes: ['application/x-www-form-urlencoded'],
+            parameters: [
+              {
+                name: 'tags',
+                in: 'formData',
+                required: true,
+                type: 'array',
+                items: { type: 'integer', format: 'int64' },
+              },
+            ],
+            responses: { '200': { description: 'Success' } },
+          },
+        },
+      },
+    };
+    const normalizedOptions = await normalizeOptions(
+      { output: { target: '' }, input: { target: spec } },
+      'test',
+      {},
+    );
+    const result = await importSpecs('test', normalizedOptions);
+    const body = result.schemas.find((s) => s.name === 'SubmitFormBody');
+    expect(body?.model).toContain('tags: number[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+
   it('does not alter OAS 3 formData array parameters (#3857)', async () => {
     // The working OAS 3.0 counterpart from the issue: item types are already
     // preserved by the upgrader, so the repair must be a no-op.

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -641,6 +641,69 @@ describe('swagger2FormData', () => {
     expect(body?.model).not.toContain('unknown[]');
   });
 
+  it('keeps shared path-level bodies intact when an operation overrides a parameter (#3857)', async () => {
+    // A reusable path-level formData parameter is promoted to a shared
+    // components.requestBodies entry referenced from the Path Item. When one
+    // operation overrides that parameter, the override lives in the operation's
+    // own request body — it must never be written into the shared body, which
+    // other operations still use.
+    const spec = {
+      swagger: '2.0',
+      info: { title: 'Shared path-level override', version: '1.0.0' },
+      parameters: {
+        tagList: {
+          name: 'tags',
+          in: 'formData',
+          required: true,
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+      paths: {
+        '/submit': {
+          parameters: [{ $ref: '#/parameters/tagList' }],
+          // The overriding operation is declared first so the repair cannot
+          // hide behind iteration order: the shared body is patched by the
+          // override before the non-overriding operation visits it.
+          put: {
+            operationId: 'replaceForm',
+            consumes: ['multipart/form-data'],
+            parameters: [
+              {
+                name: 'tags',
+                in: 'formData',
+                required: true,
+                type: 'array',
+                items: { type: 'integer', format: 'int64' },
+              },
+            ],
+            responses: { '200': { description: 'Success' } },
+          },
+          post: {
+            operationId: 'submitForm',
+            consumes: ['multipart/form-data'],
+            responses: { '200': { description: 'Success' } },
+          },
+        },
+      },
+    };
+    const normalizedOptions = await normalizeOptions(
+      { output: { target: '' }, input: { target: spec } },
+      'test',
+      {},
+    );
+    const result = await importSpecs('test', normalizedOptions);
+    // The shared, path-level request body must keep the path-level item type.
+    const shared = result.schemas.find((s) => s.name === 'TagListBody');
+    expect(shared?.model).toContain('tags: string[]');
+    expect(shared?.model).not.toContain('unknown[]');
+    expect(shared?.model).not.toContain('number[]');
+    // The overriding operation gets its own body with the operation-level type.
+    const override = result.schemas.find((s) => s.name === 'ReplaceFormBody');
+    expect(override?.model).toContain('tags: number[]');
+    expect(override?.model).not.toContain('unknown[]');
+  });
+
   it('does not alter OAS 3 formData array parameters (#3857)', async () => {
     // The working OAS 3.0 counterpart from the issue: item types are already
     // preserved by the upgrader, so the repair must be a no-op.

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -420,6 +420,172 @@ describe('validation', () => {
   });
 });
 
+describe('swagger2FormData', () => {
+  // Regression spec for https://github.com/orval-labs/orval/issues/3857:
+  // @scalar/openapi-parser's upgrade() drops the `items` of Swagger 2.0
+  // formData array parameters when converting them to a requestBody schema,
+  // so generated types would degrade from `string[]` to `unknown[]`.
+  const SWAGGER2_FORM_DATA_SPEC = {
+    swagger: '2.0',
+    info: { title: 'Form Data API (OAS 2.0)', version: '1.0.0' },
+    basePath: '/',
+    parameters: {
+      tagList: {
+        name: 'tags',
+        in: 'formData',
+        required: true,
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+    paths: {
+      '/submit': {
+        post: {
+          operationId: 'submitForm',
+          consumes: ['application/x-www-form-urlencoded'],
+          produces: ['application/json'],
+          parameters: [
+            {
+              name: 'tags',
+              in: 'formData',
+              required: true,
+              type: 'array',
+              items: { type: 'string' },
+              collectionFormat: 'csv',
+            },
+          ],
+          responses: {
+            '200': {
+              description: 'Success',
+              schema: {
+                type: 'object',
+                properties: { ok: { type: 'boolean' } },
+              },
+            },
+          },
+        },
+      },
+      '/upload': {
+        post: {
+          operationId: 'uploadForm',
+          consumes: ['multipart/form-data'],
+          parameters: [{ $ref: '#/parameters/tagList' }],
+          responses: { '200': { description: 'Success' } },
+        },
+      },
+      '/ints': {
+        post: {
+          operationId: 'intListForm',
+          consumes: ['application/x-www-form-urlencoded'],
+          parameters: [
+            {
+              name: 'ids',
+              in: 'formData',
+              required: true,
+              type: 'array',
+              items: { type: 'integer', format: 'int64' },
+            },
+          ],
+          responses: { '200': { description: 'Success' } },
+        },
+      },
+    },
+  };
+
+  async function importSwagger2FormData() {
+    const normalizedOptions = await normalizeOptions(
+      {
+        output: { target: '' },
+        input: { target: SWAGGER2_FORM_DATA_SPEC },
+      },
+      'test',
+      {},
+    );
+    return importSpecs('test', normalizedOptions);
+  }
+
+  it('keeps items on inline formData array parameters (#3857)', async () => {
+    const spec = await importSwagger2FormData();
+    const body = spec.schemas.find((s) => s.name === 'SubmitFormBody');
+    expect(body?.model).toContain('tags: string[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+
+  it('keeps items on reusable formData parameters referenced via #/parameters (#3857)', async () => {
+    const spec = await importSwagger2FormData();
+    const body = spec.schemas.find((s) => s.name === 'TagListBody');
+    expect(body?.model).toContain('tags: string[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+
+  it('keeps non-string item types (integer → number[]) (#3857)', async () => {
+    const spec = await importSwagger2FormData();
+    const body = spec.schemas.find((s) => s.name === 'IntListFormBody');
+    expect(body?.model).toContain('ids: number[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+
+  it('does not alter OAS 3 formData array parameters (#3857)', async () => {
+    // The working OAS 3.0 counterpart from the issue: item types are already
+    // preserved by the upgrader, so the repair must be a no-op.
+    const normalizedOptions = await normalizeOptions(
+      {
+        output: { target: '' },
+        input: {
+          target: {
+            openapi: '3.0.3',
+            info: { title: 'Form Data API (OAS 3.0)', version: '1.0.0' },
+            paths: {
+              '/submit': {
+                post: {
+                  operationId: 'submitForm',
+                  requestBody: {
+                    required: true,
+                    content: {
+                      'application/x-www-form-urlencoded': {
+                        schema: {
+                          type: 'object',
+                          required: ['tags'],
+                          properties: {
+                            tags: {
+                              type: 'array',
+                              items: { type: 'string' },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  responses: {
+                    '200': {
+                      description: 'Success',
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: { ok: { type: 'boolean' } },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      'test',
+      {},
+    );
+
+    const spec = await importSpecs('test', normalizedOptions);
+    const body = spec.schemas.find((s) => s.name === 'SubmitFormBody');
+    expect(body?.model).toContain('tags: string[]');
+    expect(body?.model).not.toContain('unknown[]');
+  });
+});
+
 describe('externalRefs', () => {
   async function createExternalRefWorkspace() {
     const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-allow-'));

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -128,11 +128,204 @@ async function resolveSpec(
     }
   }
 
-  const { specification } = upgrade(transformedData);
+  // The upgrader converts Swagger 2.0 `formData` parameters into a
+  // `requestBody` schema but drops the `items` of array-typed parameters,
+  // which would degrade generated types from e.g. `string[]` to `unknown[]`
+  // (#3857). Capture the item schemas before upgrading (the upgrader also
+  // mutates its input, so `swagger: '2.0'` is gone afterwards) and re-apply
+  // them to the upgraded document.
+  const formDataItems = isSwagger2(transformedData)
+    ? collectSwagger2FormDataItems(transformedData)
+    : undefined;
+
+  const upgraded = upgrade(transformedData);
+  let specification = upgraded.specification;
 
   // upgrade() returns @scalar/openapi-types/3.1 Document (openapi: string);
   // OpenApiDocument uses the legacy OpenAPIV3_1 namespace (openapi version literals).
+  if (formDataItems && formDataItems.size > 0) {
+    specification = restoreSwagger2FormDataItems(specification, formDataItems);
+  }
+
   return specification as OpenApiDocument;
+}
+
+// ─── Swagger 2.0 formData array items repair (#3857) ───────────────────────
+
+/**
+ * A capture of Swagger 2.0 `formData` array parameter item schemas, keyed by
+ * path → method → parameter name. `@scalar/openapi-parser`'s `upgrade()`
+ * rewrites `formData` parameters into a `requestBody.content` schema but does
+ * not carry the parameter's `items` over, so array-typed fields would be
+ * generated as `unknown[]` instead of e.g. `string[]`.
+ */
+type Swagger2FormDataItems = Map<
+  string,
+  Map<string, Map<string, Record<string, unknown>>>
+>;
+
+function isSwagger2(document: Record<string, unknown>): boolean {
+  return document.swagger === '2.0';
+}
+
+function collectSwagger2FormDataItems(
+  document: Record<string, unknown>,
+): Swagger2FormDataItems {
+  const reusableParameters = isObject(document.parameters)
+    ? (document.parameters as Record<string, unknown>)
+    : {};
+
+  const resolveParameter = (
+    param: unknown,
+  ): Record<string, unknown> | undefined => {
+    if (!isObject(param)) {
+      return undefined;
+    }
+    if ('$ref' in param && isString(param.$ref)) {
+      const ref = param.$ref;
+      if (!ref.startsWith('#/parameters/')) {
+        return undefined;
+      }
+      const target = reusableParameters[ref.slice('#/parameters/'.length)];
+      return isObject(target) ? target : undefined;
+    }
+    return param;
+  };
+
+  const formDataItems: Swagger2FormDataItems = new Map();
+  const paths = isObject(document.paths) ? document.paths : {};
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!isObject(pathItem)) continue;
+
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!isObject(operation) || !Array.isArray(operation.parameters)) {
+        continue;
+      }
+
+      const byName = new Map<string, Record<string, unknown>>();
+      for (const rawParam of operation.parameters) {
+        const param = resolveParameter(rawParam);
+        if (!param || param.in !== 'formData' || !isObject(param.items)) {
+          continue;
+        }
+        byName.set(String(param.name), param.items);
+      }
+
+      if (byName.size > 0) {
+        let methods = formDataItems.get(path);
+        if (!methods) {
+          methods = new Map();
+          formDataItems.set(path, methods);
+        }
+        methods.set(method, byName);
+      }
+    }
+  }
+
+  return formDataItems;
+}
+
+/**
+ * Re-apply captured Swagger 2.0 formData item schemas onto the upgraded
+ * document. Only patches array-typed schema properties that the upgrader
+ * left without an `items` key, so it never overrides anything the upgrader
+ * already preserved.
+ */
+function restoreSwagger2FormDataItems<T extends Record<string, unknown>>(
+  document: T,
+  captured: Swagger2FormDataItems,
+): T {
+  const paths = isObject(document.paths) ? document.paths : {};
+
+  // The upgrader promotes reusable formData parameters (`$ref` to
+  // `#/parameters/...`) to `components.requestBodies` and leaves the
+  // operation's `requestBody` as a `$ref` to them.
+  const components = isObject(document.components) ? document.components : {};
+  const requestBodies = isObject(components.requestBodies)
+    ? (components.requestBodies as Record<string, unknown>)
+    : {};
+
+  const resolveRequestBody = (
+    requestBody: unknown,
+  ): Record<string, unknown> | undefined => {
+    if (!isObject(requestBody)) {
+      return undefined;
+    }
+    if ('$ref' in requestBody && isString(requestBody.$ref)) {
+      const ref = requestBody.$ref;
+      if (!ref.startsWith('#/components/requestBodies/')) {
+        return undefined;
+      }
+      const target =
+        requestBodies[ref.slice('#/components/requestBodies/'.length)];
+      return isObject(target) ? target : undefined;
+    }
+    return requestBody;
+  };
+
+  const patchProperties = (
+    requestBody: Record<string, unknown>,
+    byName: Map<string, Record<string, unknown>>,
+  ): void => {
+    const content = requestBody.content;
+    if (!isObject(content)) return;
+
+    for (const mediaType of Object.values(content)) {
+      if (!isObject(mediaType)) continue;
+      const schema = mediaType.schema;
+      if (!isObject(schema)) continue;
+      const properties = schema.properties;
+      if (!isObject(properties)) continue;
+
+      for (const [paramName, items] of byName) {
+        const property = properties[paramName];
+        if (!isObject(property)) continue;
+
+        const propType = property.type;
+        const isArray =
+          propType === 'array' ||
+          (Array.isArray(propType) && propType.includes('array'));
+        if (!isArray || property.items !== undefined) continue;
+
+        // The captured item schema is a plain Items Object (a `$ref` is not
+        // valid there in Swagger 2.0), so it can be assigned as-is.
+        property.items = items;
+      }
+    }
+  };
+
+  for (const [path, methods] of captured) {
+    const pathItem = paths[path];
+    if (!isObject(pathItem)) continue;
+
+    for (const [method, byName] of methods) {
+      const operation = pathItem[method];
+      if (!isObject(operation)) continue;
+
+      const bodies = new Set<Record<string, unknown>>();
+      const directBody = resolveRequestBody(operation.requestBody);
+      if (directBody) {
+        bodies.add(directBody);
+      }
+      // The upgrader leaves reusable formData parameters as `$ref` entries in
+      // the operation's `parameters` array pointing at components.requestBodies.
+      if (Array.isArray(operation.parameters)) {
+        for (const rawParam of operation.parameters) {
+          const body = resolveRequestBody(rawParam);
+          if (body) {
+            bodies.add(body);
+          }
+        }
+      }
+
+      for (const body of bodies) {
+        patchProperties(body, byName);
+      }
+    }
+  }
+
+  return document;
 }
 
 async function applyInputTransformer(

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -198,13 +198,32 @@ function collectSwagger2FormDataItems(
   for (const [path, pathItem] of Object.entries(paths)) {
     if (!isObject(pathItem)) continue;
 
+    const pathLevelParams = Array.isArray(pathItem.parameters)
+      ? pathItem.parameters
+      : [];
+
     for (const [method, operation] of Object.entries(pathItem)) {
-      if (!isObject(operation) || !Array.isArray(operation.parameters)) {
+      if (!isObject(operation)) {
+        continue;
+      }
+      const operationParams = Array.isArray(operation.parameters)
+        ? operation.parameters
+        : undefined;
+      if (!operationParams && pathLevelParams.length === 0) {
         continue;
       }
 
+      // Swagger 2.0 applies path-item parameters to every operation, with
+      // operation-level parameters overriding path-level ones on the same
+      // (name, in) pair — including a ref and its inline equivalent.
+      const merged = mergePathAndOperationParameters(
+        pathLevelParams,
+        operationParams,
+        resolveParameter,
+      );
+
       const byName = new Map<string, Record<string, unknown>>();
-      for (const rawParam of operation.parameters) {
+      for (const rawParam of merged) {
         const param = resolveParameter(rawParam);
         if (!param || param.in !== 'formData' || !isObject(param.items)) {
           continue;
@@ -224,6 +243,34 @@ function collectSwagger2FormDataItems(
   }
 
   return formDataItems;
+}
+
+/**
+ * Merge path-item parameters into an operation's own parameters per Swagger 2.0
+ * semantics: operation-level parameters override path-level ones with the same
+ * (name, in) pair. `$ref`s are resolved (when possible) so a ref and its inline
+ * equivalent dedupe against each other.
+ */
+function mergePathAndOperationParameters(
+  pathLevel: unknown[],
+  operationLevel: unknown[] | undefined,
+  resolveParameter: (p: unknown) => Record<string, unknown> | undefined,
+): unknown[] {
+  const keyOf = (p: unknown): string | undefined => {
+    const resolved = resolveParameter(p);
+    if (!resolved) return undefined;
+    return `${String(resolved.in ?? '')}:${String(resolved.name ?? '')}`;
+  };
+  const opKeys = new Set(
+    (operationLevel ?? [])
+      .map(keyOf)
+      .filter((k): k is string => k !== undefined),
+  );
+  const kept = pathLevel.filter((p) => {
+    const key = keyOf(p);
+    return key === undefined || !opKeys.has(key);
+  });
+  return [...kept, ...(operationLevel ?? [])];
 }
 
 /**
@@ -309,13 +356,15 @@ function restoreSwagger2FormDataItems<T extends Record<string, unknown>>(
         bodies.add(directBody);
       }
       // The upgrader leaves reusable formData parameters as `$ref` entries in
-      // the operation's `parameters` array pointing at components.requestBodies.
-      if (Array.isArray(operation.parameters)) {
-        for (const rawParam of operation.parameters) {
-          const body = resolveRequestBody(rawParam);
-          if (body) {
-            bodies.add(body);
-          }
+      // the operation's `parameters` array pointing at components.requestBodies
+      // — or, for path-level parameters, in the Path Item's `parameters` array.
+      for (const rawParam of [
+        ...(Array.isArray(operation.parameters) ? operation.parameters : []),
+        ...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
+      ]) {
+        const body = resolveRequestBody(rawParam);
+        if (body) {
+          bodies.add(body);
         }
       }
 

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -161,8 +161,31 @@ async function resolveSpec(
  */
 type Swagger2FormDataItems = Map<
   string,
-  Map<string, Map<string, Record<string, unknown>>>
+  Map<
+    string,
+    {
+      byName: Map<string, Record<string, unknown>>;
+      /** Path-level formData parameter names this operation overrides. */
+      overriddenNames: Set<string>;
+    }
+  >
 >;
+
+/**
+ * A stable identity for a parameter: `in` + `name`. Only string values
+ * participate — a non-string `in`/`name` cannot dedupe against anything.
+ */
+function paramKey(
+  param: unknown,
+  resolveParameter: (p: unknown) => Record<string, unknown> | undefined,
+): string | undefined {
+  const resolved = resolveParameter(param);
+  if (!resolved) return undefined;
+  if (!isString(resolved.in) || !isString(resolved.name)) {
+    return undefined;
+  }
+  return `${resolved.in}:${resolved.name}`;
+}
 
 function isSwagger2(document: Record<string, unknown>): boolean {
   return document.swagger === '2.0';
@@ -231,13 +254,34 @@ function collectSwagger2FormDataItems(
         byName.set(String(param.name), param.items);
       }
 
+      // Path-level formData parameters this operation overrides on the same
+      // (name, in) key. Their effective items live in the operation's own
+      // request body — never in the shared path-level body that other
+      // operations may still use.
+      const opKeys = new Set(
+        (operationParams ?? [])
+          .map((p) => paramKey(p, resolveParameter))
+          .filter((k): k is string => k !== undefined),
+      );
+      const overriddenNames = new Set<string>();
+      for (const rawParam of pathLevelParams) {
+        const param = resolveParameter(rawParam);
+        if (!param || param.in !== 'formData' || !isString(param.name)) {
+          continue;
+        }
+        const key = paramKey(rawParam, resolveParameter);
+        if (key !== undefined && opKeys.has(key)) {
+          overriddenNames.add(param.name);
+        }
+      }
+
       if (byName.size > 0) {
         let methods = formDataItems.get(path);
         if (!methods) {
           methods = new Map();
           formDataItems.set(path, methods);
         }
-        methods.set(method, byName);
+        methods.set(method, { byName, overriddenNames });
       }
     }
   }
@@ -256,18 +300,13 @@ function mergePathAndOperationParameters(
   operationLevel: unknown[] | undefined,
   resolveParameter: (p: unknown) => Record<string, unknown> | undefined,
 ): unknown[] {
-  const keyOf = (p: unknown): string | undefined => {
-    const resolved = resolveParameter(p);
-    if (!resolved) return undefined;
-    return `${String(resolved.in ?? '')}:${String(resolved.name ?? '')}`;
-  };
   const opKeys = new Set(
     (operationLevel ?? [])
-      .map(keyOf)
+      .map((p) => paramKey(p, resolveParameter))
       .filter((k): k is string => k !== undefined),
   );
   const kept = pathLevel.filter((p) => {
-    const key = keyOf(p);
+    const key = paramKey(p, resolveParameter);
     return key === undefined || !opKeys.has(key);
   });
   return [...kept, ...(operationLevel ?? [])];
@@ -346,30 +385,44 @@ function restoreSwagger2FormDataItems<T extends Record<string, unknown>>(
     const pathItem = paths[path];
     if (!isObject(pathItem)) continue;
 
-    for (const [method, byName] of methods) {
+    for (const [method, capture] of methods) {
       const operation = pathItem[method];
       if (!isObject(operation)) continue;
 
-      const bodies = new Set<Record<string, unknown>>();
+      const { byName, overriddenNames } = capture;
+      // Bodies owned by the operation (its direct requestBody plus any refs in
+      // its own parameters array) carry the effective, merged parameter set.
+      const effectiveBodies = new Set<Record<string, unknown>>();
       const directBody = resolveRequestBody(operation.requestBody);
       if (directBody) {
-        bodies.add(directBody);
+        effectiveBodies.add(directBody);
       }
-      // The upgrader leaves reusable formData parameters as `$ref` entries in
-      // the operation's `parameters` array pointing at components.requestBodies
-      // — or, for path-level parameters, in the Path Item's `parameters` array.
-      for (const rawParam of [
-        ...(Array.isArray(operation.parameters) ? operation.parameters : []),
-        ...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
-      ]) {
+      for (const rawParam of Array.isArray(operation.parameters)
+        ? operation.parameters
+        : []) {
         const body = resolveRequestBody(rawParam);
         if (body) {
-          bodies.add(body);
+          effectiveBodies.add(body);
         }
       }
-
-      for (const body of bodies) {
+      for (const body of effectiveBodies) {
         patchProperties(body, byName);
+      }
+
+      // The Path Item's parameters reference shared request bodies that other
+      // operations may also use. Patch only the names this operation does not
+      // override; an overridden name lives in the operation's own body, and
+      // writing its items here would corrupt the shared body for everyone else.
+      const sharedByNames = new Map(
+        [...byName].filter(([name]) => !overriddenNames.has(name)),
+      );
+      for (const rawParam of Array.isArray(pathItem.parameters)
+        ? pathItem.parameters
+        : []) {
+        const body = resolveRequestBody(rawParam);
+        if (body) {
+          patchProperties(body, sharedByNames);
+        }
       }
     }
   }


### PR DESCRIPTION
## What

Fixes #3857 — Swagger 2.0 `formData` array parameters lost their item type during the OAS 3.1 upgrade, so generated body types degraded from `string[]` to `unknown[]`.

## Root cause

`@scalar/openapi-parser`'s `upgrade()` converts Swagger 2.0 `formData` parameters into a `requestBody` schema, but drops the parameter's `items` — `tags` arrives as `{ type: 'array' }` with no `items`, and orval falls back to `unknown[]`.

## Fix

In `import-specs.ts`, capture the item schemas of Swagger 2.0 `formData` array parameters **before** calling `upgrade()` (the upgrader also mutates its input, so the `swagger: '2.0'` marker is gone afterwards), then re-apply them to the upgraded document. Handles:

- Inline `formData` array parameters (urlencoded and multipart) — `tags: string[]`, `ids: number[]`
- Reusable parameters referenced via `$ref: '#/parameters/...'` — the upgrader promotes these to `components.requestBodies` and leaves a `$ref` in the operation's `parameters` array, which the restore resolves
- Non-string item types (`integer` → `number[]`)

Only patches array-typed properties that the upgrader left without `items`, so OAS 3 documents and any items the upgrader already preserved are untouched (guarded by a regression test).

## Validation

- 4 new unit tests in `import-specs.test.ts` covering inline, reusable-ref, non-string items, and an OAS 3 no-op guard — all proven to fail before the fix
- Full `orval` package suite: 224 tests pass; typecheck, lint, and format clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Swagger 2.0 form-data arrays so their item types are preserved correctly.
  * Added support for inline and reusable array parameters, including integer-to-number conversions.
  * Ensured path-level and operation-level parameter handling follows Swagger semantics without altering shared request definitions.
  * Preserved existing OpenAPI 3 form-data behavior.

* **Tests**
  * Added regression coverage for inline, reusable, path-level, and overridden Swagger 2.0 form-data arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->