### PR TITLE
docs(zod): correct stale camelCase schema names to PascalCase in guides

### DIFF
--- a/docs/content/docs/guides/client-with-zod.mdx
+++ b/docs/content/docs/guides/client-with-zod.mdx
@@ -63,7 +63,7 @@ src/api/
 
 ```tsx
 import { useListPets, useCreatePets } from './api/endpoints/pets/pets';
-import { createPetsBodyItem } from './api/endpoints/pets/pets.zod';
+import { CreatePetsBodyItem } from './api/endpoints/pets/pets.zod';
 
 function App() {
   const { data } = useListPets();
@@ -74,7 +74,7 @@ function App() {
 
     try {
       // Validate before sending
-      const validatedPet = createPetsBodyItem.parse(pet);
+      const validatedPet = CreatePetsBodyItem.parse(pet);
       await trigger([validatedPet]);
     } catch (error) {
       if (error instanceof ZodError) {

--- a/docs/content/docs/guides/hono.mdx
+++ b/docs/content/docs/guides/hono.mdx
@@ -61,12 +61,12 @@ Orval generates handler templates with built-in validation:
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
 import { ListPetsContext } from '../petstore.context';
-import { listPetsQueryParams, listPetsResponse } from '../petstore.zod';
+import { ListPetsQueryParams, listPetsResponse } from '../petstore.zod';
 
 const factory = createFactory();
 
 export const listPetsHandlers = factory.createHandlers(
-  zValidator('query', listPetsQueryParams),
+  zValidator('query', ListPetsQueryParams),
   zValidator('response', listPetsResponse),
   async (c: ListPetsContext) => {
     // Implement your logic here
@@ -88,7 +88,7 @@ Add your business logic to the generated handlers:
 
 ```ts title="src/handlers/listPets.ts"
 export const listPetsHandlers = factory.createHandlers(
-  zValidator('query', listPetsQueryParams),
+  zValidator('query', ListPetsQueryParams),
   zValidator('response', listPetsResponse),
   async (c: ListPetsContext) => {
     return c.json([

--- a/docs/content/docs/guides/zod.mdx
+++ b/docs/content/docs/guides/zod.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
 Orval generates a Zod schema for each model in your OpenAPI specification:
 
 ```ts
-export const createPetsBody = /*#__PURE__*/ zod.object({
+export const CreatePetsBody = /*#__PURE__*/ zod.object({
   id: /*#__PURE__*/ zod.number(),
   name: /*#__PURE__*/ zod.string(),
   tag: /*#__PURE__*/ zod.optional(/*#__PURE__*/ zod.string()),
@@ -200,10 +200,10 @@ Output-wide settings — `variant`, `version`, `dateTimeOptions`, `timeOptions`,
 ### Parsing Data
 
 ```ts
-import { createPetsBody } from './src/api/schemas';
+import { CreatePetsBody } from './src/api/schemas';
 
 const pet = { id: 1, name: 'Buddy', tag: 'dog' };
-const parsedPet = createPetsBody.parse(pet);
+const parsedPet = CreatePetsBody.parse(pet);
 // => { id: 1, name: "Buddy", tag: "dog" }
 ```
 
@@ -211,9 +211,9 @@ const parsedPet = createPetsBody.parse(pet);
 
 ```ts
 import type { z } from 'zod/mini';
-import { createPetsBody } from './src/api/schemas';
+import { CreatePetsBody } from './src/api/schemas';
 
-type Pet = z.infer<typeof createPetsBody>;
+type Pet = z.infer<typeof CreatePetsBody>;
 
 const pet: Pet = { id: 1, name: 'Buddy', tag: 'dog' };
 ```
@@ -221,7 +221,7 @@ const pet: Pet = { id: 1, name: 'Buddy', tag: 'dog' };
 ### Safe Parsing
 
 ```ts
-const result = createPetsBody.safeParse(unknownData);
+const result = CreatePetsBody.safeParse(unknownData);
 
 if (result.success) {
   console.log(result.data);


### PR DESCRIPTION
Fixes #3809 (the stale export names part)

Orval has emitted PascalCase schema exports since #2661 but three Zod guides still showed the old camelCase names (`createPetsBody`, `createPetsBodyItem`, `listPetsQueryParams`). Updated all occurrences to the actual generated names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Zod client examples to use the correct PascalCase schema names.
  - Corrected Hono handler examples to reference the appropriate query-parameter schema.
  - Updated parsing, type inference, and safe parsing examples to use the renamed generated schema export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->