### PR TITLE
feat(query): add options mutator hook control

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1395,17 +1395,14 @@ Because the mutator receives `operationId`, one file can serve every
 operation and branch where the behaviour needs to differ, which is the usual
 alternative to a per-operation configuration option.
 
-#### Controlling the `use` / `get` prefix on query options
+#### Controlling the `use` / `get` prefix on options factories
 
-By default orval names the exported query options factory
-`use<Operation>QueryOptions` when a `queryOptions` mutator (or a hook
-mutator) is configured, and `get<Operation>QueryOptions` otherwise — the
-`use` prefix is meant to signal a hook. Sometimes the factory is consumed
-outside a React component, for example in a router loader or in
-`prefetchQuery` / `ensureQueryData`, where a `use*` name is misleading and
-can trip rules-of-hooks lint rules. In that case, name the exported function
-yourself via the `queryOptions` mutator and the generated code will use
-your name verbatim:
+Set `useHooks: false` on a `queryOptions` or `mutationOptions` mutator to
+generate a `get<Operation>QueryOptions` or `get<Operation>MutationOptions`
+factory instead of the default `use`-prefixed factory. This is useful when the
+mutator does not call hooks and the factory is consumed outside a React
+component, for example in a router loader or with `prefetchQuery` /
+`ensureQueryData`.
 
 ```ts title="src/mutators/custom-query-options.ts"
 export function customQueryOptions<T extends { queryKey: QueryKey }>(
@@ -1425,6 +1422,12 @@ export default defineConfig({
           queryOptions: {
             path: './src/mutators/custom-query-options.ts',
             name: 'customQueryOptions',
+            useHooks: false,
+          },
+          mutationOptions: {
+            path: './src/mutators/custom-mutation-options.ts',
+            name: 'customMutationOptions',
+            useHooks: false,
           },
         },
       },
@@ -1433,9 +1436,10 @@ export default defineConfig({
 });
 ```
 
-The generated hook then calls `getPetstoreQueryOptions(...)` (the name of
-the mutator export) instead of an auto-derived `usePetstoreQueryOptions`,
-and it can be used safely with `prefetchQuery` / `ensureQueryData`:
+With this configuration, Orval generates `getPetstoreQueryOptions(...)` and
+`getPetstoreMutationOptions(...)` instead of their `use`-prefixed variants.
+The query options factory can then be used safely with `prefetchQuery` /
+`ensureQueryData`:
 
 ```ts
 export async function loader(queryClient: QueryClient) {

--- a/packages/core/src/generators/mutator.test.ts
+++ b/packages/core/src/generators/mutator.test.ts
@@ -45,6 +45,7 @@ describe('generateMutator', () => {
           path: '@acme/esm-mutator/fetch',
           name: 'customInstance',
           default: false,
+          useHooks: false,
         },
       });
 
@@ -52,6 +53,7 @@ describe('generateMutator', () => {
         path: '@acme/esm-mutator/fetch',
         name: 'customInstance',
         hasSecondArg: true,
+        useHooks: false,
       });
     } finally {
       await rm(workspace, { recursive: true, force: true });

--- a/packages/core/src/generators/mutator.ts
+++ b/packages/core/src/generators/mutator.ts
@@ -120,6 +120,7 @@ export async function generateMutator({
       : mutatorInfo.numberOfParams > 1,
     hasThirdArg: mutatorInfo.numberOfParams > 2,
     isHook,
+    useHooks: mutator.useHooks,
     ...(hasBodyType ? { bodyTypeName } : {}),
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -193,6 +193,7 @@ export interface NormalizedMutator {
   alias?: Record<string, string>;
   external?: string[];
   extension?: string;
+  useHooks?: boolean;
 }
 
 export interface NormalizedOperationOptions {
@@ -678,6 +679,7 @@ export interface MutatorObject {
   alias?: Record<string, string>;
   external?: string[];
   extension?: string;
+  useHooks?: boolean;
 }
 
 export type Mutator = string | MutatorObject;
@@ -1811,6 +1813,7 @@ export interface GeneratorMutator {
   hasThirdArg: boolean;
   isHook: boolean;
   bodyTypeName?: string;
+  useHooks?: boolean;
 }
 
 export type ClientBuilder = (

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -928,6 +928,7 @@ function normalizeMutator(
       alias: m.alias,
       external: m.external,
       extension: m.extension,
+      useHooks: m.useHooks,
     };
   }
 

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -27,6 +27,7 @@ import {
 import type { FrameworkAdapter } from './framework-adapter';
 import { getQueryKeyVerbPrefix } from './query-generator';
 import { getQueryOptionsDefinition } from './query-options';
+import { shouldUseOptionsHook } from './utils';
 
 interface NormalizedTarget {
   query: string;
@@ -546,7 +547,10 @@ export const generateMutationHook = async ({
   });
 
   const mutationOptionsFnName = camel(
-    mutationOptionsMutator || mutator?.isHook
+    shouldUseOptionsHook({
+      optionsMutator: mutationOptionsMutator,
+      mutator,
+    })
       ? `use-${operationName}-mutationOptions`
       : `get-${operationName}-mutationOptions`,
   );

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -32,7 +32,7 @@ import {
   QueryType,
   requiresUserSuppliedQueryOptions,
 } from './query-options';
-import { getHasSignal } from './utils';
+import { getHasSignal, shouldUseOptionsHook } from './utils';
 
 /**
  * Decide whether the current operation's configuration conflicts with a
@@ -694,7 +694,11 @@ const generateQueryImplementation = ({
   });
 
   const queryOptionsFnName = camel(
-    queryKeyMutator || queryOptionsMutator || mutator?.isHook
+    shouldUseOptionsHook({
+      optionsMutator: queryOptionsMutator,
+      queryKeyMutator,
+      mutator,
+    })
       ? `use-${name}-queryOptions`
       : `get-${name}-queryOptions`,
   );

--- a/packages/query/src/utils.test.ts
+++ b/packages/query/src/utils.test.ts
@@ -1,8 +1,25 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { normalizeQueryOptions } from './utils';
+import type { GeneratorMutator } from '@orval/core';
+
+import { normalizeQueryOptions, shouldUseOptionsHook } from './utils';
 
 describe('normalizeQueryOptions', () => {
+  it('preserves useHooks for options mutators', () => {
+    const result = normalizeQueryOptions(
+      {
+        queryOptions: {
+          path: './query-options.ts',
+          name: 'customQueryOptions',
+          useHooks: false,
+        },
+      },
+      '/workspace',
+    );
+
+    expect(result.queryOptions?.useHooks).toBe(false);
+  });
+
   it('should include useOperationIdAsQueryKey when provided', () => {
     const result = normalizeQueryOptions(
       { useOperationIdAsQueryKey: true },
@@ -22,5 +39,78 @@ describe('normalizeQueryOptions', () => {
   it('should not include useOperationIdAsQueryKey when not provided', () => {
     const result = normalizeQueryOptions({}, '/workspace');
     expect(result.useOperationIdAsQueryKey).toBeUndefined();
+  });
+});
+
+describe('shouldUseOptionsHook', () => {
+  const mutator: GeneratorMutator = {
+    name: 'customMutator',
+    path: './custom-mutator',
+    default: false,
+    hasErrorType: false,
+    errorTypeName: '',
+    hasSecondArg: false,
+    hasThirdArg: false,
+    isHook: false,
+  };
+
+  it.each([
+    [
+      'uses hooks when the options mutator omits useHooks',
+      true,
+      {},
+      undefined,
+      undefined,
+    ],
+    [
+      'uses hooks when the options mutator enables useHooks',
+      true,
+      { useHooks: true },
+      undefined,
+      undefined,
+    ],
+    [
+      'does not use hooks when the options mutator disables useHooks',
+      false,
+      { useHooks: false },
+      undefined,
+      undefined,
+    ],
+    [
+      'disables query hooks when the query-key mutator would use hooks',
+      false,
+      { useHooks: false },
+      mutator,
+      undefined,
+    ],
+    [
+      'disables mutation hooks when the base mutator would use hooks',
+      false,
+      { useHooks: false },
+      undefined,
+      { ...mutator, isHook: true },
+    ],
+    [
+      'falls back to the query-key mutator when no options mutator exists',
+      true,
+      undefined,
+      mutator,
+      undefined,
+    ],
+    [
+      'falls back to the base mutator when no options or query-key mutator exists',
+      true,
+      undefined,
+      undefined,
+      { ...mutator, isHook: true },
+    ],
+  ])('%s', (_name, expected, optionsMutator, queryKeyMutator, baseMutator) => {
+    expect(
+      shouldUseOptionsHook({
+        optionsMutator: optionsMutator && { ...mutator, ...optionsMutator },
+        queryKeyMutator,
+        mutator: baseMutator,
+      }),
+    ).toBe(expected);
   });
 });

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -4,6 +4,7 @@ import { styleText } from 'node:util';
 import {
   isObject,
   isString,
+  type GeneratorMutator,
   type Mutator,
   type NormalizedMutator,
   type NormalizedQueryOptions,
@@ -97,6 +98,7 @@ const normalizeMutator = (
       alias: m.alias,
       external: m.external,
       extension: m.extension,
+      useHooks: m.useHooks,
     };
   }
 
@@ -108,6 +110,22 @@ const normalizeMutator = (
   }
 
   return undefined;
+};
+
+export const shouldUseOptionsHook = ({
+  optionsMutator,
+  queryKeyMutator,
+  mutator,
+}: {
+  optionsMutator?: GeneratorMutator;
+  queryKeyMutator?: GeneratorMutator;
+  mutator?: GeneratorMutator;
+}): boolean => {
+  if (optionsMutator) {
+    return optionsMutator.useHooks ?? true;
+  }
+
+  return !!queryKeyMutator || !!mutator?.isHook;
 };
 
 export const getQueryTypeForFramework = (type: string): string => {


### PR DESCRIPTION
- Add `useHooks?: boolean` to query and mutation options mutators.
- Generate `get…Options` when it is explicitly `false`; generate `use…Options` when `true` or omitted.
- Let explicit `false` override query-key and base-mutator hook inference.
- Cover normalization, propagation, and query/mutation precedence.

 Closes #3898 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring whether generated query and mutation option hooks are used.
  * Hook generation now respects explicit settings and related mutator configurations.

* **Bug Fixes**
  * Preserved hook settings during mutator processing and generation.
  * Improved consistency when selecting option hooks for queries and mutations.

* **Documentation**
  * Documented disabling option hooks and the resulting generated option factory names.

* **Tests**
  * Added coverage for hook configuration preservation and selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->