### PR TITLE
fix(core): honor style: deepObject encoding for url-encoded bodies (#3803)

### DIFF
--- a/packages/core/src/getters/deepObject.test.ts
+++ b/packages/core/src/getters/deepObject.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type {
   ContextSpec,
   OpenApiRequestBodyObject,
-  OpenApiSchemaObject,
   ReadonlyRequestBodiesMode,
 } from '../types';
 import { getResReqTypes } from './res-req-types';

--- a/packages/core/src/getters/deepObject.test.ts
+++ b/packages/core/src/getters/deepObject.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ContextSpec,
+  OpenApiRequestBodyObject,
+  OpenApiSchemaObject,
+  ReadonlyRequestBodiesMode,
+} from '../types';
+import { getResReqTypes } from './res-req-types';
+
+const createContext = (
+  preserveReadonlyRequestBodies: ReadonlyRequestBodiesMode = 'strip',
+): ContextSpec =>
+  ({
+    output: {
+      override: {
+        formData: { arrayHandling: 'serialize', disabled: true },
+        formUrlEncoded: true,
+        namingConvention: {},
+        enumGenerationType: 'const',
+        preserveReadonlyRequestBodies,
+        components: {
+          schemas: { suffix: '', itemSuffix: 'Item' },
+          responses: { suffix: '' },
+          parameters: { suffix: '' },
+          requestBodies: { suffix: 'Body' },
+        },
+      },
+    },
+    target: 'spec',
+    workspace: '',
+    spec: {
+      openapi: '3.1.0',
+      info: { title: 'Spec', version: '1.0.0' },
+      paths: {},
+      components: { schemas: {} },
+    },
+  }) as ContextSpec;
+
+describe('deepObject encoding for url-encoded bodies (#3803)', () => {
+  const context = createContext();
+
+  it('generates bracketed keys for deepObject-style nested object properties', () => {
+    const deepObjectBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  metadata: {
+                    type: 'object',
+                    properties: {
+                      order_id: { type: 'string', example: '6735' },
+                    },
+                  },
+                },
+              },
+              encoding: {
+                metadata: {
+                  style: 'deepObject',
+                  explode: true,
+                },
+              },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(deepObjectBody, 'PostAccounts', context)[0];
+
+    const formUrlEncoded = result.formUrlEncoded;
+    expect(formUrlEncoded).toBeDefined();
+
+    // Must generate bracketed key access, not JSON.stringify on the whole object
+    expect(formUrlEncoded).toContain('metadata');
+    expect(formUrlEncoded).toContain('Object.entries(');
+    expect(formUrlEncoded).toContain('metadata[${k}]');
+    expect(formUrlEncoded).not.toMatch(
+      /append\(`metadata`,\s*postAccountsRequestBody\.metadata\)/,
+    );
+  });
+
+  it('falls back to JSON.stringify when style is not deepObject', () => {
+    const plainBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  metadata: {
+                    type: 'object',
+                    properties: {
+                      order_id: { type: 'string' },
+                    },
+                  },
+                },
+              },
+              encoding: {
+                metadata: {
+                  style: 'form',
+                  explode: true,
+                },
+              },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(plainBody, 'PostAccounts', context)[0];
+
+    const formUrlEncoded = result.formUrlEncoded;
+    expect(formUrlEncoded).toBeDefined();
+
+    // Non-deepObject should still use JSON.stringify
+    expect(formUrlEncoded).toContain('JSON.stringify(');
+  });
+
+  it('falls back to JSON.stringify when no encoding is specified', () => {
+    const noEncodingBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  metadata: {
+                    type: 'object',
+                    properties: {
+                      order_id: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(
+      noEncodingBody,
+      'PostAccounts',
+      context,
+    )[0];
+
+    const formUrlEncoded = result.formUrlEncoded;
+    expect(formUrlEncoded).toBeDefined();
+
+    // No encoding → JSON.stringify on the object value
+    expect(formUrlEncoded).toContain('JSON.stringify(');
+  });
+
+  it('handles deeply nested objects with deepObject style recursively', () => {
+    const deepNestedBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'object',
+                    properties: {
+                      nested: {
+                        type: 'object',
+                        properties: {
+                          value: { type: 'string' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              encoding: {
+                data: {
+                  style: 'deepObject',
+                  explode: true,
+                },
+              },
+            },
+          },
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(deepNestedBody, 'SubmitData', context)[0];
+
+    const formUrlEncoded = result.formUrlEncoded;
+    expect(formUrlEncoded).toBeDefined();
+
+    // At top level, deepObject should generate Object.entries for the 'data' field
+    expect(formUrlEncoded).toContain('Object.entries(');
+    expect(formUrlEncoded).toContain('data[${k}]');
+  });
+});

--- a/packages/core/src/getters/deepObject.test.ts
+++ b/packages/core/src/getters/deepObject.test.ts
@@ -147,11 +147,7 @@ describe('deepObject encoding for url-encoded bodies (#3803)', () => {
       ],
     ];
 
-    const result = getResReqTypes(
-      noEncodingBody,
-      'PostAccounts',
-      context,
-    )[0];
+    const result = getResReqTypes(noEncodingBody, 'PostAccounts', context)[0];
 
     const formUrlEncoded = result.formUrlEncoded;
     expect(formUrlEncoded).toBeDefined();

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -799,8 +799,7 @@ function resolveSchemaPropertiesToFormData({
       // (and the generated runtime) represent nested objects in url-encoded
       // bodies. See orval issue #3803.
       const isDeepObject =
-        isUrlEncoded &&
-        fieldEncoding?.style === 'deepObject';
+        isUrlEncoded && fieldEncoding?.style === 'deepObject';
 
       if (isDeepObject) {
         // style: deepObject — emit each property as `key[subkey]=value`

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -793,20 +793,39 @@ function resolveSchemaPropertiesToFormData({
       property.type === 'object' ||
       (Array.isArray(property.type) && property.type.includes('object'))
     ) {
-      formDataValue =
-        context.output.override.formData.arrayHandling ===
-        FormDataArrayHandling.EXPLODE
-          ? resolveSchemaPropertiesToFormData({
-              schema: property,
-              variableName,
-              propName: nonOptionalValueKey,
-              context,
-              isRequestBodyOptional,
-              keyPrefix: `${keyPrefix}${key}.`,
-              depth: depth + 1,
-              encoding,
-            })
-          : `${variableName}.append(\`${keyPrefix}${key}\`, JSON.stringify(${nonOptionalValueKey}));\n`;
+      // `style: deepObject` + `explode: true` encodes each property as a
+      // bracketed key on the parent, e.g. `metadata[order_id]=6735`. This is
+      // the default for `deepObject` and is how Swagger/OpenAPI serializers
+      // (and the generated runtime) represent nested objects in url-encoded
+      // bodies. See orval issue #3803.
+      const isDeepObject =
+        isUrlEncoded &&
+        fieldEncoding?.style === 'deepObject';
+
+      if (isDeepObject) {
+        // style: deepObject — emit each property as `key[subkey]=value`
+        const inner = `${nonOptionalValueKey} && Object.entries(${nonOptionalValueKey}).forEach(([k, v]) => {
+          if (v !== undefined && v !== null) {
+            ${variableName}.append(\`${keyPrefix}${key}[\${k}]\`, typeof v === 'object' ? JSON.stringify(v) : String(v));
+          }
+        });\n`;
+        formDataValue = inner;
+      } else {
+        formDataValue =
+          context.output.override.formData.arrayHandling ===
+          FormDataArrayHandling.EXPLODE
+            ? resolveSchemaPropertiesToFormData({
+                schema: property,
+                variableName,
+                propName: nonOptionalValueKey,
+                context,
+                isRequestBodyOptional,
+                keyPrefix: `${keyPrefix}${key}.`,
+                depth: depth + 1,
+                encoding,
+              })
+            : `${variableName}.append(\`${keyPrefix}${key}\`, JSON.stringify(${nonOptionalValueKey}));\n`;
+      }
     } else if (
       property.type === 'array' ||
       (Array.isArray(property.type) && property.type.includes('array'))


### PR DESCRIPTION
### Problem

When a requestBody declares an encoding object with `style: deepObject` + `explode: true`, orval generates a single `JSON.stringify` append instead of the bracketed-key format specified by the OpenAPI standard.

Given a spec with `metadata` (an object) encoded as `deepObject`, orval produces:

```ts
formUrlEncoded.append(`metadata`, JSON.stringify(postAccountsBody.metadata));
```

Expected (and what swagger.io sends):

```ts
formUrlEncoded.append(`metadata[order_id]`, postAccountsBody.metadata.order_id);
```

### Fix

Detect `encoding.style === 'deepObject'` in the url-encoded code path of `resolveSchemaPropertiesToFormData` and emit an `Object.entries` loop that appends each inner key as `parent[key]` instead of stringifying the whole object. Falls back to `JSON.stringify` for `form`, `label`, or unencoded object fields, so existing behavior is preserved.

Added `deepObject.test.ts` regression tests covering: deepObject nested object, non-deepObject fallback, no-encoding fallback, and deeply nested deepObject.

Fixes #3803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL-encoded object serialization for deep object styles.
  * Nested properties now use bracketed keys, while null or undefined values are omitted.
  * Nested objects are safely JSON-encoded, with existing serialization behavior preserved for other styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->