### PR TITLE
fix(angular): apply zod runtime validation to inline array responses (#3718)

### DIFF
--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -1806,6 +1806,118 @@ describe('angular HttpClient generator', () => {
       );
     });
 
+    it('validates inline array responses with zod.array composition (#3718)', () => {
+      const output = createOutput({
+        schemas: {
+          type: 'zod',
+          path: '/tmp/schemas',
+        } as NormalizedOutputOptions['schemas'],
+        override: {
+          ...createOutput().override,
+          angular: {
+            ...angularOverride,
+            runtimeValidation: true,
+          },
+        },
+      });
+      const verbOption = createVerbOption({
+        response: baseResponse({
+          definition: { success: 'Pet[]', errors: 'Error' },
+          imports: [{ name: 'Pet' }],
+          types: {
+            success: [createSuccessType('Pet[]', 'application/json')],
+            errors: [],
+          },
+        }),
+        override: {
+          ...createVerbOption().override,
+          angular: {
+            ...angularOverride,
+            runtimeValidation: true,
+          },
+        } as GeneratorVerbOptions['override'],
+      });
+      const options = {
+        route: '/api/pets/${petId}',
+        pathRoute: '/pets/{petId}',
+        override: output.override,
+        context: createContextSpec(output),
+        output: output.target,
+      } satisfies GeneratorOptions;
+
+      const impl = generateHttpClientImplementation(verbOption, options);
+
+      // The inline array has no generated schema, so validation composes the
+      // element schema: `zod.array(Pet).parse(...)` in all observe modes.
+      expect(impl).toContain('.pipe(map(data => zod.array(Pet).parse(data)))');
+      expect(impl).toContain(
+        'response.clone({ body: zod.array(Pet).parse(response.body) })',
+      );
+      expect(impl).toContain(
+        'event instanceof AngularHttpResponse ? event.clone({ body: zod.array(Pet).parse(event.body) }) : event',
+      );
+      // The validated return type is the element zod output type, array-wrapped.
+      expect(impl).toContain('Observable<PetOutput[]>');
+      expect(impl).toContain('this.http.get<PetOutput[]>');
+      expect(impl).not.toContain('Pet[].parse');
+    });
+
+    it('promotes inline array response imports for zod composition (#3718)', async () => {
+      const output = createOutput({
+        schemas: {
+          type: 'zod',
+          path: '/tmp/schemas',
+        } as NormalizedOutputOptions['schemas'],
+        override: {
+          ...createOutput().override,
+          angular: {
+            ...angularOverride,
+            runtimeValidation: true,
+          },
+        },
+      });
+      const verbOption = createVerbOption({
+        response: baseResponse({
+          definition: { success: 'Pet[]', errors: 'Error' },
+          imports: [{ name: 'Pet' }],
+          types: {
+            success: [createSuccessType('Pet[]', 'application/json')],
+            errors: [],
+          },
+        }),
+        override: {
+          ...createVerbOption().override,
+          angular: {
+            ...angularOverride,
+            runtimeValidation: true,
+          },
+        } as GeneratorVerbOptions['override'],
+      });
+      const options = createGeneratorOptions({
+        route: '/api/pets/${petId}',
+        pathRoute: '/pets/{petId}',
+        context: createContextSpec(output),
+        override: output.override,
+      });
+
+      const generated = await generateAngular(
+        verbOption,
+        options,
+        'angular',
+        output,
+      );
+      const importNames = generated.imports.map((imp) => imp.name);
+
+      // The element schema is promoted to a value import (used by
+      // `zod.array(Pet)`) and the `zod` namespace is imported for composition.
+      const petImport = generated.imports.find((imp) => imp.name === 'Pet');
+      expect(petImport?.values).toBe(true);
+      expect(importNames).toContain('zod');
+      const zodImport = generated.imports.find((imp) => imp.name === 'zod');
+      expect(zodImport?.namespaceImport).toBe(true);
+      expect(importNames).toContain('PetOutput');
+    });
+
     it('uses Zod output types inside multi-content client result aliases', () => {
       const output = createOutput({
         schemas: {

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -39,6 +39,7 @@ import {
 } from './types';
 import {
   createReturnTypesRegistry,
+  getInlineArrayElement,
   getRelevantVerbOptionsForTag,
   getSchemaOutputTypeRef,
   isPrimitiveType,
@@ -374,7 +375,10 @@ export const generateHttpClientImplementation = (
 
   const dataType = response.definition.success || 'unknown';
   const isPrimitive = isPrimitiveType(dataType);
-  const hasSchema = hasSchemaImport(response.imports, dataType);
+  const inlineArrayElement = getInlineArrayElement(response.imports, dataType);
+  const hasSchema =
+    hasSchemaImport(response.imports, dataType) ||
+    inlineArrayElement != undefined;
   const isZodOutput = isZodSchemaOutput(context.output);
   const shouldValidateResponse =
     override.angular.runtimeValidation &&
@@ -382,7 +386,9 @@ export const generateHttpClientImplementation = (
     !isPrimitive &&
     hasSchema;
   const parsedDataType = shouldValidateResponse
-    ? getSchemaOutputTypeRef(dataType)
+    ? inlineArrayElement != undefined
+      ? `${getSchemaOutputTypeRef(inlineArrayElement)}[]`
+      : getSchemaOutputTypeRef(dataType)
     : dataType;
   const getGeneratedResponseType = (
     value: string,
@@ -393,10 +399,15 @@ export const generateHttpClientImplementation = (
       isZodOutput &&
       !!contentType &&
       (contentType.includes('json') || contentType.includes('+json')) &&
-      !isPrimitiveType(value) &&
-      hasSchemaImport(response.imports, value)
+      !isPrimitiveType(value)
     ) {
-      return getSchemaOutputTypeRef(value);
+      const valueArrayElement = getInlineArrayElement(response.imports, value);
+      if (valueArrayElement != undefined) {
+        return `${getSchemaOutputTypeRef(valueArrayElement)}[]`;
+      }
+      if (hasSchemaImport(response.imports, value)) {
+        return getSchemaOutputTypeRef(value);
+      }
     }
 
     return getContentTypeReturnType(contentType, value);
@@ -413,7 +424,9 @@ export const generateHttpClientImplementation = (
           ),
         ].join(' | ') || parsedDataType;
   const schemaValueRef = shouldValidateResponse
-    ? getSchemaValueRef(dataType)
+    ? inlineArrayElement != undefined
+      ? `zod.array(${getSchemaValueRef(inlineArrayElement)})`
+      : getSchemaValueRef(dataType)
     : dataType;
   // When Zod runtime validation is enabled the emitted method signature exposes
   // `parsedDataType` (e.g. `PetsOutput`) directly instead of a caller-overridable
@@ -585,9 +598,19 @@ export const generateHttpClientImplementation = (
     jsonSuccessValues.length === 1 &&
     override.angular.runtimeValidation &&
     isZodOutput &&
-    !isPrimitiveType(jsonSuccessValues[0]) &&
-    hasSchemaImport(response.imports, jsonSuccessValues[0])
-      ? getSchemaOutputTypeRef(jsonSuccessValues[0])
+    !isPrimitiveType(jsonSuccessValues[0])
+      ? (() => {
+          const jsonArrayElement = getInlineArrayElement(
+            response.imports,
+            jsonSuccessValues[0],
+          );
+          if (jsonArrayElement != undefined) {
+            return `${getSchemaOutputTypeRef(jsonArrayElement)}[]`;
+          }
+          return hasSchemaImport(response.imports, jsonSuccessValues[0])
+            ? getSchemaOutputTypeRef(jsonSuccessValues[0])
+            : jsonReturnType;
+        })()
       : jsonReturnType;
 
   let jsonValidationPipe = shouldValidateResponse
@@ -602,9 +625,15 @@ export const generateHttpClientImplementation = (
   ) {
     const jsonType = jsonSuccessValues[0];
     const jsonIsPrimitive = isPrimitiveType(jsonType);
-    const jsonHasSchema = hasSchemaImport(response.imports, jsonType);
+    const jsonArrayElement = getInlineArrayElement(response.imports, jsonType);
+    const jsonHasSchema =
+      hasSchemaImport(response.imports, jsonType) ||
+      jsonArrayElement != undefined;
     if (!jsonIsPrimitive && jsonHasSchema) {
-      const jsonSchemaRef = getSchemaValueRef(jsonType);
+      const jsonSchemaRef =
+        jsonArrayElement != undefined
+          ? `zod.array(${getSchemaValueRef(jsonArrayElement)})`
+          : getSchemaValueRef(jsonType);
       jsonValidationPipe = `.pipe(map(data => ${jsonSchemaRef}.parse(data)))`;
     }
   }
@@ -870,19 +899,37 @@ export const generateAngular: ClientBuilder = (verbOptions, options) => {
       },
     };
 
+    const inlineArrayElement = getInlineArrayElement(
+      result.response.imports,
+      responseType,
+    );
     if (
       !isPrimitiveResponse &&
-      hasSchemaImport(result.response.imports, responseType)
+      (hasSchemaImport(result.response.imports, responseType) ||
+        inlineArrayElement != undefined)
     ) {
+      const schemaName = inlineArrayElement ?? responseType;
       result = {
         ...result,
         response: {
           ...result.response,
           imports: [
             ...result.response.imports.map((imp) =>
-              imp.name === responseType ? { ...imp, values: true } : imp,
+              imp.name === schemaName ? { ...imp, values: true } : imp,
             ),
-            { name: getSchemaOutputTypeRef(responseType) },
+            { name: getSchemaOutputTypeRef(schemaName) },
+            // Inline array responses validate with `zod.array(X).parse(...)`,
+            // which references the `zod` namespace directly in the client file.
+            ...(inlineArrayElement != undefined
+              ? [
+                  {
+                    name: 'zod',
+                    values: true,
+                    namespaceImport: true,
+                    importPath: 'zod',
+                  },
+                ]
+              : []),
           ],
         },
       };
@@ -907,19 +954,35 @@ export const generateAngular: ClientBuilder = (verbOptions, options) => {
       if (jsonSchemaNames.length === 1) {
         const jsonType = jsonSchemaNames[0];
         const jsonIsPrimitive = isPrimitiveType(jsonType);
+        const jsonArrayElement = getInlineArrayElement(
+          result.response.imports,
+          jsonType,
+        );
         if (
           !jsonIsPrimitive &&
-          hasSchemaImport(result.response.imports, jsonType)
+          (hasSchemaImport(result.response.imports, jsonType) ||
+            jsonArrayElement != undefined)
         ) {
+          const jsonSchemaName = jsonArrayElement ?? jsonType;
           result = {
             ...result,
             response: {
               ...result.response,
               imports: [
                 ...result.response.imports.map((imp) =>
-                  imp.name === jsonType ? { ...imp, values: true } : imp,
+                  imp.name === jsonSchemaName ? { ...imp, values: true } : imp,
                 ),
-                { name: getSchemaOutputTypeRef(jsonType) },
+                { name: getSchemaOutputTypeRef(jsonSchemaName) },
+                ...(jsonArrayElement != undefined
+                  ? [
+                      {
+                        name: 'zod',
+                        values: true,
+                        namespaceImport: true,
+                        importPath: 'zod',
+                      },
+                    ]
+                  : []),
               ],
             },
           };

--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -458,6 +458,10 @@ describe('angular httpResource generator', () => {
           type: 'zod',
           path: '/tmp/schemas',
         } as NormalizedOutputOptions['schemas'],
+        override: {
+          ...createOutput().override,
+          angular: angularOverride('httpResource', false),
+        },
       });
       const verbOption = createVerbOption({
         response: baseResponse({
@@ -2677,6 +2681,44 @@ describe('angular httpResource generator', () => {
       } as never);
 
       expect(header).toContain('parse: Pet.parse');
+    });
+
+    it('emits zod.array parse for inline array responses with runtime validation (#3718)', () => {
+      const verbOption = createVerbOption({
+        response: baseResponse({
+          definition: { success: 'Pet[]', errors: 'Error' },
+          imports: [{ name: 'Pet' }],
+          types: {
+            success: [createSuccessType('Pet[]', 'application/json')],
+            errors: [],
+          },
+        }),
+      });
+      routeRegistry.set('getPetById', '/api/pets/${petId}');
+
+      const output = createOutput({
+        schemas: {
+          type: 'zod',
+          path: '/tmp/schemas',
+        } as NormalizedOutputOptions['schemas'],
+      });
+
+      const header = generateHttpResourceHeader({
+        title: 'PetService',
+        isRequestOptions: true,
+        isMutator: false,
+        isGlobalMutator: false,
+        provideIn: 'root',
+        hasAwaitedType: false,
+        output,
+        verbOptions: { getPetById: verbOption },
+        clientImplementation: '',
+      } as never);
+
+      // Inline arrays have no generated schema: the resource composes the
+      // element schema with `zod.array(...)` instead of `Schema.parse`.
+      expect(header).toContain('parse: zod.array(Pet).parse');
+      expect(header).not.toContain('parse: Pet[].parse');
     });
 
     it('does not add parse when schemas.type is not zod', () => {

--- a/packages/angular/src/http-resource.ts
+++ b/packages/angular/src/http-resource.ts
@@ -59,6 +59,7 @@ import {
   createReturnTypesRegistry,
   createRouteRegistry,
   getDefaultSuccessType,
+  getInlineArrayElement,
   getRelevantVerbOptionsForTag,
   getSchemaOutputTypeRef,
   isMutationVerb,
@@ -634,6 +635,15 @@ const getParseSchemaName = (
   if (!responseType) return undefined;
   if (isPrimitiveType(responseType)) return undefined;
 
+  // An inline array response (`Item[]`) has no generated schema of its own;
+  // the element name is returned so the element import is promoted to a value
+  // import and its `…Output` type is added (see `getParseExpression`).
+  const inlineArrayElement = getInlineArrayElement(
+    response.imports,
+    responseType,
+  );
+  if (inlineArrayElement != undefined) return inlineArrayElement;
+
   // Verify a matching import exists (the response type name resolves to a zod schema)
   const hasMatchingImport = response.imports.some(
     (imp) => imp.name === responseType,
@@ -681,6 +691,12 @@ const getHttpResourceVerbImports = (
   const parsedZodImports = responseImports.filter((imp) =>
     parsedZodImportNames.has(imp.name),
   );
+  // An inline array response (`Item[]`) validates via `zod.array(Item).parse`,
+  // which references the `zod` namespace directly in the resource file.
+  const needsZodNamespaceImport = response.types.success.some(
+    (successType) =>
+      getInlineArrayElement(response.imports, successType.value) != undefined,
+  );
 
   return [
     ...responseImports.map((imp) =>
@@ -689,6 +705,16 @@ const getHttpResourceVerbImports = (
     ...parsedZodImports
       .filter((imp) => !isPrimitiveType(imp.name))
       .map((imp) => ({ name: getSchemaOutputTypeRef(imp.name) })),
+    ...(needsZodNamespaceImport
+      ? [
+          {
+            name: 'zod',
+            values: true,
+            namespaceImport: true,
+            importPath: 'zod',
+          },
+        ]
+      : []),
     ...body.imports,
     ...props.flatMap((prop) =>
       prop.type === GetterPropType.NAMED_PATH_PARAMS
@@ -717,8 +743,20 @@ const getParseExpression = (
     output,
     responseTypeOverride,
   );
+  if (!schemaName) return undefined;
 
-  return schemaName ? `${schemaName}.parse` : undefined;
+  // Inline array responses have no dedicated schema; compose the parse
+  // expression from the element schema (`zod.array(Item).parse`).
+  const responseType = responseTypeOverride ?? response.definition.success;
+  const inlineArrayElement = getInlineArrayElement(
+    response.imports,
+    responseType,
+  );
+  if (inlineArrayElement != undefined) {
+    return `zod.array(${inlineArrayElement}).parse`;
+  }
+
+  return `${schemaName}.parse`;
 };
 
 /**
@@ -879,16 +917,19 @@ const buildHttpResourceFunction = (
   const dataType = response.definition.success || 'unknown';
   const omitParse = isZodSchemaOutput(output);
   const responseSchemaImports = getHttpResourceResponseImports(response);
-  const hasResponseSchemaImport = responseSchemaImports.some(
-    (imp) => imp.name === dataType,
-  );
+  const inlineArrayElement = getInlineArrayElement(response.imports, dataType);
+  const hasResponseSchemaImport =
+    responseSchemaImports.some((imp) => imp.name === dataType) ||
+    inlineArrayElement != undefined;
   const resourceName = `${operationName}Resource`;
   const parsedDataType =
     omitParse &&
     output.override.angular.runtimeValidation &&
     !isPrimitiveType(dataType) &&
     hasResponseSchemaImport
-      ? getSchemaOutputTypeRef(dataType)
+      ? inlineArrayElement != undefined
+        ? `${getSchemaOutputTypeRef(inlineArrayElement)}[]`
+        : getSchemaOutputTypeRef(dataType)
       : dataType;
   const successTypes = response.types.success;
   const overallReturnType =
@@ -1341,10 +1382,15 @@ const getHttpResourceGeneratedResponseType = (
     output.override.angular.runtimeValidation &&
     !!contentType &&
     (contentType.includes('json') || contentType.includes('+json')) &&
-    !isPrimitiveType(value) &&
-    responseImports.some((imp) => imp.name === value)
+    !isPrimitiveType(value)
   ) {
-    return getSchemaOutputTypeRef(value);
+    const arrayElement = getInlineArrayElement(responseImports, value);
+    if (arrayElement != undefined) {
+      return `${getSchemaOutputTypeRef(arrayElement)}[]`;
+    }
+    if (responseImports.some((imp) => imp.name === value)) {
+      return getSchemaOutputTypeRef(value);
+    }
   }
 
   return getContentTypeReturnType(contentType, value);

--- a/packages/angular/src/utils.ts
+++ b/packages/angular/src/utils.ts
@@ -66,6 +66,27 @@ export const getSchemaOutputTypeRef = (typeName: string): string =>
   `${typeName}Output`;
 
 /**
+ * Detects an inline array response definition (`X[]`) whose element `X` is a
+ * non-primitive name present in `imports`.
+ *
+ * Named schemas validate with `Schema.parse(...)`; an inline array has no
+ * generated schema of its own, so it must be composed as `zod.array(X)`. This
+ * helper recognizes exactly that shape and returns the element name (or
+ * `undefined` for primitives, `Array<...>` spellings, and unnamed arrays).
+ */
+export const getInlineArrayElement = (
+  imports: readonly { name: string }[],
+  typeName: string | undefined,
+): string | undefined => {
+  if (typeName == undefined) return undefined;
+  const match = /^(\w+)\[\]$/.exec(typeName);
+  if (!match) return undefined;
+  const element = match[1];
+  if (isPrimitiveType(element)) return undefined;
+  return imports.some((imp) => imp.name === element) ? element : undefined;
+};
+
+/**
  * Converts an operation/tag title into the generated Angular service class name.
  */
 export const generateAngularTitle = (title: string) => {


### PR DESCRIPTION
Closes #3718

## Summary

With `client: 'angular'`, `schemas: { type: 'zod' }` and `override.angular.runtimeValidation: true`, a response whose schema is an **inline** `type: array` got no runtime validation: the generator matched `response.definition.success` against the response imports verbatim, and `Item[]` never equals the import `Item`, so the validation branch was skipped entirely (and the `httpResource` helper emitted no `parse`).

This PR composes the element schema instead of requiring a generated schema for the array itself.

## Changes

- `packages/angular/src/utils.ts`: new `getInlineArrayElement()` — recognizes an `X[]` response definition whose element `X` is a non-primitive name present in the response imports.
- `packages/angular/src/http-client.ts`: `shouldValidateResponse` is now true for that shape; the body / `observe: 'response'` / `observe: 'events'` pipes emit `zod.array(Item).parse(...)`; the validated return type is `ItemOutput[]` and the `<TData>` generic is dropped (matching named-schema responses). Multi-content JSON paths get the same treatment.
- `packages/angular/src/http-resource.ts`: `getParseSchemaName`/`getParseExpression` recognize the inline-array shape and emit `parse: zod.array(Item).parse`; return types become `ItemOutput[]`.
- Import hygiene: the element schema is promoted to a value import and `import * as zod from 'zod'` is emitted **only** when a composed expression is present.

## Validation

- `bunx vitest run` in `packages/angular` → 276 passed (incl. new regression tests for the HttpClient pipes, import promotion, and the httpResource parse expression).
- `tsc --noEmit` clean; `vp lint` (monorepo, type-aware) → 0 warnings / 0 errors.
- End-to-end: generated a real Angular+zod client from a spec with an inline array response — all three observe modes emit `zod.array(Item).parse(...)`, return `Observable<ItemOutput[]>`, and the file gains `import * as zod from 'zod'`. With `runtimeValidation: false` the output is unchanged (no zod import, `<TData>` preserved).

## Behavior notes (matching the issue's proposal)

- Validated array methods drop the `TData` generic and return `<Element>Output[]`, consistent with named-schema responses.
- Primitive element arrays (`string[]`) stay unvalidated (no zod schema exists for them).
- Named array components (`$ref` to a `type: array` schema) keep emitting `Schema.parse` unchanged.
