### PR TITLE
fix(core): handle unevaluatedProperties like additionalProperties (#2156)

### DIFF
--- a/packages/core/src/generators/factory.ts
+++ b/packages/core/src/generators/factory.ts
@@ -103,7 +103,9 @@ function getItems(
 function getAdditionalProperties(
   schema: OpenApiSchemaObject,
 ): OpenApiSchemaObject | OpenApiReferenceObject | boolean | undefined {
-  return schema.additionalProperties as
+  // `unevaluatedProperties` (OAS 3.1) has the same shape and circularity
+  // implications as `additionalProperties`. See issue #2156.
+  return (schema.additionalProperties ?? schema.unevaluatedProperties) as
     | OpenApiSchemaObject
     | OpenApiReferenceObject
     | boolean

--- a/packages/core/src/getters/object.test.ts
+++ b/packages/core/src/getters/object.test.ts
@@ -114,4 +114,46 @@ describe('getObject', () => {
       ]),
     );
   });
+
+  it('renders unevaluatedProperties as an index signature like additionalProperties', () => {
+    const context = createTestContextSpec({ spec: {} });
+
+    const result = getObject({
+      item: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+        required: ['id'],
+        unevaluatedProperties: { type: 'string', maxLength: 10 },
+      },
+      name: 'WithExtras',
+      context,
+      nullable: '',
+    });
+
+    // Falls back to unknown because named key types can't be proven equal
+    // to the index value type without propertyNames constraint — same as
+    // additionalProperties. See object.ts line 563–575.
+    expect(result.value).toContain('[key: string]: unknown;');
+  });
+
+  it('renders unevaluatedProperties: true as unknown index signature', () => {
+    const context = createTestContextSpec({ spec: {} });
+
+    const result = getObject({
+      item: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+        unevaluatedProperties: true,
+      },
+      name: 'OpenObject',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('[key: string]: unknown;');
+  });
 });

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -510,9 +510,15 @@ export function getObject({
       }
 
       if (entries.length - 1 === index) {
+        // OpenAPI 3.1: `unevaluatedProperties` supersedes `additionalProperties`
+        // in composed schemas. Both carry boolean | SchemaObject | ReferenceObject
+        // and both mean "extra keys are allowed with this value type", so they
+        // render identically as an index signature / Record intersection.
+        // See issue #2156.
         // Bridge assertion: additionalProperties is boolean | ReferenceObject | SchemaObject
         // but AnyOtherAttribute infects property access
-        const additionalProps = schemaItem.additionalProperties as
+        const additionalProps = (schemaItem.additionalProperties ??
+          schemaItem.unevaluatedProperties) as
           | boolean
           | OpenApiSchemaObject
           | OpenApiReferenceObject
@@ -585,7 +591,9 @@ export function getObject({
   }
 
   // Bridge assertion: additionalProperties is boolean | ReferenceObject | SchemaObject
-  const outerAdditionalProps = schemaItem.additionalProperties as
+  // Unevaluated fallback mirrors the first spot above (see issue #2156).
+  const outerAdditionalProps = (schemaItem.additionalProperties ??
+    schemaItem.unevaluatedProperties) as
     | boolean
     | OpenApiSchemaObject
     | OpenApiReferenceObject

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -169,6 +169,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
       requestOptions: true,
       splitByContentType: false,
       aliasCombinedTypes: false,
+      includeZodSchemaInArguments: false,
       mcp: {},
     },
   };


### PR DESCRIPTION
## Problem
Fixes #2156 
`unevaluatedProperties` from OpenAPI 3.1 / JSON Schema 2020-12 is silently ignored. Schemas that use it (e.g. from TypeSpec output) produce `unknown` types instead of index signatures or Record types.

## Fix

`unevaluatedProperties` has the same shape (`boolean | SchemaObject | ReferenceObject`) as `additionalProperties` and should produce the same TypeScript output. The fix falls back to `unevaluatedProperties` when `additionalProperties` is absent, in three spots:

- `packages/core/src/getters/object.ts` — properties-iteration path (after last property)
- `packages/core/src/getters/object.ts` — no-properties standalone object path
- `packages/core/src/generators/factory.ts` — circular reference detection

Two unit tests added covering `unevaluatedProperties: true` and `unevaluatedProperties: { type: 'string' }`.

## Test plan

- `vp run -F './packages/core' test` — all 2363 tests pass
- `vp run -F './packages/orval' -F './packages/fetch' -F './packages/query' test` — 274 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAPI 3.1 `unevaluatedProperties` when generating object types.
  * Generates appropriate index signatures and `Record` types for schemas using this setting.

* **Tests**
  * Added coverage for schema-valued and boolean `unevaluatedProperties` configurations.
  * Updated test configuration for outputs that omit embedded Zod schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->