### PR TITLE
fix(angular): serialize Date query params to ISO in filterParams (#3856)

### DIFF
--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -506,6 +506,26 @@ describe('angular HttpClient generator', () => {
       expect(header).toContain('function filterParams(');
     });
 
+    it('serializes Date query params to ISO instead of dropping them (#3856)', () => {
+      const verbOptionWithQueryParams = createVerbOption({
+        tags: [],
+        queryParams: createQueryParams({
+          schema: { name: 'GetApiProductParams', model: '', imports: [] },
+        }),
+      });
+
+      const header = generateAngularHeader(
+        createHeaderParams({
+          title: 'DefaultService',
+          verbOptions: { getApiProduct: verbOptionWithQueryParams },
+          tag: 'default',
+        }),
+      );
+
+      expect(header).toContain('value instanceof Date');
+      expect(header).toContain('value.toISOString()');
+    });
+
     it('includes both explicit default-tagged and untagged operations in the default bucket', () => {
       const untaggedVerb = createVerbOption({
         operationId: 'getUntaggedProduct',

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -634,6 +634,10 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -618,13 +618,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -925,6 +930,61 @@ function filterParams(
       );
 
       expect(result).toEqual({ arg0: 'itemReferences,a,b,pageNumber,1' });
+    });
+
+    it('serializes Date array elements to ISO instead of dropping them (#3856)', () => {
+      const filterParams = loadFilterParams(
+        getAngularFilteredParamsHelperBody({ hasObjectParams: true }),
+      );
+      const date = new Date('2026-01-02T03:04:05.000Z');
+
+      const result = filterParams(
+        { dates: [date, 'a', null, { x: 1 }] },
+        new Set(),
+        false,
+        new Set(),
+      );
+
+      expect(result).toEqual({ dates: ['2026-01-02T03:04:05.000Z', 'a'] });
+    });
+
+    it('serializes Date properties in comma object params to ISO (#3856)', () => {
+      const filterParams = loadFilterParams(
+        getAngularFilteredParamsHelperBody({ hasObjectParams: true }),
+      );
+      const date = new Date('2026-01-02T03:04:05.000Z');
+
+      const result = filterParams(
+        { filter: { since: date, page: 1 } },
+        new Set(),
+        false,
+        new Set(),
+        { filter: 'comma' },
+      );
+
+      expect(result).toEqual({
+        filter: 'since,2026-01-02T03:04:05.000Z,page,1',
+      });
+    });
+
+    it('serializes Date properties in flatten/deepObject params to ISO (#3856)', () => {
+      const filterParams = loadFilterParams(
+        getAngularFilteredParamsHelperBody({ hasObjectParams: true }),
+      );
+      const date = new Date('2026-01-02T03:04:05.000Z');
+
+      const result = filterParams(
+        { filter: { since: date, page: 1 } },
+        new Set(),
+        false,
+        new Set(),
+        { filter: 'deepObject' },
+      );
+
+      expect(result).toEqual({
+        'filter[since]': '2026-01-02T03:04:05.000Z',
+        'filter[page]': 1,
+      });
     });
 
     it('emits bracketed keys for deepObject, preserving array values', () => {

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -634,7 +634,7 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -90,6 +90,11 @@ export const getAngularFilteredParamsExpression = (
               typeof propValue === 'boolean')
           ) {
             commaParts.push(prop, String(propValue));
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            commaParts.push(prop, propValue.toISOString());
           }
         }
         if (commaParts.length) {
@@ -117,6 +122,11 @@ export const getAngularFilteredParamsExpression = (
               typeof propValue === 'boolean')
           ) {
             filteredParams[targetKey] = propValue;
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            filteredParams[targetKey] = propValue.toISOString();
           }
         }
       }
@@ -170,13 +180,21 @@ ${passthroughDecl}${objectStrategiesDecl}  ${requiredNullableParamKeysBranch}
   const filteredParams: Record<string, ${filteredParamValueType}> = {};
   for (const [key, value] of Object.entries(${paramsExpression})) {
 ${passthroughBranch}${objectStrategyBranch}    if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              ((item as unknown) instanceof Date &&
+                !Number.isNaN((item as unknown as Date).getTime()))),
+        )
+        .map((item) =>
+          (item as unknown) instanceof Date
+            ? (item as unknown as Date).toISOString()
+            : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -244,13 +262,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -317,13 +340,18 @@ function filterParams(
   const filterPrimitiveArray = (
     value: unknown[],
   ): Array<string | number | boolean> =>
-    value.filter(
-      (item) =>
-        item != null &&
-        (typeof item === 'string' ||
-          typeof item === 'number' ||
-          typeof item === 'boolean'),
-    ) as Array<string | number | boolean>;
+    value
+      .filter(
+        (item) =>
+          item != null &&
+          (typeof item === 'string' ||
+            typeof item === 'number' ||
+            typeof item === 'boolean' ||
+            (item instanceof Date && !Number.isNaN(item.getTime()))),
+      )
+      .map((item) => (item instanceof Date ? item.toISOString() : item)) as Array<
+      string | number | boolean
+    >;
   for (const [key, value] of Object.entries(params)) {
     if (passthroughKeys.has(key)) {
       if (value !== undefined) {
@@ -354,6 +382,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             commaParts.push(prop, String(propValue));
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            commaParts.push(prop, propValue.toISOString());
           }
         }
         if (commaParts.length) {
@@ -375,6 +408,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             filteredParams[targetKey] = propValue;
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            filteredParams[targetKey] = propValue.toISOString();
           }
         }
       }

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -142,10 +142,13 @@ export const getAngularFilteredParamsExpression = (
     ? `const requiredNullableParamKeys = new Set<string>(${JSON.stringify(requiredNullableParamKeys)});`
     : '';
 
-  const scalarBranch = `    } else if (value instanceof Date) {
+  const scalarBranch = `    } else if (
+      (value as unknown) instanceof Date &&
+      !Number.isNaN((value as unknown as Date).getTime())
+    ) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
-      filteredParams[key] = value.toISOString();
+      filteredParams[key] = (value as unknown as Date).toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -257,7 +260,7 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();
@@ -388,7 +391,7 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -142,7 +142,11 @@ export const getAngularFilteredParamsExpression = (
     ? `const requiredNullableParamKeys = new Set<string>(${JSON.stringify(requiredNullableParamKeys)});`
     : '';
 
-  const scalarBranch = `    } else if (
+  const scalarBranch = `    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
+    } else if (
       value != null &&
       (typeof value === 'string' ||
         typeof value === 'number' ||
@@ -253,6 +257,10 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -380,6 +388,10 @@ function filterParams(
       // string so the required key still reaches the wire as \`?key=\`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
@@ -17,6 +17,8 @@ import type {
 import { inject } from '@angular/core';
 import type { ResourceStatus, Signal } from '@angular/core';
 
+import { map } from 'rxjs';
+
 import { PETSTORE_BASE_URL } from '../petstore.base-url';
 
 export interface OrvalHttpResourceRequestExtension {
@@ -143,13 +145,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
@@ -159,7 +159,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.resource.ts
@@ -159,6 +159,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
@@ -121,7 +121,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
@@ -121,6 +121,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/base-url-token/pets/pets.service.ts
@@ -105,13 +105,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -106,13 +106,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -122,6 +122,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod/pets/pets.service.ts
@@ -122,7 +122,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
@@ -16,6 +16,8 @@ import type {
 
 import type { ResourceStatus, Signal } from '@angular/core';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -140,13 +142,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
@@ -156,7 +156,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.resource.ts
@@ -156,6 +156,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
@@ -103,13 +103,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
@@ -119,7 +119,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-both/pets/pets.service.ts
@@ -119,6 +119,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -121,7 +121,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -121,6 +121,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client-custom-params/pets/pets.service.ts
@@ -105,13 +105,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -105,13 +105,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -238,13 +243,21 @@ export class PetsService {
           > = {};
           for (const [key, value] of Object.entries(params ?? {})) {
             if (Array.isArray(value)) {
-              const filtered = value.filter(
-                (item) =>
-                  item != null &&
-                  (typeof item === 'string' ||
-                    typeof item === 'number' ||
-                    typeof item === 'boolean'),
-              ) as Array<string | number | boolean>;
+              const filtered = value
+                .filter(
+                  (item) =>
+                    item != null &&
+                    (typeof item === 'string' ||
+                      typeof item === 'number' ||
+                      typeof item === 'boolean' ||
+                      ((item as unknown) instanceof Date &&
+                        !Number.isNaN((item as unknown as Date).getTime()))),
+                )
+                .map((item) =>
+                  (item as unknown) instanceof Date
+                    ? (item as unknown as Date).toISOString()
+                    : item,
+                ) as Array<string | number | boolean>;
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -121,7 +121,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();
@@ -248,10 +248,13 @@ export class PetsService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
-            } else if (value instanceof Date) {
+            } else if (
+              (value as unknown) instanceof Date &&
+              !Number.isNaN((value as unknown as Date).getTime())
+            ) {
               // useDates produces Date query params; serialize to ISO so they reach
               // the wire instead of being dropped by the primitive check below. See #3856.
-              filteredParams[key] = value.toISOString();
+              filteredParams[key] = (value as unknown as Date).toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-client/pets/pets.service.ts
@@ -121,6 +121,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -244,6 +248,10 @@ export class PetsService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
+            } else if (value instanceof Date) {
+              // useDates produces Date query params; serialize to ISO so they reach
+              // the wire instead of being dropped by the primitive check below. See #3856.
+              filteredParams[key] = value.toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -159,13 +159,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -175,7 +175,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource-zod/pets/pets.service.ts
@@ -175,6 +175,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -172,6 +172,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -172,7 +172,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/http-resource/pets/pets.service.ts
@@ -32,6 +32,8 @@ import type {
   SearchPetsParams,
 } from '../model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -156,13 +158,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
@@ -17,6 +17,8 @@ import type {
 import { inject } from '@angular/core';
 import type { ResourceStatus, Signal } from '@angular/core';
 
+import { map } from 'rxjs';
+
 import { PETSTORE_BASE_URL } from '../petstore.base-url';
 
 export interface OrvalHttpResourceRequestExtension {
@@ -143,13 +145,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
@@ -159,7 +159,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.resource.ts
@@ -159,6 +159,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
@@ -121,7 +121,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
@@ -121,6 +121,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
+++ b/samples/angular-app/src/api/base-url-token/pets/pets.service.ts
@@ -105,13 +105,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -106,13 +106,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -122,6 +122,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod/pets/pets.service.ts
@@ -122,7 +122,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.resource.ts
@@ -16,6 +16,8 @@ import type {
 
 import type { ResourceStatus, Signal } from '@angular/core';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -140,13 +142,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.resource.ts
@@ -156,7 +156,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/http-both/pets/pets.resource.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.resource.ts
@@ -156,6 +156,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.service.ts
@@ -103,13 +103,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.service.ts
@@ -119,7 +119,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/http-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-both/pets/pets.service.ts
@@ -119,6 +119,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -121,7 +121,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -121,6 +121,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client-custom-params/pets/pets.service.ts
@@ -105,13 +105,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -105,13 +105,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -238,13 +243,21 @@ export class PetsService {
           > = {};
           for (const [key, value] of Object.entries(params ?? {})) {
             if (Array.isArray(value)) {
-              const filtered = value.filter(
-                (item) =>
-                  item != null &&
-                  (typeof item === 'string' ||
-                    typeof item === 'number' ||
-                    typeof item === 'boolean'),
-              ) as Array<string | number | boolean>;
+              const filtered = value
+                .filter(
+                  (item) =>
+                    item != null &&
+                    (typeof item === 'string' ||
+                      typeof item === 'number' ||
+                      typeof item === 'boolean' ||
+                      ((item as unknown) instanceof Date &&
+                        !Number.isNaN((item as unknown as Date).getTime()))),
+                )
+                .map((item) =>
+                  (item as unknown) instanceof Date
+                    ? (item as unknown as Date).toISOString()
+                    : item,
+                ) as Array<string | number | boolean>;
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -121,7 +121,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();
@@ -248,10 +248,13 @@ export class PetsService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
-            } else if (value instanceof Date) {
+            } else if (
+              (value as unknown) instanceof Date &&
+              !Number.isNaN((value as unknown as Date).getTime())
+            ) {
               // useDates produces Date query params; serialize to ISO so they reach
               // the wire instead of being dropped by the primitive check below. See #3856.
-              filteredParams[key] = value.toISOString();
+              filteredParams[key] = (value as unknown as Date).toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-client/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-client/pets/pets.service.ts
@@ -121,6 +121,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -244,6 +248,10 @@ export class PetsService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
+            } else if (value instanceof Date) {
+              // useDates produces Date query params; serialize to ISO so they reach
+              // the wire instead of being dropped by the primitive check below. See #3856.
+              filteredParams[key] = value.toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -159,13 +159,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -175,7 +175,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource-zod/pets/pets.service.ts
@@ -175,6 +175,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -172,6 +172,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -172,7 +172,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-app/src/api/http-resource/pets/pets.service.ts
+++ b/samples/angular-app/src/api/http-resource/pets/pets.service.ts
@@ -32,6 +32,8 @@ import type {
   SearchPetsParams,
 } from '../model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -156,13 +158,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -93,7 +93,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();
@@ -140,10 +140,13 @@ export const searchPets = (
             }
           } else if (value === null && requiredNullableParamKeys.has(key)) {
             filteredParams[key] = '';
-          } else if (value instanceof Date) {
+          } else if (
+            (value as unknown) instanceof Date &&
+            !Number.isNaN((value as unknown as Date).getTime())
+          ) {
             // useDates produces Date query params; serialize to ISO so they reach
             // the wire instead of being dropped by the primitive check below. See #3856.
-            filteredParams[key] = value.toISOString();
+            filteredParams[key] = (value as unknown as Date).toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||
@@ -268,10 +271,13 @@ export const listPets = (
             if (filtered.length) {
               filteredParams[key] = filtered;
             }
-          } else if (value instanceof Date) {
+          } else if (
+            (value as unknown) instanceof Date &&
+            !Number.isNaN((value as unknown as Date).getTime())
+          ) {
             // useDates produces Date query params; serialize to ISO so they reach
             // the wire instead of being dropped by the primitive check below. See #3856.
-            filteredParams[key] = value.toISOString();
+            filteredParams[key] = (value as unknown as Date).toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -93,6 +93,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -136,6 +140,10 @@ export const searchPets = (
             }
           } else if (value === null && requiredNullableParamKeys.has(key)) {
             filteredParams[key] = '';
+          } else if (value instanceof Date) {
+            // useDates produces Date query params; serialize to ISO so they reach
+            // the wire instead of being dropped by the primitive check below. See #3856.
+            filteredParams[key] = value.toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||
@@ -260,6 +268,10 @@ export const listPets = (
             if (filtered.length) {
               filteredParams[key] = filtered;
             }
+          } else if (value instanceof Date) {
+            // useDates produces Date query params; serialize to ISO so they reach
+            // the wire instead of being dropped by the primitive check below. See #3856.
+            filteredParams[key] = value.toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -21,6 +21,8 @@ import type {
   QueryFunction,
 } from '@tanstack/angular-query-experimental';
 
+import { map } from 'rxjs/operators';
+
 import type {
   CreatePetsBody,
   Error,
@@ -77,13 +79,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -128,13 +135,21 @@ export const searchPets = (
         > = {};
         for (const [key, value] of Object.entries(params ?? {})) {
           if (Array.isArray(value)) {
-            const filtered = value.filter(
-              (item) =>
-                item != null &&
-                (typeof item === 'string' ||
-                  typeof item === 'number' ||
-                  typeof item === 'boolean'),
-            ) as Array<string | number | boolean>;
+            const filtered = value
+              .filter(
+                (item) =>
+                  item != null &&
+                  (typeof item === 'string' ||
+                    typeof item === 'number' ||
+                    typeof item === 'boolean' ||
+                    ((item as unknown) instanceof Date &&
+                      !Number.isNaN((item as unknown as Date).getTime()))),
+              )
+              .map((item) =>
+                (item as unknown) instanceof Date
+                  ? (item as unknown as Date).toISOString()
+                  : item,
+              ) as Array<string | number | boolean>;
             if (filtered.length) {
               filteredParams[key] = filtered;
             }
@@ -261,13 +276,21 @@ export const listPets = (
         > = {};
         for (const [key, value] of Object.entries(params ?? {})) {
           if (Array.isArray(value)) {
-            const filtered = value.filter(
-              (item) =>
-                item != null &&
-                (typeof item === 'string' ||
-                  typeof item === 'number' ||
-                  typeof item === 'boolean'),
-            ) as Array<string | number | boolean>;
+            const filtered = value
+              .filter(
+                (item) =>
+                  item != null &&
+                  (typeof item === 'string' ||
+                    typeof item === 'number' ||
+                    typeof item === 'boolean' ||
+                    ((item as unknown) instanceof Date &&
+                      !Number.isNaN((item as unknown as Date).getTime()))),
+              )
+              .map((item) =>
+                (item as unknown) instanceof Date
+                  ? (item as unknown as Date).toISOString()
+                  : item,
+              ) as Array<string | number | boolean>;
             if (filtered.length) {
               filteredParams[key] = filtered;
             }

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -92,7 +92,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -92,6 +92,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -23,7 +23,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -76,13 +76,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -89,7 +89,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -73,13 +73,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -89,6 +89,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -95,7 +95,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -95,6 +95,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -26,7 +26,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -79,13 +79,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -93,7 +93,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();
@@ -140,10 +140,13 @@ export const searchPets = (
             }
           } else if (value === null && requiredNullableParamKeys.has(key)) {
             filteredParams[key] = '';
-          } else if (value instanceof Date) {
+          } else if (
+            (value as unknown) instanceof Date &&
+            !Number.isNaN((value as unknown as Date).getTime())
+          ) {
             // useDates produces Date query params; serialize to ISO so they reach
             // the wire instead of being dropped by the primitive check below. See #3856.
-            filteredParams[key] = value.toISOString();
+            filteredParams[key] = (value as unknown as Date).toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||
@@ -268,10 +271,13 @@ export const listPets = (
             if (filtered.length) {
               filteredParams[key] = filtered;
             }
-          } else if (value instanceof Date) {
+          } else if (
+            (value as unknown) instanceof Date &&
+            !Number.isNaN((value as unknown as Date).getTime())
+          ) {
             // useDates produces Date query params; serialize to ISO so they reach
             // the wire instead of being dropped by the primitive check below. See #3856.
-            filteredParams[key] = value.toISOString();
+            filteredParams[key] = (value as unknown as Date).toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -93,6 +93,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||
@@ -136,6 +140,10 @@ export const searchPets = (
             }
           } else if (value === null && requiredNullableParamKeys.has(key)) {
             filteredParams[key] = '';
+          } else if (value instanceof Date) {
+            // useDates produces Date query params; serialize to ISO so they reach
+            // the wire instead of being dropped by the primitive check below. See #3856.
+            filteredParams[key] = value.toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||
@@ -260,6 +268,10 @@ export const listPets = (
             if (filtered.length) {
               filteredParams[key] = filtered;
             }
+          } else if (value instanceof Date) {
+            // useDates produces Date query params; serialize to ISO so they reach
+            // the wire instead of being dropped by the primitive check below. See #3856.
+            filteredParams[key] = value.toISOString();
           } else if (
             value != null &&
             (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -21,6 +21,8 @@ import type {
   QueryFunction,
 } from '@tanstack/angular-query-experimental';
 
+import { map } from 'rxjs/operators';
+
 import type {
   CreatePetsBody,
   Error,
@@ -77,13 +79,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -128,13 +135,21 @@ export const searchPets = (
         > = {};
         for (const [key, value] of Object.entries(params ?? {})) {
           if (Array.isArray(value)) {
-            const filtered = value.filter(
-              (item) =>
-                item != null &&
-                (typeof item === 'string' ||
-                  typeof item === 'number' ||
-                  typeof item === 'boolean'),
-            ) as Array<string | number | boolean>;
+            const filtered = value
+              .filter(
+                (item) =>
+                  item != null &&
+                  (typeof item === 'string' ||
+                    typeof item === 'number' ||
+                    typeof item === 'boolean' ||
+                    ((item as unknown) instanceof Date &&
+                      !Number.isNaN((item as unknown as Date).getTime()))),
+              )
+              .map((item) =>
+                (item as unknown) instanceof Date
+                  ? (item as unknown as Date).toISOString()
+                  : item,
+              ) as Array<string | number | boolean>;
             if (filtered.length) {
               filteredParams[key] = filtered;
             }
@@ -261,13 +276,21 @@ export const listPets = (
         > = {};
         for (const [key, value] of Object.entries(params ?? {})) {
           if (Array.isArray(value)) {
-            const filtered = value.filter(
-              (item) =>
-                item != null &&
-                (typeof item === 'string' ||
-                  typeof item === 'number' ||
-                  typeof item === 'boolean'),
-            ) as Array<string | number | boolean>;
+            const filtered = value
+              .filter(
+                (item) =>
+                  item != null &&
+                  (typeof item === 'string' ||
+                    typeof item === 'number' ||
+                    typeof item === 'boolean' ||
+                    ((item as unknown) instanceof Date &&
+                      !Number.isNaN((item as unknown as Date).getTime()))),
+              )
+              .map((item) =>
+                (item as unknown) instanceof Date
+                  ? (item as unknown as Date).toISOString()
+                  : item,
+              ) as Array<string | number | boolean>;
             if (filtered.length) {
               filteredParams[key] = filtered;
             }

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -92,7 +92,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -92,6 +92,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -23,7 +23,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -76,13 +76,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -89,7 +89,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -73,13 +73,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -89,6 +89,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -95,7 +95,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -95,6 +95,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -26,7 +26,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -79,13 +79,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -23,7 +23,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -75,13 +75,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -91,6 +91,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -91,7 +91,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -23,7 +23,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -75,13 +75,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -91,6 +91,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -91,7 +91,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -23,7 +23,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -75,13 +75,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -91,6 +91,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -91,7 +91,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
@@ -23,7 +23,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -82,13 +82,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
@@ -98,7 +98,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
@@ -98,6 +98,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -92,7 +92,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -24,7 +24,7 @@ import type {
 
 import { fromEvent, lastValueFrom } from 'rxjs';
 
-import { takeUntil } from 'rxjs/operators';
+import { map, takeUntil } from 'rxjs/operators';
 
 import type {
   CreatePetsBody,
@@ -76,13 +76,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -92,6 +92,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
@@ -159,7 +159,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
@@ -17,6 +17,8 @@ import type {
 import { inject } from '@angular/core';
 import type { ResourceStatus, Signal } from '@angular/core';
 
+import { map } from 'rxjs';
+
 import { PETSTORE_API_BASE_URL } from '../endpoints.base-url';
 
 export interface OrvalHttpResourceRequestExtension {
@@ -143,13 +145,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.resource.ts
@@ -159,6 +159,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
@@ -106,13 +106,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
@@ -122,6 +122,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/base-url-token-both/pets/pets.service.ts
@@ -122,7 +122,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
@@ -24,8 +24,6 @@ import type { ResourceStatus, Signal } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
-import { PETSTORE_API_BASE_URL } from './endpoints.base-url';
-
 import type {
   CreatePetsBody,
   CreatePetsParams,
@@ -34,6 +32,10 @@ import type {
   PetWithTag,
   Pets,
 } from './model';
+
+import { map } from 'rxjs';
+
+import { PETSTORE_API_BASE_URL } from './endpoints.base-url';
 
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
@@ -159,13 +161,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
@@ -175,7 +175,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-http-resource/endpoints.ts
@@ -175,6 +175,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
@@ -125,6 +125,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
@@ -109,13 +109,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token-zod/endpoints.ts
@@ -125,7 +125,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/base-url-token/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token/endpoints.ts
@@ -106,13 +106,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/base-url-token/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token/endpoints.ts
@@ -122,6 +122,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/base-url-token/endpoints.ts
+++ b/tests/__snapshots__/angular/base-url-token/endpoints.ts
@@ -122,7 +122,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/custom-client/endpoints.ts
+++ b/tests/__snapshots__/angular/custom-client/endpoints.ts
@@ -48,13 +48,21 @@ export class SwaggerPetstoreService {
           > = {};
           for (const [key, value] of Object.entries(params ?? {})) {
             if (Array.isArray(value)) {
-              const filtered = value.filter(
-                (item) =>
-                  item != null &&
-                  (typeof item === 'string' ||
-                    typeof item === 'number' ||
-                    typeof item === 'boolean'),
-              ) as Array<string | number | boolean>;
+              const filtered = value
+                .filter(
+                  (item) =>
+                    item != null &&
+                    (typeof item === 'string' ||
+                      typeof item === 'number' ||
+                      typeof item === 'boolean' ||
+                      ((item as unknown) instanceof Date &&
+                        !Number.isNaN((item as unknown as Date).getTime()))),
+                )
+                .map((item) =>
+                  (item as unknown) instanceof Date
+                    ? (item as unknown as Date).toISOString()
+                    : item,
+                ) as Array<string | number | boolean>;
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
@@ -102,13 +110,21 @@ export class SwaggerPetstoreService {
           > = {};
           for (const [key, value] of Object.entries(params ?? {})) {
             if (Array.isArray(value)) {
-              const filtered = value.filter(
-                (item) =>
-                  item != null &&
-                  (typeof item === 'string' ||
-                    typeof item === 'number' ||
-                    typeof item === 'boolean'),
-              ) as Array<string | number | boolean>;
+              const filtered = value
+                .filter(
+                  (item) =>
+                    item != null &&
+                    (typeof item === 'string' ||
+                      typeof item === 'number' ||
+                      typeof item === 'boolean' ||
+                      ((item as unknown) instanceof Date &&
+                        !Number.isNaN((item as unknown as Date).getTime()))),
+                )
+                .map((item) =>
+                  (item as unknown) instanceof Date
+                    ? (item as unknown as Date).toISOString()
+                    : item,
+                ) as Array<string | number | boolean>;
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }

--- a/tests/__snapshots__/angular/custom-client/endpoints.ts
+++ b/tests/__snapshots__/angular/custom-client/endpoints.ts
@@ -58,10 +58,13 @@ export class SwaggerPetstoreService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
-            } else if (value instanceof Date) {
+            } else if (
+              (value as unknown) instanceof Date &&
+              !Number.isNaN((value as unknown as Date).getTime())
+            ) {
               // useDates produces Date query params; serialize to ISO so they reach
               // the wire instead of being dropped by the primitive check below. See #3856.
-              filteredParams[key] = value.toISOString();
+              filteredParams[key] = (value as unknown as Date).toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||
@@ -109,10 +112,13 @@ export class SwaggerPetstoreService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
-            } else if (value instanceof Date) {
+            } else if (
+              (value as unknown) instanceof Date &&
+              !Number.isNaN((value as unknown as Date).getTime())
+            ) {
               // useDates produces Date query params; serialize to ISO so they reach
               // the wire instead of being dropped by the primitive check below. See #3856.
-              filteredParams[key] = value.toISOString();
+              filteredParams[key] = (value as unknown as Date).toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/custom-client/endpoints.ts
+++ b/tests/__snapshots__/angular/custom-client/endpoints.ts
@@ -58,6 +58,10 @@ export class SwaggerPetstoreService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
+            } else if (value instanceof Date) {
+              // useDates produces Date query params; serialize to ISO so they reach
+              // the wire instead of being dropped by the primitive check below. See #3856.
+              filteredParams[key] = value.toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||
@@ -105,6 +109,10 @@ export class SwaggerPetstoreService {
               if (filtered.length) {
                 filteredParams[key] = filtered;
               }
+            } else if (value instanceof Date) {
+              // useDates produces Date query params; serialize to ISO so they reach
+              // the wire instead of being dropped by the primitive check below. See #3856.
+              filteredParams[key] = value.toISOString();
             } else if (
               value != null &&
               (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
@@ -175,7 +175,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
@@ -175,6 +175,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-headers/endpoints.ts
@@ -35,6 +35,8 @@ import type {
   Pets,
 } from './model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -159,13 +161,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
@@ -166,6 +166,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
@@ -26,6 +26,8 @@ import type {
   ListItemsParams,
 } from './model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -150,13 +152,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-multi-content/endpoints.ts
@@ -166,7 +166,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/http-resource-tags/pets.ts
+++ b/tests/__snapshots__/angular/http-resource-tags/pets.ts
@@ -33,6 +33,8 @@ import type {
   Pets,
 } from './model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -157,13 +159,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/http-resource-tags/pets.ts
+++ b/tests/__snapshots__/angular/http-resource-tags/pets.ts
@@ -173,6 +173,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-tags/pets.ts
+++ b/tests/__snapshots__/angular/http-resource-tags/pets.ts
@@ -173,7 +173,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
@@ -187,7 +187,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
@@ -187,6 +187,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-disabled/endpoints.ts
@@ -42,6 +42,10 @@ import type {
 } from './model';
 
 import {
+  map
+} from 'rxjs';
+
+import {
   faker
 } from '@faker-js/faker';
 
@@ -171,13 +175,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
@@ -187,7 +187,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
@@ -187,6 +187,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod/endpoints.ts
@@ -42,6 +42,10 @@ import type {
 } from './model';
 
 import {
+  map
+} from 'rxjs';
+
+import {
   faker
 } from '@faker-js/faker';
 
@@ -171,13 +175,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3103/default/default.service.ts
+++ b/tests/__snapshots__/angular/issue-3103/default/default.service.ts
@@ -97,13 +97,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3103/default/default.service.ts
+++ b/tests/__snapshots__/angular/issue-3103/default/default.service.ts
@@ -113,6 +113,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3103/default/default.service.ts
+++ b/tests/__snapshots__/angular/issue-3103/default/default.service.ts
@@ -113,7 +113,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
@@ -114,6 +114,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
@@ -114,7 +114,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326-serializer/endpoints.ts
@@ -98,13 +98,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3326/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326/endpoints.ts
@@ -103,13 +103,18 @@ function filterParams(
   const filterPrimitiveArray = (
     value: unknown[],
   ): Array<string | number | boolean> =>
-    value.filter(
-      (item) =>
-        item != null &&
-        (typeof item === 'string' ||
-          typeof item === 'number' ||
-          typeof item === 'boolean'),
-    ) as Array<string | number | boolean>;
+    value
+      .filter(
+        (item) =>
+          item != null &&
+          (typeof item === 'string' ||
+            typeof item === 'number' ||
+            typeof item === 'boolean' ||
+            (item instanceof Date && !Number.isNaN(item.getTime()))),
+      )
+      .map((item) =>
+        item instanceof Date ? item.toISOString() : item,
+      ) as Array<string | number | boolean>;
   for (const [key, value] of Object.entries(params)) {
     if (passthroughKeys.has(key)) {
       if (value !== undefined) {
@@ -140,6 +145,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             commaParts.push(prop, String(propValue));
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            commaParts.push(prop, propValue.toISOString());
           }
         }
         if (commaParts.length) {
@@ -161,6 +171,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             filteredParams[targetKey] = propValue;
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            filteredParams[targetKey] = propValue.toISOString();
           }
         }
       }

--- a/tests/__snapshots__/angular/issue-3326/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326/endpoints.ts
@@ -177,7 +177,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3326/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3326/endpoints.ts
@@ -177,6 +177,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
+++ b/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
@@ -33,6 +33,8 @@ import type {
   Pets,
 } from './petstore.schemas';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -157,13 +159,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
+++ b/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
@@ -173,6 +173,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
+++ b/tests/__snapshots__/angular/issue-3624/petstore.client.service.ts
@@ -173,7 +173,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
@@ -97,13 +97,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
@@ -113,6 +113,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/ab-widget/ab-widget.service.ts
@@ -113,7 +113,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
@@ -97,13 +97,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
@@ -113,6 +113,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
+++ b/tests/__snapshots__/angular/issue-3634/widget/widget.service.ts
@@ -113,7 +113,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
@@ -227,6 +227,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
@@ -153,13 +153,18 @@ function filterParams(
   const filterPrimitiveArray = (
     value: unknown[],
   ): Array<string | number | boolean> =>
-    value.filter(
-      (item) =>
-        item != null &&
-        (typeof item === 'string' ||
-          typeof item === 'number' ||
-          typeof item === 'boolean'),
-    ) as Array<string | number | boolean>;
+    value
+      .filter(
+        (item) =>
+          item != null &&
+          (typeof item === 'string' ||
+            typeof item === 'number' ||
+            typeof item === 'boolean' ||
+            (item instanceof Date && !Number.isNaN(item.getTime()))),
+      )
+      .map((item) =>
+        item instanceof Date ? item.toISOString() : item,
+      ) as Array<string | number | boolean>;
   for (const [key, value] of Object.entries(params)) {
     if (passthroughKeys.has(key)) {
       if (value !== undefined) {
@@ -190,6 +195,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             commaParts.push(prop, String(propValue));
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            commaParts.push(prop, propValue.toISOString());
           }
         }
         if (commaParts.length) {
@@ -211,6 +221,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             filteredParams[targetKey] = propValue;
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            filteredParams[targetKey] = propValue.toISOString();
           }
         }
       }

--- a/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-http-resource/endpoints.ts
@@ -227,7 +227,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
@@ -102,13 +102,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
@@ -118,7 +118,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-legacy/endpoints.ts
@@ -118,6 +118,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
@@ -103,13 +103,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
@@ -119,7 +119,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705-serializer/endpoints.ts
@@ -119,6 +119,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705/endpoints.ts
@@ -108,13 +108,18 @@ function filterParams(
   const filterPrimitiveArray = (
     value: unknown[],
   ): Array<string | number | boolean> =>
-    value.filter(
-      (item) =>
-        item != null &&
-        (typeof item === 'string' ||
-          typeof item === 'number' ||
-          typeof item === 'boolean'),
-    ) as Array<string | number | boolean>;
+    value
+      .filter(
+        (item) =>
+          item != null &&
+          (typeof item === 'string' ||
+            typeof item === 'number' ||
+            typeof item === 'boolean' ||
+            (item instanceof Date && !Number.isNaN(item.getTime()))),
+      )
+      .map((item) =>
+        item instanceof Date ? item.toISOString() : item,
+      ) as Array<string | number | boolean>;
   for (const [key, value] of Object.entries(params)) {
     if (passthroughKeys.has(key)) {
       if (value !== undefined) {
@@ -145,6 +150,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             commaParts.push(prop, String(propValue));
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            commaParts.push(prop, propValue.toISOString());
           }
         }
         if (commaParts.length) {
@@ -166,6 +176,11 @@ function filterParams(
               typeof propValue === 'boolean')
           ) {
             filteredParams[targetKey] = propValue;
+          } else if (
+            propValue instanceof Date &&
+            !Number.isNaN(propValue.getTime())
+          ) {
+            filteredParams[targetKey] = propValue.toISOString();
           }
         }
       }

--- a/tests/__snapshots__/angular/issue-3705/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705/endpoints.ts
@@ -182,6 +182,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3705/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3705/endpoints.ts
@@ -182,7 +182,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
@@ -16,6 +16,8 @@ import type { ResourceStatus, Signal } from '@angular/core';
 
 import type { ListThingsParams } from './model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -140,13 +142,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
@@ -156,7 +156,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-http-resource/endpoints.ts
@@ -156,6 +156,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
@@ -114,6 +114,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
@@ -114,7 +114,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712-serializer/endpoints.ts
@@ -98,13 +98,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3712/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712/endpoints.ts
@@ -97,13 +97,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/issue-3712/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712/endpoints.ts
@@ -113,6 +113,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/issue-3712/endpoints.ts
+++ b/tests/__snapshots__/angular/issue-3712/endpoints.ts
@@ -113,7 +113,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
+++ b/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
@@ -115,6 +115,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
+++ b/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
@@ -99,13 +99,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
+++ b/tests/__snapshots__/angular/multi-content-query-params/endpoints.ts
@@ -115,7 +115,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/named-parameters/endpoints.ts
@@ -126,6 +126,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/named-parameters/endpoints.ts
@@ -110,13 +110,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/named-parameters/endpoints.ts
@@ -126,7 +126,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/petstore/endpoints.ts
+++ b/tests/__snapshots__/angular/petstore/endpoints.ts
@@ -127,7 +127,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/petstore/endpoints.ts
+++ b/tests/__snapshots__/angular/petstore/endpoints.ts
@@ -111,13 +111,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/petstore/endpoints.ts
+++ b/tests/__snapshots__/angular/petstore/endpoints.ts
@@ -127,6 +127,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/split/endpoints.service.ts
+++ b/tests/__snapshots__/angular/split/endpoints.service.ts
@@ -120,7 +120,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/split/endpoints.service.ts
+++ b/tests/__snapshots__/angular/split/endpoints.service.ts
@@ -120,6 +120,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/split/endpoints.service.ts
+++ b/tests/__snapshots__/angular/split/endpoints.service.ts
@@ -104,13 +104,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
@@ -120,7 +120,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
@@ -120,6 +120,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
+++ b/tests/__snapshots__/angular/tags-split/pets/pets.service.ts
@@ -104,13 +104,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/tags/pets.ts
+++ b/tests/__snapshots__/angular/tags/pets.ts
@@ -127,7 +127,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/tags/pets.ts
+++ b/tests/__snapshots__/angular/tags/pets.ts
@@ -111,13 +111,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/tags/pets.ts
+++ b/tests/__snapshots__/angular/tags/pets.ts
@@ -127,6 +127,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
@@ -33,6 +33,8 @@ import type {
   Pets,
 } from './model';
 
+import { map } from 'rxjs';
+
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
   headers?:
@@ -157,13 +159,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
@@ -173,6 +173,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters-http-resource/endpoints.ts
@@ -173,7 +173,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
@@ -127,7 +127,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
@@ -111,13 +111,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular/url-encode-parameters/endpoints.ts
@@ -127,6 +127,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
@@ -127,7 +127,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
@@ -111,13 +111,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/angular/zod-schema-response/endpoints.ts
@@ -127,6 +127,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
+++ b/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
@@ -102,13 +102,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }

--- a/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
+++ b/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
@@ -118,7 +118,7 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
-    } else if (value instanceof Date) {
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
       // useDates produces Date query params; serialize to ISO so they reach
       // the wire instead of being dropped by the primitive check below. See #3856.
       filteredParams[key] = value.toISOString();

--- a/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
+++ b/tests/__snapshots__/default/issue-2998/requests/requests.service.ts
@@ -118,6 +118,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||


### PR DESCRIPTION
Fixes #3856

When `useDates: true`, Date query params were silently dropped by the `filterParams` helper because the primitive check only accepts string/number/boolean. This adds a `value instanceof Date` branch that serializes to ISO string so the param reaches the wire.

Applied to all three emission paths: the inline IIFE, the simple helper, and the object-params helper.

Added a regression test asserting the generated helper contains the Date branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Angular query parameters with valid `Date` values being omitted.
  * Date parameters are now serialized as ISO-formatted strings, including dates within arrays and supported object formats.
  * Invalid dates are excluded instead of being serialized or causing errors.

* **Tests**
  * Added regression coverage for valid and invalid `Date` query-parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->