### PR TITLE
fix(zod): emit zod.never() for keys forbidden by not in oneOf/anyOf

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -344,7 +344,7 @@ const getForbiddenKeys = (
   // common OpenAPI tooling. A bare `not: { required: [X] }` is accepted too.
   const branches = Array.isArray(not.anyOf)
     ? not.anyOf
-    : isObject(not.required)
+    : Array.isArray(not.required)
       ? [not]
       : [];
 
@@ -852,12 +852,23 @@ export const generateZodValidationSchemaDefinition = (
       // sibling properties, forbidden keys must be emitted as `zod.never()`
       // (optional, so absence passes and any value fails). These are injected
       // as pre-generated property overrides into the object schema below. (#3780)
-      let propertyOverrides: Record<string, ZodValidationSchemaDefinition> | undefined;
+      let propertyOverrides:
+        | Record<string, ZodValidationSchemaDefinition>
+        | undefined;
       if (forbidden) {
         propertyOverrides = {};
         for (const key of forbidden) {
+          // A key that is both forbidden and required contradicts itself; emit
+          // the required form (no optional) so the `never` still rejects any
+          // value while the key is expected to be absent.
+          const isForbiddenAndRequired = required.includes(key);
           propertyOverrides[key] = {
-            functions: [['never', undefined], ['optional', undefined]],
+            functions: [
+              ['never', undefined],
+              ...(isForbiddenAndRequired
+                ? []
+                : ([['optional', undefined]] as const)),
+            ],
             consts: [],
           } as ZodValidationSchemaDefinition;
         }
@@ -885,9 +896,11 @@ export const generateZodValidationSchemaDefinition = (
         {
           required: true,
           additionalRequired: allOfRequired,
-          propertyOverrides: (withSiblingProperties(schema) as OpenApiSchemaObject)[
-            'x-orval-property-overrides'
-          ] as Record<string, ZodValidationSchemaDefinition> | undefined,
+          propertyOverrides: (
+            withSiblingProperties(schema) as OpenApiSchemaObject
+          )['x-orval-property-overrides'] as
+            | Record<string, ZodValidationSchemaDefinition>
+            | undefined,
           constNameRegistry,
           useReusableSchemas,
           urlEncoded,

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -330,6 +330,35 @@ const isConstraintOnlyMember = (
   return Object.keys(schema).every((key) => SHAPELESS_MEMBER_KEYS.has(key));
 };
 
+// Extracts the property names a member forbids via `not`. JSON Schema forbids a
+// key when `not` lists any subschema that `required`s it — i.e.
+// `not: { anyOf: [{ required: [X] }, { required: [Y] }] }` means X and Y must
+// be absent. Returns `undefined` when the member has no such constraint. (#3780)
+const getForbiddenKeys = (
+  member: OpenApiSchemaObject,
+): string[] | undefined => {
+  if (!isObject(member.not)) return undefined;
+  const not = member.not as OpenApiSchemaObject;
+
+  // `not: { anyOf: [ {required:[X]}, {required:[Y]} ] }` is the form emitted by
+  // common OpenAPI tooling. A bare `not: { required: [X] }` is accepted too.
+  const branches = Array.isArray(not.anyOf)
+    ? not.anyOf
+    : isObject(not.required)
+      ? [not]
+      : [];
+
+  const forbidden = new Set<string>();
+  for (const branch of branches) {
+    if (isObject(branch) && Array.isArray(branch.required)) {
+      for (const key of branch.required) {
+        forbidden.add(key as string);
+      }
+    }
+  }
+  return forbidden.size > 0 ? [...forbidden] : undefined;
+};
+
 // The branch must declare the discriminator key as a literal value — a `const`
 // or an `enum`. Both zod v3 (>=3.20) and v4 build their branch lookup by
 // reading discrete literal values off each option, and throw at construction if
@@ -817,12 +846,30 @@ export const generateZodValidationSchemaDefinition = (
         return member as OpenApiSchemaObject;
       }
 
+      const forbidden = getForbiddenKeys(member as OpenApiSchemaObject);
+
+      // A `not` constraint forbids keys. When the member is rendered against the
+      // sibling properties, forbidden keys must be emitted as `zod.never()`
+      // (optional, so absence passes and any value fails). These are injected
+      // as pre-generated property overrides into the object schema below. (#3780)
+      let propertyOverrides: Record<string, ZodValidationSchemaDefinition> | undefined;
+      if (forbidden) {
+        propertyOverrides = {};
+        for (const key of forbidden) {
+          propertyOverrides[key] = {
+            functions: [['never', undefined], ['optional', undefined]],
+            consts: [],
+          } as ZodValidationSchemaDefinition;
+        }
+      }
+
       return {
         type: 'object',
         properties,
         required,
         // carried over so the branch keeps its `.describe(...)`
         description: (member as OpenApiSchemaObject).description,
+        'x-orval-property-overrides': propertyOverrides,
       } as OpenApiSchemaObject;
     };
 
@@ -838,6 +885,9 @@ export const generateZodValidationSchemaDefinition = (
         {
           required: true,
           additionalRequired: allOfRequired,
+          propertyOverrides: (withSiblingProperties(schema) as OpenApiSchemaObject)[
+            'x-orval-property-overrides'
+          ] as Record<string, ZodValidationSchemaDefinition> | undefined,
           constNameRegistry,
           useReusableSchemas,
           urlEncoded,
@@ -1205,6 +1255,16 @@ export const generateZodValidationSchemaDefinition = (
 
         break;
       }
+      case 'never': {
+        // `not`-forbidden keys render as `zod.never()`. Optional, so the key's
+        // absence passes while any supplied value fails validation. (#3780)
+        functions.push(['never', undefined]);
+        if (required) {
+          functions.push(['optional', undefined]);
+        }
+        break;
+      }
+
       default: {
         // Handle const for number, boolean, null, and object types
         if ('const' in schema) {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -12578,7 +12578,7 @@ describe('constraint-only oneOf/anyOf branches (#3780)', () => {
     expect(zod).not.toContain('zod.unknown()');
     // the `not` branch is still the AB shape, not an all-optional object
     expect(zod).toContain(
-      'zod.object({\n  "A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.string().optional(),\n  "Y": zod.number().int().optional()\n})',
+      'zod.object({\n  "A": zod.string(),\n  "B": zod.number().int(),\n  "X": zod.never().optional(),\n  "Y": zod.never().optional()\n})',
     );
     expect(zod).toContain(
       'zod.object({\n  "A": zod.string().optional(),\n  "B": zod.number().int().optional(),\n  "X": zod.string(),\n  "Y": zod.number().int()\n})',


### PR DESCRIPTION
## Summary

A oneOf/anyOf member that carries `not: { anyOf: [{ required: [X] }, { required: [Y] }] }` forbids X and Y on that branch. When such a member is rendered against the composing schema's sibling properties (#3780's constraint-only member fix), the forbidden keys were emitted as ordinary optional properties - silently dropping the constraint.

This PR emits `zod.never().optional()` for forbidden keys so any supplied value fails validation while allowing the key's absence (the correct semantics).

## Changes

- `getForbiddenKeys()`: new helper that extracts forbidden key names from `not.anyOf[].required` (and the bare `not.required` form).
- `withSiblingProperties()`: threads forbidden keys as pre-generated property overrides rendered as `zod.never().optional()`.
- `case 'never':` added to the zod type dispatch for the property override path.

## Generated output (after)

```ts
zod.union([
  zod.object({
    A: zod.string(),
    B: zod.number().int(),
    X: zod.never().optional(),
    Y: zod.never().optional(),
  }),
  zod.object({
    A: zod.string().optional(),
    B: zod.number().int().optional(),
    X: zod.string(),
    Y: zod.number().int(),
  }),
])
```

Closes #3780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved generated schema handling for union constraints, including constraint-only union members.
  * Forbidden properties now reject supplied values while remaining optional when omitted.
  * Added support for rendering `never` constraints in generated Zod definitions.
  * Generated branch schemas now consistently enforce these property restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->