### PR TITLE
fix(samples): make react-query samples typecheck under TS6 and wire into test:samples

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -679,6 +679,7 @@
         "react-query": "^3.39.3",
       },
       "devDependencies": {
+        "@types/react": "catalog:react",
         "orval": "workspace:*",
         "prettier": "catalog:",
       },
@@ -692,6 +693,7 @@
         "react-query": "^3.39.3",
       },
       "devDependencies": {
+        "@types/react": "catalog:react",
         "orval": "workspace:*",
         "prettier": "catalog:",
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "vp run -F './packages/*' typecheck",
     "test": "vp run -F './packages/*' test",
     "test:cli": "vp run -F orval-tests clean && vp run -F orval-tests generate-api && vp run -F orval-tests build",
-    "test:samples": "vp run -F './samples/**' -F '!react-query-form-data' -F '!react-query-form-url-encoded' -F '!react-query-form-url-encoded-mutator' -F '!react-query-form-data-mutator' -F '!react-query-hook-mutator-axios' -F '!react-query-hook-mutator-fetch' test",
+    "test:samples": "vp run -F './samples/**' test",
     "test:snapshots": "vp run -F './packages/*' build:release && vp run -F './samples/**' -F orval-tests generate-api && vp run -F './samples/**' -F orval-tests test:snapshots",
     "test:snapshots:update": "vp run -F './packages/*' build:release && vp run -F './samples/**' -F orval-tests generate-api && vp run -F './samples/**' -F orval-tests test:snapshots:update",
     "lint": "vp lint --type-aware --type-check packages",

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -26,48 +26,6 @@ import type {
 } from './models';
 
 import { customInstance } from './custom-instance';
-export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
-export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
-export type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;
-export type HTTPStatusCode4xx =
-  | 400
-  | 401
-  | 402
-  | 403
-  | 404
-  | 405
-  | 406
-  | 407
-  | 408
-  | 409
-  | 410
-  | 411
-  | 412
-  | 413
-  | 414
-  | 415
-  | 416
-  | 417
-  | 418
-  | 419
-  | 420
-  | 421
-  | 422
-  | 423
-  | 424
-  | 426
-  | 428
-  | 429
-  | 431
-  | 451;
-export type HTTPStatusCode5xx = 500 | 501 | 502 | 503 | 504 | 505 | 507 | 511;
-export type HTTPStatusCodes =
-  | HTTPStatusCode1xx
-  | HTTPStatusCode2xx
-  | HTTPStatusCode3xx
-  | HTTPStatusCode4xx
-  | HTTPStatusCode5xx;
-
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -90,49 +48,15 @@ const withQueryKey = <T extends object, K>(
   return result;
 };
 
-export type listPetsResponse200 = {
-  data: PetsArray;
-  status: 200;
-};
-
-export type listPetsResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 200>;
-};
-
-export type listPetsResponseSuccess = listPetsResponse200 & {
-  headers: Headers;
-};
-export type listPetsResponseError = listPetsResponseDefault & {
-  headers: Headers;
-};
-
-export type listPetsResponse = listPetsResponseSuccess | listPetsResponseError;
-
-export const getListPetsUrl = (params?: ListPetsParams) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? 'null' : String(value));
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
-};
-
 /**
  * @summary List all pets
  */
-export const listPets = async (
-  params?: ListPetsParams,
-  options?: RequestInit,
-): Promise<listPetsResponse> => {
-  return customInstance<listPetsResponse>(getListPetsUrl(params), {
-    ...options,
+export const listPets = (params?: ListPetsParams, signal?: AbortSignal) => {
+  return customInstance<PetsArray>({
+    url: `/pets`,
     method: 'GET',
+    params,
+    signal,
   });
 };
 
@@ -159,7 +83,7 @@ export const getListPetsQueryOptions = <
 
   const queryFn: QueryFunction<Awaited<ReturnType<typeof listPets>>> = ({
     signal,
-  }) => listPets(params, { signal });
+  }) => listPets(params, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -199,54 +123,19 @@ export function useListPets<
   return withQueryKey(query, queryOptions.queryKey);
 }
 
-export type createPetsResponse201 = {
-  data: void;
-  status: 201;
-};
-
-export type createPetsResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 201>;
-};
-
-export type createPetsResponseSuccess = createPetsResponse201 & {
-  headers: Headers;
-};
-export type createPetsResponseError = createPetsResponseDefault & {
-  headers: Headers;
-};
-
-export type createPetsResponse =
-  | createPetsResponseSuccess
-  | createPetsResponseError;
-
-export const getCreatePetsUrl = () => {
-  return `/pets`;
-};
-
 /**
  * @summary Create a pet
  */
-export const createPets = async (
+export const createPets = (
   createPetsBody: CreatePetsBody,
-  options?: RequestInit,
-): Promise<createPetsResponse> => {
-  const getHeaders = (
-    h?: NonNullable<RequestInit['headers']>,
-  ): Record<string, string | readonly string[]> => {
-    if (!h) return {};
-    if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
-    return h;
-  };
-  return customInstance<createPetsResponse>(getCreatePetsUrl(), {
-    ...options,
+  signal?: AbortSignal,
+) => {
+  return customInstance<void>({
+    url: `/pets`,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...getHeaders(options?.headers),
-    },
-    body: JSON.stringify(createPetsBody),
+    headers: { 'Content-Type': 'application/json' },
+    data: createPetsBody,
+    signal,
   });
 };
 
@@ -313,61 +202,19 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   return useMutation(getCreatePetsMutationOptions(options));
 };
 
-export type listPetsNestedArrayResponse200 = {
-  data: PetsNestedArray;
-  status: 200;
-};
-
-export type listPetsNestedArrayResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 200>;
-};
-
-export type listPetsNestedArrayResponseSuccess =
-  listPetsNestedArrayResponse200 & {
-    headers: Headers;
-  };
-export type listPetsNestedArrayResponseError =
-  listPetsNestedArrayResponseDefault & {
-    headers: Headers;
-  };
-
-export type listPetsNestedArrayResponse =
-  | listPetsNestedArrayResponseSuccess
-  | listPetsNestedArrayResponseError;
-
-export const getListPetsNestedArrayUrl = (
-  params?: ListPetsNestedArrayParams,
-) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? 'null' : String(value));
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0
-    ? `/pets-nested-array?${stringifiedParams}`
-    : `/pets-nested-array`;
-};
-
 /**
  * @summary List all pets as nested array
  */
-export const listPetsNestedArray = async (
+export const listPetsNestedArray = (
   params?: ListPetsNestedArrayParams,
-  options?: RequestInit,
-): Promise<listPetsNestedArrayResponse> => {
-  return customInstance<listPetsNestedArrayResponse>(
-    getListPetsNestedArrayUrl(params),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
+  signal?: AbortSignal,
+) => {
+  return customInstance<PetsNestedArray>({
+    url: `/pets-nested-array`,
+    method: 'GET',
+    params,
+    signal,
+  });
 };
 
 export const getListPetsNestedArrayQueryKey = (
@@ -396,7 +243,7 @@ export const getListPetsNestedArrayQueryOptions = <
 
   const queryFn: QueryFunction<
     Awaited<ReturnType<typeof listPetsNestedArray>>
-  > = ({ signal }) => listPetsNestedArray(params, { signal });
+  > = ({ signal }) => listPetsNestedArray(params, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
     Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -436,42 +283,11 @@ export function useListPetsNestedArray<
   return withQueryKey(query, queryOptions.queryKey);
 }
 
-export type showPetByIdResponse200 = {
-  data: Pet;
-  status: 200;
-};
-
-export type showPetByIdResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 200>;
-};
-
-export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
-  headers: Headers;
-};
-export type showPetByIdResponseError = showPetByIdResponseDefault & {
-  headers: Headers;
-};
-
-export type showPetByIdResponse =
-  | showPetByIdResponseSuccess
-  | showPetByIdResponseError;
-
-export const getShowPetByIdUrl = (petId: string) => {
-  return `/pets/${petId}`;
-};
-
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = async (
-  petId: string,
-  options?: RequestInit,
-): Promise<showPetByIdResponse> => {
-  return customInstance<showPetByIdResponse>(getShowPetByIdUrl(petId), {
-    ...options,
-    method: 'GET',
-  });
+export const showPetById = (petId: string, signal?: AbortSignal) => {
+  return customInstance<Pet>({ url: `/pets/${petId}`, method: 'GET', signal });
 };
 
 export const getShowPetByIdQueryKey = (petId: string) => {
@@ -497,7 +313,7 @@ export const getShowPetByIdQueryOptions = <
 
   const queryFn: QueryFunction<Awaited<ReturnType<typeof showPetById>>> = ({
     signal,
-  }) => showPetById(petId, { signal });
+  }) => showPetById(petId, signal);
 
   return {
     queryKey,

--- a/samples/react-query/form-data-mutator/custom-form-data.ts
+++ b/samples/react-query/form-data-mutator/custom-form-data.ts
@@ -1,4 +1,4 @@
-export const customFormData = <Body>(body: Body): FormData => {
+export const customFormData = <Body extends Record<string, string | Blob>>(body: Body): FormData => {
   const formData = new FormData();
 
   Object.entries(body).forEach(([key, value]) => {

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -26,48 +26,6 @@ import type {
 } from './models';
 
 import { customInstance } from './custom-instance';
-export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
-export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
-export type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;
-export type HTTPStatusCode4xx =
-  | 400
-  | 401
-  | 402
-  | 403
-  | 404
-  | 405
-  | 406
-  | 407
-  | 408
-  | 409
-  | 410
-  | 411
-  | 412
-  | 413
-  | 414
-  | 415
-  | 416
-  | 417
-  | 418
-  | 419
-  | 420
-  | 421
-  | 422
-  | 423
-  | 424
-  | 426
-  | 428
-  | 429
-  | 431
-  | 451;
-export type HTTPStatusCode5xx = 500 | 501 | 502 | 503 | 504 | 505 | 507 | 511;
-export type HTTPStatusCodes =
-  | HTTPStatusCode1xx
-  | HTTPStatusCode2xx
-  | HTTPStatusCode3xx
-  | HTTPStatusCode4xx
-  | HTTPStatusCode5xx;
-
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -90,49 +48,15 @@ const withQueryKey = <T extends object, K>(
   return result;
 };
 
-export type listPetsResponse200 = {
-  data: PetsArray;
-  status: 200;
-};
-
-export type listPetsResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 200>;
-};
-
-export type listPetsResponseSuccess = listPetsResponse200 & {
-  headers: Headers;
-};
-export type listPetsResponseError = listPetsResponseDefault & {
-  headers: Headers;
-};
-
-export type listPetsResponse = listPetsResponseSuccess | listPetsResponseError;
-
-export const getListPetsUrl = (params?: ListPetsParams) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? 'null' : String(value));
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0 ? `/pets?${stringifiedParams}` : `/pets`;
-};
-
 /**
  * @summary List all pets
  */
-export const listPets = async (
-  params?: ListPetsParams,
-  options?: RequestInit,
-): Promise<listPetsResponse> => {
-  return customInstance<listPetsResponse>(getListPetsUrl(params), {
-    ...options,
+export const listPets = (params?: ListPetsParams, signal?: AbortSignal) => {
+  return customInstance<PetsArray>({
+    url: `/pets`,
     method: 'GET',
+    params,
+    signal,
   });
 };
 
@@ -159,7 +83,7 @@ export const getListPetsQueryOptions = <
 
   const queryFn: QueryFunction<Awaited<ReturnType<typeof listPets>>> = ({
     signal,
-  }) => listPets(params, { signal });
+  }) => listPets(params, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
     Awaited<ReturnType<typeof listPets>>,
@@ -199,54 +123,19 @@ export function useListPets<
   return withQueryKey(query, queryOptions.queryKey);
 }
 
-export type createPetsResponse201 = {
-  data: void;
-  status: 201;
-};
-
-export type createPetsResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 201>;
-};
-
-export type createPetsResponseSuccess = createPetsResponse201 & {
-  headers: Headers;
-};
-export type createPetsResponseError = createPetsResponseDefault & {
-  headers: Headers;
-};
-
-export type createPetsResponse =
-  | createPetsResponseSuccess
-  | createPetsResponseError;
-
-export const getCreatePetsUrl = () => {
-  return `/pets`;
-};
-
 /**
  * @summary Create a pet
  */
-export const createPets = async (
+export const createPets = (
   createPetsBody: CreatePetsBody,
-  options?: RequestInit,
-): Promise<createPetsResponse> => {
-  const getHeaders = (
-    h?: NonNullable<RequestInit['headers']>,
-  ): Record<string, string | readonly string[]> => {
-    if (!h) return {};
-    if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
-    return h;
-  };
-  return customInstance<createPetsResponse>(getCreatePetsUrl(), {
-    ...options,
+  signal?: AbortSignal,
+) => {
+  return customInstance<void>({
+    url: `/pets`,
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...getHeaders(options?.headers),
-    },
-    body: JSON.stringify(createPetsBody),
+    headers: { 'Content-Type': 'application/json' },
+    data: createPetsBody,
+    signal,
   });
 };
 
@@ -313,61 +202,19 @@ export const useCreatePets = <TError = Error, TContext = unknown>(options?: {
   return useMutation(getCreatePetsMutationOptions(options));
 };
 
-export type listPetsNestedArrayResponse200 = {
-  data: PetsNestedArray;
-  status: 200;
-};
-
-export type listPetsNestedArrayResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 200>;
-};
-
-export type listPetsNestedArrayResponseSuccess =
-  listPetsNestedArrayResponse200 & {
-    headers: Headers;
-  };
-export type listPetsNestedArrayResponseError =
-  listPetsNestedArrayResponseDefault & {
-    headers: Headers;
-  };
-
-export type listPetsNestedArrayResponse =
-  | listPetsNestedArrayResponseSuccess
-  | listPetsNestedArrayResponseError;
-
-export const getListPetsNestedArrayUrl = (
-  params?: ListPetsNestedArrayParams,
-) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? 'null' : String(value));
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0
-    ? `/pets-nested-array?${stringifiedParams}`
-    : `/pets-nested-array`;
-};
-
 /**
  * @summary List all pets as nested array
  */
-export const listPetsNestedArray = async (
+export const listPetsNestedArray = (
   params?: ListPetsNestedArrayParams,
-  options?: RequestInit,
-): Promise<listPetsNestedArrayResponse> => {
-  return customInstance<listPetsNestedArrayResponse>(
-    getListPetsNestedArrayUrl(params),
-    {
-      ...options,
-      method: 'GET',
-    },
-  );
+  signal?: AbortSignal,
+) => {
+  return customInstance<PetsNestedArray>({
+    url: `/pets-nested-array`,
+    method: 'GET',
+    params,
+    signal,
+  });
 };
 
 export const getListPetsNestedArrayQueryKey = (
@@ -396,7 +243,7 @@ export const getListPetsNestedArrayQueryOptions = <
 
   const queryFn: QueryFunction<
     Awaited<ReturnType<typeof listPetsNestedArray>>
-  > = ({ signal }) => listPetsNestedArray(params, { signal });
+  > = ({ signal }) => listPetsNestedArray(params, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
     Awaited<ReturnType<typeof listPetsNestedArray>>,
@@ -436,42 +283,11 @@ export function useListPetsNestedArray<
   return withQueryKey(query, queryOptions.queryKey);
 }
 
-export type showPetByIdResponse200 = {
-  data: Pet;
-  status: 200;
-};
-
-export type showPetByIdResponseDefault = {
-  data: Error;
-  status: Exclude<HTTPStatusCodes, 200>;
-};
-
-export type showPetByIdResponseSuccess = showPetByIdResponse200 & {
-  headers: Headers;
-};
-export type showPetByIdResponseError = showPetByIdResponseDefault & {
-  headers: Headers;
-};
-
-export type showPetByIdResponse =
-  | showPetByIdResponseSuccess
-  | showPetByIdResponseError;
-
-export const getShowPetByIdUrl = (petId: string) => {
-  return `/pets/${petId}`;
-};
-
 /**
  * @summary Info for a specific pet
  */
-export const showPetById = async (
-  petId: string,
-  options?: RequestInit,
-): Promise<showPetByIdResponse> => {
-  return customInstance<showPetByIdResponse>(getShowPetByIdUrl(petId), {
-    ...options,
-    method: 'GET',
-  });
+export const showPetById = (petId: string, signal?: AbortSignal) => {
+  return customInstance<Pet>({ url: `/pets/${petId}`, method: 'GET', signal });
 };
 
 export const getShowPetByIdQueryKey = (petId: string) => {
@@ -497,7 +313,7 @@ export const getShowPetByIdQueryOptions = <
 
   const queryFn: QueryFunction<Awaited<ReturnType<typeof showPetById>>> = ({
     signal,
-  }) => showPetById(petId, { signal });
+  }) => showPetById(petId, signal);
 
   return {
     queryKey,

--- a/samples/react-query/form-data-mutator/orval.config.ts
+++ b/samples/react-query/form-data-mutator/orval.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       target: './endpoints.ts',
       schemas: './models',
       client: 'react-query',
+      httpClient: 'axios',
       formatter: 'prettier',
       override: {
         mutator: {

--- a/samples/react-query/form-data-mutator/package.json
+++ b/samples/react-query/form-data-mutator/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-data-mutator/tsconfig.json
+++ b/samples/react-query/form-data-mutator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "**/*.ts"],
+  "exclude": ["node_modules", "__snapshots__", "*.spec.ts", "*.test.ts"]
+}

--- a/samples/react-query/form-data/package.json
+++ b/samples/react-query/form-data/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-data/tsconfig.json
+++ b/samples/react-query/form-data/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "**/*.ts"],
+  "exclude": ["node_modules", "__snapshots__", "*.spec.ts", "*.test.ts"]
+}

--- a/samples/react-query/form-url-encoded-mutator/custom-form-url-encoded.ts
+++ b/samples/react-query/form-url-encoded-mutator/custom-form-url-encoded.ts
@@ -1,4 +1,4 @@
-export const customFormUrlEncoded = <Body>(body: Body): URLSearchParams => {
+export const customFormUrlEncoded = <Body extends Record<string, string>>(body: Body): URLSearchParams => {
   const formData = new URLSearchParams();
 
   Object.entries(body).forEach(([key, value]) => {

--- a/samples/react-query/form-url-encoded-mutator/package.json
+++ b/samples/react-query/form-url-encoded-mutator/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-url-encoded-mutator/tsconfig.json
+++ b/samples/react-query/form-url-encoded-mutator/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "**/*.ts"],
+  "exclude": ["node_modules", "__snapshots__", "*.spec.ts", "*.test.ts"]
+}

--- a/samples/react-query/form-url-encoded/package.json
+++ b/samples/react-query/form-url-encoded/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",

--- a/samples/react-query/form-url-encoded/tsconfig.json
+++ b/samples/react-query/form-url-encoded/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "**/*.ts"],
+  "exclude": ["node_modules", "__snapshots__", "*.spec.ts", "*.test.ts"]
+}

--- a/samples/react-query/hook-mutator-axios/package.json
+++ b/samples/react-query/hook-mutator-axios/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "orval": "workspace:*",
-    "prettier": "catalog:"
+    "prettier": "catalog:",
+    "@types/react": "catalog:react"
   }
 }

--- a/samples/react-query/hook-mutator-axios/tsconfig.json
+++ b/samples/react-query/hook-mutator-axios/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "**/*.ts"],
+  "exclude": ["node_modules", "__snapshots__", "*.spec.ts", "*.test.ts"]
+}

--- a/samples/react-query/hook-mutator-fetch/package.json
+++ b/samples/react-query/hook-mutator-fetch/package.json
@@ -7,7 +7,7 @@
     "generate-api": "vp exec orval",
     "test:snapshots": "vp test run --config vitest.snapshots.ts",
     "test:snapshots:update": "vp run test:snapshots --update",
-    "test": "tsc --noEmit endpoints.ts"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "@faker-js/faker": "catalog:tooling",
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "orval": "workspace:*",
-    "prettier": "catalog:"
+    "prettier": "catalog:",
+    "@types/react": "catalog:react"
   }
 }

--- a/samples/react-query/hook-mutator-fetch/tsconfig.json
+++ b/samples/react-query/hook-mutator-fetch/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["*.ts", "**/*.ts"],
+  "exclude": ["node_modules", "__snapshots__", "*.spec.ts", "*.test.ts"]
+}


### PR DESCRIPTION
Fixes #3868

Six react-query samples were excluded from `test:samples` because their test scripts (`tsc --noEmit endpoints.ts`) fail under TypeScript 6 (TS5112: tsconfig found but filenames specified).

Changes:
- Added local `tsconfig.json` to each sample (extends base, adds DOM lib for FormData/Headers)
- Added `@types/react: catalog:react` to hook-mutator samples that import from react-query
- Fixed `form-data-mutator` httpClient mismatch: added `httpClient: 'axios'` to match the axios-style mutator, regenerated endpoints + snapshot
- Fixed unconstrained generic in `custom-form-url-encoded.ts` and `custom-form-data.ts` (`<Body>` → `<Body extends Record<string, string>>` / `Record<string, string | Blob>`)
- Removed the 6 exclusions from root `test:samples` script

All6 samples now typecheck clean under `tsc --noEmit -p <local-tsconfig>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type safety for form-data and URL-encoded request payloads.
  * Simplified sample API requests with typed responses and cancellation support.
* **Tests**
  * Expanded sample testing to cover all sample workspaces.
  * Updated sample checks to validate the complete project.
* **Chores**
  * Added TypeScript configuration and React type support across React Query samples.
  * Configured the form-data mutator sample to use Axios explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->