### PR TITLE
fix(core): don't look up tag buckets on Object.prototype

### DIFF
--- a/packages/core/src/writers/target-tags.test.ts
+++ b/packages/core/src/writers/target-tags.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import {
+  createSplitModeBuilder,
+  createSplitModeOperation,
+  createSplitModeOutput,
+} from '../test-utils/split-modes';
+import { OutputMode, type WriteSpecBuilder } from '../types';
+import { generateTargetForTags } from './target-tags';
+
+// Regression: tag bucket keys come from the OpenAPI document, and `kebab` leaves
+// `constructor` unchanged. Checking the accumulator with `in` found the inherited
+// member, so generation failed on `[...Object.imports]`.
+//
+// Buckets are read back through a Map because `result.constructor` resolves to
+// `Object.prototype.constructor`, not the index signature.
+
+const builderWith = (operations: Record<string, unknown>): WriteSpecBuilder =>
+  ({
+    ...createSplitModeBuilder('petstore.ts'),
+    operations,
+  }) as unknown as WriteSpecBuilder;
+
+const bucketsOf = (result: ReturnType<typeof generateTargetForTags>) =>
+  new Map(Object.entries(result));
+
+const generate = (operations: Record<string, unknown>) =>
+  bucketsOf(
+    generateTargetForTags(
+      builderWith(operations),
+      createSplitModeOutput('petstore.ts', { mode: OutputMode.TAGS }),
+    ),
+  );
+
+describe('generateTargetForTags — tags that collide with Object.prototype', () => {
+  it('buckets an operation tagged `constructor`', () => {
+    const buckets = generate({
+      listPets: createSplitModeOperation({
+        tags: ['constructor'],
+        operationName: 'listPets',
+        implementation: 'export const listPets = () => {};',
+      }),
+    });
+
+    expect([...buckets.keys()]).toEqual(['constructor']);
+    expect(buckets.get('constructor')?.implementation).toContain('listPets');
+    expect(buckets.get('constructor')?.imports).toEqual([]);
+  });
+
+  it('merges two operations that share the `constructor` tag', () => {
+    const buckets = generate({
+      listPets: createSplitModeOperation({
+        tags: ['Constructor'],
+        operationName: 'listPets',
+        implementation: 'export const listPets = () => {};',
+      }),
+      getPet: createSplitModeOperation({
+        tags: ['constructor'],
+        operationName: 'getPet',
+        implementation: 'export const getPet = () => {};',
+      }),
+    });
+
+    expect([...buckets.keys()]).toEqual(['constructor']);
+    const implementation = buckets.get('constructor')?.implementation;
+    expect(implementation).toContain('listPets');
+    expect(implementation).toContain('getPet');
+  });
+
+  it('still buckets ordinary tags', () => {
+    const buckets = generate({
+      listPets: createSplitModeOperation({
+        tags: ['pets'],
+        operationName: 'listPets',
+      }),
+      getHealth: createSplitModeOperation({
+        tags: ['health'],
+        operationName: 'getHealth',
+      }),
+    });
+
+    expect([...buckets.keys()].sort()).toEqual(['health', 'pets']);
+  });
+});

--- a/packages/core/src/writers/target-tags.ts
+++ b/packages/core/src/writers/target-tags.ts
@@ -167,7 +167,7 @@ function generateTargetTags(
 ): Record<string, GeneratorTargetFull> {
   const tag = getOperationTagKey(operation);
 
-  if (!(tag in currentAcc)) {
+  if (!Object.hasOwn(currentAcc, tag)) {
     currentAcc[tag] = {
       imports: operation.imports,
       mockOutputs: initialMockOutputsForOperation(operation),


### PR DESCRIPTION
A tag named `constructor` breaks generation in `tags` and `tags-split` mode.

This spec is enough to reproduce it:

```yaml
paths:
  /pets:
    get:
      operationId: listPets
      tags: [constructor]
```

orval then fails with:

```
🛑 api - currentOperation.imports is not iterable
```

No file is written, and the message does not say which tag caused it.

## Cause

Tag bucket keys come from the OpenAPI document. `generateTargetTags` checks the
accumulator with `in`:

```ts
if (!(tag in currentAcc)) {
```

`in` also looks at the prototype chain, so the check is wrong here:

```js
'constructor' in {}   // true
({})['constructor']   // function Object() { [native code] }
```

The code then takes the "bucket already exists" branch and runs on the `Object`
function.

Only `constructor` is affected. `getTagKey` kebab-cases the tag, and that
changes every other inherited name (`toString` becomes `to-string`). Casing does
not matter, because `Constructor` gives the same key.

## Change

Use `Object.hasOwn`. `client.ts` already does this for operation names.

## Tests

Three tests in `target-tags.test.ts`: one `constructor` tag, two operations that
share it, and normal tags as a control. The first two fail on `master`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tag grouping for tags that match built-in object property names, such as `constructor`.
  - Ensured these tags are correctly separated and merged without affecting ordinary tag handling.

- **Tests**
  - Added regression coverage for built-in property name collisions and standard tag bucketing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->