### PR TITLE
fix(types): use File instead of Blob for multipart form-data binary fields (#3662)

### DIFF
--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -366,16 +366,18 @@ describe('getResReqTypes (content type handling)', () => {
       expect(bodySchema).toBeDefined();
       expect(bodySchema?.model).toContain('export type BodyRequestBody = {');
 
-      // Binary files → File (filename preserved in multipart, #3662)
-      expect(bodySchema?.model).toContain('encBinary: File;');
-      expect(bodySchema?.model).toContain('cmtBinary: File;');
-      expect(bodySchema?.model).toContain('formatBinary: File;');
-      expect(bodySchema?.model).toContain('wildcardFile: File | string;');
+      // Binary files → Blob | File (filename preserved in multipart, #3662)
+      expect(bodySchema?.model).toContain('encBinary: Blob | File;');
+      expect(bodySchema?.model).toContain('cmtBinary: Blob | File;');
+      expect(bodySchema?.model).toContain('formatBinary: Blob | File;');
+      expect(bodySchema?.model).toContain(
+        'wildcardFile: Blob | File | string;',
+      );
 
-      // Text files → File | string
-      expect(bodySchema?.model).toContain('encText: File | string;');
-      expect(bodySchema?.model).toContain('cmtText: File | string;');
-      expect(bodySchema?.model).toContain('encOverride: File | string;'); // encoding precedence
+      // Text files → Blob | File | string
+      expect(bodySchema?.model).toContain('encText: Blob | File | string;');
+      expect(bodySchema?.model).toContain('cmtText: Blob | File | string;');
+      expect(bodySchema?.model).toContain('encOverride: Blob | File | string;'); // encoding precedence
 
       // base64 encoded → string (not file)
       expect(bodySchema?.model).toContain('base64Field: string;');
@@ -383,8 +385,8 @@ describe('getResReqTypes (content type handling)', () => {
       // Object field → named type
       expect(bodySchema?.model).toContain('metadata: BodyRequestBodyMetadata;');
 
-      // Array of files → File[]
-      expect(bodySchema?.model).toContain('photos: File[];');
+      // Array of files → (Blob | File)[]
+      expect(bodySchema?.model).toContain('photos: (Blob | File)[];');
 
       // Nested contentMediaType should be ignored (JSON serialization)
       const metadataSchema = result.schemas.find(
@@ -703,15 +705,17 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
       // Result references the schema type
       expect(result.value).toBe('UploadRequestBody');
 
-      // File fields → File (filename preserved in multipart, #3662)
-      expect(schema?.model).toContain('avatar?: File');
-      expect(schema?.model).toContain('fileOrFiles?: File | File[]');
-      expect(schema?.model).toContain('mixedFiles?: File[]'); // array of oneOf
-      expect(schema?.model).toContain('documents?: File[]');
-      expect(schema?.model).toContain('logo?: File'); // allOf branch (#2873)
+      // File fields → Blob | File (filename preserved in multipart, #3662)
+      expect(schema?.model).toContain('avatar?: Blob | File');
+      expect(schema?.model).toContain(
+        'fileOrFiles?: Blob | File | (Blob | File)[]',
+      );
+      expect(schema?.model).toContain('mixedFiles?: (Blob | File)[]'); // array of oneOf
+      expect(schema?.model).toContain('documents?: (Blob | File)[]');
+      expect(schema?.model).toContain('logo?: Blob | File'); // allOf branch (#2873)
 
       // allOf with $ref: intersection type (not union)
-      expect(schema?.model).toContain('ClientUpdateDto & {');
+      expect(schema?.model).toContain('ClientUpdateDto & ({');
     });
 
     // Regression tests for #3242: multipart/form-data with oneOf/anyOf

--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -366,16 +366,16 @@ describe('getResReqTypes (content type handling)', () => {
       expect(bodySchema).toBeDefined();
       expect(bodySchema?.model).toContain('export type BodyRequestBody = {');
 
-      // Binary files → Blob
-      expect(bodySchema?.model).toContain('encBinary: Blob;');
-      expect(bodySchema?.model).toContain('cmtBinary: Blob;');
-      expect(bodySchema?.model).toContain('formatBinary: Blob;');
-      expect(bodySchema?.model).toContain('wildcardFile: Blob | string;');
+      // Binary files → File (filename preserved in multipart, #3662)
+      expect(bodySchema?.model).toContain('encBinary: File;');
+      expect(bodySchema?.model).toContain('cmtBinary: File;');
+      expect(bodySchema?.model).toContain('formatBinary: File;');
+      expect(bodySchema?.model).toContain('wildcardFile: File | string;');
 
-      // Text files → Blob | string
-      expect(bodySchema?.model).toContain('encText: Blob | string;');
-      expect(bodySchema?.model).toContain('cmtText: Blob | string;');
-      expect(bodySchema?.model).toContain('encOverride: Blob | string;'); // encoding precedence
+      // Text files → File | string
+      expect(bodySchema?.model).toContain('encText: File | string;');
+      expect(bodySchema?.model).toContain('cmtText: File | string;');
+      expect(bodySchema?.model).toContain('encOverride: File | string;'); // encoding precedence
 
       // base64 encoded → string (not file)
       expect(bodySchema?.model).toContain('base64Field: string;');
@@ -383,8 +383,8 @@ describe('getResReqTypes (content type handling)', () => {
       // Object field → named type
       expect(bodySchema?.model).toContain('metadata: BodyRequestBodyMetadata;');
 
-      // Array of files → Blob[]
-      expect(bodySchema?.model).toContain('photos: Blob[];');
+      // Array of files → File[]
+      expect(bodySchema?.model).toContain('photos: File[];');
 
       // Nested contentMediaType should be ignored (JSON serialization)
       const metadataSchema = result.schemas.find(
@@ -703,12 +703,12 @@ bodyRequestBody.photos.forEach(value => formData.append(\`photos\`, value));
       // Result references the schema type
       expect(result.value).toBe('UploadRequestBody');
 
-      // File fields → Blob (not string)
-      expect(schema?.model).toContain('avatar?: Blob');
-      expect(schema?.model).toContain('fileOrFiles?: Blob | Blob[]');
-      expect(schema?.model).toContain('mixedFiles?: Blob[]'); // array of oneOf
-      expect(schema?.model).toContain('documents?: Blob[]');
-      expect(schema?.model).toContain('logo?: Blob'); // allOf branch (#2873)
+      // File fields → File (filename preserved in multipart, #3662)
+      expect(schema?.model).toContain('avatar?: File');
+      expect(schema?.model).toContain('fileOrFiles?: File | File[]');
+      expect(schema?.model).toContain('mixedFiles?: File[]'); // array of oneOf
+      expect(schema?.model).toContain('documents?: File[]');
+      expect(schema?.model).toContain('logo?: File'); // allOf branch (#2873)
 
       // allOf with $ref: intersection type (not union)
       expect(schema?.model).toContain('ClientUpdateDto & {');

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -221,23 +221,27 @@ export function getScalar({
       // fields stay `string`; enum unions computed above are left intact (#1624).
       if (!formDataContext?.urlEncoded) {
         if (schemaFormat === 'binary') {
-          // In multipart/form-data context, prefer File over Blob so the
+          // In multipart/form-data context, accept both Blob and File so the
           // filename is preserved in the Content-Disposition header (#3662).
-          value = formDataContext ? 'File' : 'Blob';
+          // Blob | File is wider than the original Blob, so existing callers
+          // keep compiling (#3915).
+          value = formDataContext ? 'Blob | File' : 'Blob';
         } else if (formDataContext?.atPart) {
           const fileType = getFormDataFieldFileType(
             item,
             formDataContext.partContentType,
           );
           if (fileType) {
-            value = fileType === 'binary' ? 'File' : 'File | string';
+            value =
+              fileType === 'binary' ? 'Blob | File' : 'Blob | File | string';
           }
         } else if (isBinaryScalarSchema(item)) {
           // The previous arm caught format: binary directly; this matches the
           // OAS 3.1 contentMediaType: application/octet-stream variant via the
           // shared predicate so any future binary shapes added there flow
-          // through here too (#2410). In multipart context prefer File (#3662).
-          value = formDataContext ? 'File' : 'Blob';
+          // through here too (#2410). In multipart context accept both Blob and
+          // File so existing callers keep compiling (#3915).
+          value = formDataContext ? 'Blob | File' : 'Blob';
         }
       }
 

--- a/packages/core/src/getters/scalar.ts
+++ b/packages/core/src/getters/scalar.ts
@@ -221,21 +221,23 @@ export function getScalar({
       // fields stay `string`; enum unions computed above are left intact (#1624).
       if (!formDataContext?.urlEncoded) {
         if (schemaFormat === 'binary') {
-          value = 'Blob';
+          // In multipart/form-data context, prefer File over Blob so the
+          // filename is preserved in the Content-Disposition header (#3662).
+          value = formDataContext ? 'File' : 'Blob';
         } else if (formDataContext?.atPart) {
           const fileType = getFormDataFieldFileType(
             item,
             formDataContext.partContentType,
           );
           if (fileType) {
-            value = fileType === 'binary' ? 'Blob' : 'Blob | string';
+            value = fileType === 'binary' ? 'File' : 'File | string';
           }
         } else if (isBinaryScalarSchema(item)) {
           // The previous arm caught format: binary directly; this matches the
           // OAS 3.1 contentMediaType: application/octet-stream variant via the
           // shared predicate so any future binary shapes added there flow
-          // through here too (#2410).
-          value = 'Blob';
+          // through here too (#2410). In multipart context prefer File (#3662).
+          value = formDataContext ? 'File' : 'Blob';
         }
       }
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1198,20 +1198,20 @@ export const generateZodValidationSchemaDefinition = (
         // url-encoded bodies serialize via URLSearchParams (strings only), so
         // binary fields stay `string` rather than becoming `File` (#3664).
         if (!urlEncoded && schema.format === 'binary') {
-          functions.push(['instanceof', 'File']);
+          functions.push(['instanceof', 'Blob']);
           break;
         }
 
         // The @scalar/openapi-parser upgrader converts format: binary to
         // contentMediaType: application/octet-stream when upgrading
         // Swagger 2.0 / OAS 3.0 → OAS 3.1. Treat it the same as
-        // format: binary so $ref-based model types generate File validation.
+        // format: binary so $ref-based model types generate Blob validation.
         if (
           !urlEncoded &&
           schema.contentMediaType === 'application/octet-stream' &&
           !schema.contentEncoding
         ) {
-          functions.push(['instanceof', 'File']);
+          functions.push(['instanceof', 'Blob']);
           break;
         }
 
@@ -1850,7 +1850,7 @@ ${Object.entries(objectArgs)
         current = {
           expr: zodMiniCall(
             'union',
-            `[${zodMiniCall('instanceof', 'File')}, ${zodMiniCall('string')}]`,
+            `[${zodMiniCall('instanceof', 'Blob')}, ${zodMiniCall('string')}]`,
           ),
           kind: 'union',
         };
@@ -2234,7 +2234,7 @@ ${Object.entries(mergedProperties)
 
     // File | string for text contentMediaType/encoding (user can pass string, runtime wraps in Blob)
     if (fn === 'fileOrString') {
-      return 'zod.instanceof(File).or(zod.string())';
+      return 'zod.instanceof(Blob).or(zod.string())';
     }
 
     if (fn === 'allOf') {
@@ -2762,7 +2762,7 @@ export const generateFormDataZodSchema = (
         const isRequired = schema.required?.includes(key);
         const fileFunctions: [string, unknown][] = [
           fileType === 'binary'
-            ? ['instanceof', 'File']
+            ? ['instanceof', 'Blob']
             : ['fileOrString', undefined],
         ];
         if (!isRequired) {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -6761,7 +6761,7 @@ describe('generateFormData', () => {
       testOutput,
     );
     expect(result.implementation).toBe(
-      'export const TestBody = zod.object({\n  "name": zod.string().optional(),\n  "catImage": zod.instanceof(File).optional()\n})\n\n',
+      'export const TestBody = zod.object({\n  "name": zod.string().optional(),\n  "catImage": zod.instanceof(Blob).optional()\n})\n\n',
     );
   });
 });
@@ -6979,7 +6979,7 @@ describe('generateFormUrlEncoded', () => {
   });
 
   // URLSearchParams serializes every value to a string, so binary/file fields
-  // must stay zod.string() rather than zod.instanceof(File) (#3664 review).
+  // must stay zod.string() rather than zod.instanceof(Blob) (#3664 review).
   it('keeps binary fields as string for application/x-www-form-urlencoded', async () => {
     const result = await generateZod(
       {
@@ -7066,7 +7066,7 @@ describe('generateFormUrlEncoded', () => {
       formUrlEncodedNestedBinarySchema,
       testOutput,
     );
-    expect(result.implementation).not.toContain('zod.instanceof(File)');
+    expect(result.implementation).not.toContain('zod.instanceof(Blob)');
     expect(result.implementation).toContain('"id": zod.string()');
     expect(result.implementation).toContain(
       '"attachment": zod.string().nullish()',
@@ -9287,22 +9287,22 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
       schema,
       testOutput,
     );
-    // encBinary: encoding image/png → File
-    // encText: encoding text/plain → File | string
-    // cmtBinary: contentMediaType image/png → File
-    // cmtText: contentMediaType application/xml → File | string
-    // encOverride: encoding text/csv overrides contentMediaType image/png → File | string
-    // formatBinary: format: binary → File (same as instanceof check)
+    // encBinary: encoding image/png → Blob
+    // encText: encoding text/plain → Blob | string
+    // cmtBinary: contentMediaType image/png → Blob
+    // cmtText: contentMediaType application/xml → Blob | string
+    // encOverride: encoding text/csv overrides contentMediaType image/png → Blob | string
+    // formatBinary: format: binary → Blob (same as instanceof check)
     // base64Field: contentEncoding base64 → stays string
     // metadata: object → object schema
     expect(result.implementation)
       .toBe(`export const UploadFormBody = zod.object({
-  "encBinary": zod.instanceof(File),
-  "encText": zod.instanceof(File).or(zod.string()),
-  "cmtBinary": zod.instanceof(File),
-  "cmtText": zod.instanceof(File).or(zod.string()),
-  "encOverride": zod.instanceof(File).or(zod.string()),
-  "formatBinary": zod.instanceof(File),
+  "encBinary": zod.instanceof(Blob),
+  "encText": zod.instanceof(Blob).or(zod.string()),
+  "cmtBinary": zod.instanceof(Blob),
+  "cmtText": zod.instanceof(Blob).or(zod.string()),
+  "encOverride": zod.instanceof(Blob).or(zod.string()),
+  "formatBinary": zod.instanceof(Blob),
   "base64Field": zod.string(),
   "metadata": zod.object({
   "name": zod.string().optional()
@@ -9413,22 +9413,22 @@ describe('generateZod (content type handling - parity with res-req-types.test.ts
       schema,
       testOutput,
     );
-    // encBinary: encoding image/png → File
-    // encText: encoding text/plain → File | string
-    // cmtBinary: contentMediaType image/png → File
-    // cmtText: contentMediaType application/xml → File | string
-    // encOverride: encoding text/csv overrides contentMediaType image/png → File | string
-    // formatBinary: format: binary → File (same as instanceof check)
+    // encBinary: encoding image/png → Blob
+    // encText: encoding text/plain → Blob | string
+    // cmtBinary: contentMediaType image/png → Blob
+    // cmtText: contentMediaType application/xml → Blob | string
+    // encOverride: encoding text/csv overrides contentMediaType image/png → Blob | string
+    // formatBinary: format: binary → Blob (same as instanceof check)
     // base64Field: contentEncoding base64 → stays string
     // metadata: object → object schema
     expect(result.implementation)
       .toBe(`export const UploadFormBody = zod.object({
-  "encBinary": zod.instanceof(File),
-  "encText": zod.instanceof(File).or(zod.string()),
-  "cmtBinary": zod.instanceof(File),
-  "cmtText": zod.instanceof(File).or(zod.string()),
-  "encOverride": zod.instanceof(File).or(zod.string()),
-  "formatBinary": zod.instanceof(File),
+  "encBinary": zod.instanceof(Blob),
+  "encText": zod.instanceof(Blob).or(zod.string()),
+  "cmtBinary": zod.instanceof(Blob),
+  "cmtText": zod.instanceof(Blob).or(zod.string()),
+  "encOverride": zod.instanceof(Blob).or(zod.string()),
+  "formatBinary": zod.instanceof(Blob),
   "base64Field": zod.string(),
   "metadata": zod.object({
   "name": zod.string().optional()
@@ -10149,7 +10149,7 @@ describe('zod split mode regressions', () => {
 });
 
 describe('generateZodValidationSchemaDefinition (contentMediaType: application/octet-stream)', () => {
-  it('contentMediaType: application/octet-stream → instanceof File', () => {
+  it('contentMediaType: application/octet-stream → instanceof Blob', () => {
     const schema: OpenApiSchemaObject = {
       type: 'string',
       contentMediaType: 'application/octet-stream',
@@ -10171,7 +10171,7 @@ describe('generateZodValidationSchemaDefinition (contentMediaType: application/o
     );
 
     expect(result).toEqual({
-      functions: [['instanceof', 'File']],
+      functions: [['instanceof', 'Blob']],
       consts: [],
     });
   });

--- a/samples/angular-query/__snapshots__/api/model-custom-instance/uploadFormDataBody.ts
+++ b/samples/angular-query/__snapshots__/api/model-custom-instance/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: Blob;
+  file?: File;
   label?: string;
 };

--- a/samples/angular-query/__snapshots__/api/model-custom-instance/uploadFormDataBody.ts
+++ b/samples/angular-query/__snapshots__/api/model-custom-instance/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: File;
+  file?: Blob | File;
   label?: string;
 };

--- a/samples/angular-query/__snapshots__/api/model-no-transformer/uploadFormDataBody.ts
+++ b/samples/angular-query/__snapshots__/api/model-no-transformer/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: Blob;
+  file?: File;
   label?: string;
 };

--- a/samples/angular-query/__snapshots__/api/model-no-transformer/uploadFormDataBody.ts
+++ b/samples/angular-query/__snapshots__/api/model-no-transformer/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: File;
+  file?: Blob | File;
   label?: string;
 };

--- a/samples/angular-query/__snapshots__/api/model/uploadFormDataBody.ts
+++ b/samples/angular-query/__snapshots__/api/model/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: Blob;
+  file?: File;
   label?: string;
 };

--- a/samples/angular-query/__snapshots__/api/model/uploadFormDataBody.ts
+++ b/samples/angular-query/__snapshots__/api/model/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: File;
+  file?: Blob | File;
   label?: string;
 };

--- a/samples/angular-query/src/api/model-custom-instance/uploadFormDataBody.ts
+++ b/samples/angular-query/src/api/model-custom-instance/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: Blob;
+  file?: File;
   label?: string;
 };

--- a/samples/angular-query/src/api/model-custom-instance/uploadFormDataBody.ts
+++ b/samples/angular-query/src/api/model-custom-instance/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: File;
+  file?: Blob | File;
   label?: string;
 };

--- a/samples/angular-query/src/api/model-no-transformer/uploadFormDataBody.ts
+++ b/samples/angular-query/src/api/model-no-transformer/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: Blob;
+  file?: File;
   label?: string;
 };

--- a/samples/angular-query/src/api/model-no-transformer/uploadFormDataBody.ts
+++ b/samples/angular-query/src/api/model-no-transformer/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: File;
+  file?: Blob | File;
   label?: string;
 };

--- a/samples/angular-query/src/api/model/uploadFormDataBody.ts
+++ b/samples/angular-query/src/api/model/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: Blob;
+  file?: File;
   label?: string;
 };

--- a/samples/angular-query/src/api/model/uploadFormDataBody.ts
+++ b/samples/angular-query/src/api/model/uploadFormDataBody.ts
@@ -6,6 +6,6 @@
  */
 
 export type UploadFormDataBody = {
-  file?: File;
+  file?: Blob | File;
   label?: string;
 };

--- a/tests/__snapshots__/default/issue-2998/model/addDocumentBody.ts
+++ b/tests/__snapshots__/default/issue-2998/model/addDocumentBody.ts
@@ -7,5 +7,5 @@
  */
 
 export type AddDocumentBody = {
-  file: Blob;
+  file: File;
 };

--- a/tests/__snapshots__/default/issue-2998/model/addDocumentBody.ts
+++ b/tests/__snapshots__/default/issue-2998/model/addDocumentBody.ts
@@ -7,5 +7,5 @@
  */
 
 export type AddDocumentBody = {
-  file: File;
+  file: Blob | File;
 };

--- a/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserImportUsersFromFileBody.zod.ts
+++ b/tests/__snapshots__/react-query/issue-3066/model/postApiAppOssIdentityUserImportUsersFromFileBody.zod.ts
@@ -7,7 +7,7 @@
 import * as zod from 'zod';
 
 export const PostApiAppOssIdentityUserImportUsersFromFileBody = zod.object({
-  File: zod.instanceof(File).optional(),
+  File: zod.instanceof(Blob).optional(),
 });
 
 export type PostApiAppOssIdentityUserImportUsersFromFileBody = zod.input<


### PR DESCRIPTION
Fixes #3662

Multipart form-data binary fields were typed as `Blob`, which loses the original filename when appended to `FormData`. Per RFC 7578, the filename belongs in the part's `Content-Disposition` header, and `FormData.append` only preserves it when the value is a `File`.

This changes the emitted type for multipart binary fields from `Blob` to `File` (and `Blob | string` to `File | string` for text files). The generated runtime already handles `File` correctly, so no runtime changes were needed.

Non-multipart binary fields (response bodies, url-encoded bodies) stay `Blob`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Multipart form-data binary fields now accept both `Blob` and `File` values.
  - Text-compatible file fields support `Blob`, `File`, and string values.
  - Arrays of uploaded files now accept combinations of `Blob` and `File`.
  - Generated upload models consistently support `Blob` and `File` inputs.
  - Zod validation for binary uploads now recognizes `Blob` values, including multipart form-data fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->