### PR TITLE
feat(query): give the mutation variables a named type

### DIFF
--- a/packages/query/src/framework-adapter.ts
+++ b/packages/query/src/framework-adapter.ts
@@ -64,6 +64,8 @@ interface InvalidateTarget {
 export interface MutationOnSuccessContext {
   operationName: string;
   definitions: string;
+  /** Named alias for the mutation variables, when the generator emitted one. */
+  mutationVariablesType?: string;
   isRequestOptions: boolean;
   generateInvalidateCall: (target: InvalidateTarget) => string;
   uniqueInvalidates: InvalidateTarget[];
@@ -268,6 +270,8 @@ export interface FrameworkAdapter {
   generateQueryArguments(args: {
     operationName: string;
     definitions: string;
+    /** Named alias for the mutation variables, when the generator emitted one. */
+    mutationVariablesType?: string;
     mutator?: GeneratorMutator;
     isRequestOptions: boolean;
     type?: (typeof QueryType)[keyof typeof QueryType];

--- a/packages/query/src/frameworks/angular.ts
+++ b/packages/query/src/frameworks/angular.ts
@@ -194,6 +194,7 @@ export const createAngularAdapter = ({
     generateQueryArguments({
       operationName,
       definitions,
+      mutationVariablesType,
       mutator,
       isRequestOptions,
       type,
@@ -209,6 +210,7 @@ export const createAngularAdapter = ({
         operationName,
         mutator,
         definitions,
+        mutationVariablesType,
         type,
         prefix,
         hasQueryV5,

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -150,6 +150,7 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => {
     generateQueryArguments({
       operationName,
       definitions,
+      mutationVariablesType,
       mutator,
       isRequestOptions,
       type,
@@ -166,6 +167,7 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => {
         operationName,
         mutator,
         definitions,
+        mutationVariablesType,
         type,
         prefix,
         hasQueryV5: composed.hasQueryV5,
@@ -213,6 +215,7 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => {
     generateMutationOnSuccess({
       operationName,
       definitions,
+      mutationVariablesType,
       isRequestOptions,
       generateInvalidateCall,
       uniqueInvalidates,
@@ -220,29 +223,31 @@ const withDefaults = (adapter: FrameworkAdapterConfig): FrameworkAdapter => {
       const invalidateCalls = uniqueInvalidates
         .map((t) => generateInvalidateCall(t))
         .join('\n');
+      const variablesType =
+        mutationVariablesType ?? (definitions ? `{${definitions}}` : 'void');
       if (composed.hasQueryV5WithMutationContextOnSuccess) {
         if (isRequestOptions) {
-          return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
+          return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, onMutateResult: TContext, context: MutationFunctionContext) => {
         if (!options?.skipInvalidation) {
     ${invalidateCalls}
         }
         mutationOptions?.onSuccess?.(data, variables, onMutateResult, context);
       };`;
         }
-        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
+        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, onMutateResult: TContext, context: MutationFunctionContext) => {
     ${invalidateCalls}
         mutationOptions?.onSuccess?.(data, variables, onMutateResult, context);
       };`;
       } else {
         if (isRequestOptions) {
-          return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${composed.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
+          return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, context: TContext${composed.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
         if (!options?.skipInvalidation) {
     ${invalidateCalls}
         }
         mutationOptions?.onSuccess?.(data, variables, context);
       };`;
         }
-        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${composed.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
+        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, context: TContext${composed.hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
     ${invalidateCalls}
         mutationOptions?.onSuccess?.(data, variables, context);
       };`;

--- a/packages/query/src/frameworks/svelte.ts
+++ b/packages/query/src/frameworks/svelte.ts
@@ -159,6 +159,7 @@ export const createSvelteAdapter = ({
     generateQueryArguments({
       operationName,
       definitions,
+      mutationVariablesType,
       mutator,
       isRequestOptions,
       type,
@@ -174,6 +175,7 @@ export const createSvelteAdapter = ({
         operationName,
         mutator,
         definitions,
+        mutationVariablesType,
         type,
         prefix,
         hasQueryV5,

--- a/packages/query/src/frameworks/vue.ts
+++ b/packages/query/src/frameworks/vue.ts
@@ -244,6 +244,7 @@ export const createVueAdapter = ({
   generateMutationOnSuccess({
     operationName,
     definitions,
+    mutationVariablesType,
     isRequestOptions,
     generateInvalidateCall,
     uniqueInvalidates,
@@ -254,29 +255,31 @@ export const createVueAdapter = ({
     const invalidateCalls = uniqueInvalidates
       .map((t) => generateInvalidateCall(t))
       .join('\n');
+    const variablesType =
+      mutationVariablesType ?? (definitions ? `{${definitions}}` : 'void');
     if (hasQueryV5WithMutationContextOnSuccess) {
       if (isRequestOptions) {
-        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
+        return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, onMutateResult: TContext, context: MutationFunctionContext) => {
         if (!options?.skipInvalidation) {
     ${invalidateCalls}
         }
         unref(unref(typeof mutationOptions === 'function' ? mutationOptions() : mutationOptions)?.onSuccess)?.(data, variables, onMutateResult, context);
       };`;
       }
-      return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, onMutateResult: TContext, context: MutationFunctionContext) => {
+      return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, onMutateResult: TContext, context: MutationFunctionContext) => {
     ${invalidateCalls}
         unref(unref(typeof mutationOptions === 'function' ? mutationOptions() : mutationOptions)?.onSuccess)?.(data, variables, onMutateResult, context);
       };`;
     }
     if (isRequestOptions) {
-      return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
+      return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, context: TContext${hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
         if (!options?.skipInvalidation) {
     ${invalidateCalls}
         }
         unref(unref(typeof mutationOptions === 'function' ? mutationOptions() : mutationOptions)?.onSuccess)?.(data, variables, context);
       };`;
     }
-    return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${definitions ? `{${definitions}}` : 'void'}, context: TContext${hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
+    return `  const onSuccess = (data: Awaited<ReturnType<typeof ${operationName}>>, variables: ${variablesType}, context: TContext${hasQueryV5WithRequiredContextOnSuccess ? '' : ' | undefined'}) => {
     ${invalidateCalls}
         unref(unref(typeof mutationOptions === 'function' ? mutationOptions() : mutationOptions)?.onSuccess)?.(data, variables, context);
       };`;

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -453,6 +453,16 @@ export const generateMutationHook = async ({
     )
     .join(';');
 
+  // The variables a mutation takes had no name of its own: the object literal
+  // was repeated at every site that mentions it, so a caller wrapping `mutate`
+  // had to infer it back out of the hook. `MutationBody` is not a substitute,
+  // since it covers the body and not the path or query params beside it. A
+  // parameterless mutation still takes `void`, which needs no alias. (#3782)
+  const variablesTypeName = definitions
+    ? `${pascal(typeName)}MutationVariables`
+    : undefined;
+  const mutationVariablesType = variablesTypeName ?? 'void';
+
   const properties = props
     .map(({ name, type }) => (type === GetterPropType.BODY ? 'data' : name))
     .join(',');
@@ -485,6 +495,7 @@ export const generateMutationHook = async ({
     operationName: operationTypeReferenceName,
     mutator,
     definitions,
+    mutationVariablesType,
     prefix: adapter.getQueryOptionsDefinitionPrefix(),
     hasQueryV5: adapter.hasQueryV5,
     hasQueryV5WithInfiniteQueryOptionsError:
@@ -513,6 +524,7 @@ export const generateMutationHook = async ({
   const mutationArguments = adapter.generateQueryArguments({
     operationName: operationTypeReferenceName,
     definitions,
+    mutationVariablesType,
     mutator,
     isRequestOptions,
     httpClient,
@@ -524,6 +536,7 @@ export const generateMutationHook = async ({
   const mutationArgumentsForOptions = adapter.generateQueryArguments({
     operationName: operationTypeReferenceName,
     definitions,
+    mutationVariablesType,
     mutator,
     isRequestOptions,
     httpClient,
@@ -565,9 +578,7 @@ ${hooksOptionImplementation}
       }
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<${dataType}>>, ${
-        definitions ? `{${definitions}}` : 'void'
-      }> = (${properties ? 'props' : ''}) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<${dataType}>>, ${mutationVariablesType}> = (${properties ? 'props' : ''}) => {
           ${properties ? `const {${properties}} = props ?? {};` : ''}
 
           return  ${operationReferenceName}(${adapter.getMutationHttpPrefix(mutator)}${properties}${
@@ -580,6 +591,7 @@ ${
     ? adapter.generateMutationOnSuccess({
         operationName,
         definitions,
+        mutationVariablesType,
         isRequestOptions,
         generateInvalidateCall: createGenerateInvalidateCall(
           context.spec,
@@ -639,7 +651,7 @@ ${
 
   const mutationReturnType = adapter.getMutationReturnType({
     dataType,
-    variableType: definitions ? `{${definitions}}` : 'void',
+    variableType: mutationVariablesType,
   });
 
   const mutationHookBody = adapter.generateMutationHookBody({
@@ -675,6 +687,11 @@ ${mutationOptionsFn}
         : ''
     }
     export type ${pascal(typeName)}MutationError = ${errorType}
+    ${
+      variablesTypeName
+        ? `export type ${variablesTypeName} = {${definitions}}`
+        : ''
+    }
 
     ${doc}export const ${camel(
       `${operationPrefix}-${operationName}`,

--- a/packages/query/src/query-options.test.ts
+++ b/packages/query/src/query-options.test.ts
@@ -237,3 +237,45 @@ describe('getQueryOptionsDefinition — solid-query type names (issue #3365)', (
     expect(out).toContain('UseMutationOptions<');
   });
 });
+
+describe('getQueryOptionsDefinition: mutation variables alias (issue #3782)', () => {
+  const buildArgs = (adapter: ReturnType<typeof createFrameworkAdapter>) => ({
+    operationName: 'updatePet',
+    definitions: 'petId: string;data?: UpdatePetBody',
+    prefix: adapter.getQueryOptionsDefinitionPrefix(),
+    hasQueryV5: adapter.hasQueryV5,
+    hasQueryV5WithInfiniteQueryOptionsError:
+      adapter.hasQueryV5WithInfiniteQueryOptionsError,
+    isReturnType: false,
+    adapter,
+  });
+
+  it('uses the alias the caller supplies instead of the inline object', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      mutationVariablesType: 'UpdatePetMutationVariables',
+    });
+
+    expect(out).toContain('UpdatePetMutationVariables, TContext>');
+    expect(out).not.toContain('{petId: string;data?: UpdatePetBody}');
+  });
+
+  it('falls back to the inline object when no alias is supplied', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = getQueryOptionsDefinition(buildArgs(adapter));
+
+    expect(out).toContain('{petId: string;data?: UpdatePetBody}, TContext>');
+  });
+
+  it('takes void from the caller for a mutation with no variables', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = getQueryOptionsDefinition({
+      ...buildArgs(adapter),
+      definitions: '',
+      mutationVariablesType: 'void',
+    });
+
+    expect(out).toContain('void, TContext>');
+  });
+});

--- a/packages/query/src/query-options.ts
+++ b/packages/query/src/query-options.ts
@@ -141,6 +141,7 @@ export const getQueryOptionsDefinition = ({
   operationName,
   mutator,
   definitions,
+  mutationVariablesType,
   type,
   prefix,
   hasQueryV5,
@@ -155,6 +156,11 @@ export const getQueryOptionsDefinition = ({
   operationName: string;
   mutator?: GeneratorMutator;
   definitions: string;
+  /**
+   * Named alias for the mutation variables, when the caller emitted one.
+   * Falls back to the inline object literal built from `definitions`.
+   */
+  mutationVariablesType?: string;
   type?: QueryType;
   /** 'Use' or 'Create' — from adapter.getQueryOptionsDefinitionPrefix() */
   prefix: string;
@@ -271,15 +277,18 @@ export const getQueryOptionsDefinition = ({
     ? adapter.getOptionsReturnTypeName('mutation')
     : undefined;
 
+  const variablesType =
+    mutationVariablesType ?? (definitions ? `{${definitions}}` : 'void');
+
   return mutationOptionsTypeName
     ? `${mutationOptionsTypeName}<Awaited<ReturnType<${
         isMutatorHook
           ? `ReturnType<typeof use${pascal(operationName)}Hook>`
           : `typeof ${operationName}`
-      }>>, TError,${definitions ? `{${definitions}}` : 'void'}, TContext>`
+      }>>, TError,${variablesType}, TContext>`
     : `${prefix}MutationOptions<Awaited<ReturnType<${
         isMutatorHook
           ? `ReturnType<typeof use${pascal(operationName)}Hook>`
           : `typeof ${operationName}`
-      }>>, TError,${definitions ? `{${definitions}}` : 'void'}, TContext>`;
+      }>>, TError,${variablesType}, TContext>`;
 };

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -384,7 +384,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -392,7 +392,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -406,7 +406,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -421,6 +421,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = ErrorType<Error>;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -432,14 +433,14 @@ export const injectCreatePets = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -564,7 +565,7 @@ export const getDeletePetMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePet>>,
       TError,
-      { petId: string },
+      DeletePetMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -572,7 +573,7 @@ export const getDeletePetMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePet'];
@@ -586,7 +587,7 @@ export const getDeletePetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePet>>,
-    { petId: string }
+    DeletePetMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -601,6 +602,7 @@ export type DeletePetMutationResult = NonNullable<
 >;
 
 export type DeletePetMutationError = ErrorType<Error>;
+export type DeletePetMutationVariables = { petId: string };
 
 /**
  * @summary Delete a pet
@@ -612,14 +614,14 @@ export const injectDeletePet = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePet>>,
     TError,
-    { petId: string },
+    DeletePetMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -654,7 +656,7 @@ export const getUpdatePetMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePet>>,
       TError,
-      { petId: string; data: Pet },
+      UpdatePetMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -662,7 +664,7 @@ export const getUpdatePetMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePet'];
@@ -676,7 +678,7 @@ export const getUpdatePetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePet>>,
-    { petId: string; data: Pet }
+    UpdatePetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -691,6 +693,7 @@ export type UpdatePetMutationResult = NonNullable<
 >;
 export type UpdatePetMutationBody = Pet;
 export type UpdatePetMutationError = ErrorType<Error>;
+export type UpdatePetMutationVariables = { petId: string; data: Pet };
 
 /**
  * @summary Update a pet
@@ -702,14 +705,14 @@ export const injectUpdatePet = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePet>>,
     TError,
-    { petId: string; data: Pet },
+    UpdatePetMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -744,7 +747,7 @@ export const getPatchPetMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof patchPet>>,
       TError,
-      { petId: string; data: PatchPetBody },
+      PatchPetMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -752,7 +755,7 @@ export const getPatchPetMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const mutationKey = ['patchPet'];
@@ -766,7 +769,7 @@ export const getPatchPetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof patchPet>>,
-    { petId: string; data: PatchPetBody }
+    PatchPetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -781,6 +784,7 @@ export type PatchPetMutationResult = NonNullable<
 >;
 export type PatchPetMutationBody = PatchPetBody;
 export type PatchPetMutationError = ErrorType<Error>;
+export type PatchPetMutationVariables = { petId: string; data: PatchPetBody };
 
 /**
  * @summary Partially update a pet
@@ -792,14 +796,14 @@ export const injectPatchPet = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof patchPet>>,
     TError,
-    { petId: string; data: PatchPetBody },
+    PatchPetMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -931,7 +935,7 @@ export const getUploadFileMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFile>>,
       TError,
-      { petId: number; data?: Blob },
+      UploadFileMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -939,7 +943,7 @@ export const getUploadFileMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFile'];
@@ -953,7 +957,7 @@ export const getUploadFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFile>>,
-    { petId: number; data?: Blob }
+    UploadFileMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -968,6 +972,7 @@ export type UploadFileMutationResult = NonNullable<
 >;
 export type UploadFileMutationBody = Blob | undefined;
 export type UploadFileMutationError = ErrorType<void | Error>;
+export type UploadFileMutationVariables = { petId: number; data?: Blob };
 
 /**
  * @summary Uploads an image.
@@ -979,14 +984,14 @@ export const injectUploadFile = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFile>>,
     TError,
-    { petId: number; data?: Blob },
+    UploadFileMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -1028,7 +1033,7 @@ export const getUploadFormDataMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFormData>>,
       TError,
-      { petId: number; data: UploadFormDataBody },
+      UploadFormDataMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -1036,7 +1041,7 @@ export const getUploadFormDataMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFormData'];
@@ -1050,7 +1055,7 @@ export const getUploadFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFormData>>,
-    { petId: number; data: UploadFormDataBody }
+    UploadFormDataMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -1065,6 +1070,10 @@ export type UploadFormDataMutationResult = NonNullable<
 >;
 export type UploadFormDataMutationBody = UploadFormDataBody;
 export type UploadFormDataMutationError = ErrorType<void | Error>;
+export type UploadFormDataMutationVariables = {
+  petId: number;
+  data: UploadFormDataBody;
+};
 
 /**
  * @summary Upload a file via multipart form data.
@@ -1076,14 +1085,14 @@ export const injectUploadFormData = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFormData>>,
     TError,
-    { petId: number; data: UploadFormDataBody },
+    UploadFormDataMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -333,7 +333,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -341,7 +341,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -355,7 +355,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -370,6 +370,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -378,14 +379,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -515,7 +516,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePet>>,
       TError,
-      { petId: string },
+      DeletePetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -523,7 +524,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePet'];
@@ -537,7 +538,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePet>>,
-    { petId: string }
+    DeletePetMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -552,6 +553,7 @@ export type DeletePetMutationResult = NonNullable<
 >;
 
 export type DeletePetMutationError = Error;
+export type DeletePetMutationVariables = { petId: string };
 
 /**
  * @summary Delete a pet
@@ -560,14 +562,14 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePet>>,
     TError,
-    { petId: string },
+    DeletePetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -597,7 +599,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePet>>,
       TError,
-      { petId: string; data: Pet },
+      UpdatePetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -605,7 +607,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePet'];
@@ -619,7 +621,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePet>>,
-    { petId: string; data: Pet }
+    UpdatePetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -634,6 +636,7 @@ export type UpdatePetMutationResult = NonNullable<
 >;
 export type UpdatePetMutationBody = Pet;
 export type UpdatePetMutationError = Error;
+export type UpdatePetMutationVariables = { petId: string; data: Pet };
 
 /**
  * @summary Update a pet
@@ -642,14 +645,14 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePet>>,
     TError,
-    { petId: string; data: Pet },
+    UpdatePetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -679,7 +682,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof patchPet>>,
       TError,
-      { petId: string; data: PatchPetBody },
+      PatchPetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -687,7 +690,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const mutationKey = ['patchPet'];
@@ -701,7 +704,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof patchPet>>,
-    { petId: string; data: PatchPetBody }
+    PatchPetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -716,6 +719,7 @@ export type PatchPetMutationResult = NonNullable<
 >;
 export type PatchPetMutationBody = PatchPetBody;
 export type PatchPetMutationError = Error;
+export type PatchPetMutationVariables = { petId: string; data: PatchPetBody };
 
 /**
  * @summary Partially update a pet
@@ -724,14 +728,14 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof patchPet>>,
     TError,
-    { petId: string; data: PatchPetBody },
+    PatchPetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -865,7 +869,7 @@ export const getUploadFileMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFile>>,
       TError,
-      { petId: number; data?: Blob },
+      UploadFileMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -873,7 +877,7 @@ export const getUploadFileMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFile'];
@@ -887,7 +891,7 @@ export const getUploadFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFile>>,
-    { petId: number; data?: Blob }
+    UploadFileMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -902,6 +906,7 @@ export type UploadFileMutationResult = NonNullable<
 >;
 export type UploadFileMutationBody = Blob | undefined;
 export type UploadFileMutationError = void | Error;
+export type UploadFileMutationVariables = { petId: number; data?: Blob };
 
 /**
  * @summary Uploads an image.
@@ -913,14 +918,14 @@ export const injectUploadFile = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFile>>,
     TError,
-    { petId: number; data?: Blob },
+    UploadFileMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -961,7 +966,7 @@ export const getUploadFormDataMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFormData>>,
       TError,
-      { petId: number; data: UploadFormDataBody },
+      UploadFormDataMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -969,7 +974,7 @@ export const getUploadFormDataMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFormData'];
@@ -983,7 +988,7 @@ export const getUploadFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFormData>>,
-    { petId: number; data: UploadFormDataBody }
+    UploadFormDataMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -998,6 +1003,10 @@ export type UploadFormDataMutationResult = NonNullable<
 >;
 export type UploadFormDataMutationBody = UploadFormDataBody;
 export type UploadFormDataMutationError = void | Error;
+export type UploadFormDataMutationVariables = {
+  petId: number;
+  data: UploadFormDataBody;
+};
 
 /**
  * @summary Upload a file via multipart form data.
@@ -1009,14 +1018,14 @@ export const injectUploadFormData = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFormData>>,
     TError,
-    { petId: number; data: UploadFormDataBody },
+    UploadFormDataMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -231,7 +231,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -239,7 +239,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -253,7 +253,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -268,6 +268,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -276,14 +280,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -416,7 +420,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -424,7 +428,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -438,7 +442,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -453,6 +457,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -464,14 +469,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -394,7 +394,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; version?: number },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -403,7 +403,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -417,7 +417,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, version } = props ?? {};
 
@@ -426,7 +426,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; version?: number },
+    variables: CreatePetsMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -444,6 +444,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -452,7 +456,7 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -460,7 +464,7 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -623,7 +627,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePet>>,
       TError,
-      { petId: string; version?: number },
+      DeletePetMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -632,7 +636,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string; version?: number },
+  DeletePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePet'];
@@ -646,7 +650,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePet>>,
-    { petId: string; version?: number }
+    DeletePetMutationVariables
   > = (props) => {
     const { petId, version } = props ?? {};
 
@@ -655,7 +659,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePet>>,
-    variables: { petId: string; version?: number },
+    variables: DeletePetMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -676,6 +680,7 @@ export type DeletePetMutationResult = NonNullable<
 >;
 
 export type DeletePetMutationError = Error;
+export type DeletePetMutationVariables = { petId: string; version?: number };
 
 /**
  * @summary Delete a pet
@@ -684,7 +689,7 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePet>>,
     TError,
-    { petId: string; version?: number },
+    DeletePetMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -692,7 +697,7 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string; version?: number },
+  DeletePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -729,7 +734,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePet>>,
       TError,
-      { petId: string; data: Pet; version?: number },
+      UpdatePetMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -738,7 +743,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet; version?: number },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePet'];
@@ -752,7 +757,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePet>>,
-    { petId: string; data: Pet; version?: number }
+    UpdatePetMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -761,7 +766,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof updatePet>>,
-    variables: { petId: string; data: Pet; version?: number },
+    variables: UpdatePetMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -782,6 +787,11 @@ export type UpdatePetMutationResult = NonNullable<
 >;
 export type UpdatePetMutationBody = Pet;
 export type UpdatePetMutationError = Error;
+export type UpdatePetMutationVariables = {
+  petId: string;
+  data: Pet;
+  version?: number;
+};
 
 /**
  * @summary Update a pet
@@ -790,7 +800,7 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePet>>,
     TError,
-    { petId: string; data: Pet; version?: number },
+    UpdatePetMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -798,7 +808,7 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet; version?: number },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -835,7 +845,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof patchPet>>,
       TError,
-      { petId: string; data: PatchPetBody; version?: number },
+      PatchPetMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -844,7 +854,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody; version?: number },
+  PatchPetMutationVariables,
   TContext
 > => {
   const mutationKey = ['patchPet'];
@@ -858,7 +868,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof patchPet>>,
-    { petId: string; data: PatchPetBody; version?: number }
+    PatchPetMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -867,7 +877,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof patchPet>>,
-    variables: { petId: string; data: PatchPetBody; version?: number },
+    variables: PatchPetMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -888,6 +898,11 @@ export type PatchPetMutationResult = NonNullable<
 >;
 export type PatchPetMutationBody = PatchPetBody;
 export type PatchPetMutationError = Error;
+export type PatchPetMutationVariables = {
+  petId: string;
+  data: PatchPetBody;
+  version?: number;
+};
 
 /**
  * @summary Partially update a pet
@@ -896,7 +911,7 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof patchPet>>,
     TError,
-    { petId: string; data: PatchPetBody; version?: number },
+    PatchPetMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -904,7 +919,7 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody; version?: number },
+  PatchPetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -1071,7 +1086,7 @@ export const getUploadFileMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFile>>,
       TError,
-      { petId: number; data?: Blob; version?: number },
+      UploadFileMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -1080,7 +1095,7 @@ export const getUploadFileMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob; version?: number },
+  UploadFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFile'];
@@ -1094,7 +1109,7 @@ export const getUploadFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFile>>,
-    { petId: number; data?: Blob; version?: number }
+    UploadFileMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -1103,7 +1118,7 @@ export const getUploadFileMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof uploadFile>>,
-    variables: { petId: number; data?: Blob; version?: number },
+    variables: UploadFileMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -1121,6 +1136,11 @@ export type UploadFileMutationResult = NonNullable<
 >;
 export type UploadFileMutationBody = Blob | undefined;
 export type UploadFileMutationError = void | Error;
+export type UploadFileMutationVariables = {
+  petId: number;
+  data?: Blob;
+  version?: number;
+};
 
 /**
  * @summary Uploads an image.
@@ -1132,7 +1152,7 @@ export const injectUploadFile = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFile>>,
     TError,
-    { petId: number; data?: Blob; version?: number },
+    UploadFileMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -1140,7 +1160,7 @@ export const injectUploadFile = <
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob; version?: number },
+  UploadFileMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -1187,7 +1207,7 @@ export const getUploadFormDataMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFormData>>,
       TError,
-      { petId: number; data: UploadFormDataBody; version?: number },
+      UploadFormDataMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -1195,7 +1215,7 @@ export const getUploadFormDataMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody; version?: number },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFormData'];
@@ -1209,7 +1229,7 @@ export const getUploadFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFormData>>,
-    { petId: number; data: UploadFormDataBody; version?: number }
+    UploadFormDataMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -1224,6 +1244,11 @@ export type UploadFormDataMutationResult = NonNullable<
 >;
 export type UploadFormDataMutationBody = UploadFormDataBody;
 export type UploadFormDataMutationError = void | Error;
+export type UploadFormDataMutationVariables = {
+  petId: number;
+  data: UploadFormDataBody;
+  version?: number;
+};
 
 /**
  * @summary Upload a file via multipart form data.
@@ -1235,14 +1260,14 @@ export const injectUploadFormData = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFormData>>,
     TError,
-    { petId: number; data: UploadFormDataBody; version?: number },
+    UploadFormDataMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody; version?: number },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -384,7 +384,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -392,7 +392,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -406,7 +406,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -421,6 +421,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = ErrorType<Error>;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -432,14 +433,14 @@ export const injectCreatePets = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -564,7 +565,7 @@ export const getDeletePetMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePet>>,
       TError,
-      { petId: string },
+      DeletePetMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -572,7 +573,7 @@ export const getDeletePetMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePet'];
@@ -586,7 +587,7 @@ export const getDeletePetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePet>>,
-    { petId: string }
+    DeletePetMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -601,6 +602,7 @@ export type DeletePetMutationResult = NonNullable<
 >;
 
 export type DeletePetMutationError = ErrorType<Error>;
+export type DeletePetMutationVariables = { petId: string };
 
 /**
  * @summary Delete a pet
@@ -612,14 +614,14 @@ export const injectDeletePet = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePet>>,
     TError,
-    { petId: string },
+    DeletePetMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -654,7 +656,7 @@ export const getUpdatePetMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePet>>,
       TError,
-      { petId: string; data: Pet },
+      UpdatePetMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -662,7 +664,7 @@ export const getUpdatePetMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePet'];
@@ -676,7 +678,7 @@ export const getUpdatePetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePet>>,
-    { petId: string; data: Pet }
+    UpdatePetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -691,6 +693,7 @@ export type UpdatePetMutationResult = NonNullable<
 >;
 export type UpdatePetMutationBody = Pet;
 export type UpdatePetMutationError = ErrorType<Error>;
+export type UpdatePetMutationVariables = { petId: string; data: Pet };
 
 /**
  * @summary Update a pet
@@ -702,14 +705,14 @@ export const injectUpdatePet = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePet>>,
     TError,
-    { petId: string; data: Pet },
+    UpdatePetMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -744,7 +747,7 @@ export const getPatchPetMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof patchPet>>,
       TError,
-      { petId: string; data: PatchPetBody },
+      PatchPetMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -752,7 +755,7 @@ export const getPatchPetMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const mutationKey = ['patchPet'];
@@ -766,7 +769,7 @@ export const getPatchPetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof patchPet>>,
-    { petId: string; data: PatchPetBody }
+    PatchPetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -781,6 +784,7 @@ export type PatchPetMutationResult = NonNullable<
 >;
 export type PatchPetMutationBody = PatchPetBody;
 export type PatchPetMutationError = ErrorType<Error>;
+export type PatchPetMutationVariables = { petId: string; data: PatchPetBody };
 
 /**
  * @summary Partially update a pet
@@ -792,14 +796,14 @@ export const injectPatchPet = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof patchPet>>,
     TError,
-    { petId: string; data: PatchPetBody },
+    PatchPetMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -931,7 +935,7 @@ export const getUploadFileMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFile>>,
       TError,
-      { petId: number; data?: Blob },
+      UploadFileMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -939,7 +943,7 @@ export const getUploadFileMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFile'];
@@ -953,7 +957,7 @@ export const getUploadFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFile>>,
-    { petId: number; data?: Blob }
+    UploadFileMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -968,6 +972,7 @@ export type UploadFileMutationResult = NonNullable<
 >;
 export type UploadFileMutationBody = Blob | undefined;
 export type UploadFileMutationError = ErrorType<void | Error>;
+export type UploadFileMutationVariables = { petId: number; data?: Blob };
 
 /**
  * @summary Uploads an image.
@@ -979,14 +984,14 @@ export const injectUploadFile = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFile>>,
     TError,
-    { petId: number; data?: Blob },
+    UploadFileMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -1028,7 +1033,7 @@ export const getUploadFormDataMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFormData>>,
       TError,
-      { petId: number; data: UploadFormDataBody },
+      UploadFormDataMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof responseType>;
@@ -1036,7 +1041,7 @@ export const getUploadFormDataMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFormData'];
@@ -1050,7 +1055,7 @@ export const getUploadFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFormData>>,
-    { petId: number; data: UploadFormDataBody }
+    UploadFormDataMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -1065,6 +1070,10 @@ export type UploadFormDataMutationResult = NonNullable<
 >;
 export type UploadFormDataMutationBody = UploadFormDataBody;
 export type UploadFormDataMutationError = ErrorType<void | Error>;
+export type UploadFormDataMutationVariables = {
+  petId: number;
+  data: UploadFormDataBody;
+};
 
 /**
  * @summary Upload a file via multipart form data.
@@ -1076,14 +1085,14 @@ export const injectUploadFormData = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFormData>>,
     TError,
-    { petId: number; data: UploadFormDataBody },
+    UploadFormDataMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof responseType>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -333,7 +333,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -341,7 +341,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -355,7 +355,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -370,6 +370,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -378,14 +379,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -515,7 +516,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePet>>,
       TError,
-      { petId: string },
+      DeletePetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -523,7 +524,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePet'];
@@ -537,7 +538,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePet>>,
-    { petId: string }
+    DeletePetMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -552,6 +553,7 @@ export type DeletePetMutationResult = NonNullable<
 >;
 
 export type DeletePetMutationError = Error;
+export type DeletePetMutationVariables = { petId: string };
 
 /**
  * @summary Delete a pet
@@ -560,14 +562,14 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePet>>,
     TError,
-    { petId: string },
+    DeletePetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string },
+  DeletePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -597,7 +599,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePet>>,
       TError,
-      { petId: string; data: Pet },
+      UpdatePetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -605,7 +607,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePet'];
@@ -619,7 +621,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePet>>,
-    { petId: string; data: Pet }
+    UpdatePetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -634,6 +636,7 @@ export type UpdatePetMutationResult = NonNullable<
 >;
 export type UpdatePetMutationBody = Pet;
 export type UpdatePetMutationError = Error;
+export type UpdatePetMutationVariables = { petId: string; data: Pet };
 
 /**
  * @summary Update a pet
@@ -642,14 +645,14 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePet>>,
     TError,
-    { petId: string; data: Pet },
+    UpdatePetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -679,7 +682,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof patchPet>>,
       TError,
-      { petId: string; data: PatchPetBody },
+      PatchPetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -687,7 +690,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const mutationKey = ['patchPet'];
@@ -701,7 +704,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof patchPet>>,
-    { petId: string; data: PatchPetBody }
+    PatchPetMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -716,6 +719,7 @@ export type PatchPetMutationResult = NonNullable<
 >;
 export type PatchPetMutationBody = PatchPetBody;
 export type PatchPetMutationError = Error;
+export type PatchPetMutationVariables = { petId: string; data: PatchPetBody };
 
 /**
  * @summary Partially update a pet
@@ -724,14 +728,14 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof patchPet>>,
     TError,
-    { petId: string; data: PatchPetBody },
+    PatchPetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody },
+  PatchPetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -865,7 +869,7 @@ export const getUploadFileMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFile>>,
       TError,
-      { petId: number; data?: Blob },
+      UploadFileMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -873,7 +877,7 @@ export const getUploadFileMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFile'];
@@ -887,7 +891,7 @@ export const getUploadFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFile>>,
-    { petId: number; data?: Blob }
+    UploadFileMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -902,6 +906,7 @@ export type UploadFileMutationResult = NonNullable<
 >;
 export type UploadFileMutationBody = Blob | undefined;
 export type UploadFileMutationError = void | Error;
+export type UploadFileMutationVariables = { petId: number; data?: Blob };
 
 /**
  * @summary Uploads an image.
@@ -913,14 +918,14 @@ export const injectUploadFile = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFile>>,
     TError,
-    { petId: number; data?: Blob },
+    UploadFileMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob },
+  UploadFileMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -961,7 +966,7 @@ export const getUploadFormDataMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFormData>>,
       TError,
-      { petId: number; data: UploadFormDataBody },
+      UploadFormDataMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -969,7 +974,7 @@ export const getUploadFormDataMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFormData'];
@@ -983,7 +988,7 @@ export const getUploadFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFormData>>,
-    { petId: number; data: UploadFormDataBody }
+    UploadFormDataMutationVariables
   > = (props) => {
     const { petId, data } = props ?? {};
 
@@ -998,6 +1003,10 @@ export type UploadFormDataMutationResult = NonNullable<
 >;
 export type UploadFormDataMutationBody = UploadFormDataBody;
 export type UploadFormDataMutationError = void | Error;
+export type UploadFormDataMutationVariables = {
+  petId: number;
+  data: UploadFormDataBody;
+};
 
 /**
  * @summary Upload a file via multipart form data.
@@ -1009,14 +1018,14 @@ export const injectUploadFormData = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFormData>>,
     TError,
-    { petId: number; data: UploadFormDataBody },
+    UploadFormDataMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -231,7 +231,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -239,7 +239,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -253,7 +253,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -268,6 +268,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -276,14 +280,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -416,7 +420,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -424,7 +428,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -438,7 +442,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -453,6 +457,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -464,14 +469,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -394,7 +394,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; version?: number },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -403,7 +403,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -417,7 +417,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, version } = props ?? {};
 
@@ -426,7 +426,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; version?: number },
+    variables: CreatePetsMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -444,6 +444,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -452,7 +456,7 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -460,7 +464,7 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -623,7 +627,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePet>>,
       TError,
-      { petId: string; version?: number },
+      DeletePetMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -632,7 +636,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string; version?: number },
+  DeletePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePet'];
@@ -646,7 +650,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePet>>,
-    { petId: string; version?: number }
+    DeletePetMutationVariables
   > = (props) => {
     const { petId, version } = props ?? {};
 
@@ -655,7 +659,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePet>>,
-    variables: { petId: string; version?: number },
+    variables: DeletePetMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -676,6 +680,7 @@ export type DeletePetMutationResult = NonNullable<
 >;
 
 export type DeletePetMutationError = Error;
+export type DeletePetMutationVariables = { petId: string; version?: number };
 
 /**
  * @summary Delete a pet
@@ -684,7 +689,7 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePet>>,
     TError,
-    { petId: string; version?: number },
+    DeletePetMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -692,7 +697,7 @@ export const injectDeletePet = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePet>>,
   TError,
-  { petId: string; version?: number },
+  DeletePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -729,7 +734,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePet>>,
       TError,
-      { petId: string; data: Pet; version?: number },
+      UpdatePetMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -738,7 +743,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet; version?: number },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePet'];
@@ -752,7 +757,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePet>>,
-    { petId: string; data: Pet; version?: number }
+    UpdatePetMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -761,7 +766,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof updatePet>>,
-    variables: { petId: string; data: Pet; version?: number },
+    variables: UpdatePetMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -782,6 +787,11 @@ export type UpdatePetMutationResult = NonNullable<
 >;
 export type UpdatePetMutationBody = Pet;
 export type UpdatePetMutationError = Error;
+export type UpdatePetMutationVariables = {
+  petId: string;
+  data: Pet;
+  version?: number;
+};
 
 /**
  * @summary Update a pet
@@ -790,7 +800,7 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePet>>,
     TError,
-    { petId: string; data: Pet; version?: number },
+    UpdatePetMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -798,7 +808,7 @@ export const injectUpdatePet = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePet>>,
   TError,
-  { petId: string; data: Pet; version?: number },
+  UpdatePetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -835,7 +845,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof patchPet>>,
       TError,
-      { petId: string; data: PatchPetBody; version?: number },
+      PatchPetMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -844,7 +854,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody; version?: number },
+  PatchPetMutationVariables,
   TContext
 > => {
   const mutationKey = ['patchPet'];
@@ -858,7 +868,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof patchPet>>,
-    { petId: string; data: PatchPetBody; version?: number }
+    PatchPetMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -867,7 +877,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof patchPet>>,
-    variables: { petId: string; data: PatchPetBody; version?: number },
+    variables: PatchPetMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -888,6 +898,11 @@ export type PatchPetMutationResult = NonNullable<
 >;
 export type PatchPetMutationBody = PatchPetBody;
 export type PatchPetMutationError = Error;
+export type PatchPetMutationVariables = {
+  petId: string;
+  data: PatchPetBody;
+  version?: number;
+};
 
 /**
  * @summary Partially update a pet
@@ -896,7 +911,7 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof patchPet>>,
     TError,
-    { petId: string; data: PatchPetBody; version?: number },
+    PatchPetMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -904,7 +919,7 @@ export const injectPatchPet = <TError = Error, TContext = unknown>(options?: {
 }): CreateMutationResult<
   Awaited<ReturnType<typeof patchPet>>,
   TError,
-  { petId: string; data: PatchPetBody; version?: number },
+  PatchPetMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -1071,7 +1086,7 @@ export const getUploadFileMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFile>>,
       TError,
-      { petId: number; data?: Blob; version?: number },
+      UploadFileMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -1080,7 +1095,7 @@ export const getUploadFileMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob; version?: number },
+  UploadFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFile'];
@@ -1094,7 +1109,7 @@ export const getUploadFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFile>>,
-    { petId: number; data?: Blob; version?: number }
+    UploadFileMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -1103,7 +1118,7 @@ export const getUploadFileMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof uploadFile>>,
-    variables: { petId: number; data?: Blob; version?: number },
+    variables: UploadFileMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -1121,6 +1136,11 @@ export type UploadFileMutationResult = NonNullable<
 >;
 export type UploadFileMutationBody = Blob | undefined;
 export type UploadFileMutationError = void | Error;
+export type UploadFileMutationVariables = {
+  petId: number;
+  data?: Blob;
+  version?: number;
+};
 
 /**
  * @summary Uploads an image.
@@ -1132,7 +1152,7 @@ export const injectUploadFile = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFile>>,
     TError,
-    { petId: number; data?: Blob; version?: number },
+    UploadFileMutationVariables,
     TContext
   >;
   skipInvalidation?: boolean;
@@ -1140,7 +1160,7 @@ export const injectUploadFile = <
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFile>>,
   TError,
-  { petId: number; data?: Blob; version?: number },
+  UploadFileMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -1187,7 +1207,7 @@ export const getUploadFormDataMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof uploadFormData>>,
       TError,
-      { petId: number; data: UploadFormDataBody; version?: number },
+      UploadFormDataMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -1195,7 +1215,7 @@ export const getUploadFormDataMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody; version?: number },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadFormData'];
@@ -1209,7 +1229,7 @@ export const getUploadFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadFormData>>,
-    { petId: number; data: UploadFormDataBody; version?: number }
+    UploadFormDataMutationVariables
   > = (props) => {
     const { petId, data, version } = props ?? {};
 
@@ -1224,6 +1244,11 @@ export type UploadFormDataMutationResult = NonNullable<
 >;
 export type UploadFormDataMutationBody = UploadFormDataBody;
 export type UploadFormDataMutationError = void | Error;
+export type UploadFormDataMutationVariables = {
+  petId: number;
+  data: UploadFormDataBody;
+  version?: number;
+};
 
 /**
  * @summary Upload a file via multipart form data.
@@ -1235,14 +1260,14 @@ export const injectUploadFormData = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof uploadFormData>>,
     TError,
-    { petId: number; data: UploadFormDataBody; version?: number },
+    UploadFormDataMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof uploadFormData>>,
   TError,
-  { petId: number; data: UploadFormDataBody; version?: number },
+  UploadFormDataMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -790,13 +790,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -810,7 +810,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, version } = props ?? {};
 
@@ -825,6 +825,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = ErrorType<Error>;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -834,7 +838,7 @@ export const useCreatePets = <TError = ErrorType<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; version?: number },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -842,7 +846,7 @@ export const useCreatePets = <TError = ErrorType<Error>, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -790,13 +790,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -810,7 +810,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, version } = props ?? {};
 
@@ -825,6 +825,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = ErrorType<Error>;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -834,7 +838,7 @@ export const useCreatePets = <TError = ErrorType<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; version?: number },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -842,7 +846,7 @@ export const useCreatePets = <TError = ErrorType<Error>, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -341,14 +341,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBodyItem[] },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -362,7 +362,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -377,6 +377,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -386,7 +387,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -395,7 +396,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -456,14 +457,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -477,7 +478,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -492,6 +493,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -501,7 +503,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updatePets>>,
       TError,
-      { data: NonReadonly<Pet> },
+      UpdatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -510,7 +512,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -341,14 +341,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBodyItem[] },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -362,7 +362,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -377,6 +377,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -386,7 +387,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -395,7 +396,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -456,14 +457,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -477,7 +478,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -492,6 +493,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -501,7 +503,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updatePets>>,
       TError,
-      { data: NonReadonly<Pet> },
+      UpdatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -510,7 +512,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -255,13 +255,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -275,7 +275,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -290,6 +290,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -298,13 +299,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -255,13 +255,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -275,7 +275,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -290,6 +290,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -298,13 +299,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-data/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data/__snapshots__/endpoints.ts
@@ -146,13 +146,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -166,7 +166,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -181,6 +181,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -189,13 +190,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-data/endpoints.ts
+++ b/samples/react-query/form-data/endpoints.ts
@@ -146,13 +146,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -166,7 +166,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -181,6 +181,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -189,13 +190,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
@@ -147,13 +147,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -167,7 +167,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -182,6 +182,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -190,13 +191,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -147,13 +147,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -167,7 +167,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -182,6 +182,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -190,13 +191,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
@@ -146,13 +146,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -166,7 +166,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -181,6 +181,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -189,13 +190,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -146,13 +146,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -166,7 +166,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -181,6 +181,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -189,13 +190,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options));

--- a/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
@@ -156,13 +156,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -178,7 +178,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -193,6 +193,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -201,13 +202,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options));

--- a/samples/react-query/hook-mutator-axios/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/endpoints.ts
@@ -156,13 +156,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -178,7 +178,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -193,6 +193,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -201,13 +202,13 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options));

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -274,14 +274,14 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<ReturnType<typeof useCustomFetch>>;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -297,7 +297,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -312,6 +312,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -320,14 +321,14 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<ReturnType<typeof useCustomFetch>>;
 }): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options));

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -274,14 +274,14 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<ReturnType<typeof useCustomFetch>>;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -297,7 +297,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -312,6 +312,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -320,14 +321,14 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<ReturnType<typeof useCustomFetch>>;
 }): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options));

--- a/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -142,13 +142,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -162,7 +162,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, version } = props ?? {};
 
@@ -177,6 +177,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -185,13 +189,13 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -142,13 +142,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -162,7 +162,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, version } = props ?? {};
 
@@ -177,6 +177,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -185,13 +189,13 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -267,7 +267,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -276,7 +276,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -290,7 +290,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -299,7 +299,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBodyItem[] },
+    variables: CreatePetsMutationVariables,
     context: TContext | undefined,
   ) => {
     if (!options?.skipInvalidation) {
@@ -316,6 +316,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -325,7 +326,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -335,7 +336,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -399,14 +400,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -420,7 +421,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -435,6 +436,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -443,14 +445,14 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getUpdatePetsMutationOptions(options));

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -267,7 +267,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -276,7 +276,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -290,7 +290,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -299,7 +299,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBodyItem[] },
+    variables: CreatePetsMutationVariables,
     context: TContext | undefined,
   ) => {
     if (!options?.skipInvalidation) {
@@ -316,6 +316,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -325,7 +326,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -335,7 +336,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -399,14 +400,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -420,7 +421,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -435,6 +436,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -443,14 +445,14 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getUpdatePetsMutationOptions(options));

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -289,7 +289,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -298,7 +298,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -312,7 +312,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -321,7 +321,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBodyItem[] },
+    variables: CreatePetsMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -339,6 +339,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -348,7 +349,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +359,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient(queryClient?.());
@@ -423,14 +424,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -444,7 +445,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -459,6 +460,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -468,7 +470,7 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePets>>,
       TError,
-      { data: NonReadonly<Pet> },
+      UpdatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -477,7 +479,7 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return createMutation(

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -289,7 +289,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -298,7 +298,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -312,7 +312,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -321,7 +321,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBodyItem[] },
+    variables: CreatePetsMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -339,6 +339,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -348,7 +349,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +359,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient(queryClient?.());
@@ -423,14 +424,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -444,7 +445,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -459,6 +460,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -468,7 +470,7 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof updatePets>>,
       TError,
-      { data: NonReadonly<Pet> },
+      UpdatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -477,7 +479,7 @@ export const createUpdatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return createMutation(

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -275,14 +275,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBodyItem[] },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -296,7 +296,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -311,6 +311,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -320,7 +321,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -329,7 +330,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -390,14 +391,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -411,7 +412,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -426,6 +427,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -435,7 +437,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updatePets>>,
       TError,
-      { data: NonReadonly<Pet> },
+      UpdatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -444,7 +446,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -275,14 +275,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBodyItem[] },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -296,7 +296,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBodyItem[] }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -311,6 +311,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBodyItem[];
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBodyItem[] };
 
 /**
  * @summary Create a pet
@@ -320,7 +321,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBodyItem[] },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -329,7 +330,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBodyItem[] },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -390,14 +391,14 @@ export const getUpdatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updatePets>>,
     TError,
-    { data: NonReadonly<Pet> },
+    UpdatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['updatePets'];
@@ -411,7 +412,7 @@ export const getUpdatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updatePets>>,
-    { data: NonReadonly<Pet> }
+    UpdatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -426,6 +427,7 @@ export type UpdatePetsMutationResult = NonNullable<
 >;
 export type UpdatePetsMutationBody = NonReadonly<Pet>;
 export type UpdatePetsMutationError = Error;
+export type UpdatePetsMutationVariables = { data: NonReadonly<Pet> };
 
 /**
  * @summary Update a pet
@@ -435,7 +437,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updatePets>>,
       TError,
-      { data: NonReadonly<Pet> },
+      UpdatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -444,7 +446,7 @@ export const useUpdatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof updatePets>>,
   TError,
-  { data: NonReadonly<Pet> },
+  UpdatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getUpdatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -229,7 +229,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -237,7 +237,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -251,7 +251,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -266,6 +266,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -274,14 +278,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -415,7 +419,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -423,7 +427,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -437,7 +441,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -452,6 +456,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -463,14 +468,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -229,7 +229,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -237,7 +237,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -251,7 +251,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -266,6 +266,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -274,14 +278,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -415,7 +419,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -423,7 +427,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -437,7 +441,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -452,6 +456,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -463,14 +468,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -229,7 +229,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -237,7 +237,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -251,7 +251,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -266,6 +266,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -274,14 +278,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -414,7 +418,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -422,7 +426,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -436,7 +440,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -451,6 +455,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -462,14 +467,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
@@ -236,7 +236,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -244,7 +244,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -258,7 +258,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -273,6 +273,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -281,14 +285,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -422,7 +426,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -430,7 +434,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -444,7 +448,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -459,6 +463,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -470,14 +475,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -258,7 +258,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -266,7 +266,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -280,7 +280,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -295,6 +295,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -303,14 +307,14 @@ export const injectCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);
@@ -472,7 +476,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -480,7 +484,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -494,7 +498,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -509,6 +513,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -520,14 +525,14 @@ export const injectDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const http = inject(HttpClient);

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -637,14 +641,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -658,7 +662,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -673,6 +677,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -682,7 +687,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -691,7 +696,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -636,14 +640,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -657,7 +661,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -672,6 +676,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -681,7 +686,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -690,7 +695,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -636,14 +640,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -657,7 +661,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -672,6 +676,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -681,7 +686,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -690,7 +695,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -163,14 +163,14 @@ export const getUpdateProfileWithJsonMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updateProfileWithJson>>,
     TError,
-    { id: string; data: UpdateProfileBody },
+    UpdateProfileWithJsonMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updateProfileWithJson>>,
   TError,
-  { id: string; data: UpdateProfileBody },
+  UpdateProfileWithJsonMutationVariables,
   TContext
 > => {
   const mutationKey = ['updateProfileWithJson'];
@@ -184,7 +184,7 @@ export const getUpdateProfileWithJsonMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updateProfileWithJson>>,
-    { id: string; data: UpdateProfileBody }
+    UpdateProfileWithJsonMutationVariables
   > = (props) => {
     const { id, data } = props ?? {};
 
@@ -199,6 +199,10 @@ export type UpdateProfileWithJsonMutationResult = NonNullable<
 >;
 export type UpdateProfileWithJsonMutationBody = UpdateProfileBody;
 export type UpdateProfileWithJsonMutationError = Error;
+export type UpdateProfileWithJsonMutationVariables = {
+  id: string;
+  data: UpdateProfileBody;
+};
 
 /**
  * @summary Update a profile
@@ -208,7 +212,7 @@ export const useUpdateProfileWithJson = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updateProfileWithJson>>,
       TError,
-      { id: string; data: UpdateProfileBody },
+      UpdateProfileWithJsonMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -217,7 +221,7 @@ export const useUpdateProfileWithJson = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof updateProfileWithJson>>,
   TError,
-  { id: string; data: UpdateProfileBody },
+  UpdateProfileWithJsonMutationVariables,
   TContext
 > => {
   return useMutation(
@@ -292,14 +296,14 @@ export const getUpdateProfileWithFormDataMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updateProfileWithFormData>>,
     TError,
-    { id: string; data: UpdateProfileBody },
+    UpdateProfileWithFormDataMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updateProfileWithFormData>>,
   TError,
-  { id: string; data: UpdateProfileBody },
+  UpdateProfileWithFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['updateProfileWithFormData'];
@@ -313,7 +317,7 @@ export const getUpdateProfileWithFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updateProfileWithFormData>>,
-    { id: string; data: UpdateProfileBody }
+    UpdateProfileWithFormDataMutationVariables
   > = (props) => {
     const { id, data } = props ?? {};
 
@@ -328,6 +332,10 @@ export type UpdateProfileWithFormDataMutationResult = NonNullable<
 >;
 export type UpdateProfileWithFormDataMutationBody = UpdateProfileBody;
 export type UpdateProfileWithFormDataMutationError = Error;
+export type UpdateProfileWithFormDataMutationVariables = {
+  id: string;
+  data: UpdateProfileBody;
+};
 
 /**
  * @summary Update a profile
@@ -340,7 +348,7 @@ export const useUpdateProfileWithFormData = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updateProfileWithFormData>>,
       TError,
-      { id: string; data: UpdateProfileBody },
+      UpdateProfileWithFormDataMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -349,7 +357,7 @@ export const useUpdateProfileWithFormData = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof updateProfileWithFormData>>,
   TError,
-  { id: string; data: UpdateProfileBody },
+  UpdateProfileWithFormDataMutationVariables,
   TContext
 > => {
   return useMutation(
@@ -423,14 +431,14 @@ export const getUploadAvatarWithFormDataMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof uploadAvatarWithFormData>>,
     TError,
-    { data: AvatarUpload },
+    UploadAvatarWithFormDataMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof uploadAvatarWithFormData>>,
   TError,
-  { data: AvatarUpload },
+  UploadAvatarWithFormDataMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadAvatarWithFormData'];
@@ -444,7 +452,7 @@ export const getUploadAvatarWithFormDataMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadAvatarWithFormData>>,
-    { data: AvatarUpload }
+    UploadAvatarWithFormDataMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -459,6 +467,7 @@ export type UploadAvatarWithFormDataMutationResult = NonNullable<
 >;
 export type UploadAvatarWithFormDataMutationBody = AvatarUpload;
 export type UploadAvatarWithFormDataMutationError = Error;
+export type UploadAvatarWithFormDataMutationVariables = { data: AvatarUpload };
 
 /**
  * @summary Upload an avatar
@@ -468,7 +477,7 @@ export const useUploadAvatarWithFormData = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof uploadAvatarWithFormData>>,
       TError,
-      { data: AvatarUpload },
+      UploadAvatarWithFormDataMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -477,7 +486,7 @@ export const useUploadAvatarWithFormData = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof uploadAvatarWithFormData>>,
   TError,
-  { data: AvatarUpload },
+  UploadAvatarWithFormDataMutationVariables,
   TContext
 > => {
   return useMutation(
@@ -555,14 +564,14 @@ export const getUploadAvatarWithBlobMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof uploadAvatarWithBlob>>,
     TError,
-    { data: Blob },
+    UploadAvatarWithBlobMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof uploadAvatarWithBlob>>,
   TError,
-  { data: Blob },
+  UploadAvatarWithBlobMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadAvatarWithBlob'];
@@ -576,7 +585,7 @@ export const getUploadAvatarWithBlobMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadAvatarWithBlob>>,
-    { data: Blob }
+    UploadAvatarWithBlobMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -591,6 +600,7 @@ export type UploadAvatarWithBlobMutationResult = NonNullable<
 >;
 export type UploadAvatarWithBlobMutationBody = Blob;
 export type UploadAvatarWithBlobMutationError = Error;
+export type UploadAvatarWithBlobMutationVariables = { data: Blob };
 
 /**
  * @summary Upload an avatar
@@ -600,7 +610,7 @@ export const useUploadAvatarWithBlob = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof uploadAvatarWithBlob>>,
       TError,
-      { data: Blob },
+      UploadAvatarWithBlobMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -609,7 +619,7 @@ export const useUploadAvatarWithBlob = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof uploadAvatarWithBlob>>,
   TError,
-  { data: Blob },
+  UploadAvatarWithBlobMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -367,22 +367,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -396,11 +388,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -415,6 +403,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -424,11 +417,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -437,11 +426,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -681,14 +666,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -702,7 +687,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -717,6 +702,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -726,7 +712,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -735,7 +721,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
+++ b/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
@@ -531,13 +531,13 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -551,7 +551,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -566,6 +566,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = ErrorType<Error>;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -575,7 +576,7 @@ export const useDeletePetById = <TError = ErrorType<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
   },
@@ -583,7 +584,7 @@ export const useDeletePetById = <TError = ErrorType<Error>, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -344,14 +344,14 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -365,7 +365,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -386,6 +386,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -395,7 +399,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -404,7 +408,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
@@ -644,14 +648,14 @@ export const useDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -665,7 +669,7 @@ export const useDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -686,6 +690,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -695,7 +700,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -704,7 +709,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -571,22 +571,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -600,11 +592,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -619,6 +607,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -628,11 +621,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -641,11 +630,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -887,14 +872,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -908,7 +893,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -923,6 +908,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -932,7 +918,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -941,7 +927,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -373,14 +373,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -394,7 +394,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -409,6 +409,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -418,7 +422,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -427,7 +431,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -703,14 +707,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -724,7 +728,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -739,6 +743,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -748,7 +753,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -757,7 +762,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -345,7 +345,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -354,7 +354,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -368,7 +368,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -377,7 +377,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -394,6 +394,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -403,7 +407,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -413,7 +417,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -657,14 +661,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -678,7 +682,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -693,6 +697,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -702,7 +707,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -711,7 +716,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -345,7 +345,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -354,7 +354,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -368,7 +368,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -377,7 +377,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -394,6 +394,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -403,7 +407,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -413,7 +417,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -657,14 +661,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -678,7 +682,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -693,6 +697,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -702,7 +707,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -711,7 +716,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
@@ -98,13 +98,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: Pet },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -120,7 +120,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: Pet }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -135,6 +135,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = Pet;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: Pet };
 
 /**
  * @summary Create a pet
@@ -144,7 +145,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
       TError,
-      { data: Pet },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -152,7 +153,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/form-data-with-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-mutator/endpoints.ts
@@ -44,13 +44,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: Pet },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -64,7 +64,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: Pet }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -79,6 +79,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = Pet;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: Pet };
 
 /**
  * @summary Create a pet
@@ -88,7 +89,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: Pet },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -96,7 +97,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data/endpoints.ts
@@ -89,13 +89,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: Pet },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -109,7 +109,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: Pet }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -124,6 +124,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = Pet;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: Pet };
 
 /**
  * @summary Create a pet
@@ -133,7 +134,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: Pet },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -141,7 +142,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-url-encoded/endpoints.ts
@@ -53,13 +53,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -73,7 +73,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -88,6 +88,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -97,7 +98,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -105,7 +106,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -140,13 +141,13 @@ export const getUploadPetContentMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof uploadPetContent>>,
     TError,
-    { data: UploadPetContentBody },
+    UploadPetContentMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof uploadPetContent>>,
   TError,
-  { data: UploadPetContentBody },
+  UploadPetContentMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadPetContent'];
@@ -160,7 +161,7 @@ export const getUploadPetContentMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadPetContent>>,
-    { data: UploadPetContentBody }
+    UploadPetContentMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -175,6 +176,7 @@ export type UploadPetContentMutationResult = NonNullable<
 >;
 export type UploadPetContentMutationBody = UploadPetContentBody;
 export type UploadPetContentMutationError = Error;
+export type UploadPetContentMutationVariables = { data: UploadPetContentBody };
 
 /**
  * @summary Upload pet content as url-encoded form
@@ -184,7 +186,7 @@ export const useUploadPetContent = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof uploadPetContent>>,
       TError,
-      { data: UploadPetContentBody },
+      UploadPetContentMutationVariables,
       TContext
     >;
   },
@@ -192,7 +194,7 @@ export const useUploadPetContent = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof uploadPetContent>>,
   TError,
-  { data: UploadPetContentBody },
+  UploadPetContentMutationVariables,
   TContext
 > => {
   return useMutation(getUploadPetContentMutationOptions(options), queryClient);
@@ -227,13 +229,13 @@ export const getUploadPetContentRefMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof uploadPetContentRef>>,
     TError,
-    { data: UploadPetContentRefBody },
+    UploadPetContentRefMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof uploadPetContentRef>>,
   TError,
-  { data: UploadPetContentRefBody },
+  UploadPetContentRefMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadPetContentRef'];
@@ -247,7 +249,7 @@ export const getUploadPetContentRefMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadPetContentRef>>,
-    { data: UploadPetContentRefBody }
+    UploadPetContentRefMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -262,6 +264,9 @@ export type UploadPetContentRefMutationResult = NonNullable<
 >;
 export type UploadPetContentRefMutationBody = UploadPetContentRefBody;
 export type UploadPetContentRefMutationError = Error;
+export type UploadPetContentRefMutationVariables = {
+  data: UploadPetContentRefBody;
+};
 
 /**
  * @summary Upload pet content using a $ref to a binary component schema
@@ -271,7 +276,7 @@ export const useUploadPetContentRef = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof uploadPetContentRef>>,
       TError,
-      { data: UploadPetContentRefBody },
+      UploadPetContentRefMutationVariables,
       TContext
     >;
   },
@@ -279,7 +284,7 @@ export const useUploadPetContentRef = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof uploadPetContentRef>>,
   TError,
-  { data: UploadPetContentRefBody },
+  UploadPetContentRefMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/react-query/formUrlEncoded/endpoints.ts
+++ b/tests/__snapshots__/react-query/formUrlEncoded/endpoints.ts
@@ -51,13 +51,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -71,7 +71,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -86,6 +86,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -95,7 +96,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -103,7 +104,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -133,13 +134,13 @@ export const getUploadPetContentMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof uploadPetContent>>,
     TError,
-    { data: UploadPetContentBody },
+    UploadPetContentMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof uploadPetContent>>,
   TError,
-  { data: UploadPetContentBody },
+  UploadPetContentMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadPetContent'];
@@ -153,7 +154,7 @@ export const getUploadPetContentMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadPetContent>>,
-    { data: UploadPetContentBody }
+    UploadPetContentMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -168,6 +169,7 @@ export type UploadPetContentMutationResult = NonNullable<
 >;
 export type UploadPetContentMutationBody = UploadPetContentBody;
 export type UploadPetContentMutationError = Error;
+export type UploadPetContentMutationVariables = { data: UploadPetContentBody };
 
 /**
  * @summary Upload pet content as url-encoded form
@@ -177,7 +179,7 @@ export const useUploadPetContent = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof uploadPetContent>>,
       TError,
-      { data: UploadPetContentBody },
+      UploadPetContentMutationVariables,
       TContext
     >;
   },
@@ -185,7 +187,7 @@ export const useUploadPetContent = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof uploadPetContent>>,
   TError,
-  { data: UploadPetContentBody },
+  UploadPetContentMutationVariables,
   TContext
 > => {
   return useMutation(getUploadPetContentMutationOptions(options), queryClient);
@@ -215,13 +217,13 @@ export const getUploadPetContentRefMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof uploadPetContentRef>>,
     TError,
-    { data: UploadPetContentRefBody },
+    UploadPetContentRefMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof uploadPetContentRef>>,
   TError,
-  { data: UploadPetContentRefBody },
+  UploadPetContentRefMutationVariables,
   TContext
 > => {
   const mutationKey = ['uploadPetContentRef'];
@@ -235,7 +237,7 @@ export const getUploadPetContentRefMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof uploadPetContentRef>>,
-    { data: UploadPetContentRefBody }
+    UploadPetContentRefMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -250,6 +252,9 @@ export type UploadPetContentRefMutationResult = NonNullable<
 >;
 export type UploadPetContentRefMutationBody = UploadPetContentRefBody;
 export type UploadPetContentRefMutationError = Error;
+export type UploadPetContentRefMutationVariables = {
+  data: UploadPetContentRefBody;
+};
 
 /**
  * @summary Upload pet content using a $ref to a binary component schema
@@ -259,7 +264,7 @@ export const useUploadPetContentRef = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof uploadPetContentRef>>,
       TError,
-      { data: UploadPetContentRefBody },
+      UploadPetContentRefMutationVariables,
       TContext
     >;
   },
@@ -267,7 +272,7 @@ export const useUploadPetContentRef = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof uploadPetContentRef>>,
   TError,
-  { data: UploadPetContentRefBody },
+  UploadPetContentRefMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -191,14 +191,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -212,7 +212,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -227,6 +227,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -236,7 +240,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -245,7 +249,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -354,14 +358,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -375,7 +379,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -390,6 +394,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -399,7 +404,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -408,7 +413,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
@@ -240,13 +240,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -262,7 +262,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -277,6 +277,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -286,7 +290,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -294,7 +298,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
@@ -483,13 +487,13 @@ export const useDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -505,7 +509,7 @@ export const useDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -520,6 +524,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -529,7 +534,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
   },
@@ -537,7 +542,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
@@ -255,14 +255,14 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<ReturnType<typeof useCustomInstance>>;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -278,7 +278,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -293,6 +293,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -302,7 +306,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<ReturnType<typeof useCustomInstance>>;
@@ -311,7 +315,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
@@ -519,14 +523,14 @@ export const useDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   request?: SecondParameter<ReturnType<typeof useCustomInstance>>;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -542,7 +546,7 @@ export const useDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -557,6 +561,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -566,7 +571,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     request?: SecondParameter<ReturnType<typeof useCustomInstance>>;
@@ -575,7 +580,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
@@ -240,13 +240,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -262,7 +262,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -277,6 +277,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -286,7 +290,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -294,7 +298,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
@@ -483,13 +487,13 @@ export const useDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -505,7 +509,7 @@ export const useDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -520,6 +524,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -529,7 +534,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
   },
@@ -537,7 +542,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -339,14 +339,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -360,7 +360,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -375,6 +375,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -384,7 +388,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -393,7 +397,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -613,14 +617,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -634,7 +638,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -649,6 +653,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -658,7 +663,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -667,7 +672,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -257,14 +257,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -278,7 +278,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -293,6 +293,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -302,7 +306,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -311,7 +315,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -498,14 +502,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -519,7 +523,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -534,6 +538,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -543,7 +548,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -552,7 +557,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -362,14 +362,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -383,7 +383,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -401,6 +401,10 @@ export type CreatePetsMutationError = globalThis.Error & {
   info?: Error;
   status?: number;
 };
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -413,7 +417,7 @@ export const useCreatePets = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -422,7 +426,7 @@ export const useCreatePets = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -676,14 +680,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -697,7 +701,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -715,6 +719,7 @@ export type DeletePetByIdMutationError = globalThis.Error & {
   info?: Error;
   status?: number;
 };
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -727,7 +732,7 @@ export const useDeletePetById = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -736,7 +741,7 @@ export const useDeletePetById = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -349,7 +349,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +358,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -372,7 +372,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -381,7 +381,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -403,6 +403,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -412,7 +416,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -422,7 +426,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -349,7 +349,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +358,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -372,7 +372,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -381,7 +381,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -400,6 +400,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -409,7 +413,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -419,7 +423,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -663,14 +667,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -684,7 +688,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -699,6 +703,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -708,7 +713,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -717,7 +722,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -349,7 +349,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +358,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -372,7 +372,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -381,7 +381,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -400,6 +400,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -409,7 +413,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -419,7 +423,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -663,14 +667,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -684,7 +688,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -699,6 +703,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -708,7 +713,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -717,7 +722,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -349,7 +349,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +358,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -372,7 +372,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -381,7 +381,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -402,6 +402,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -411,7 +415,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -421,7 +425,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -665,14 +669,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -686,7 +690,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -701,6 +705,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -710,7 +715,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -719,7 +724,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -349,7 +349,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -358,7 +358,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -372,7 +372,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -381,7 +381,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -402,6 +402,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -411,7 +415,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -421,7 +425,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -665,14 +669,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -686,7 +690,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -701,6 +705,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -710,7 +715,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -719,7 +724,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -345,7 +345,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -354,7 +354,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -368,7 +368,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -377,7 +377,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -394,6 +394,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -403,7 +407,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -413,7 +417,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -345,7 +345,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -354,7 +354,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -368,7 +368,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -377,7 +377,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -399,6 +399,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -408,7 +412,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -418,7 +422,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -716,7 +716,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -725,7 +725,7 @@ export const getDeletePetByIdMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -739,7 +739,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -748,7 +748,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePetById>>,
-    variables: { petId: string },
+    variables: DeletePetByIdMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -765,6 +765,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -774,7 +775,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -784,7 +785,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -345,7 +345,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -354,7 +354,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -368,7 +368,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -377,7 +377,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -394,6 +394,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -403,7 +407,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -413,7 +417,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -657,14 +661,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -678,7 +682,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -693,6 +697,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -702,7 +707,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -711,7 +716,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -347,7 +347,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -356,7 +356,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -370,7 +370,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,7 +379,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: { data: CreatePetsBody; params: CreatePetsParams },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -396,6 +396,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -405,7 +409,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -415,7 +419,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -658,14 +662,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -679,7 +683,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -694,6 +698,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -703,7 +708,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -712,7 +717,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -369,11 +369,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -382,11 +378,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -400,11 +392,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -413,11 +401,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    variables: CreatePetsMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -442,6 +426,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -451,11 +440,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -465,11 +450,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -715,7 +696,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -724,7 +705,7 @@ export const getDeletePetByIdMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -738,7 +719,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -747,7 +728,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePetById>>,
-    variables: { petId: string },
+    variables: DeletePetByIdMutationVariables,
     context: TContext,
   ) => {
     if (!options?.skipInvalidation) {
@@ -767,6 +748,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -776,7 +758,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -786,7 +768,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -68,14 +68,14 @@ export const useCreateEntityMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createEntity>>,
     TError,
-    { version: number; entityId: string; data: CreateEntityBody },
+    CreateEntityMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createEntity>>,
   TError,
-  { version: number; entityId: string; data: CreateEntityBody },
+  CreateEntityMutationVariables,
   TContext
 > => {
   const mutationKey = ['createEntity'];
@@ -89,7 +89,7 @@ export const useCreateEntityMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createEntity>>,
-    { version: number; entityId: string; data: CreateEntityBody }
+    CreateEntityMutationVariables
   > = (props) => {
     const { version, entityId, data } = props ?? {};
 
@@ -110,13 +110,18 @@ export type CreateEntityMutationResult = NonNullable<
 >;
 export type CreateEntityMutationBody = CreateEntityBody;
 export type CreateEntityMutationError = unknown;
+export type CreateEntityMutationVariables = {
+  version: number;
+  entityId: string;
+  data: CreateEntityBody;
+};
 
 export const useCreateEntity = <TError = unknown, TContext = unknown>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createEntity>>,
       TError,
-      { version: number; entityId: string; data: CreateEntityBody },
+      CreateEntityMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -125,7 +130,7 @@ export const useCreateEntity = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createEntity>>,
   TError,
-  { version: number; entityId: string; data: CreateEntityBody },
+  CreateEntityMutationVariables,
   TContext
 > => {
   return useMutation(useCreateEntityMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -89,20 +89,14 @@ export const getPostApiAppOssIdentityUserImportUsersFromFileMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof postApiAppOssIdentityUserImportUsersFromFile>>,
     TError,
-    {
-      data?: PostApiAppOssIdentityUserImportUsersFromFileBody;
-      params?: PostApiAppOssIdentityUserImportUsersFromFileParams;
-    },
+    PostApiAppOssIdentityUserImportUsersFromFileMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof postApiAppOssIdentityUserImportUsersFromFile>>,
   TError,
-  {
-    data?: PostApiAppOssIdentityUserImportUsersFromFileBody;
-    params?: PostApiAppOssIdentityUserImportUsersFromFileParams;
-  },
+  PostApiAppOssIdentityUserImportUsersFromFileMutationVariables,
   TContext
 > => {
   const mutationKey = ['postApiAppOssIdentityUserImportUsersFromFile'];
@@ -116,10 +110,7 @@ export const getPostApiAppOssIdentityUserImportUsersFromFileMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof postApiAppOssIdentityUserImportUsersFromFile>>,
-    {
-      data?: PostApiAppOssIdentityUserImportUsersFromFileBody;
-      params?: PostApiAppOssIdentityUserImportUsersFromFileParams;
-    }
+    PostApiAppOssIdentityUserImportUsersFromFileMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -141,6 +132,10 @@ export type PostApiAppOssIdentityUserImportUsersFromFileMutationBody =
   | PostApiAppOssIdentityUserImportUsersFromFileBody
   | undefined;
 export type PostApiAppOssIdentityUserImportUsersFromFileMutationError = unknown;
+export type PostApiAppOssIdentityUserImportUsersFromFileMutationVariables = {
+  data?: PostApiAppOssIdentityUserImportUsersFromFileBody;
+  params?: PostApiAppOssIdentityUserImportUsersFromFileParams;
+};
 
 export const usePostApiAppOssIdentityUserImportUsersFromFile = <
   TError = unknown,
@@ -150,10 +145,7 @@ export const usePostApiAppOssIdentityUserImportUsersFromFile = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof postApiAppOssIdentityUserImportUsersFromFile>>,
       TError,
-      {
-        data?: PostApiAppOssIdentityUserImportUsersFromFileBody;
-        params?: PostApiAppOssIdentityUserImportUsersFromFileParams;
-      },
+      PostApiAppOssIdentityUserImportUsersFromFileMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -162,10 +154,7 @@ export const usePostApiAppOssIdentityUserImportUsersFromFile = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof postApiAppOssIdentityUserImportUsersFromFile>>,
   TError,
-  {
-    data?: PostApiAppOssIdentityUserImportUsersFromFileBody;
-    params?: PostApiAppOssIdentityUserImportUsersFromFileParams;
-  },
+  PostApiAppOssIdentityUserImportUsersFromFileMutationVariables,
   TContext
 > => {
   return useMutation(
@@ -238,14 +227,14 @@ export const getPostApiAppOssIdentityUserSignInMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof postApiAppOssIdentityUserSignIn>>,
     TError,
-    { data: PostApiAppOssIdentityUserSignInBody },
+    PostApiAppOssIdentityUserSignInMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof postApiAppOssIdentityUserSignIn>>,
   TError,
-  { data: PostApiAppOssIdentityUserSignInBody },
+  PostApiAppOssIdentityUserSignInMutationVariables,
   TContext
 > => {
   const mutationKey = ['postApiAppOssIdentityUserSignIn'];
@@ -259,7 +248,7 @@ export const getPostApiAppOssIdentityUserSignInMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof postApiAppOssIdentityUserSignIn>>,
-    { data: PostApiAppOssIdentityUserSignInBody }
+    PostApiAppOssIdentityUserSignInMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -275,6 +264,9 @@ export type PostApiAppOssIdentityUserSignInMutationResult = NonNullable<
 export type PostApiAppOssIdentityUserSignInMutationBody =
   PostApiAppOssIdentityUserSignInBody;
 export type PostApiAppOssIdentityUserSignInMutationError = unknown;
+export type PostApiAppOssIdentityUserSignInMutationVariables = {
+  data: PostApiAppOssIdentityUserSignInBody;
+};
 
 export const usePostApiAppOssIdentityUserSignIn = <
   TError = unknown,
@@ -284,7 +276,7 @@ export const usePostApiAppOssIdentityUserSignIn = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof postApiAppOssIdentityUserSignIn>>,
       TError,
-      { data: PostApiAppOssIdentityUserSignInBody },
+      PostApiAppOssIdentityUserSignInMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -293,7 +285,7 @@ export const usePostApiAppOssIdentityUserSignIn = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof postApiAppOssIdentityUserSignIn>>,
   TError,
-  { data: PostApiAppOssIdentityUserSignInBody },
+  PostApiAppOssIdentityUserSignInMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -239,14 +239,14 @@ export const getCreateWidgetMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createWidget>>,
     TError,
-    { data: Widget | null },
+    CreateWidgetMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createWidget>>,
   TError,
-  { data: Widget | null },
+  CreateWidgetMutationVariables,
   TContext
 > => {
   const mutationKey = ['createWidget'];
@@ -260,7 +260,7 @@ export const getCreateWidgetMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createWidget>>,
-    { data: Widget | null }
+    CreateWidgetMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -275,13 +275,14 @@ export type CreateWidgetMutationResult = NonNullable<
 >;
 export type CreateWidgetMutationBody = Widget | null;
 export type CreateWidgetMutationError = unknown;
+export type CreateWidgetMutationVariables = { data: Widget | null };
 
 export const useCreateWidget = <TError = unknown, TContext = unknown>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createWidget>>,
       TError,
-      { data: Widget | null },
+      CreateWidgetMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -290,7 +291,7 @@ export const useCreateWidget = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createWidget>>,
   TError,
-  { data: Widget | null },
+  CreateWidgetMutationVariables,
   TContext
 > => {
   return useMutation(getCreateWidgetMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/issue-607/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-607/endpoints.ts
@@ -52,14 +52,14 @@ export const getPetIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof petIdRequestFn2>>,
     TError,
-    { petId: number; petIdRequestFn: string },
+    PetIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof petIdRequestFn2>>,
   TError,
-  { petId: number; petIdRequestFn: string },
+  PetIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['petId'];
@@ -73,7 +73,7 @@ export const getPetIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof petIdRequestFn2>>,
-    { petId: number; petIdRequestFn: string }
+    PetIdMutationVariables
   > = (props) => {
     const { petId, petIdRequestFn } = props ?? {};
 
@@ -88,13 +88,14 @@ export type PetIdMutationResult = NonNullable<
 >;
 
 export type PetIdMutationError = unknown;
+export type PetIdMutationVariables = { petId: number; petIdRequestFn: string };
 
 export const usePetId = <TError = unknown, TContext = unknown>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof petIdRequestFn2>>,
       TError,
-      { petId: number; petIdRequestFn: string },
+      PetIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -103,7 +104,7 @@ export const usePetId = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof petIdRequestFn2>>,
   TError,
-  { petId: number; petIdRequestFn: string },
+  PetIdMutationVariables,
   TContext
 > => {
   return useMutation(getPetIdMutationOptions(options), queryClient);
@@ -146,14 +147,14 @@ export const getOptionsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof optionsRequestFn>>,
     TError,
-    { petId: number },
+    OptionsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof optionsRequestFn>>,
   TError,
-  { petId: number },
+  OptionsMutationVariables,
   TContext
 > => {
   const mutationKey = ['options'];
@@ -167,7 +168,7 @@ export const getOptionsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof optionsRequestFn>>,
-    { petId: number }
+    OptionsMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -182,13 +183,14 @@ export type OptionsMutationResult = NonNullable<
 >;
 
 export type OptionsMutationError = unknown;
+export type OptionsMutationVariables = { petId: number };
 
 export const useOptions = <TError = unknown, TContext = unknown>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof optionsRequestFn>>,
       TError,
-      { petId: number },
+      OptionsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -197,7 +199,7 @@ export const useOptions = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof optionsRequestFn>>,
   TError,
-  { petId: number },
+  OptionsMutationVariables,
   TContext
 > => {
   return useMutation(getOptionsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -350,14 +350,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -371,7 +371,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -386,6 +386,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -395,7 +399,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -404,7 +408,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -644,14 +648,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -665,7 +669,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -680,6 +684,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -689,7 +694,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -698,7 +703,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -350,14 +350,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -371,7 +371,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -386,6 +386,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -395,7 +399,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -404,7 +408,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -644,14 +648,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -665,7 +669,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -680,6 +684,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -689,7 +694,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -698,7 +703,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator/endpoints.ts
@@ -762,13 +762,13 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams; version?: number },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -782,7 +782,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams; version?: number }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, version } = props ?? {};
 
@@ -797,6 +797,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  version?: number;
+};
 
 /**
  * @summary Create a pet
@@ -806,7 +811,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams; version?: number },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -814,7 +819,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams; version?: number },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -1126,13 +1131,13 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string; version?: number },
+    DeletePetByIdMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string; version?: number },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -1146,7 +1151,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string; version?: number }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId, version } = props ?? {};
 
@@ -1161,6 +1166,10 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = {
+  petId: string;
+  version?: number;
+};
 
 /**
  * @summary Deletes a specific pet
@@ -1170,7 +1179,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string; version?: number },
+      DeletePetByIdMutationVariables,
       TContext
     >;
   },
@@ -1178,7 +1187,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string; version?: number },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -373,22 +373,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    {
-      pathParams: CreatePetsPathParameters;
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-    },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    pathParams: CreatePetsPathParameters;
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -402,11 +394,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      pathParams: CreatePetsPathParameters;
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { pathParams, data, params } = props ?? {};
 
@@ -421,6 +409,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  pathParams: CreatePetsPathParameters;
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -430,11 +423,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        pathParams: CreatePetsPathParameters;
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -443,11 +432,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    pathParams: CreatePetsPathParameters;
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -701,14 +686,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { pathParams: DeletePetByIdPathParameters },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { pathParams: DeletePetByIdPathParameters },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -722,7 +707,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { pathParams: DeletePetByIdPathParameters }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { pathParams } = props ?? {};
 
@@ -737,6 +722,9 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = {
+  pathParams: DeletePetByIdPathParameters;
+};
 
 /**
  * @summary Deletes a specific pet
@@ -746,7 +734,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { pathParams: DeletePetByIdPathParameters },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -755,7 +743,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { pathParams: DeletePetByIdPathParameters },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -457,14 +461,14 @@ export const getShowPetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof showPetById>>,
     TError,
-    { petId: string },
+    ShowPetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof showPetById>>,
   TError,
-  { petId: string },
+  ShowPetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['showPetById'];
@@ -478,7 +482,7 @@ export const getShowPetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof showPetById>>,
-    { petId: string }
+    ShowPetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -493,6 +497,7 @@ export type ShowPetByIdMutationResult = NonNullable<
 >;
 
 export type ShowPetByIdMutationError = Error;
+export type ShowPetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Info for a specific pet
@@ -502,7 +507,7 @@ export const useShowPetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof showPetById>>,
       TError,
-      { petId: string },
+      ShowPetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -511,7 +516,7 @@ export const useShowPetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof showPetById>>,
   TError,
-  { petId: string },
+  ShowPetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getShowPetByIdMutationOptions(options), queryClient);
@@ -573,14 +578,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -594,7 +599,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -609,6 +614,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -618,7 +624,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -627,7 +633,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -309,14 +309,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -330,7 +330,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -345,6 +345,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -354,7 +358,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -363,7 +367,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -602,14 +606,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -623,7 +627,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -638,6 +642,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -647,7 +652,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -656,7 +661,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -636,14 +640,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -657,7 +661,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -672,6 +676,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -681,7 +686,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -690,7 +695,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -504,14 +504,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -525,7 +525,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -540,6 +540,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -549,7 +553,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -558,7 +562,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -953,14 +957,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -974,7 +978,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -989,6 +993,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -998,7 +1003,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -1007,7 +1012,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -337,14 +337,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -358,7 +358,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -373,6 +373,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: CreatePetsBody };
 
 /**
  * @summary Create a pet
@@ -382,7 +383,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -391,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -637,14 +641,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -658,7 +662,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -673,6 +677,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -682,7 +687,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -691,7 +696,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -343,14 +343,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -364,7 +364,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -379,6 +379,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -388,7 +392,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -397,7 +401,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -637,14 +641,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -658,7 +662,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -673,6 +677,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -682,7 +687,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -691,7 +696,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
@@ -243,13 +243,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -265,7 +265,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -280,6 +280,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -289,7 +293,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -297,7 +301,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
@@ -486,13 +490,13 @@ export const useDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -508,7 +512,7 @@ export const useDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -523,6 +527,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -532,7 +537,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
   },
@@ -540,7 +545,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -350,14 +350,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -371,7 +371,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -386,6 +386,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -395,7 +399,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -404,7 +408,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -643,14 +647,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -664,7 +668,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -679,6 +683,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -688,7 +693,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -697,7 +702,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -354,14 +354,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -375,7 +375,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -390,6 +390,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -399,7 +403,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -408,7 +412,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -659,14 +663,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -680,7 +684,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -695,6 +699,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -704,7 +709,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -713,7 +718,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -370,14 +370,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -391,7 +391,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -406,6 +406,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -415,7 +419,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -424,7 +428,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -685,14 +689,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -706,7 +710,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -721,6 +725,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -730,7 +735,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -739,7 +744,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -360,14 +360,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -381,7 +381,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -396,6 +396,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -405,7 +409,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -414,7 +418,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -670,14 +674,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -691,7 +695,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -706,6 +710,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -715,7 +720,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -724,7 +729,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -366,14 +366,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -387,7 +387,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -402,6 +402,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -411,7 +415,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -420,7 +424,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -683,14 +687,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -704,7 +708,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -719,6 +723,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -728,7 +733,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -737,7 +742,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
@@ -266,13 +266,13 @@ export const useCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -288,7 +288,7 @@ export const useCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -303,6 +303,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -312,7 +316,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
   },
@@ -320,7 +324,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useCreatePetsHook>>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(useCreatePetsMutationOptions(options), queryClient);
@@ -535,13 +539,13 @@ export const useDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -557,7 +561,7 @@ export const useDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -572,6 +576,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -581,7 +586,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
   },
@@ -589,7 +594,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<ReturnType<typeof useDeletePetByIdHook>>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(useDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -599,14 +599,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -620,7 +620,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -635,6 +635,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -644,7 +648,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -653,7 +657,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -914,14 +918,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -935,7 +939,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -950,6 +954,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -959,7 +964,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -968,7 +973,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -395,22 +395,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    {
-      pathParams: CreatePetsPathParameters;
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-    },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    pathParams: CreatePetsPathParameters;
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -424,11 +416,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      pathParams: CreatePetsPathParameters;
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { pathParams, data, params } = props ?? {};
 
@@ -443,6 +431,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  pathParams: CreatePetsPathParameters;
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -452,11 +445,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        pathParams: CreatePetsPathParameters;
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -465,11 +454,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    pathParams: CreatePetsPathParameters;
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -744,14 +729,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { pathParams: DeletePetByIdPathParameters },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { pathParams: DeletePetByIdPathParameters },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -765,7 +750,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { pathParams: DeletePetByIdPathParameters }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { pathParams } = props ?? {};
 
@@ -780,6 +765,9 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = {
+  pathParams: DeletePetByIdPathParameters;
+};
 
 /**
  * @summary Deletes a specific pet
@@ -789,7 +777,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { pathParams: DeletePetByIdPathParameters },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -798,7 +786,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { pathParams: DeletePetByIdPathParameters },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -364,14 +364,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -385,7 +385,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -400,6 +400,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -409,7 +413,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -418,7 +422,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -679,14 +683,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -700,7 +704,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -715,6 +719,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -724,7 +729,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -733,7 +738,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -350,14 +350,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -371,7 +371,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -386,6 +386,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -395,7 +399,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -404,7 +408,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -644,14 +648,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -665,7 +669,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -680,6 +684,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -689,7 +694,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -698,7 +703,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -338,14 +338,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -359,7 +359,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -374,6 +374,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -383,7 +387,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -392,7 +396,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -647,14 +651,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -668,7 +672,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -683,6 +687,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -692,7 +697,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -701,7 +706,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -256,14 +256,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -277,7 +277,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -292,6 +292,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -301,7 +305,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -310,7 +314,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -532,14 +536,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -553,7 +557,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -568,6 +572,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -577,7 +582,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -586,7 +591,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
@@ -342,14 +342,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -363,7 +363,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -378,6 +378,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -387,7 +391,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -396,7 +400,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -670,14 +674,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -691,7 +695,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -706,6 +710,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -715,7 +720,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -724,7 +729,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
@@ -551,14 +551,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -572,7 +572,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -587,6 +587,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -596,7 +600,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -605,7 +609,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -1088,14 +1092,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -1109,7 +1113,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -1124,6 +1128,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -1133,7 +1138,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -1142,7 +1147,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
@@ -342,14 +342,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -363,7 +363,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -378,6 +378,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -387,7 +391,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -396,7 +400,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -670,14 +674,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -691,7 +695,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -706,6 +710,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -715,7 +720,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -724,7 +729,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/split/endpoints.ts
+++ b/tests/__snapshots__/solid-query/split/endpoints.ts
@@ -342,14 +342,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -363,7 +363,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -378,6 +378,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -387,7 +391,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -396,7 +400,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -671,14 +675,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -692,7 +696,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -707,6 +711,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -716,7 +721,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -725,7 +730,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/suspense/endpoints.ts
+++ b/tests/__snapshots__/solid-query/suspense/endpoints.ts
@@ -685,14 +685,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -706,7 +706,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -721,6 +721,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -730,7 +734,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -739,7 +743,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -1151,14 +1155,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -1172,7 +1176,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -1187,6 +1191,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -1196,7 +1201,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -1205,7 +1210,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/tags/pets.ts
+++ b/tests/__snapshots__/solid-query/tags/pets.ts
@@ -349,14 +349,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -370,7 +370,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -385,6 +385,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -394,7 +398,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -403,7 +407,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -677,14 +681,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -698,7 +702,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -713,6 +717,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -722,7 +727,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -731,7 +736,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
@@ -349,14 +349,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -370,7 +370,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -385,6 +385,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -394,7 +398,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -403,7 +407,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(() => getCreatePetsMutationOptions(options), queryClient);
@@ -678,14 +682,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: SolidMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): SolidMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -699,7 +703,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -714,6 +718,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -723,7 +728,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: SolidMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -732,7 +737,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -258,14 +258,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -279,7 +279,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -294,6 +294,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -302,14 +306,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -471,14 +475,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -492,7 +496,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -507,6 +511,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -518,14 +523,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -176,14 +176,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -197,7 +197,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -212,6 +212,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -220,14 +224,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -356,14 +360,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -377,7 +381,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -392,6 +396,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -403,14 +408,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -262,14 +262,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -283,7 +283,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -298,6 +298,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -306,14 +310,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -494,14 +498,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -515,7 +519,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -530,6 +534,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -541,14 +546,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -292,11 +292,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -305,11 +301,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -323,11 +315,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -336,11 +324,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    variables: CreatePetsMutationVariables,
     context: TContext | undefined,
   ) => {
     if (!options?.skipInvalidation) {
@@ -358,6 +342,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -367,11 +356,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -381,11 +366,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -571,7 +552,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -580,7 +561,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -594,7 +575,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -603,7 +584,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePetById>>,
-    variables: { petId: string },
+    variables: DeletePetByIdMutationVariables,
     context: TContext | undefined,
   ) => {
     if (!options?.skipInvalidation) {
@@ -624,6 +605,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -633,7 +615,7 @@ export const createDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -643,7 +625,7 @@ export const createDeletePetById = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -290,11 +290,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -303,11 +299,7 @@ export const getCreatePetsMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -321,11 +313,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -334,11 +322,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    variables: CreatePetsMutationVariables,
     context: TContext | undefined,
   ) => {
     if (!options?.skipInvalidation) {
@@ -355,6 +339,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -364,11 +353,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -378,11 +363,7 @@ export const createCreatePets = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -569,7 +550,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -578,7 +559,7 @@ export const getDeletePetByIdMutationOptions = <
 ): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -592,7 +573,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -601,7 +582,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePetById>>,
-    variables: { petId: string },
+    variables: DeletePetByIdMutationVariables,
     context: TContext | undefined,
   ) => {
     if (!options?.skipInvalidation) {
@@ -621,6 +602,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -630,7 +612,7 @@ export const createDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: CreateMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -640,7 +622,7 @@ export const createDeletePetById = <TError = Error, TContext = unknown>(
 ): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -262,14 +262,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -283,7 +283,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -298,6 +298,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -306,14 +310,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -494,14 +498,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -515,7 +519,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -530,6 +534,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -541,14 +546,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -262,14 +262,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -283,7 +283,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -298,6 +298,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -306,14 +310,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -495,14 +499,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -516,7 +520,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -531,6 +535,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -542,14 +547,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -269,14 +269,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -290,7 +290,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -305,6 +305,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -313,14 +317,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -501,14 +505,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -522,7 +526,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -537,6 +541,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -548,14 +553,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -269,14 +269,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -290,7 +290,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -305,6 +305,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -313,14 +317,14 @@ export const createCreatePets = <TError = Error, TContext = unknown>(options?: {
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return createMutation(getCreatePetsMutationOptions(options));
@@ -502,14 +506,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -523,7 +527,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -538,6 +542,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -549,14 +554,14 @@ export const createDeletePetById = <
   mutation?: CreateMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): CreateMutationResult<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return createMutation(getDeletePetByIdMutationOptions(options));

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -279,14 +279,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params?: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params?: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -300,7 +300,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params?: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -315,6 +315,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params?: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -324,7 +328,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params?: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -333,7 +337,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params?: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -518,14 +522,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string | undefined | null },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string | undefined | null },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -539,7 +543,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string | undefined | null }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -554,6 +558,9 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = {
+  petId: string | undefined | null;
+};
 
 /**
  * @summary Deletes a specific pet
@@ -563,7 +570,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string | undefined | null },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -572,7 +579,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string | undefined | null },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -279,14 +279,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params?: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params?: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -300,7 +300,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params?: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -315,6 +315,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params?: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -324,7 +328,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params?: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -333,7 +337,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params?: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -518,14 +522,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string | undefined | null },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string | undefined | null },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -539,7 +543,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string | undefined | null }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -554,6 +558,9 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = {
+  petId: string | undefined | null;
+};
 
 /**
  * @summary Deletes a specific pet
@@ -563,7 +570,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string | undefined | null },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -572,7 +579,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string | undefined | null },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/form-data/endpoints.ts
@@ -158,14 +158,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: Pet },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -179,7 +179,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: Pet }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data } = props ?? {};
 
@@ -194,6 +194,7 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = Pet;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = { data: Pet };
 
 /**
  * @summary Create a pet
@@ -203,7 +204,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: Pet },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -212,7 +213,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: Pet },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -268,14 +268,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -289,7 +289,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -304,6 +304,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -313,7 +317,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -322,7 +326,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -485,14 +489,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   request?: SecondParameter<typeof customFetch>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -506,7 +510,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -521,6 +525,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -530,7 +535,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     request?: SecondParameter<typeof customFetch>;
@@ -539,7 +544,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -186,14 +186,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -207,7 +207,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -222,6 +222,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -231,7 +235,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -240,7 +244,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -370,14 +374,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -391,7 +395,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -406,6 +410,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -415,7 +420,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -424,7 +429,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -272,14 +272,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -293,7 +293,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -308,6 +308,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -317,7 +321,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -326,7 +330,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -508,14 +512,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -529,7 +533,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -544,6 +548,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -553,7 +558,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -562,7 +567,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -299,11 +299,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -312,11 +308,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -330,11 +322,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -343,11 +331,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    variables: CreatePetsMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -372,6 +356,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -381,11 +370,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -395,11 +380,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -587,7 +568,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -596,7 +577,7 @@ export const getDeletePetByIdMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -610,7 +591,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -619,7 +600,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePetById>>,
-    variables: { petId: string },
+    variables: DeletePetByIdMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -647,6 +628,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -656,7 +638,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -666,7 +648,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -297,11 +297,7 @@ export const getCreatePetsMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -310,11 +306,7 @@ export const getCreatePetsMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -328,11 +320,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params, headers } = props ?? {};
 
@@ -341,11 +329,7 @@ export const getCreatePetsMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof createPets>>,
-    variables: {
-      data: CreatePetsBody;
-      params: CreatePetsParams;
-      headers: CreatePetsHeaders;
-    },
+    variables: CreatePetsMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -369,6 +353,11 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};
 
 /**
  * @summary Create a pet
@@ -378,11 +367,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -392,11 +377,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  {
-    data: CreatePetsBody;
-    params: CreatePetsParams;
-    headers: CreatePetsHeaders;
-  },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();
@@ -585,7 +566,7 @@ export const getDeletePetByIdMutationOptions = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -594,7 +575,7 @@ export const getDeletePetByIdMutationOptions = <
 ): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -608,7 +589,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -617,7 +598,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const onSuccess = (
     data: Awaited<ReturnType<typeof deletePetById>>,
-    variables: { petId: string },
+    variables: DeletePetByIdMutationVariables,
     onMutateResult: TContext,
     context: MutationFunctionContext,
   ) => {
@@ -644,6 +625,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -653,7 +635,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     skipInvalidation?: boolean;
@@ -663,7 +645,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const backupQueryClient = useQueryClient();

--- a/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
@@ -145,14 +145,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -166,7 +166,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -181,6 +181,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = AxiosError<Error>;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -190,7 +194,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -199,7 +203,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -309,14 +313,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -330,7 +334,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -345,6 +349,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = AxiosError<Error>;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -357,7 +362,7 @@ export const useDeletePetById = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -366,7 +371,7 @@ export const useDeletePetById = <
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/split/endpoints.ts
+++ b/tests/__snapshots__/vue-query/split/endpoints.ts
@@ -145,14 +145,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -166,7 +166,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -181,6 +181,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = AxiosError<Error>;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -190,7 +194,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -199,7 +203,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -310,14 +314,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -331,7 +335,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -346,6 +350,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = AxiosError<Error>;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -358,7 +363,7 @@ export const useDeletePetById = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -367,7 +372,7 @@ export const useDeletePetById = <
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/tags/pets.ts
+++ b/tests/__snapshots__/vue-query/tags/pets.ts
@@ -152,14 +152,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -173,7 +173,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -188,6 +188,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = AxiosError<Error>;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -197,7 +201,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -206,7 +210,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -316,14 +320,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -337,7 +341,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -352,6 +356,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = AxiosError<Error>;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -364,7 +369,7 @@ export const useDeletePetById = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -373,7 +378,7 @@ export const useDeletePetById = <
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -279,14 +279,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -300,7 +300,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -315,6 +315,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -324,7 +328,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -333,7 +337,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -516,14 +520,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -537,7 +541,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -552,6 +556,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -561,7 +566,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -570,7 +575,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -291,14 +291,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -312,7 +312,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -327,6 +327,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -336,7 +340,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -345,7 +349,7 @@ export const useCreatePets = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -547,14 +551,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   fetch?: RequestInit;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -568,7 +572,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -583,6 +587,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = Error;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -592,7 +597,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     fetch?: RequestInit;
@@ -601,7 +606,7 @@ export const useDeletePetById = <TError = Error, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
@@ -152,14 +152,14 @@ export const getCreatePetsMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof createPets>>,
     TError,
-    { data: CreatePetsBody; params: CreatePetsParams },
+    CreatePetsMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   const mutationKey = ['createPets'];
@@ -173,7 +173,7 @@ export const getCreatePetsMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof createPets>>,
-    { data: CreatePetsBody; params: CreatePetsParams }
+    CreatePetsMutationVariables
   > = (props) => {
     const { data, params } = props ?? {};
 
@@ -188,6 +188,10 @@ export type CreatePetsMutationResult = NonNullable<
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = AxiosError<Error>;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+};
 
 /**
  * @summary Create a pet
@@ -197,7 +201,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      { data: CreatePetsBody; params: CreatePetsParams },
+      CreatePetsMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -206,7 +210,7 @@ export const useCreatePets = <TError = AxiosError<Error>, TContext = unknown>(
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof createPets>>,
   TError,
-  { data: CreatePetsBody; params: CreatePetsParams },
+  CreatePetsMutationVariables,
   TContext
 > => {
   return useMutation(getCreatePetsMutationOptions(options), queryClient);
@@ -317,14 +321,14 @@ export const getDeletePetByIdMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof deletePetById>>,
     TError,
-    { petId: string },
+    DeletePetByIdMutationVariables,
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   const mutationKey = ['deletePetById'];
@@ -338,7 +342,7 @@ export const getDeletePetByIdMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof deletePetById>>,
-    { petId: string }
+    DeletePetByIdMutationVariables
   > = (props) => {
     const { petId } = props ?? {};
 
@@ -353,6 +357,7 @@ export type DeletePetByIdMutationResult = NonNullable<
 >;
 
 export type DeletePetByIdMutationError = AxiosError<Error>;
+export type DeletePetByIdMutationVariables = { petId: string };
 
 /**
  * @summary Deletes a specific pet
@@ -365,7 +370,7 @@ export const useDeletePetById = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof deletePetById>>,
       TError,
-      { petId: string },
+      DeletePetByIdMutationVariables,
       TContext
     >;
     axios?: AxiosRequestConfig;
@@ -374,7 +379,7 @@ export const useDeletePetById = <
 ): UseMutationReturnType<
   Awaited<ReturnType<typeof deletePetById>>,
   TError,
-  { petId: string },
+  DeletePetByIdMutationVariables,
   TContext
 > => {
   return useMutation(getDeletePetByIdMutationOptions(options), queryClient);

--- a/tests/regressions/mutation-variables.ts
+++ b/tests/regressions/mutation-variables.ts
@@ -1,0 +1,22 @@
+import type {
+  CreatePetsMutationBody,
+  CreatePetsMutationVariables,
+  DeletePetByIdMutationVariables,
+} from '../generated/react-query/basic/endpoints';
+
+// #3782: the variables a mutation takes have a name of their own, so a wrapper
+// can annotate them instead of inferring them back out of the hook.
+const deletePetByIdVariables: DeletePetByIdMutationVariables = {
+  petId: 'a-pet',
+};
+
+export const deletedPetId: string = deletePetByIdVariables.petId;
+
+// MutationBody is not a substitute: it covers the body and not the params
+// beside it, which is why the wrapper needs the variables type.
+export const createPetsBody = (
+  variables: CreatePetsMutationVariables,
+): CreatePetsMutationBody => variables.data;
+
+export const createPetsSort = (variables: CreatePetsMutationVariables) =>
+  variables.params.sort;


### PR DESCRIPTION
Closes #3782.

A mutation already exports a name for its result, its body and its error. The variables it actually takes had none, so the object literal was spelled out at every site that mentions it, and a caller wrapping `mutate` had to dig it back out of the hook.

`<Operation>MutationVariables` now sits with the other three, and the repeated literal is gone:

```diff
 export type CreatePetsMutationResult = NonNullable<
   Awaited<ReturnType<typeof createPets>>
 >;
 export type CreatePetsMutationBody = CreatePetsBody;
 export type CreatePetsMutationError = Error;
+export type CreatePetsMutationVariables = {
+  data: CreatePetsBody;
+  params: CreatePetsParams;
+  headers: CreatePetsHeaders;
+};

 export const useCreatePets = <TError = Error, TContext = unknown>(
   options?: {
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof createPets>>,
       TError,
-      {
-        data: CreatePetsBody;
-        params: CreatePetsParams;
-        headers: CreatePetsHeaders;
-      },
+      CreatePetsMutationVariables,
       TContext
     >;
```

The literal appeared in five places per mutation: the options helper's parameter and its return type, `MutationFunction`, the hook's `options.mutation`, and the hook return type. All five now name it, and the generated files come out smaller for it.

A mutation with no variables still takes `void` and gets no alias, the same way `MutationBody` is only emitted when there is a body.

Under the hood, `getQueryOptionsDefinition`, `generateQueryArguments` and `generateMutationOnSuccess` take an optional `mutationVariablesType`. When it is absent they build the literal from `definitions` exactly as before, so the query side and any adapter that does not pass it are untouched.

## Tests

- three unit tests in `packages/query/src/query-options.test.ts`: the alias wins, the literal is the fallback, and `void` still comes through
- `tests/regressions/mutation-variables.ts`, a compile-time fixture that annotates a wrapper with the exported type and pulls `MutationBody` out of it, which is the case from the issue
- `vp test` in `packages/query`: 164 passing, 268 across the package suites
- `vp run -w test:snapshots`: 6200 passing. 98 fixtures under `tests/` moved and 12 sample clients were regenerated, all of them the same substitution
- `vp run -w lint` and `vp run -w typecheck`: clean
- `tsc --noEmit` on the seven regenerated react-query samples: clean
- typecheck of the generated react-query, vue-query, svelte-query and angular-query output together with the regressions folder: clean. I could not typecheck solid-query locally, since `@tanstack/solid-query` does not install on this machine, so that one rides on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated mutation code now exposes reusable, named types for mutation variables.
  * Mutation options, callbacks, request bodies, and return types consistently use these shared variable types.
  * Parameterless mutations continue to use `void`, while custom variable type aliases are supported.

* **Bug Fixes**
  * Improved type consistency for generated mutation callbacks and options.

* **Tests**
  * Added coverage for custom, inline, and parameterless mutation variable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->