### PR TITLE
fix(angular): serialize Date query params to ISO string in filterParams

### DIFF
--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -634,6 +634,8 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -665,6 +667,24 @@ function filterParams(
       expect(body).not.toBe(PRE_3705_HELPER_BODY);
       expect(body).toContain('objectParamStrategies');
       expect(body).toContain("'flatten' | 'comma' | 'deepObject'");
+    });
+  });
+
+  describe('getAngularFilteredParamsHelperBody date handling (#3856)', () => {
+    it('serializes Date values to ISO strings in both helper variants', () => {
+      for (const hasObjectParams of [false, true]) {
+        const body = getAngularFilteredParamsHelperBody({ hasObjectParams });
+
+        expect(body).toContain('value instanceof Date');
+        expect(body).toContain('value.toISOString()');
+        // The Date branch must run before the primitive check so Date values
+        // are never silently dropped by the typeof filter.
+        const dateBranch = body.indexOf('value instanceof Date');
+        const primitiveBranch = body.indexOf("typeof value === 'string'");
+        expect(dateBranch).toBeGreaterThan(-1);
+        expect(primitiveBranch).toBeGreaterThan(-1);
+        expect(dateBranch).toBeLessThan(primitiveBranch);
+      }
     });
   });
 

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -253,6 +253,8 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -380,6 +382,8 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
@@ -160,6 +160,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
@@ -121,6 +121,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -122,6 +122,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
@@ -157,6 +157,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
@@ -119,6 +119,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -121,6 +121,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -121,6 +121,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -176,6 +176,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -173,6 +173,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
@@ -160,6 +160,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
@@ -121,6 +121,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -122,6 +122,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.resource.ts
@@ -157,6 +157,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.service.ts
@@ -119,6 +119,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -121,6 +121,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -121,6 +121,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -176,6 +176,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -173,6 +173,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -93,6 +93,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -92,6 +92,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -89,6 +89,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -95,6 +95,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -93,6 +93,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -92,6 +92,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -89,6 +89,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -95,6 +95,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -91,6 +91,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -91,6 +91,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -91,6 +91,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
@@ -98,6 +98,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -92,6 +92,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
@@ -160,6 +160,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
@@ -122,6 +122,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
@@ -176,6 +176,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
@@ -125,6 +125,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token/endpoints.ts
@@ -122,6 +122,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
@@ -176,6 +176,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
@@ -167,6 +167,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-tags/pets.ts
+++ b/tests/__snapshots__/angular/http-resource-tags/pets.ts
@@ -174,6 +174,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
@@ -188,6 +188,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
@@ -188,6 +188,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3103/default/default.service.ts
+++ b/tests/__snapshots__/angular/issue-3103/default/default.service.ts
@@ -113,6 +113,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
@@ -114,6 +114,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3326/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326/endpoints.ts
@@ -177,6 +177,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
+++ b/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
@@ -174,6 +174,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
@@ -113,6 +113,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
@@ -113,6 +113,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
@@ -228,6 +228,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
@@ -118,6 +118,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
@@ -119,6 +119,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705/endpoints.ts
@@ -182,6 +182,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
@@ -157,6 +157,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
@@ -114,6 +114,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3712/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712/endpoints.ts
@@ -113,6 +113,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
+++ b/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
@@ -115,6 +115,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/named-parameters/endpoints.ts
@@ -126,6 +126,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/petstore/endpoints.ts
+++ b/tests/__snapshots__/angular/petstore/endpoints.ts
@@ -127,6 +127,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/split/endpoints.service.ts
+++ b/tests/__snapshots__/angular/split/endpoints.service.ts
@@ -120,6 +120,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
@@ -120,6 +120,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/tags/pets.ts
+++ b/tests/__snapshots__/angular/tags/pets.ts
@@ -127,6 +127,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
@@ -174,6 +174,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
@@ -127,6 +127,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
@@ -127,6 +127,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
+++ b/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
@@ -118,6 +118,8 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||


### PR DESCRIPTION
Fixes #3856

When `useDates: true`, query params typed as `Date` were silently dropped by the generated `filterParams` helper since it only kept `string | number | boolean`. The helper now serializes `Date` values with `toISOString()` before they reach HttpParams.

Added a test covering both helper variants (with and without object params). All 2361 core tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Angular query-parameter filtering now correctly includes `Date` values by converting them to ISO-formatted strings.
  * This behavior is supported whether or not object parameters are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->