### PR TITLE
fix(angular): type multi-content text responses as Observable<string>

### DIFF
--- a/docs/content/docs/guides/angular.mdx
+++ b/docs/content/docs/guides/angular.mdx
@@ -203,6 +203,8 @@ With `override.angular.baseUrl` set, Orval emits a sibling `<target>.base-url.ts
 file alongside the generated client:
 
 ```ts title="petstore.base-url.ts"
+import { InjectionToken, inject, type Provider } from '@angular/core';
+
 export const PETSTORE_SERVER_URL: string = 'http://petstore.swagger.io/v1';
 
 export function normalizeBaseUrl(baseUrl: string): string {
@@ -332,7 +334,7 @@ import {
   providePetstoreBaseUrl,
   providePetstoreBaseUrlResolver,
 } from './api/petstore.base-url';
-import { PetsService } from './api/petstore.service';
+import { PetsService } from './api/pets/pets.service';
 
 describe('PetsService', () => {
   let httpMock: HttpTestingController;
@@ -373,7 +375,7 @@ inside an injection context, and fall back to `options.injector.get(...)` when
 an explicit `injector` is passed — the same rule that already applies to every
 other injected dependency in generated `httpResource` functions:
 
-```ts title="petstore.resource.ts"
+```ts title="pets/pets.resource.ts"
 export function showPetByIdResource(
   petId: Signal<string>,
   accept?: ShowPetByIdAccept,

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -1304,7 +1304,7 @@ describe('angular HttpClient generator', () => {
       expect(impl).toContain('accept?: GetPetFileAccept');
       expect(impl).toContain('Observable<Pet | string>');
       expect(impl).toContain('this.http.get<Pet>');
-      expect(impl).toContain('as Observable<any>');
+      expect(impl).toContain('as Observable<string>');
       // Content-type dispatch logic
       expect(impl).toContain("responseType: 'json'");
       expect(impl).toContain("responseType: 'text'");

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -781,7 +781,7 @@ export const generateHttpClientImplementation = (
     if (accept.includes('json') || accept.includes('+json')) {
       return ${buildHttpClientCall(`<${parsedJsonReturnType}>`, buildOptionsObject('json'))}${jsonValidationPipe};
     } else if (accept.startsWith('text/') || accept.includes('xml')) {
-      return ${buildHttpClientCall('', buildOptionsObject('text'))} as Observable<any>;
+      return ${buildHttpClientCall('', buildOptionsObject('text'))} as Observable<string>;
     }${
       blobSuccessTypes.length > 0
         ? ` else {

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
@@ -189,7 +189,7 @@ export const ShowPetByIdAccept = {
 } as const;
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function searchPetsResource(
   params: Signal<SearchPetsParams>,
@@ -227,7 +227,7 @@ export function searchPetsResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function listPetsResource(
   accept: 'application/json',
@@ -292,7 +292,7 @@ export function listPetsResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetByIdResource(
   petId: Signal<string>,
@@ -360,7 +360,7 @@ export function showPetByIdResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetTextResource(
   petId: Signal<string>,
@@ -393,7 +393,7 @@ export function showPetTextResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function downloadFileResource(
   petId: Signal<number>,
@@ -442,8 +442,13 @@ export interface ResourceState<T> {
   readonly status: Signal<ResourceStatus>;
   readonly error: Signal<globalThis.Error | undefined>;
   readonly isLoading: Signal<boolean>;
-  readonly hasValue: () => boolean;
+  /** Guard reads of `value()` with this call: `value()` throws in the error state. */
+  readonly hasValue: () => this is ResolvedResourceState<T>;
   readonly reload: () => boolean;
+}
+
+export interface ResolvedResourceState<T> extends ResourceState<T> {
+  readonly value: Signal<Exclude<T, undefined>>;
 }
 
 /**
@@ -456,7 +461,9 @@ export function toResourceState<T>(ref: HttpResourceRef<T>): ResourceState<T> {
     status: ref.status,
     error: ref.error,
     isLoading: ref.isLoading,
-    hasValue: () => ref.hasValue(),
+    hasValue(this: ResourceState<T>): this is ResolvedResourceState<T> {
+      return ref.hasValue();
+    },
     reload: () => ref.reload(),
   };
 }

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
@@ -270,7 +270,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pets>(`${this.baseUrl}/v${version}/pets`, {
@@ -383,7 +383,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`${this.baseUrl}/v${version}/pets/${petId}`, {
@@ -447,7 +447,7 @@ export class PetsService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<any>;
+      ) as Observable<string>;
     }
 
     return this.http.put<Pet>(
@@ -515,7 +515,7 @@ export class PetsService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<any>;
+      ) as Observable<string>;
     }
 
     return this.http.patch<Pet>(

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -290,7 +290,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -395,7 +395,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -455,7 +455,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -515,7 +515,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
@@ -267,7 +267,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -368,7 +368,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -424,7 +424,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -480,7 +480,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -278,7 +278,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -379,7 +379,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -435,7 +435,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -491,7 +491,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -350,7 +350,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -406,7 +406,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -462,7 +462,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -578,7 +578,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -636,7 +636,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -567,7 +567,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -621,7 +621,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
@@ -189,7 +189,7 @@ export const ShowPetByIdAccept = {
 } as const;
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function searchPetsResource(
   params: Signal<SearchPetsParams>,
@@ -227,7 +227,7 @@ export function searchPetsResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function listPetsResource(
   accept: 'application/json',
@@ -292,7 +292,7 @@ export function listPetsResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetByIdResource(
   petId: Signal<string>,
@@ -360,7 +360,7 @@ export function showPetByIdResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetTextResource(
   petId: Signal<string>,
@@ -393,7 +393,7 @@ export function showPetTextResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function downloadFileResource(
   petId: Signal<number>,
@@ -442,8 +442,13 @@ export interface ResourceState<T> {
   readonly status: Signal<ResourceStatus>;
   readonly error: Signal<globalThis.Error | undefined>;
   readonly isLoading: Signal<boolean>;
-  readonly hasValue: () => boolean;
+  /** Guard reads of `value()` with this call: `value()` throws in the error state. */
+  readonly hasValue: () => this is ResolvedResourceState<T>;
   readonly reload: () => boolean;
+}
+
+export interface ResolvedResourceState<T> extends ResourceState<T> {
+  readonly value: Signal<Exclude<T, undefined>>;
 }
 
 /**
@@ -456,7 +461,9 @@ export function toResourceState<T>(ref: HttpResourceRef<T>): ResourceState<T> {
     status: ref.status,
     error: ref.error,
     isLoading: ref.isLoading,
-    hasValue: () => ref.hasValue(),
+    hasValue(this: ResourceState<T>): this is ResolvedResourceState<T> {
+      return ref.hasValue();
+    },
     reload: () => ref.reload(),
   };
 }

--- a/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
@@ -270,7 +270,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pets>(`${this.baseUrl}/v${version}/pets`, {
@@ -383,7 +383,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`${this.baseUrl}/v${version}/pets/${petId}`, {
@@ -447,7 +447,7 @@ export class PetsService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<any>;
+      ) as Observable<string>;
     }
 
     return this.http.put<Pet>(
@@ -515,7 +515,7 @@ export class PetsService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<any>;
+      ) as Observable<string>;
     }
 
     return this.http.patch<Pet>(

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -290,7 +290,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -395,7 +395,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -455,7 +455,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -515,7 +515,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http

--- a/samples/angular-app/src/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.service.ts
@@ -267,7 +267,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -368,7 +368,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -424,7 +424,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -480,7 +480,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -278,7 +278,7 @@ export class PetsService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pets>(`/v${version}/pets`, {
@@ -379,7 +379,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -435,7 +435,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -491,7 +491,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -350,7 +350,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Pet>(`/v${version}/pets/${petId}`, {
@@ -406,7 +406,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -462,7 +462,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -578,7 +578,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http
@@ -636,7 +636,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -567,7 +567,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.put<Pet>(`/v${version}/pets/${petId}/update`, pet, {
@@ -621,7 +621,7 @@ export class PetsService {
         ...options,
         responseType: 'text',
         headers,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.patch<Pet>(`/v${version}/pets/${petId}/update`, pet, {

--- a/samples/angular-app/tsconfig.spec.json
+++ b/samples/angular-app/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "outDir": "./out-tsc/spec",
     "types": ["vitest/globals"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "vitest.setup.ts"]
 }

--- a/tests/__snapshots__/angular/base-url-token-both/health/health.resource.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/health/health.resource.ts
@@ -102,7 +102,7 @@ export function applyOrvalRequestExtension(
   return options.request ? options.request(next) : next;
 }
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function healthCheckResource(
   options: OrvalHttpResourceOptions<string, string> & {
@@ -137,8 +137,13 @@ export interface ResourceState<T> {
   readonly status: Signal<ResourceStatus>;
   readonly error: Signal<globalThis.Error | undefined>;
   readonly isLoading: Signal<boolean>;
-  readonly hasValue: () => boolean;
+  /** Guard reads of `value()` with this call: `value()` throws in the error state. */
+  readonly hasValue: () => this is ResolvedResourceState<T>;
   readonly reload: () => boolean;
+}
+
+export interface ResolvedResourceState<T> extends ResourceState<T> {
+  readonly value: Signal<Exclude<T, undefined>>;
 }
 
 /**
@@ -151,7 +156,9 @@ export function toResourceState<T>(ref: HttpResourceRef<T>): ResourceState<T> {
     status: ref.status,
     error: ref.error,
     isLoading: ref.isLoading,
-    hasValue: () => ref.hasValue(),
+    hasValue(this: ResourceState<T>): this is ResolvedResourceState<T> {
+      return ref.hasValue();
+    },
     reload: () => ref.reload(),
   };
 }

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
@@ -172,7 +172,7 @@ function filterParams(
   return filteredParams;
 }
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function listPetsResource(
   params: Signal<ListPetsParams>,
@@ -201,7 +201,7 @@ export function listPetsResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetByIdResource(
   petId: Signal<string>,
@@ -227,7 +227,7 @@ export function showPetByIdResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetWithOwnerResource(
   petId: Signal<string>,
@@ -268,8 +268,13 @@ export interface ResourceState<T> {
   readonly status: Signal<ResourceStatus>;
   readonly error: Signal<globalThis.Error | undefined>;
   readonly isLoading: Signal<boolean>;
-  readonly hasValue: () => boolean;
+  /** Guard reads of `value()` with this call: `value()` throws in the error state. */
+  readonly hasValue: () => this is ResolvedResourceState<T>;
   readonly reload: () => boolean;
+}
+
+export interface ResolvedResourceState<T> extends ResourceState<T> {
+  readonly value: Signal<Exclude<T, undefined>>;
 }
 
 /**
@@ -282,7 +287,9 @@ export function toResourceState<T>(ref: HttpResourceRef<T>): ResourceState<T> {
     status: ref.status,
     error: ref.error,
     isLoading: ref.isLoading,
-    hasValue: () => ref.hasValue(),
+    hasValue(this: ResourceState<T>): this is ResolvedResourceState<T> {
+      return ref.hasValue();
+    },
     reload: () => ref.reload(),
   };
 }

--- a/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
@@ -188,7 +188,7 @@ function filterParams(
   return filteredParams;
 }
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function listPetsResource(
   params: Signal<ListPetsParams>,
@@ -217,7 +217,7 @@ export function listPetsResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetByIdResource(
   petId: Signal<string>,
@@ -243,7 +243,7 @@ export function showPetByIdResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function healthCheckResource(
   options: OrvalHttpResourceOptions<string, string> & {
@@ -266,7 +266,7 @@ export function healthCheckResource(
 }
 
 /**
- * @experimental httpResource is experimental (Angular v19.2+)
+ * @remarks httpResource is available in Angular 19.2 and later.
  */
 export function showPetWithOwnerResource(
   petId: Signal<string>,
@@ -441,8 +441,13 @@ export interface ResourceState<T> {
   readonly status: Signal<ResourceStatus>;
   readonly error: Signal<globalThis.Error | undefined>;
   readonly isLoading: Signal<boolean>;
-  readonly hasValue: () => boolean;
+  /** Guard reads of `value()` with this call: `value()` throws in the error state. */
+  readonly hasValue: () => this is ResolvedResourceState<T>;
   readonly reload: () => boolean;
+}
+
+export interface ResolvedResourceState<T> extends ResourceState<T> {
+  readonly value: Signal<Exclude<T, undefined>>;
 }
 
 /**
@@ -455,7 +460,9 @@ export function toResourceState<T>(ref: HttpResourceRef<T>): ResourceState<T> {
     status: ref.status,
     error: ref.error,
     isLoading: ref.isLoading,
-    hasValue: () => ref.hasValue(),
+    hasValue(this: ResourceState<T>): this is ResolvedResourceState<T> {
+      return ref.hasValue();
+    },
     reload: () => ref.reload(),
   };
 }

--- a/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
@@ -345,7 +345,7 @@ export class AngularMultiContentQueryParamsTestService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<any>;
+      ) as Observable<string>;
     }
 
     return this.http.post<Item>(

--- a/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
+++ b/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
@@ -197,7 +197,7 @@ export class AngularMultiContentQueryParamsTestService {
           responseType: 'text',
           headers,
         },
-      ) as Observable<any>;
+      ) as Observable<string>;
     }
 
     return this.http.post<Item>(
@@ -257,7 +257,7 @@ export class AngularMultiContentQueryParamsTestService {
         responseType: 'text',
         headers,
         params: filteredParams,
-      }) as Observable<any>;
+      }) as Observable<string>;
     }
 
     return this.http.get<Items>(`/items`, {


### PR DESCRIPTION
Follow-up to #3711, which merged with two unaddressed review threads on the Angular guide. Fixing those surfaced a real typing defect in the generated multi-content-type dispatch, which is the bulk of this diff.

## Generated services no longer cast to `any`

Operations with multiple response content types generate a three-way dispatch on the `Accept` header. The `text/`/`xml` branch cast its result to `Observable<any>`, which silently disabled type checking for every consumer of those operations:

```ts
// before
return this.http.get(`/v${version}/pets/${petId}`, {
  ...options,
  responseType: 'text',
  headers,
}) as Observable<any>;
```

The adjacent blob branch already casts precisely (`as Observable<Blob>`), so this was an inconsistency rather than a constraint — `responseType: 'text'` always resolves to `Observable<string>`, which is assignable to the declared union return type. The cast is kept (it documents where `HttpClient` overload resolution is ambiguous) but narrowed to `Observable<string>`.

This removes 23 `any` casts from the Angular sample output and 26 more across the committed snapshots. Consumers gain type checking they should already have had; anyone who was relying on the `any` to assign the result somewhere unrelated will now see an error, which is the point.

## Angular guide snippets now match generated output

Three snippets in the `override.angular.baseUrl` section could not be used as written:

- The `petstore.base-url.ts` snippet used `InjectionToken`, `Provider`, and `inject` with no import statement, so copying it verbatim fails to compile.
- The TestBed example imported `PetsService` from `./api/petstore.service`, but the `tags-split` config shown directly above it emits the service at `./api/pets/pets.service`.
- The `httpResource` snippet was titled `petstore.resource.ts` for the same reason; under `tags-split` it is `pets/pets.resource.ts`.

The first two were raised on #3711; the third is the same bug in a snippet nobody flagged.

## Where to start reviewing

`packages/angular/src/http-client.ts` is the only behavioral change — one line. Everything under `samples/` and `tests/__snapshots__/` is regenerated output.

Two things worth knowing about that regenerated diff:

**It is wider than the `any` fix, and that part is currently breaking master.** The committed `base-url-token` sample predates daa07fb06 (#3828) and was never regenerated when that landed, so this branch also picks up the `@experimental` → `@remarks` note and the `hasValue(): this is ResolvedResourceState<T>` type guard.

That drift is unrelated in origin but cannot be separated from a regeneration — and it is not cosmetic. Because `pr-checks` runs `on: pull_request` only, master was never re-verified after #3828 merged, so **every PR branched off current master fails `Verify snapshot`** on `samples/angular-app/src/api/base-url-token/pets/pets.resource.ts`, whatever it changes. Demonstrated on #3867, a branch whose only change is a workflow file. This PR already contains the regeneration, which is why its own CI is green; merging it restores master. (#3867 adds a `push` trigger so this class of drift is caught at merge time instead.)

**Every changed line falls into one of those two buckets.** The full generated diff reduces to exactly four distinct line changes — the `any` → `string` cast, the doc-comment note, and the two `hasValue` guard lines — so a spot check of one service and one resource file covers the rest.

`samples/angular-app/tsconfig.spec.json` is unrelated housekeeping: the setup file registered in `angular.json` lives at the project root and was outside the spec `include`, so every `ng test` run warned that it was bundled without being type-checked.

Refs #3711


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved type safety for text and XML HTTP responses by using string-specific observable types.
  * Enhanced resource state handling with clearer type narrowing and guaranteed values after resolution.
  * Updated Angular resource guidance to reflect availability in Angular 19.2 and later.

* **Documentation**
  * Updated Angular examples and generated service paths for consistency.

* **Tests**
  * Refined test configuration and response type expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
