### PR TITLE
fix(core): treat a falsy parameter default as a default

### DIFF
--- a/packages/core/src/getters/params.test.ts
+++ b/packages/core/src/getters/params.test.ts
@@ -11,6 +11,20 @@ const pathParam = (name: string): GetterParameters['path'][number] => ({
   imports: [],
 });
 
+const pathParamWithDefault = (
+  name: string,
+  type: string,
+  defaultValue: unknown,
+): GetterParameters['path'][number] => ({
+  parameter: {
+    name,
+    in: 'path',
+    required: true,
+    schema: { type, default: defaultValue } as never,
+  },
+  imports: [],
+});
+
 describe('getParams getter', () => {
   it('matches a dotted spec name to its generated identifier in the route', () => {
     const params = getParams({
@@ -53,4 +67,29 @@ describe('getParams getter', () => {
       "Path parameters 'scope.id', 'scope_id' all map to the same generated identifier 'scopeId' (getItems). Rename them so they don't collide.",
     );
   });
+
+  it.each([
+    ['number', 1, '1'],
+    ['number', 0, '0'],
+    ['boolean', true, 'true'],
+    ['boolean', false, 'false'],
+    ['string', 'v1', "'v1'"],
+    ['string', '', "''"],
+  ])(
+    'carries a %s default of %o into the signature',
+    (type, defaultValue, rendered) => {
+      const params = getParams({
+        route: '/api/${version}/items',
+        pathParams: [pathParamWithDefault('version', type, defaultValue)],
+        operationId: 'getItems',
+        context,
+        output: context.output,
+      });
+
+      expect(params).toHaveLength(1);
+      expect(params[0].default).toBe(defaultValue);
+      expect(params[0].definition).toBe(`version?: ${type}`);
+      expect(params[0].implementation).toBe(`version: ${type} = ${rendered}`);
+    },
+  );
 });

--- a/packages/core/src/getters/params.ts
+++ b/packages/core/src/getters/params.ts
@@ -96,7 +96,7 @@ export function getParams({
         name,
         definition: `${name}${required ? '' : '?'}: unknown`,
         implementation: `${name}${required ? '' : '?'}: unknown`,
-        default: false,
+        default: undefined,
         required,
         imports: [],
       };

--- a/packages/core/src/getters/params.ts
+++ b/packages/core/src/getters/params.ts
@@ -121,12 +121,16 @@ export function getParams({
       paramType = `${paramType} | undefined | null`; // TODO: maybe check that `paramType` isn't already undefined or null
     }
 
+    // `0`, `false` and `''` are defaults like any other, so the presence of one
+    // is a check against `undefined` rather than a truthiness test.
+    const hasSchemaDefault = schemaDefault !== undefined;
+
     const definition = `${name}${
-      !required || schemaDefault ? '?' : ''
+      !required || hasSchemaDefault ? '?' : ''
     }: ${paramType}`;
 
-    const implementation = `${name}${!required && !schemaDefault ? '?' : ''}${
-      schemaDefault
+    const implementation = `${name}${!required && !hasSchemaDefault ? '?' : ''}${
+      hasSchemaDefault
         ? `: ${paramType} = ${stringify(schemaDefault)}`
         : `: ${paramType}`
     }`; // FIXME: in Vue if we have `version: MaybeRef<number | undefined | null> = 1` and we don't pass version, the unref(version) will be `undefined` and not `1`, so we need to handle default value somewhere in implementation and not in the definition

--- a/packages/core/src/getters/props.ts
+++ b/packages/core/src/getters/props.ts
@@ -29,7 +29,7 @@ export function getProps({
     name: body.implementation,
     definition: `${body.implementation}${body.isOptional && !context.output.optionsParamRequired ? '?' : ''}: ${body.definition}`,
     implementation: `${body.implementation}${body.isOptional && !context.output.optionsParamRequired ? '?' : ''}: ${body.definition}`,
-    default: false,
+    default: undefined,
     required: !body.isOptional || context.output.optionsParamRequired,
     type: GetterPropType.BODY,
   };
@@ -38,7 +38,7 @@ export function getProps({
     name: 'params',
     definition: getQueryParamDefinition(queryParams, context),
     implementation: getQueryParamDefinition(queryParams, context),
-    default: false,
+    default: undefined,
     required: isNullish(queryParams?.isOptional)
       ? !context.output.allParamsOptional || context.output.optionsParamRequired
       : (!queryParams.isOptional && !context.output.allParamsOptional) ||
@@ -54,7 +54,7 @@ export function getProps({
     implementation: `headers${headers?.isOptional && !context.output.optionsParamRequired ? '?' : ''}: ${
       headers?.schema.name
     }`,
-    default: false,
+    default: undefined,
     required: isNullish(headers?.isOptional)
       ? false
       : !headers.isOptional || context.output.optionsParamRequired,
@@ -95,7 +95,7 @@ export function getProps({
         name,
         definition: `${name}: ${parameterTypeName}`,
         implementation,
-        default: false,
+        default: undefined,
         destructured,
         required: true,
         schema: {

--- a/packages/core/src/getters/query-params.ts
+++ b/packages/core/src/getters/query-params.ts
@@ -308,7 +308,7 @@ function getQueryParamsTypes(
       return {
         name,
         required,
-        definition: `${doc}${key}${!required || schema.default ? '?' : ''}: ${
+        definition: `${doc}${key}${!required || schema.default !== undefined ? '?' : ''}: ${
           parameterImports[0].name
         };`,
         imports: parameterImports,
@@ -346,7 +346,7 @@ function getQueryParamsTypes(
         name,
         required,
         definition: `${doc}${key}${
-          !required || schema.default ? '?' : ''
+          !required || schema.default !== undefined ? '?' : ''
         }: ${enumName};`,
         imports: [{ name: enumName }],
         schemas: [
@@ -359,7 +359,7 @@ function getQueryParamsTypes(
     }
 
     const definition = `${doc}${key}${
-      !required || schema.default ? '?' : ''
+      !required || schema.default !== undefined ? '?' : ''
     }: ${resolvedValue.value};`;
 
     return {

--- a/packages/core/src/utils/sort.ts
+++ b/packages/core/src/utils/sort.ts
@@ -2,11 +2,13 @@ export const sortByPriority = <T>(
   arr: (T & { default?: unknown; required?: boolean })[],
 ) =>
   arr.toSorted((a, b) => {
-    if (a.default) {
+    // A parameter carrying a default goes last, and `0`, `false` or an empty
+    // string is a default like any other.
+    if (a.default !== undefined) {
       return 1;
     }
 
-    if (b.default) {
+    if (b.default !== undefined) {
       return -1;
     }
 

--- a/packages/core/src/utils/sort.ts
+++ b/packages/core/src/utils/sort.ts
@@ -4,12 +4,10 @@ export const sortByPriority = <T>(
   arr.toSorted((a, b) => {
     // A parameter carrying a default goes last, and `0`, `false` or an empty
     // string is a default like any other.
-    if (a.default !== undefined) {
-      return 1;
-    }
-
-    if (b.default !== undefined) {
-      return -1;
+    const aHasDefault = a.default !== undefined;
+    const bHasDefault = b.default !== undefined;
+    if (aHasDefault !== bHasDefault) {
+      return aHasDefault ? 1 : -1;
     }
 
     if (a.required && b.required) {

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -1008,7 +1008,7 @@ describe('optionsParamRequired', () => {
     expect(body?.implementation).toBe(
       'handleResourceBody?: HandleResourceBody',
     );
-    expect(body?.default).toBe(false);
+    expect(body?.default).toBeUndefined();
     expect(body?.required).toBe(false);
     expect(body?.type).toBe('body');
 
@@ -1022,7 +1022,7 @@ describe('optionsParamRequired', () => {
     expect(params?.name).toBe('params');
     expect(params?.definition).toBe('params?: HandleResourceParams');
     expect(params?.implementation).toBe('params?: HandleResourceParams');
-    expect(params?.default).toBe(false);
+    expect(params?.default).toBeUndefined();
     expect(params?.required).toBe(false);
     expect(params?.type).toBe('queryParam');
 
@@ -1078,7 +1078,7 @@ export const handleResource = (
     expect(body?.name).toBe('handleResourceBody');
     expect(body?.definition).toBe('handleResourceBody: HandleResourceBody');
     expect(body?.implementation).toBe('handleResourceBody: HandleResourceBody');
-    expect(body?.default).toBe(false);
+    expect(body?.default).toBeUndefined();
     expect(body?.required).toBe(true);
     expect(body?.type).toBe('body');
 
@@ -1092,7 +1092,7 @@ export const handleResource = (
     expect(params?.name).toBe('params');
     expect(params?.definition).toBe('params: HandleResourceParams');
     expect(params?.implementation).toBe('params: HandleResourceParams');
-    expect(params?.default).toBe(false);
+    expect(params?.default).toBeUndefined();
     expect(params?.required).toBe(true);
     expect(params?.type).toBe('queryParam');
 


### PR DESCRIPTION
A parameter whose schema default is `0`, `false` or `""` is generated as if it had no default at all.

Take the repository's own `tests/transformers/add-version.js`, which injects a required path parameter `version` with `schema: { type: number, default: 1 }`, and change nothing but the default:

```
default: 1   ->  showPetById(petId: string, version: number = 1)
default: 0   ->  showPetById(version: number, petId: string)
```

Three things go wrong at once. The `= 0` is gone, the parameter turns mandatory, and it moves to the front of the signature.

The last one is what breaks the build rather than just the behaviour. `sortByPriority` keeps a defaulted parameter last precisely so it does not precede a required one, and the emitted type is a parameter list:

```
default=1 definitions: petId: string, version?: number
default=0 definitions: version?: number, petId: string     // TS1016
```

With `useNamedParameters` the two halves disagree instead. `props.ts` already asks `param.default !== undefined`, so it appends the `= {}` initializer, while `params.ts` asks for truthiness and marks the property required:

```ts
export type ListPetsPathParameters = { version: number };
listPets({ version = 0 }: ListPetsPathParameters = {}, ...)
// TS2322: Property 'version' is missing in type '{}'
```

Five places read the default for its truthiness: two in `getters/params.ts`, three in `getters/query-params.ts`, and `utils/sort.ts`. `stringify()` already renders `0`, `false` and `''` correctly, so the truthiness test is the only thing in the way. They now ask whether the default is `undefined`, which is what `getters/props.ts` has always asked.

`sort.ts` reads `default` off the prop objects, and `getters/props.ts` was using the literal `false` as its "no default" sentinel for the body, query and header props. Under the strict check that sentinel would read as a real default and move those props to the end, so it is now `undefined`, which is what it always meant. That is also what the workaround in `angular/src/http-resource.ts:358-365` is written against, and its guard keeps behaving the same way, so I left it alone.

## What I ran

Six new cases in `packages/core/src/getters/params.test.ts`, one per default value across number, boolean and string. The three falsy ones fail on `master` and the three truthy ones pass on both, so they pin the behaviour that was already right.

`vp run -F './packages/*' test` is green: 3885 tests across 11 packages, no failures. `vp run -F './packages/*' typecheck` exits 0 and `vp fmt --check` is clean on every touched file.

Four assertions in `packages/orval/src/import-specs.test.ts` pinned the old `false` sentinel and now expect `undefined`.

No snapshot moved. I rebuilt the packages and regenerated all 17 configs under `tests/configs` with the built CLI, and `git status tests/` came back empty. That matches what the corpus contains: the only two falsy defaults anywhere in it are `tests/specifications/issue-708.yaml`, where `default: 0` sits on a query parameter that is already `required: false` so the `!required` half short-circuits either way, and `zod-required-default-values.yaml`, where the `default: false` is on a component schema property rather than a parameter. The sentinel change is ordering-neutral too, since neither `false` nor `undefined` sorted a prop to the end under the old predicate and `undefined` does not under the new one.

I could not run `vp run -F orval-tests generate-api` itself on this machine: it goes through `npm run`, whose `devEngines.runtime` gate wants Node `>=22.22.3` and I am on 22.20.0. Driving `packages/orval/dist/bin/orval.mjs` per config is the same work without that gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved path, query, body, and header parameter defaults when values are `0`, `false`, or empty strings.
  * Correctly marked parameters with defined defaults as optional across generated definitions and implementations.
  * Improved parameter ordering so defaulted and required parameters are ordered consistently.
  * Removed unintended `false` defaults from generated parameter properties when no default is provided.
  * Updated generated parameter metadata to accurately reflect missing defaults as undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->