### PR TITLE
ci: run sample tests, and run pr-checks on master pushes

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -5,6 +5,13 @@ on:
     branches:
       - 'master'
       - 'next'
+  # Also run after merge. Without this, drift that lands on master (e.g. a
+  # generator change whose fixtures were only partly regenerated) goes
+  # unnoticed until it fails an unrelated PR days later.
+  push:
+    branches:
+      - 'master'
+      - 'next'
 
 permissions:
   contents: read
@@ -72,6 +79,10 @@ jobs:
 
   publish-preview:
     needs: pr-checks
+    # Pull requests only: this job checks out
+    # `github.event.pull_request.head.sha` and comments the preview back on
+    # the PR, neither of which exists on a push event.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -55,6 +55,18 @@ jobs:
         # this step also runs the generate-api task
         run: vp run -w test:snapshots
 
+      - name: Test samples
+        # Runtime tests for the generated clients (Angular TestBed suites,
+        # vue-query component tests, and the tsc/svelte-check type gates).
+        # The snapshot step above only proves generated code matches the
+        # committed fixtures; this proves it actually runs.
+        #
+        # Must stay after "Verify snapshot": that step regenerates every
+        # sample's client, and several samples gitignore their generated
+        # output, so these tests cannot compile on a fresh checkout until
+        # it has run.
+        run: vp run -w test:samples
+
       - name: Verify generated code can build
         run: vp run -F orval-tests build
 

--- a/samples/angular-query/package.json
+++ b/samples/angular-query/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "CI=true ng test --no-watch",
+    "test": "ng test --no-watch",
     "lint": "ng lint",
     "test:snapshots": "vitest run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",

--- a/samples/angular-query/tsconfig.spec.json
+++ b/samples/angular-query/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "outDir": "./out-tsc/spec",
     "types": ["vitest/globals"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "vitest.setup.ts"]
 }


### PR DESCRIPTION
Two independent holes in `pr-checks`, both of which let regressions reach master unseen.

## 1. Sample runtime tests have not run in CI since February

CI verifies that generated clients match the committed snapshots and that they compile. It never verifies that they *run*.

The root `test` script is scoped `-F './packages/*'`, so `vp run -w test` covers packages only. `test:samples` — the Angular TestBed suites, vue-query's component tests, and the `tsc --noEmit` / `svelte-check` type gates — exists in the root `package.json` but is invoked by no workflow.

This is regressed coverage, not new coverage. Until 02ba045a9 (#3013, 22 Feb 2026), `tests.yaml` ran `yarn test:ci`:

```
test:ci = CI=true yarn lint && CI=true yarn test && yarn test:cli && yarn test:samples
```

#3013 replaced `tests.yaml` with the current `pr-checks.yaml` and narrowed the test step to `vp run -w test` (packages only). `test:samples` was not carried over, so sample runtime tests have been dark for roughly six months.

What that costs: `samples/angular-app` is one of only three samples with real runtime tests, and those tests are the only thing in the repo that executes generated Angular code. Snapshots prove the generated text is unchanged and `orval-tests build` proves it compiles — neither proves a generated client actually works. A generated service that compiles cleanly and matches its fixture can still send the wrong URL, drop a query parameter, or fail to inject its dependencies, and nothing in CI would notice.

### Step ordering is load-bearing

The step must stay after `Verify snapshot`. That step regenerates every sample's client, and several samples gitignore their generated output, so on a fresh checkout their tests cannot compile until it has run.

Verified both ways in a clean worktree:

| Order | Result |
|---|---|
| `test:samples` on its own | 4 tasks fail — `TS2307: Cannot find module './api/endpoints/...'` |
| after `Verify snapshot` | 13/13 tasks pass |

### Cost

Negligible — the full filtered set completes in a couple of seconds, parallelized by `vp run`. No new dependencies. Both Angular samples use `@angular/build:unit-test` with the Vitest runner rather than Karma, so no browser binary is needed, and every script is explicitly non-watching (`--no-watch`, `--run`, one-shot `tsc`).

## 2. Nothing runs after a merge

`pr-checks` ran `on: pull_request` only. A PR is verified against its own head, and then never again — so anything that lands on master and breaks it stays invisible until it fails somebody else's unrelated PR.

#3828 is a live example, and it is why this PR's first CI run is red. That PR regenerated most Angular fixtures but not `samples/angular-app/src/api/base-url-token/**` — the newest output, added days earlier by #3711 and easy to miss in a partial regeneration. Its own run was green, master was never re-checked, and the next branch cut from master (this one, which only touches a workflow file) failed `Verify snapshot` on a file it had not touched:

```
FAIL angular-app api-generation.spec.ts > API Generation Snapshots >
     samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
```

Note this is a snapshot failure, so `Verify snapshot` does detect it — just never at the moment it lands. A `push` trigger closes that window from days to minutes. (#3866 carries the regenerated fixture; once it merges this branch should go green.)

`publish-preview` is guarded with `if: github.event_name == 'pull_request'` — it checks out `github.event.pull_request.head.sha` and comments the preview back on the PR, neither of which exists on a push event, so it would misbehave on merge without the guard.

## Known gaps this does not address

The six `react-query` samples already excluded by the `test:samples` filters stay excluded. Their `test` script is `tsc --noEmit endpoints.ts`, which fails under TypeScript 6 with `TS5112` (a filename passed on the command line alongside a `tsconfig.json`). Fixing that surfaces further errors in four of them, including what looks like a genuine mutator/`httpClient` mismatch. Filed as #3868 so this step can land without dragging it in.

## Windows portability

`samples/angular-query`'s test script was `CI=true ng test --no-watch`. That inline env assignment is POSIX-only, and running sample tests on the `windows-latest` matrix cell would have handed it to cmd/pwsh. Note that `shell: bash` on the workflow step does not fix this — `vp` spawns each package script through the platform shell itself, below the step.

The prefix is removed instead, which is lossless: nothing in the sample reads `CI`, `--no-watch` already gives the one-shot behavior, Actions sets `CI=true` for every step regardless, and the sibling `angular-app` sample has always used the bare form. It was the only script in the repo using inline env syntax.

## Log noise this step would otherwise surface

`samples/angular-query/angular.json` registers `vitest.setup.ts` as a setup file, but its spec tsconfig only included `src/**/*.ts`, so every run printed `WARNING File 'vitest.setup.ts' not found in TypeScript compilation` — the file was bundled but never type-checked. It is now in `include`, which both silences the warning and puts the setup file under the same checking as the specs it supports.

`samples/angular-app` had the identical gap; that copy is fixed in #3866, and these two are the only samples with a `vitest.setup.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added runtime and type-check validation to pull request checks after snapshot verification.
  * Extended automated checks to run for pushes to the main development branches.
  * Included the test setup in Angular sample TypeScript validation.

* **Chores**
  * Preview publishing now runs only for pull request events.
  * Updated Angular sample tests to run without forcing CI mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->