### PR TITLE
fix(angular): omit undeclared text response branch

### DIFF
--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -1314,6 +1314,34 @@ describe('angular HttpClient generator', () => {
       expect(impl).toContain("accept: GetPetFileAccept = 'application/json'");
     });
 
+    it('omits text dispatch for JSON and Blob response types', () => {
+      const verbOption = createVerbOption({
+        operationId: 'getPetImage',
+        operationName: 'getPetImage',
+        typeName: 'getPetImage',
+        response: baseResponse({
+          definition: { success: 'Pet | Blob', errors: 'Error' },
+          types: {
+            success: [
+              createSuccessType('Pet', 'application/json'),
+              createSuccessType('Blob', 'image/png'),
+            ],
+            errors: [],
+          },
+          contentTypes: ['application/json', 'image/png'],
+        }),
+      });
+      const options = createGeneratorOptions();
+
+      const impl = generateHttpClientImplementation(verbOption, options);
+
+      expect(impl).toContain('Observable<Pet | Blob>');
+      expect(impl).toContain("responseType: 'json'");
+      expect(impl).toContain("responseType: 'blob'");
+      expect(impl).not.toContain("responseType: 'text'");
+      expect(impl).not.toContain('as Observable<string>');
+    });
+
     it('passes request bodies for PUT operations with multiple response types', () => {
       const verbOption = createVerbOption({
         operationId: 'updatePet',

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -780,8 +780,12 @@ export const generateHttpClientImplementation = (
 
     if (accept.includes('json') || accept.includes('+json')) {
       return ${buildHttpClientCall(`<${parsedJsonReturnType}>`, buildOptionsObject('json'))}${jsonValidationPipe};
-    } else if (accept.startsWith('text/') || accept.includes('xml')) {
+    }${
+      textSuccessTypes.length > 0
+        ? ` else if (accept.startsWith('text/') || accept.includes('xml')) {
       return ${buildHttpClientCall('', buildOptionsObject('text'))} as Observable<string>;
+    }`
+        : ''
     }${
       blobSuccessTypes.length > 0
         ? ` else {


### PR DESCRIPTION
## Summary

- omit Angular text-response dispatch when an operation declares no text or XML success content type
- add a regression test for JSON/blob multi-content responses

Fixes #3906.

## Test plan

- `vp run -F '@orval/angular' test` (274 tests passed)
- `vp run -F '@orval/angular' typecheck`
- regenerated the affected JSON/blob service shape in the downstream Angular 21 app and verified its production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP responses with multiple content types.
  * Prevented unnecessary text/XML processing when only JSON or Blob responses are supported.
  * Ensured generated clients select the appropriate JSON or Blob response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->