### PR TITLE
docs: show how to control the use/get prefix on query options (#3790)

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1395,6 +1395,60 @@ Because the mutator receives `operationId`, one file can serve every
 operation and branch where the behaviour needs to differ, which is the usual
 alternative to a per-operation configuration option.
 
+#### Controlling the `use` / `get` prefix on query options
+
+By default orval names the exported query options factory
+`use<Operation>QueryOptions` when a `queryOptions` mutator (or a hook
+mutator) is configured, and `get<Operation>QueryOptions` otherwise — the
+`use` prefix is meant to signal a hook. Sometimes the factory is consumed
+outside a React component, for example in a router loader or in
+`prefetchQuery` / `ensureQueryData`, where a `use*` name is misleading and
+can trip rules-of-hooks lint rules. In that case, name the exported function
+yourself via the `queryOptions` mutator and the generated code will use
+your name verbatim:
+
+```ts title="src/mutators/custom-query-options.ts"
+export function customQueryOptions<T extends { queryKey: QueryKey }>(
+  options: T,
+): T {
+  return options;
+}
+```
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      client: 'react-query',
+      override: {
+        query: {
+          queryOptions: {
+            path: './src/mutators/custom-query-options.ts',
+            name: 'customQueryOptions',
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+The generated hook then calls `getPetstoreQueryOptions(...)` (the name of
+the mutator export) instead of an auto-derived `usePetstoreQueryOptions`,
+and it can be used safely with `prefetchQuery` / `ensureQueryData`:
+
+```ts
+export async function loader(queryClient: QueryClient) {
+  return queryClient.ensureQueryData(getPetstoreQueryOptions());
+}
+```
+
+<Callout type="info">
+  The `use`/`get` prefix only affects the *name* of the exported options
+  factory. The hook itself is still exported as `use<Operation>` and must
+  be called from a React component.
+</Callout>
+
 ### shouldExportMutatorHooks
 
 **Type:** `Boolean`


### PR DESCRIPTION
Closes #3790

## Summary

The maintainer discussion on #3790 noted that the docs for `queryKey` / `queryOptions` / `mutationOptions` were "sorely lacking" an example of the exact use case the issue describes: controlling the `use` / `get` prefix on the generated query-options factory. The `use` prefix is undesirable when the options factory is consumed outside React — e.g. in router loaders with `prefetchQuery` / `ensureQueryData`.

## Change

Adds a "Controlling the `use` / `get` prefix on query options" subsection to the `queryKey / queryOptions / mutationOptions` reference docs, with a working example:

- `src/mutators/custom-query-options.ts` — the mutator
- `orval.config.ts` — wiring `queryOptions` to it
- usage with `ensureQueryData` in a loader
- a callout clarifying the prefix only affects the options factory's *name*; the hook itself stays `use<Operation>`

## Validation

- `bun run types:check` in `docs/` passes (MDX + tsc)
- `bunx biome check` on the changed file passes (exit 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for customizing generated query-options factory names through the `queryOptions` mutator.
  * Clarified that custom names support non-hook use cases such as router loaders, query prefetching, and ensuring query data.
  * Documented that customizing options factory names does not change generated hook names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->