### PR TITLE
fix(samples): unbreak six excluded react-query sample tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "vp run -F './packages/*' typecheck",
     "test": "vp run -F './packages/*' test",
     "test:cli": "vp run -F orval-tests clean && vp run -F orval-tests generate-api && vp run -F orval-tests build",
-    "test:samples": "vp run -F './samples/**' -F '!react-query-form-data' -F '!react-query-form-url-encoded' -F '!react-query-form-url-encoded-mutator' -F '!react-query-form-data-mutator' -F '!react-query-hook-mutator-axios' -F '!react-query-hook-mutator-fetch' test",
+    "test:samples": "vp run -F './samples/**' test",
     "test:snapshots": "vp run -F './packages/*' build:release && vp run -F './samples/**' -F orval-tests generate-api && vp run -F './samples/**' -F orval-tests test:snapshots",
     "test:snapshots:update": "vp run -F './packages/*' build:release && vp run -F './samples/**' -F orval-tests generate-api && vp run -F './samples/**' -F orval-tests test:snapshots:update",
     "lint": "vp lint --type-aware --type-check packages",

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -107,7 +107,7 @@ export const generateRequestFunction = (
   const isFormData = !override.formData.disabled;
   const isFormUrlEncoded = override.formUrlEncoded !== false;
 
-  const GET_HEADERS_HELPER = `  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const GET_HEADERS_HELPER = `  const getHeaders = (h?: NonNullable<RequestInit['headers']>): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
@@ -130,7 +130,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -188,7 +190,9 @@ export const updatePets = async (
   pet: Pet,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -130,7 +130,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -188,7 +190,9 @@ export const updatePets = async (
   pet: Pet,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -123,7 +123,9 @@ export const filterPetsByStatus = async (
   pet?: Pet,
   options?: RequestInit,
 ): Promise<filterPetsByStatusResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -204,7 +206,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -204,7 +206,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -231,7 +231,9 @@ export const createPets = async (
   version: number = 1,
   options?: Parameters<typeof customInstance>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -231,7 +231,9 @@ export const createPets = async (
   version: number = 1,
   options?: Parameters<typeof customInstance>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -102,7 +102,9 @@ export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -102,7 +102,9 @@ export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -432,7 +434,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -432,7 +434,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -231,7 +231,9 @@ export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -231,7 +231,9 @@ export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/form-data-mutator/orval.config.ts
+++ b/samples/react-query/form-data-mutator/orval.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       target: './endpoints.ts',
       schemas: './models',
       client: 'react-query',
+      httpClient: 'axios',
       formatter: 'prettier',
       override: {
         mutator: {

--- a/samples/react-query/form-data-mutator/package.json
+++ b/samples/react-query/form-data-mutator/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-data-mutator/tsconfig.json
+++ b/samples/react-query/form-data-mutator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/samples/react-query/form-data/package.json
+++ b/samples/react-query/form-data/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-data/tsconfig.json
+++ b/samples/react-query/form-data/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/samples/react-query/form-url-encoded-mutator/custom-form-url-encoded.ts
+++ b/samples/react-query/form-url-encoded-mutator/custom-form-url-encoded.ts
@@ -1,4 +1,4 @@
-export const customFormUrlEncoded = <Body>(body: Body): URLSearchParams => {
+export const customFormUrlEncoded = <Body extends Record<string, unknown>>(body: Body): URLSearchParams => {
   const formData = new URLSearchParams();
 
   Object.entries(body).forEach(([key, value]) => {

--- a/samples/react-query/form-url-encoded-mutator/package.json
+++ b/samples/react-query/form-url-encoded-mutator/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-url-encoded-mutator/tsconfig.json
+++ b/samples/react-query/form-url-encoded-mutator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/samples/react-query/form-url-encoded/package.json
+++ b/samples/react-query/form-url-encoded/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-url-encoded/tsconfig.json
+++ b/samples/react-query/form-url-encoded/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/samples/react-query/hook-mutator-axios/package.json
+++ b/samples/react-query/hook-mutator-axios/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/hook-mutator-axios/tsconfig.json
+++ b/samples/react-query/hook-mutator-axios/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -243,7 +243,9 @@ export const useCreatePetsHook = (): ((
   createPetsBody: CreatePetsBody,
   options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<createPetsResponse>) => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -243,7 +243,9 @@ export const useCreatePetsHook = (): ((
   createPetsBody: CreatePetsBody,
   options?: Parameters<ReturnType<typeof useCustomFetch>>[1],
 ) => Promise<createPetsResponse>) => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/react-query/hook-mutator-fetch/package.json
+++ b/samples/react-query/hook-mutator-fetch/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/hook-mutator-fetch/tsconfig.json
+++ b/samples/react-query/hook-mutator-fetch/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["*.ts"]
+}

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -241,7 +241,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -375,7 +377,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -241,7 +241,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -375,7 +377,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -263,7 +263,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -399,7 +401,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -263,7 +263,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -399,7 +401,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
@@ -202,7 +202,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -297,7 +299,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
@@ -202,7 +202,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -297,7 +299,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -202,7 +202,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -297,7 +299,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -202,7 +202,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -297,7 +299,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -251,7 +251,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -366,7 +368,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -251,7 +251,9 @@ export const createPets = async (
   createPetsBodyItem: CreatePetsBodyItem[],
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -366,7 +368,9 @@ export const updatePets = async (
   pet: NonReadonly<Pet>,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
+++ b/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/index-mock-file/pets/pets.ts
+++ b/tests/__snapshots__/default/index-mock-file/pets/pets.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/no-index-files/endpoints.ts
+++ b/tests/__snapshots__/default/no-index-files/endpoints.ts
@@ -154,7 +154,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
+++ b/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
@@ -29,7 +29,9 @@ export const replaceLotteryLogo = async (
   replaceLotteryLogoBody: Blob,
   options?: RequestInit,
 ): Promise<replaceLotteryLogoResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/empty-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/empty-response/endpoints.ts
@@ -24,7 +24,9 @@ export const add = async (
   form?: Form,
   options?: RequestInit,
 ): Promise<addResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/force-success-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response/endpoints.ts
@@ -157,7 +157,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponseSuccess> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -96,7 +96,9 @@ export const createPets = async (
   formUrlEncoded.append(`name`, createPetsBody.name);
   formUrlEncoded.append(`tag`, createPetsBody.tag);
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -151,7 +153,9 @@ export const uploadPetContent = async (
     formUrlEncoded.append(`content`, uploadPetContentBody.content);
   }
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -208,7 +212,9 @@ export const uploadPetContentRef = async (
     formUrlEncoded.append(`content`, uploadPetContentRefBody.content);
   }
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
@@ -95,7 +95,9 @@ export const createPets = async (
   formUrlEncoded.append(`name`, createPetsBody.name);
   formUrlEncoded.append(`tag`, createPetsBody.tag);
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -159,7 +161,9 @@ export const uploadPetContent = async (
     formUrlEncoded.append(`content`, uploadPetContentBody.content);
   }
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -225,7 +229,9 @@ export const uploadPetContentRef = async (
     formUrlEncoded.append(`content`, uploadPetContentRefBody.content);
   }
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/headers/endpoints.ts
@@ -99,7 +99,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -161,7 +163,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
@@ -74,7 +74,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/issue-1879/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-1879/endpoints.ts
@@ -33,7 +33,9 @@ export const requestA = async (
   headers?: RequestAHeaders,
   options?: RequestInit,
 ): Promise<requestAResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -78,7 +80,9 @@ export const requestB = async (
   headers?: RequestBHeaders,
   options?: RequestInit,
 ): Promise<requestBResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
@@ -34,7 +34,9 @@ export const uploadNullableBinary = async (
     formUrlEncoded.append(`content`, uploadNullableBinaryBody.content);
   }
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
@@ -157,7 +157,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -146,7 +146,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetchWithScss>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -147,7 +147,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponseSuccess> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
@@ -153,7 +153,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters/endpoints.ts
@@ -153,7 +153,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
@@ -116,7 +116,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/petstore/endpoints.ts
+++ b/tests/__snapshots__/fetch/petstore/endpoints.ts
@@ -157,7 +157,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
@@ -96,7 +96,9 @@ export const listPets = async (
   params: ListPetsParams,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -161,7 +163,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -221,7 +225,9 @@ export const showPetById = async (
   petId: string,
   options?: RequestInit,
 ): Promise<showPetByIdResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -279,7 +285,9 @@ export const deletePetById = async (
   petId: string,
   options?: RequestInit,
 ): Promise<deletePetByIdResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -338,7 +346,9 @@ export const getHealthCheckUrl = () => {
 export const healthCheck = async (
   options?: RequestInit,
 ): Promise<healthCheckResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -401,7 +411,9 @@ export const showPetWithOwner = async (
   petId: string,
   options?: RequestInit,
 ): Promise<showPetWithOwnerResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/reviver/pets/pets.ts
+++ b/tests/__snapshots__/fetch/reviver/pets/pets.ts
@@ -154,7 +154,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
@@ -30,7 +30,9 @@ export const getStreamUrl = () => {
 export const stream = async (
   options?: RequestInit,
 ): Promise<streamResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
@@ -156,7 +156,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/split/endpoints.ts
+++ b/tests/__snapshots__/fetch/split/endpoints.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/stream/endpoints.ts
@@ -30,7 +30,9 @@ export const getStreamUrl = () => {
 export const stream = async (
   options?: RequestInit,
 ): Promise<streamResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/tags/pets.ts
+++ b/tests/__snapshots__/fetch/tags/pets.ts
@@ -157,7 +157,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
@@ -286,7 +286,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -156,7 +156,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -162,7 +162,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -156,7 +156,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -156,7 +156,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -150,7 +150,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -128,7 +128,9 @@ export const updateProfileWithJson = async (
   updateProfileBody: UpdateProfileBody,
   options?: RequestInit,
 ): Promise<updateProfileWithJsonResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -520,7 +522,9 @@ export const uploadAvatarWithBlob = async (
   uploadAvatarBody: Blob,
   options?: RequestInit,
 ): Promise<uploadAvatarWithBlobResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -140,7 +140,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -333,7 +335,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
+++ b/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
@@ -55,7 +55,9 @@ export const createItem = async (
   createItemBody: CreateItem,
   options?: RequestInit,
 ): Promise<createItemResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -311,7 +311,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -138,7 +138,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -537,7 +539,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -340,7 +340,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
@@ -307,7 +307,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
@@ -307,7 +307,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -158,7 +158,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -228,7 +228,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -320,7 +320,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponseSuccess> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -312,7 +312,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -140,7 +140,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -333,7 +335,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -35,7 +35,9 @@ export const createEntity = async (
   createEntityBody: CreateEntityBody,
   options?: RequestInit,
 ): Promise<createEntityResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -436,7 +436,9 @@ export const musclesControllerCreate = async (
   createMuscleDto: CreateMuscleDto,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -249,7 +249,9 @@ export const musclesControllerCreate = async (
   createMuscleDto: CreateMuscleDto,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<Muscle> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -203,7 +203,9 @@ export const postApiAppOssIdentityUserSignIn = async (
     postApiAppOssIdentityUserSignInBody.password,
   );
 
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -206,7 +206,9 @@ export const createWidget = async (
   widgetNull: Widget | null,
   options?: RequestInit,
 ): Promise<createWidgetResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -340,7 +340,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -276,7 +276,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -469,7 +469,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -304,7 +304,9 @@ export const createPets = async (
   createPetsBody: CreatePetsBody,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -310,7 +310,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -321,7 +321,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -337,7 +337,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -327,7 +327,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -333,7 +333,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -566,7 +566,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -362,7 +362,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -331,7 +331,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -227,7 +227,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
@@ -309,7 +309,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
@@ -518,7 +518,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
@@ -611,7 +611,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
@@ -309,7 +309,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/solid-query/petstore/endpoints.ts
@@ -608,7 +608,9 @@ export const createPets = async (
   version: number = 1,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
+++ b/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
@@ -547,7 +547,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/split/endpoints.ts
+++ b/tests/__snapshots__/solid-query/split/endpoints.ts
@@ -309,7 +309,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/suspense/endpoints.ts
+++ b/tests/__snapshots__/solid-query/suspense/endpoints.ts
@@ -652,7 +652,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/tags/pets.ts
+++ b/tests/__snapshots__/solid-query/tags/pets.ts
@@ -316,7 +316,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
@@ -316,7 +316,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -234,7 +234,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -147,7 +147,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -229,7 +229,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -124,7 +124,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -256,7 +258,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -122,7 +122,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -254,7 +256,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -350,7 +350,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -229,7 +229,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -347,7 +347,9 @@ export const createPets = async (
   version: number = 1,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -229,7 +229,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -236,7 +236,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -236,7 +236,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
@@ -30,7 +30,9 @@ export const createPet = async (
   requiredPetBodyBody?: RequiredPetBodyBody,
   options?: RequestInit,
 ): Promise<createPetResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
@@ -30,7 +30,9 @@ export const createPet = async (
   requiredPetBodyBody?: RequiredPetBodyBody,
   options?: RequestInit,
 ): Promise<createPetResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -200,7 +200,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -112,7 +112,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -201,7 +201,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponseSuccess> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -218,7 +218,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/optional-request-body/endpoints.ts
+++ b/tests/__snapshots__/swr/optional-request-body/endpoints.ts
@@ -32,7 +32,9 @@ export const createPets = async (
   requiredPetBodyBody?: RequiredPetBodyBody,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -110,7 +112,9 @@ export const updatePets = async (
   optionalPetBodyBody?: OptionalPetBodyBody,
   options?: RequestInit,
 ): Promise<updatePetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -188,7 +192,9 @@ export const createCookies = async (
   cookie?: Cookie,
   options?: RequestInit,
 ): Promise<createCookiesResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -268,7 +274,9 @@ export const updateCookies = async (
   cookie?: Cookie,
   options?: RequestInit,
 ): Promise<updateCookiesResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -321,7 +321,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -194,7 +194,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -111,7 +111,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -283,7 +285,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -214,7 +214,9 @@ export const createPets = async (
   version: number = 1,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -195,7 +195,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -232,7 +232,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -196,7 +196,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -201,7 +201,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -202,7 +202,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -246,7 +246,9 @@ export const createPets = async (
   params?: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -246,7 +246,9 @@ export const createPets = async (
   params?: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -244,7 +244,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: Parameters<typeof customFetch>[1],
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -157,7 +157,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<Pet> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -239,7 +239,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -125,7 +125,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -263,7 +265,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -123,7 +123,9 @@ export const listPets = async (
   headers: ListPetsHeaders,
   options?: RequestInit,
 ): Promise<listPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);
@@ -261,7 +263,9 @@ export const createPets = async (
   headers: CreatePetsHeaders,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -246,7 +246,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -258,7 +258,9 @@ export const createPets = async (
   params: CreatePetsParams,
   options?: RequestInit,
 ): Promise<createPetsResponse> => {
-  const getHeaders = (h?: HeadersInit | Headers): Record<string, string> => {
+  const getHeaders = (
+    h?: NonNullable<RequestInit['headers']>,
+  ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Array.isArray(h)) return Object.fromEntries(h);


### PR DESCRIPTION
Fixes #3868.

Six react-query samples are excluded from the root test:samples script and their test scripts fail under TypeScript 6. This PR addresses the root cause and re-enables them in CI.

Changes:
- Add a minimal local tsconfig.json (moduleResolution: bundler, skipLibCheck, noEmit) to each of the six samples so tsc --noEmit uses the local config instead of resolving the repo-root TS6 config (TS5112).
- Revert each sample test script from 'tsc --noEmit endpoints.ts' to plain 'tsc --noEmit'.
- form-data-mutator: add httpClient: axios to match the committed Axios-style custom-instance (default changed to fetch in #1085, TS2554).
- form-url-encoded-mutator: constrain generic to Record<string,unknown> so Object.entries is valid (TS2769).
- Drop the six !react-query-* exclusions from the root test:samples script so they are covered again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fetch request header handling to preserve readonly array values across generated clients and samples.
  * Improved type safety for URL-encoded form request bodies.

* **Tests**
  * Expanded sample validation to cover complete TypeScript projects, including form-data, URL-encoded, and mutator examples.
  * Added consistent strict TypeScript checking across React Query samples.
  * Ensured Axios-based form-data examples are validated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->