### PR TITLE
feat(angular-app): demo pages for retrievalClient 'both' and the DI base URL token

### DIFF
--- a/samples/angular-app/src/app/app.config.ts
+++ b/samples/angular-app/src/app/app.config.ts
@@ -5,6 +5,7 @@ import {
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { providePetstoreBaseUrl } from '../api/base-url-token/petstore.base-url';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -13,5 +14,12 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     provideHttpClient(),
     provideRouter(routes),
+    // Redirects the `base-url-token` generated client (see BaseUrlTokenPage).
+    // Its embedded default is the absolute, cross-origin
+    // `http://petstore.swagger.io/v1` taken from the spec's `servers` field;
+    // this points it at a same-origin gateway path the demo's MSW handlers
+    // serve. Root is the correct place for this: the generated services are
+    // `providedIn: 'root'`, so a component-level provider would not reach them.
+    providePetstoreBaseUrl('/gateway/petstore'),
   ],
 };

--- a/samples/angular-app/src/app/app.routes.ts
+++ b/samples/angular-app/src/app/app.routes.ts
@@ -50,5 +50,17 @@ export const routes: Routes = [
         (module) => module.ZodValidationDemo,
       ),
   },
+  {
+    path: 'http-both',
+    title: 'HttpClient + httpResource · Orval Angular Demo',
+    loadComponent: () =>
+      import('./http-both.page').then((module) => module.HttpBothPage),
+  },
+  {
+    path: 'base-url-token',
+    title: 'DI base URL token · Orval Angular Demo',
+    loadComponent: () =>
+      import('./base-url-token.page').then((module) => module.BaseUrlTokenPage),
+  },
   { path: '**', redirectTo: '' },
 ];

--- a/samples/angular-app/src/app/app.shell.ts
+++ b/samples/angular-app/src/app/app.shell.ts
@@ -67,6 +67,24 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
         >
           <span class="nav-icon">⬡</span> Zod Validation
         </a>
+        <a
+          routerLink="/http-both"
+          #httpBothRla="routerLinkActive"
+          routerLinkActive="active"
+          [attr.aria-current]="httpBothRla.isActive ? 'page' : null"
+          class="nav-link"
+        >
+          <span class="nav-icon">⇄</span> Both Clients
+        </a>
+        <a
+          routerLink="/base-url-token"
+          #baseUrlTokenRla="routerLinkActive"
+          routerLinkActive="active"
+          [attr.aria-current]="baseUrlTokenRla.isActive ? 'page' : null"
+          class="nav-link"
+        >
+          <span class="nav-icon">⚓</span> Base URL Token
+        </a>
       </nav>
     </header>
 

--- a/samples/angular-app/src/app/base-url-token.page.html
+++ b/samples/angular-app/src/app/base-url-token.page.html
@@ -1,0 +1,81 @@
+<app-demo-page-frame
+  eyebrow="override.angular.baseUrl"
+  title="Base URL via DI"
+  description="This page showcases the opt-in override.angular.baseUrl DI token: instead of baking a base URL into every generated route, the generated code injects PETSTORE_BASE_URL and composes each request from it at call time."
+  why="Use this variant when the same generated client needs to target different hosts per environment, per gateway, or per tenant — a single provider redirects the entire generated surface without touching a single route."
+  badge="DI-composed"
+  [highlights]="highlights"
+>
+  <app-demo-panel
+    class="panel--wide"
+    title="Resolved PETSTORE_BASE_URL"
+    description="The generated default is the absolute, cross-origin http://petstore.swagger.io/v1 embedded from the OpenAPI spec. This app calls providePetstoreBaseUrl('/gateway/petstore') once in app.config.ts to override it with a same-origin path, so requests land on the demo's mock handlers."
+  >
+    <pre>{{ resolvedBaseUrl }}</pre>
+    <p>
+      Register it at application root — the generated services are
+      <code>providedIn: 'root'</code>, so a component-level provider would never
+      reach them:
+    </p>
+    <pre>
+// app.config.ts
+providers: [
+  provideHttpClient(),
+  providePetstoreBaseUrl('/gateway/petstore'),
+]</pre
+    >
+  </app-demo-panel>
+
+  <div class="demo-grid demo-grid--even">
+    <app-demo-panel
+      class="panel--wide"
+      title="PetsService.listPets()"
+      description="Generated HttpClient service reading the injected PETSTORE_BASE_URL."
+    >
+      @if (petsState$ | async; as petsState) {
+      <app-badge panel-badge>Status: {{ petsState.status }}</app-badge>
+      } @if (petsState$ | async; as petsState) { @if (petsState.status ===
+      'loading') {
+      <p class="muted">Loading pets…</p>
+      } @else if (petsState.status === 'error') {
+      <p class="error">{{ petsState.error }}</p>
+      } @else if (petsState.data.length) {
+      <div class="pet-grid" role="list" aria-label="Pets list from listPets()">
+        @for (pet of petsState.data; track pet.id) {
+        <app-pet-card [pet]="pet" />
+        }
+      </div>
+      } @else {
+      <p class="muted">No pets returned.</p>
+      } }
+    </app-demo-panel>
+
+    <app-demo-panel
+      class="panel--wide"
+      title="listPetsResource()"
+      description="Generated httpResource function reading the very same PETSTORE_BASE_URL — one provider, two surfaces."
+    >
+      <app-badge panel-badge>Status: {{ listResource.status() }}</app-badge>
+
+      @if (listResource.isLoading()) {
+      <p class="muted">Loading pets…</p>
+      } @else if (listResource.error()) {
+      <p class="error">
+        Failed to load pets: {{ listResource.error()?.message }}
+      </p>
+      } @else if (listResource.hasValue() && listResource.value().length) {
+      <div
+        class="pet-grid"
+        role="list"
+        aria-label="Pets list from listPetsResource()"
+      >
+        @for (pet of listResource.value(); track pet.id) {
+        <app-pet-card [pet]="pet" />
+        }
+      </div>
+      } @else {
+      <p class="muted">No pets returned.</p>
+      }
+    </app-demo-panel>
+  </div>
+</app-demo-page-frame>

--- a/samples/angular-app/src/app/base-url-token.page.spec.ts
+++ b/samples/angular-app/src/app/base-url-token.page.spec.ts
@@ -1,0 +1,93 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { providePetstoreBaseUrl } from '../api/base-url-token/petstore.base-url';
+import { BaseUrlTokenPage } from './base-url-token.page';
+
+// Page-level coverage for the override.angular.baseUrl DI feature (#3711):
+// token-resolution mechanics (default value, normalization, resolver
+// precedence) are already covered by base-url-token.spec.ts. This spec only
+// checks that an application-level providePetstoreBaseUrl() redirects both
+// consumption surfaces — the generated PetsService (HttpClient) and the
+// generated listPetsResource() (httpResource) — to the same gateway-prefixed
+// base URL, and that the flushed data renders.
+//
+// The provider below mirrors the real registration in app.config.ts; it has to
+// live in the TestBed (root) injector rather than on the component, because
+// the generated services are `providedIn: 'root'`.
+describe('BaseUrlTokenPage', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BaseUrlTokenPage],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        providePetstoreBaseUrl('/gateway/petstore'),
+      ],
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('renders the resolved gateway-prefixed base URL', () => {
+    const fixture = TestBed.createComponent(BaseUrlTokenPage);
+    fixture.detectChanges();
+
+    for (const req of httpMock.match('/gateway/petstore/v1/pets')) {
+      req.flush([]);
+    }
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('/gateway/petstore');
+  });
+
+  it('prefixes the PetsService (HttpClient) request with the application-provided base URL and renders it', async () => {
+    const fixture = TestBed.createComponent(BaseUrlTokenPage);
+    fixture.detectChanges();
+
+    const requests = httpMock.match('/gateway/petstore/v1/pets');
+    expect(requests.length).toBe(2);
+
+    const [serviceReq, resourceReq] = requests;
+    expect(serviceReq.request.method).toBe('GET');
+    serviceReq.flush([{ id: 1, name: 'Rex', requiredNullableString: null }]);
+    resourceReq.flush([{ id: 1, name: 'Rex', requiredNullableString: null }]);
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Rex');
+  });
+
+  it('prefixes the listPetsResource() (httpResource) request with the same base URL and renders it', async () => {
+    const fixture = TestBed.createComponent(BaseUrlTokenPage);
+    fixture.detectChanges();
+
+    const requests = httpMock.match('/gateway/petstore/v1/pets');
+    expect(requests.length).toBe(2);
+
+    for (const req of requests) {
+      req.flush([{ id: 2, name: 'Milo', requiredNullableString: null }]);
+    }
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Status: resolved');
+    expect(compiled.textContent).toContain('Milo');
+  });
+});

--- a/samples/angular-app/src/app/base-url-token.page.ts
+++ b/samples/angular-app/src/app/base-url-token.page.ts
@@ -1,0 +1,59 @@
+import { AsyncPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { shareReplay } from 'rxjs';
+
+import type { Pets } from '../api/base-url-token/model';
+import { PETSTORE_BASE_URL } from '../api/base-url-token/petstore.base-url';
+import { listPetsResource } from '../api/base-url-token/pets/pets.resource';
+import { PetsService } from '../api/base-url-token/pets/pets.service';
+import { DemoPageFrameComponent } from './demo-page-frame.component';
+import { toLoadState } from './load-state';
+import { BadgeComponent } from './ui/badge.component';
+import { DemoPanelComponent } from './ui/demo-panel.component';
+import { PetCardComponent } from './ui/pet-card.component';
+
+@Component({
+  selector: 'app-base-url-token-page',
+  imports: [
+    AsyncPipe,
+    BadgeComponent,
+    DemoPageFrameComponent,
+    DemoPanelComponent,
+    PetCardComponent,
+  ],
+  // No providers here on purpose: `providePetstoreBaseUrl('/gateway/petstore')`
+  // is registered once at application root in `app.config.ts`, which is where
+  // it belongs. The generated services are `providedIn: 'root'`, so a
+  // component-level override would never reach them.
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './base-url-token.page.html',
+  styleUrl: './demo-page.styles.css',
+})
+export class BaseUrlTokenPage {
+  private readonly petService = inject(PetsService);
+  protected readonly resolvedBaseUrl = inject(PETSTORE_BASE_URL);
+
+  protected readonly highlights = [
+    'A single providePetstoreBaseUrl() call redirects every generated call site',
+    'Both the HttpClient service and the httpResource function read the same DI token',
+    'The embedded absolute spec URL is overridden with a same-origin gateway path',
+  ] as const;
+
+  protected readonly version = signal(1);
+
+  protected readonly petsState$ = toLoadState<Pets>(
+    this.petService.listPets('application/json', undefined, 1),
+    [] as Pets,
+  ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+  protected readonly listResource = listPetsResource(
+    'application/json',
+    undefined,
+    this.version,
+  );
+}

--- a/samples/angular-app/src/app/demo-page.styles.css
+++ b/samples/angular-app/src/app/demo-page.styles.css
@@ -5,6 +5,12 @@
   align-items: start;
 }
 
+/* Symmetric variant for pages that compare two peer panels side by side
+   (rather than the default main-content + sidebar split). */
+.demo-grid--even {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .panel-stack {
   display: grid;
   gap: 16px;

--- a/samples/angular-app/src/app/http-both.page.html
+++ b/samples/angular-app/src/app/http-both.page.html
@@ -1,0 +1,62 @@
+<app-demo-page-frame
+  eyebrow="One operation, two consumption styles"
+  title="retrievalClient: 'both'"
+  description="This page showcases orval's Angular retrievalClient: 'both' output, where the same listPets operation generates both an HttpClient service method and a signal-based httpResource helper. Both panels below hit the identical /v1/pets endpoint."
+  why="Use this variant when different parts of your app want different ergonomics from the same generated contract: imperative Observable subscriptions in one place, signal-driven resource reads in another, without maintaining two separate API clients."
+  [highlights]="highlights"
+>
+  <div class="demo-grid demo-grid--even">
+    <app-demo-panel
+      title="PetsService.listPets()"
+      description="HttpClient Observable, wrapped with toLoadState and shared via AsyncPipe."
+    >
+      @if (petsState$ | async; as state) {
+      <app-badge panel-badge>Status: {{ state.status }}</app-badge>
+      }
+
+      @if (petsState$ | async; as state) {
+      @if (state.status === 'loading') {
+      <p class="muted">Loading pets…</p>
+      } @else if (state.status === 'error') {
+      <p class="error">Failed to load pets: {{ state.error }}</p>
+      } @else if (state.data.length) {
+      <div
+        class="pet-grid"
+        role="list"
+        aria-label="Pets list from PetsService.listPets()"
+      >
+        @for (pet of state.data; track pet.id) {
+        <app-pet-card [pet]="pet" />
+        }
+      </div>
+      } @else {
+      <p class="muted">No pets returned.</p>
+      } }
+    </app-demo-panel>
+
+    <app-demo-panel
+      title="listPetsResource()"
+      description="Signal-based httpResource, read with isLoading() / hasValue() / value()."
+    >
+      <app-badge panel-badge>Status: {{ listStatus() }}</app-badge>
+
+      @if (listResource.isLoading()) {
+      <p class="muted">Loading pets…</p>
+      } @else if (listResource.error()) {
+      <p class="error">Failed to load pets: {{ listError() }}</p>
+      } @else if (pets().length) {
+      <div
+        class="pet-grid"
+        role="list"
+        aria-label="Pets list from listPetsResource()"
+      >
+        @for (pet of pets(); track pet.id) {
+        <app-pet-card [pet]="pet" />
+        }
+      </div>
+      } @else {
+      <p class="muted">No pets returned.</p>
+      }
+    </app-demo-panel>
+  </div>
+</app-demo-page-frame>

--- a/samples/angular-app/src/app/http-both.page.spec.ts
+++ b/samples/angular-app/src/app/http-both.page.spec.ts
@@ -1,0 +1,96 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { HttpBothPage } from './http-both.page';
+
+describe('HttpBothPage', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpBothPage],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('renders both the HttpClient and httpResource panels for the same /v1/pets endpoint', async () => {
+    const fixture = TestBed.createComponent(HttpBothPage);
+    fixture.detectChanges();
+
+    const requests = httpMock.match('/v1/pets');
+    expect(requests.length).toBe(2);
+
+    for (const req of requests) {
+      expect(req.request.method).toBe('GET');
+      expect(req.request.headers.get('Accept')).toBe('application/json');
+      req.flush([
+        {
+          id: 1,
+          name: 'Rex',
+          requiredNullableString: null,
+        },
+        {
+          id: 2,
+          name: 'Milo',
+          requiredNullableString: null,
+        },
+      ]);
+    }
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('PetsService.listPets()');
+    expect(compiled.textContent).toContain('listPetsResource()');
+    expect(compiled.textContent).toContain('Status: success');
+    expect(compiled.textContent).toContain('Status: resolved');
+
+    const lists = compiled.querySelectorAll('.pet-grid');
+    expect(lists.length).toBe(2);
+    for (const list of Array.from(lists)) {
+      expect(list.textContent).toContain('Rex');
+      expect(list.textContent).toContain('Milo');
+    }
+  });
+
+  it('renders backend errors from both panels without unsafe value() access', async () => {
+    const fixture = TestBed.createComponent(HttpBothPage);
+    fixture.detectChanges();
+
+    const requests = httpMock.match('/v1/pets');
+    expect(requests.length).toBe(2);
+
+    for (const req of requests) {
+      req.flush('Failed!', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+    }
+
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const errorMessages = compiled.querySelectorAll('.error');
+    expect(errorMessages.length).toBe(2);
+    for (const message of Array.from(errorMessages)) {
+      expect(message.textContent).toContain('Failed to load pets:');
+    }
+  });
+});

--- a/samples/angular-app/src/app/http-both.page.ts
+++ b/samples/angular-app/src/app/http-both.page.ts
@@ -1,0 +1,62 @@
+import { AsyncPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { shareReplay } from 'rxjs';
+
+import type { Pets } from '../api/http-both/model';
+import { listPetsResource } from '../api/http-both/pets/pets.resource';
+import { PetsService } from '../api/http-both/pets/pets.service';
+import { DemoPageFrameComponent } from './demo-page-frame.component';
+import { toLoadState } from './load-state';
+import { BadgeComponent } from './ui/badge.component';
+import { DemoPanelComponent } from './ui/demo-panel.component';
+import { PetCardComponent } from './ui/pet-card.component';
+
+@Component({
+  selector: 'app-http-both-page',
+  imports: [
+    AsyncPipe,
+    BadgeComponent,
+    DemoPageFrameComponent,
+    DemoPanelComponent,
+    PetCardComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './http-both.page.html',
+  styleUrl: './demo-page.styles.css',
+})
+export class HttpBothPage {
+  private readonly petService = inject(PetsService);
+
+  protected readonly highlights = [
+    'retrievalClient: "both" emits an HttpClient method and an httpResource helper from the same operation',
+    'PetsService.listPets() and listPetsResource() call the identical /v1/pets endpoint side by side',
+    'Pick the Observable style for imperative flows, the signal style for template-driven reads',
+  ] as const;
+
+  protected readonly version = signal(1);
+
+  protected readonly petsState$ = toLoadState<Pets>(
+    this.petService.listPets('application/json', undefined, this.version()),
+    [] as Pets,
+  ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+  protected readonly listResource = listPetsResource(
+    'application/json',
+    undefined,
+    this.version,
+  );
+
+  protected readonly pets = computed<Pets>(() =>
+    this.listResource.hasValue() ? this.listResource.value() : [],
+  );
+  protected readonly listStatus = computed(() => this.listResource.status());
+  protected readonly listError = computed(
+    () => this.listResource.error()?.message ?? 'Unknown error',
+  );
+}

--- a/samples/angular-app/src/orval/browser.ts
+++ b/samples/angular-app/src/orval/browser.ts
@@ -1,6 +1,7 @@
 import { setupWorker } from 'msw/browser';
 import { http, HttpResponse, RequestHandler } from 'msw';
 
+import * as httpBothMocks from '../api/http-both/index.msw';
 import * as httpClientMocks from '../api/http-client/index.msw';
 import * as httpClientCustomParamsMocks from '../api/http-client-custom-params/index.msw';
 import * as httpResourceMocks from '../api/http-resource/index.msw';
@@ -135,6 +136,7 @@ const allMocks = {
   ...httpClientCustomParamsMocks,
   ...httpResourceMocks,
   ...httpResourceZodMocks,
+  ...httpBothMocks,
 };
 
 const generatedHandlers = Object.entries(allMocks)

--- a/samples/angular-app/src/orval/node.ts
+++ b/samples/angular-app/src/orval/node.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node';
 import type { RequestHandler } from 'msw';
 
+import * as httpBothMocks from '../api/http-both/index.msw';
 import * as httpClientMocks from '../api/http-client/index.msw';
 import * as httpClientCustomParamsMocks from '../api/http-client-custom-params/index.msw';
 import * as httpResourceMocks from '../api/http-resource/index.msw';
@@ -11,6 +12,7 @@ const allMocks = {
   ...httpClientCustomParamsMocks,
   ...httpResourceMocks,
   ...httpResourceZodMocks,
+  ...httpBothMocks,
 };
 
 const handlers = Object.entries(allMocks).flatMap(([, getMock]) =>


### PR DESCRIPTION
`samples/angular-app` generates seven Angular outputs but only ships five pages. Two of them exist purely as fixtures:

- **`http-both`** (`retrievalClient: 'both'`) was generated and then imported by nothing at all — no component, no spec, no MSW registration. Completely untested output.
- **`base-url-token`** (`override.angular.baseUrl`, added by #3711) existed only to back `base-url-token.spec.ts`, so the DI base-URL feature was invisible in the running demo.

This adds a page for each.

## `/http-both`

Puts `PetsService.listPets()` (Observable + `toLoadState` + `AsyncPipe`) beside `listPetsResource()` (signals, `hasValue()`-guarded) hitting the identical `/v1/pets` endpoint — which is the entire point of `retrievalClient: 'both'`, and the one thing neither the `http-client` nor the `http-resource` page can show on its own.

Also registers the already-generated `http-both` MSW mocks in `src/orval/browser.ts` and `src/orval/node.ts`. They were never wired up.

## `/base-url-token`

Shows the resolved `PETSTORE_BASE_URL` and both consumption surfaces reading it, so a single provider visibly redirects the whole generated surface.

The generated default is the absolute, cross-origin `http://petstore.swagger.io/v1` embedded from the spec's `servers` field, which cannot work in the demo. The app therefore registers `providePetstoreBaseUrl('/gateway/petstore')` in `app.config.ts`.

**Root is the only correct place for it.** The generated services are `providedIn: 'root'`, so a component-level provider never reaches them — a component-scoped override would appear to work for the `httpResource` function (which `inject()`s in the component's context) while silently doing nothing for the `HttpClient` service. The page states this on screen and shows the snippet, since it is an easy trap. The existing `*/v:version/...` MSW handlers match the prefixed path with no changes.

## Tests

Five new tests at the established `TestBed` + `HttpTestingController` layer.

`base-url-token.page.spec.ts` deliberately does not re-test token mechanics — default value, normalization, and resolver precedence are already covered by `base-url-token.spec.ts`. It covers only page-level behavior: that an application-level provider routes *both* surfaces through the gateway prefix, and that flushed data renders.

## Also

A `.demo-grid--even` modifier in `demo-page.styles.css`. The default `.demo-grid` is an intentional `1.45fr / minmax(320px, 1fr)` content-plus-sidebar split; both new pages compare two *peer* panels, which left the right-hand panel's `.pet-grid` collapsed to a single column.

## Verification

- 43/43 sample tests, stable across repeated runs
- `ng build`, `ng lint`, snapshots 91/91
- Both pages driven in a real browser: `/gateway/petstore/v1/pets` confirmed returning 200 for both surfaces, zero console errors or warnings

## Note on CI

Per #3867, `test:samples` is not currently invoked by any workflow, so the five tests added here will not gate anything until that lands.

## Verification after rebase

Rebased onto master following the merge of #3866, so this is now a single additive commit (12 files, no deletions). Re-verified against the new master: 43/43 sample tests across 10 files, snapshots clean, `ng lint` and `ng build` both pass with no warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Angular demo comparing Observable-based and signal-based pet retrieval from the same API.
  * Added a Base URL configuration demo showing how requests can use a shared `/gateway/petstore` prefix.
  * Added navigation links and lazy-loaded routes for both demonstrations.
  * Added side-by-side layouts with loading, error, empty, and populated result states.
  * Added mock data support for reliable demo and test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->