### PR TITLE
feat(query): export a mutation key getter per operation

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1465,7 +1465,11 @@ Export mutator hooks.
 **Type:** `Boolean`
 **Default:** `true`
 
-Export query keys.
+Export query keys. Also applies to mutation keys, which are emitted as a getter next to the mutation options factory:
+
+```ts title="endpoints.ts"
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+```
 
 ### shouldFilterQueryKey
 

--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -497,7 +497,7 @@ export default defineConfig({
 
 ### shouldExportQueryKey
 
-控制是否导出 query key helper。
+控制是否导出 query key helper。该选项同样作用于 mutation key，会在 mutation options 工厂函数旁生成 `getXxxMutationKey()` 导出。
 
 ### shouldSplitQueryKey
 

--- a/packages/query/src/client.test.ts
+++ b/packages/query/src/client.test.ts
@@ -14,6 +14,7 @@ import {
   generateAxiosRequestFunction,
   generateRequestOptionsArguments,
   getHookOptions,
+  getHooksOptionImplementation,
   getQueryArgumentsRequestType,
   getQueryHeader,
   getQueryOptions,
@@ -817,5 +818,29 @@ describe('generateAxiosRequestFunction with useDatesTransform', () => {
     );
     expect(dateFree).not.toContain('deserializeGetPetResponse');
     expect(dateFree).not.toContain('.then(');
+  });
+});
+
+describe('getHooksOptionImplementation', () => {
+  it('reads the mutation key from the hoisted getter', () => {
+    const implementation = getHooksOptionImplementation(
+      true,
+      OutputHttpClient.FETCH,
+      'getCreatePetsMutationKey',
+    );
+
+    expect(implementation).toContain(
+      'const mutationKey = getCreatePetsMutationKey();',
+    );
+  });
+
+  it('emits nothing when request options are disabled', () => {
+    expect(
+      getHooksOptionImplementation(
+        false,
+        OutputHttpClient.FETCH,
+        'getCreatePetsMutationKey',
+      ),
+    ).toBe('');
   });
 });

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -671,10 +671,15 @@ export const getQueryErrorType = (
   return errorsType;
 };
 
+/**
+ * Options destructuring at the top of `get/useXxxMutationOptions`. The mutation
+ * key is read from the hoisted `getXxxMutationKey()` getter emitted by the
+ * mutation generator.
+ */
 export const getHooksOptionImplementation = (
   isRequestOptions: boolean,
   httpClient: OutputHttpClient,
-  operationName: string,
+  mutationKeyFnName: string,
   mutator?: GeneratorMutator,
   useRuntimeFetcher?: boolean,
 ) => {
@@ -688,7 +693,7 @@ export const getHooksOptionImplementation = (
       : `, fetch: fetchOptions${fetcherOption}`;
 
   return isRequestOptions
-    ? `const mutationKey = ['${operationName}'];
+    ? `const mutationKey = ${mutationKeyFnName}();
 const {mutation: mutationOptions${
         mutator
           ? mutator.hasSecondArg

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -555,10 +555,20 @@ export const generateMutationHook = async ({
       : `get-${operationName}-mutationOptions`,
   );
 
+  const mutationKeyFnName = camel(`get-${operationName}-mutation-key`);
+
+  // Hoisted out of the options factory so the key can be read without running
+  // it. Mirrors `getXxxQueryKey`, including its `shouldExportQueryKey` gate;
+  // skipped only when it would be both unexported and unused.
+  const mutationKeyFn =
+    query.shouldExportQueryKey || isRequestOptions
+      ? `${query.shouldExportQueryKey ? 'export ' : ''}const ${mutationKeyFnName} = () => ['${camel(operationName)}'] as const;`
+      : '';
+
   const hooksOptionImplementation = getHooksOptionImplementation(
     isRequestOptions,
     httpClient,
-    camel(operationName),
+    mutationKeyFnName,
     mutator,
     useRuntimeFetcher,
   );
@@ -676,6 +686,8 @@ ${
 
   const implementation = `
 ${operationReferenceDeclaration}
+${mutationKeyFn}
+
 ${mutationOptionsFn}
 
     export type ${pascal(

--- a/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-custom-instance/pets/pets.ts
@@ -375,6 +375,8 @@ export const createPets = (
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -395,7 +397,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -556,6 +558,8 @@ export const deletePet = (
   );
 };
 
+export const getDeletePetMutationKey = () => ['deletePet'] as const;
+
 export const getDeletePetMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -576,7 +580,7 @@ export const getDeletePetMutationOptions = <
   DeletePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePet'];
+  const mutationKey = getDeletePetMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -647,6 +651,8 @@ export const updatePet = (
   );
 };
 
+export const getUpdatePetMutationKey = () => ['updatePet'] as const;
+
 export const getUpdatePetMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -667,7 +673,7 @@ export const getUpdatePetMutationOptions = <
   UpdatePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePet'];
+  const mutationKey = getUpdatePetMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -738,6 +744,8 @@ export const patchPet = (
   );
 };
 
+export const getPatchPetMutationKey = () => ['patchPet'] as const;
+
 export const getPatchPetMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -758,7 +766,7 @@ export const getPatchPetMutationOptions = <
   PatchPetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['patchPet'];
+  const mutationKey = getPatchPetMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -926,6 +934,8 @@ export const uploadFile = (
   );
 };
 
+export const getUploadFileMutationKey = () => ['uploadFile'] as const;
+
 export const getUploadFileMutationOptions = <
   TError = ErrorType<void | Error>,
   TContext = unknown,
@@ -946,7 +956,7 @@ export const getUploadFileMutationOptions = <
   UploadFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFile'];
+  const mutationKey = getUploadFileMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1024,6 +1034,8 @@ export const uploadFormData = (
   );
 };
 
+export const getUploadFormDataMutationKey = () => ['uploadFormData'] as const;
+
 export const getUploadFormDataMutationOptions = <
   TError = ErrorType<void | Error>,
   TContext = unknown,
@@ -1044,7 +1056,7 @@ export const getUploadFormDataMutationOptions = <
   UploadFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFormData'];
+  const mutationKey = getUploadFormDataMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-no-transformer/pets/pets.ts
@@ -324,6 +324,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -344,7 +346,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -510,6 +512,8 @@ export const deletePet = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetMutationKey = () => ['deletePet'] as const;
+
 export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   options?: {
@@ -527,7 +531,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   DeletePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePet'];
+  const mutationKey = getDeletePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -593,6 +597,8 @@ export const updatePet = (
   return lastValueFrom(request$);
 };
 
+export const getUpdatePetMutationKey = () => ['updatePet'] as const;
+
 export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   options?: {
@@ -610,7 +616,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   UpdatePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePet'];
+  const mutationKey = getUpdatePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -676,6 +682,8 @@ export const patchPet = (
   return lastValueFrom(request$);
 };
 
+export const getPatchPetMutationKey = () => ['patchPet'] as const;
+
 export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   options?: {
@@ -693,7 +701,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   PatchPetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['patchPet'];
+  const mutationKey = getPatchPetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -860,6 +868,8 @@ export const uploadFile = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFileMutationKey = () => ['uploadFile'] as const;
+
 export const getUploadFileMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -880,7 +890,7 @@ export const getUploadFileMutationOptions = <
   UploadFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFile'];
+  const mutationKey = getUploadFileMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -957,6 +967,8 @@ export const uploadFormData = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFormDataMutationKey = () => ['uploadFormData'] as const;
+
 export const getUploadFormDataMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -977,7 +989,7 @@ export const getUploadFormDataMutationOptions = <
   UploadFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFormData'];
+  const mutationKey = getUploadFormDataMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -222,6 +222,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -242,7 +244,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -411,6 +413,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -431,7 +435,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -384,6 +384,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -406,7 +408,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -620,6 +622,8 @@ export const deletePet = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetMutationKey = () => ['deletePet'] as const;
+
 export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   queryClient: QueryClient,
@@ -639,7 +643,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   DeletePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePet'];
+  const mutationKey = getDeletePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -727,6 +731,8 @@ export const updatePet = (
   return lastValueFrom(request$);
 };
 
+export const getUpdatePetMutationKey = () => ['updatePet'] as const;
+
 export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   queryClient: QueryClient,
@@ -746,7 +752,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   UpdatePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePet'];
+  const mutationKey = getUpdatePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -838,6 +844,8 @@ export const patchPet = (
   return lastValueFrom(request$);
 };
 
+export const getPatchPetMutationKey = () => ['patchPet'] as const;
+
 export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   queryClient: QueryClient,
@@ -857,7 +865,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   PatchPetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['patchPet'];
+  const mutationKey = getPatchPetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1076,6 +1084,8 @@ export const uploadFile = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFileMutationKey = () => ['uploadFile'] as const;
+
 export const getUploadFileMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -1098,7 +1108,7 @@ export const getUploadFileMutationOptions = <
   UploadFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFile'];
+  const mutationKey = getUploadFileMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1198,6 +1208,8 @@ export const uploadFormData = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFormDataMutationKey = () => ['uploadFormData'] as const;
+
 export const getUploadFormDataMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -1218,7 +1230,7 @@ export const getUploadFormDataMutationOptions = <
   UploadFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFormData'];
+  const mutationKey = getUploadFormDataMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-custom-instance/pets/pets.ts
@@ -375,6 +375,8 @@ export const createPets = (
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -395,7 +397,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -556,6 +558,8 @@ export const deletePet = (
   );
 };
 
+export const getDeletePetMutationKey = () => ['deletePet'] as const;
+
 export const getDeletePetMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -576,7 +580,7 @@ export const getDeletePetMutationOptions = <
   DeletePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePet'];
+  const mutationKey = getDeletePetMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -647,6 +651,8 @@ export const updatePet = (
   );
 };
 
+export const getUpdatePetMutationKey = () => ['updatePet'] as const;
+
 export const getUpdatePetMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -667,7 +673,7 @@ export const getUpdatePetMutationOptions = <
   UpdatePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePet'];
+  const mutationKey = getUpdatePetMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -738,6 +744,8 @@ export const patchPet = (
   );
 };
 
+export const getPatchPetMutationKey = () => ['patchPet'] as const;
+
 export const getPatchPetMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -758,7 +766,7 @@ export const getPatchPetMutationOptions = <
   PatchPetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['patchPet'];
+  const mutationKey = getPatchPetMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -926,6 +934,8 @@ export const uploadFile = (
   );
 };
 
+export const getUploadFileMutationKey = () => ['uploadFile'] as const;
+
 export const getUploadFileMutationOptions = <
   TError = ErrorType<void | Error>,
   TContext = unknown,
@@ -946,7 +956,7 @@ export const getUploadFileMutationOptions = <
   UploadFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFile'];
+  const mutationKey = getUploadFileMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1024,6 +1034,8 @@ export const uploadFormData = (
   );
 };
 
+export const getUploadFormDataMutationKey = () => ['uploadFormData'] as const;
+
 export const getUploadFormDataMutationOptions = <
   TError = ErrorType<void | Error>,
   TContext = unknown,
@@ -1044,7 +1056,7 @@ export const getUploadFormDataMutationOptions = <
   UploadFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFormData'];
+  const mutationKey = getUploadFormDataMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-no-transformer/pets/pets.ts
@@ -324,6 +324,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -344,7 +346,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -510,6 +512,8 @@ export const deletePet = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetMutationKey = () => ['deletePet'] as const;
+
 export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   options?: {
@@ -527,7 +531,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   DeletePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePet'];
+  const mutationKey = getDeletePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -593,6 +597,8 @@ export const updatePet = (
   return lastValueFrom(request$);
 };
 
+export const getUpdatePetMutationKey = () => ['updatePet'] as const;
+
 export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   options?: {
@@ -610,7 +616,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   UpdatePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePet'];
+  const mutationKey = getUpdatePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -676,6 +682,8 @@ export const patchPet = (
   return lastValueFrom(request$);
 };
 
+export const getPatchPetMutationKey = () => ['patchPet'] as const;
+
 export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   options?: {
@@ -693,7 +701,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   PatchPetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['patchPet'];
+  const mutationKey = getPatchPetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -860,6 +868,8 @@ export const uploadFile = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFileMutationKey = () => ['uploadFile'] as const;
+
 export const getUploadFileMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -880,7 +890,7 @@ export const getUploadFileMutationOptions = <
   UploadFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFile'];
+  const mutationKey = getUploadFileMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -957,6 +967,8 @@ export const uploadFormData = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFormDataMutationKey = () => ['uploadFormData'] as const;
+
 export const getUploadFormDataMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -977,7 +989,7 @@ export const getUploadFormDataMutationOptions = <
   UploadFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFormData'];
+  const mutationKey = getUploadFormDataMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -222,6 +222,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -242,7 +244,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -411,6 +413,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -431,7 +435,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -384,6 +384,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -406,7 +408,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -620,6 +622,8 @@ export const deletePet = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetMutationKey = () => ['deletePet'] as const;
+
 export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   queryClient: QueryClient,
@@ -639,7 +643,7 @@ export const getDeletePetMutationOptions = <TError = Error, TContext = unknown>(
   DeletePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePet'];
+  const mutationKey = getDeletePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -727,6 +731,8 @@ export const updatePet = (
   return lastValueFrom(request$);
 };
 
+export const getUpdatePetMutationKey = () => ['updatePet'] as const;
+
 export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   queryClient: QueryClient,
@@ -746,7 +752,7 @@ export const getUpdatePetMutationOptions = <TError = Error, TContext = unknown>(
   UpdatePetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePet'];
+  const mutationKey = getUpdatePetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -838,6 +844,8 @@ export const patchPet = (
   return lastValueFrom(request$);
 };
 
+export const getPatchPetMutationKey = () => ['patchPet'] as const;
+
 export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   http: HttpClient,
   queryClient: QueryClient,
@@ -857,7 +865,7 @@ export const getPatchPetMutationOptions = <TError = Error, TContext = unknown>(
   PatchPetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['patchPet'];
+  const mutationKey = getPatchPetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1076,6 +1084,8 @@ export const uploadFile = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFileMutationKey = () => ['uploadFile'] as const;
+
 export const getUploadFileMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -1098,7 +1108,7 @@ export const getUploadFileMutationOptions = <
   UploadFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFile'];
+  const mutationKey = getUploadFileMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1198,6 +1208,8 @@ export const uploadFormData = (
   return lastValueFrom(request$);
 };
 
+export const getUploadFormDataMutationKey = () => ['uploadFormData'] as const;
+
 export const getUploadFormDataMutationOptions = <
   TError = void | Error,
   TContext = unknown,
@@ -1218,7 +1230,7 @@ export const getUploadFormDataMutationOptions = <
   UploadFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadFormData'];
+  const mutationKey = getUploadFormDataMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -783,6 +783,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -799,7 +801,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -783,6 +783,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -799,7 +801,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -336,6 +336,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -353,7 +355,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -454,6 +456,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -471,7 +475,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -336,6 +336,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -353,7 +355,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -454,6 +456,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -471,7 +475,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data-mutator/__snapshots__/endpoints.ts
@@ -139,6 +139,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-data-mutator/endpoints.ts
+++ b/samples/react-query/form-data-mutator/endpoints.ts
@@ -139,6 +139,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-data/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-data/__snapshots__/endpoints.ts
@@ -139,6 +139,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-data/endpoints.ts
+++ b/samples/react-query/form-data/endpoints.ts
@@ -139,6 +139,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/__snapshots__/endpoints.ts
@@ -140,6 +140,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -156,7 +158,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-url-encoded-mutator/endpoints.ts
+++ b/samples/react-query/form-url-encoded-mutator/endpoints.ts
@@ -140,6 +140,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -156,7 +158,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
+++ b/samples/react-query/form-url-encoded/__snapshots__/endpoints.ts
@@ -139,6 +139,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/form-url-encoded/endpoints.ts
+++ b/samples/react-query/form-url-encoded/endpoints.ts
@@ -139,6 +139,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/__snapshots__/endpoints.ts
@@ -149,6 +149,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -165,7 +167,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/hook-mutator-axios/endpoints.ts
+++ b/samples/react-query/hook-mutator-axios/endpoints.ts
@@ -149,6 +149,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -165,7 +167,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -269,6 +269,8 @@ export const useCreatePetsHook = (): ((
   };
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -286,7 +288,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -269,6 +269,8 @@ export const useCreatePetsHook = (): ((
   };
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -286,7 +288,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -135,6 +135,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -151,7 +153,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/svelte-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -135,6 +135,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -151,7 +153,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -260,6 +260,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -281,7 +283,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -397,6 +399,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -414,7 +418,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -260,6 +260,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -281,7 +283,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -397,6 +399,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -414,7 +418,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -282,6 +282,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -303,7 +305,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -421,6 +423,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -438,7 +442,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -282,6 +282,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -303,7 +305,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -421,6 +423,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -438,7 +442,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -270,6 +270,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -287,7 +289,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -388,6 +390,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -405,7 +409,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -270,6 +270,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -287,7 +289,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -388,6 +390,8 @@ export const updatePets = async (
   });
 };
 
+export const getUpdatePetsMutationKey = () => ['updatePets'] as const;
+
 export const getUpdatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -405,7 +409,7 @@ export const getUpdatePetsMutationOptions = <
   UpdatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updatePets'];
+  const mutationKey = getUpdatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/angular-query/basic/endpoints.ts
+++ b/tests/__snapshots__/angular-query/basic/endpoints.ts
@@ -220,6 +220,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -240,7 +242,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -410,6 +412,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -430,7 +434,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/angular-query/split/endpoints.ts
+++ b/tests/__snapshots__/angular-query/split/endpoints.ts
@@ -220,6 +220,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -240,7 +242,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -410,6 +412,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -430,7 +434,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
+++ b/tests/__snapshots__/angular-query/tags-split/pets/pets.ts
@@ -220,6 +220,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -240,7 +242,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -409,6 +411,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -429,7 +433,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/angular-query/url-encode-parameters/endpoints.ts
@@ -227,6 +227,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -247,7 +249,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -417,6 +419,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -437,7 +441,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
+++ b/tests/__snapshots__/angular-query/use-prefetch/endpoints.ts
@@ -249,6 +249,8 @@ export const createPets = (
   return lastValueFrom(request$);
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -269,7 +271,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -467,6 +469,8 @@ export const deletePetById = (
   return lastValueFrom(request$);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -487,7 +491,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -636,6 +638,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -653,7 +657,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -635,6 +637,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -652,7 +656,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -635,6 +637,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -652,7 +656,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -158,6 +158,9 @@ export const updateProfileWithJson = async (
   } as updateProfileWithJsonResponse;
 };
 
+export const getUpdateProfileWithJsonMutationKey = () =>
+  ['updateProfileWithJson'] as const;
+
 export const getUpdateProfileWithJsonMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -175,7 +178,7 @@ export const getUpdateProfileWithJsonMutationOptions = <
   UpdateProfileWithJsonMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updateProfileWithJson'];
+  const mutationKey = getUpdateProfileWithJsonMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -291,6 +294,9 @@ export const updateProfileWithFormData = async (
   } as updateProfileWithFormDataResponse;
 };
 
+export const getUpdateProfileWithFormDataMutationKey = () =>
+  ['updateProfileWithFormData'] as const;
+
 export const getUpdateProfileWithFormDataMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -308,7 +314,7 @@ export const getUpdateProfileWithFormDataMutationOptions = <
   UpdateProfileWithFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['updateProfileWithFormData'];
+  const mutationKey = getUpdateProfileWithFormDataMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -426,6 +432,9 @@ export const uploadAvatarWithFormData = async (
   } as uploadAvatarWithFormDataResponse;
 };
 
+export const getUploadAvatarWithFormDataMutationKey = () =>
+  ['uploadAvatarWithFormData'] as const;
+
 export const getUploadAvatarWithFormDataMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -443,7 +452,7 @@ export const getUploadAvatarWithFormDataMutationOptions = <
   UploadAvatarWithFormDataMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadAvatarWithFormData'];
+  const mutationKey = getUploadAvatarWithFormDataMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -561,6 +570,9 @@ export const uploadAvatarWithBlob = async (
   } as uploadAvatarWithBlobResponse;
 };
 
+export const getUploadAvatarWithBlobMutationKey = () =>
+  ['uploadAvatarWithBlob'] as const;
+
 export const getUploadAvatarWithBlobMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -578,7 +590,7 @@ export const getUploadAvatarWithBlobMutationOptions = <
   UploadAvatarWithBlobMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadAvatarWithBlob'];
+  const mutationKey = getUploadAvatarWithBlobMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -364,6 +364,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -381,7 +383,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -663,6 +665,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -680,7 +684,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
+++ b/tests/__snapshots__/react-query/body-type-wrap-non-get-query/endpoints.ts
@@ -524,6 +524,8 @@ export const deletePetById = (petId: string, signal?: AbortSignal) => {
   });
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = ErrorType<Error>,
   TContext = unknown,
@@ -540,7 +542,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -339,6 +339,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -356,7 +358,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -643,6 +645,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const useDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -660,7 +664,7 @@ export const useDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -568,6 +568,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -585,7 +587,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -869,6 +871,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -886,7 +890,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -368,6 +368,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -385,7 +387,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -702,6 +704,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -719,7 +723,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -359,7 +361,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -656,6 +658,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -673,7 +677,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -359,7 +361,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -656,6 +658,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -673,7 +677,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-hook/endpoints.ts
@@ -91,6 +91,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -107,7 +109,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/form-data-with-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data-with-mutator/endpoints.ts
@@ -37,6 +37,8 @@ export const createPets = (pet: Pet, signal?: AbortSignal) => {
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -53,7 +55,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-data/endpoints.ts
@@ -82,6 +82,8 @@ export const createPets = (pet: Pet, signal?: AbortSignal) => {
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -98,7 +100,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/react-query/form-url-encoded/endpoints.ts
@@ -46,6 +46,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -62,7 +64,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -134,6 +136,9 @@ export const uploadPetContent = (
   });
 };
 
+export const getUploadPetContentMutationKey = () =>
+  ['uploadPetContent'] as const;
+
 export const getUploadPetContentMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -150,7 +155,7 @@ export const getUploadPetContentMutationOptions = <
   UploadPetContentMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadPetContent'];
+  const mutationKey = getUploadPetContentMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -222,6 +227,9 @@ export const uploadPetContentRef = (
   });
 };
 
+export const getUploadPetContentRefMutationKey = () =>
+  ['uploadPetContentRef'] as const;
+
 export const getUploadPetContentRefMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -238,7 +246,7 @@ export const getUploadPetContentRefMutationOptions = <
   UploadPetContentRefMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadPetContentRef'];
+  const mutationKey = getUploadPetContentRefMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/formUrlEncoded/endpoints.ts
+++ b/tests/__snapshots__/react-query/formUrlEncoded/endpoints.ts
@@ -44,6 +44,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -60,7 +62,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -127,6 +129,9 @@ export const uploadPetContent = (
   });
 };
 
+export const getUploadPetContentMutationKey = () =>
+  ['uploadPetContent'] as const;
+
 export const getUploadPetContentMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -143,7 +148,7 @@ export const getUploadPetContentMutationOptions = <
   UploadPetContentMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadPetContent'];
+  const mutationKey = getUploadPetContentMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -210,6 +215,9 @@ export const uploadPetContentRef = (
   });
 };
 
+export const getUploadPetContentRefMutationKey = () =>
+  ['uploadPetContentRef'] as const;
+
 export const getUploadPetContentRefMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -226,7 +234,7 @@ export const getUploadPetContentRefMutationOptions = <
   UploadPetContentRefMutationVariables,
   TContext
 > => {
-  const mutationKey = ['uploadPetContentRef'];
+  const mutationKey = getUploadPetContentRefMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -186,6 +186,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -203,7 +205,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -353,6 +355,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -370,7 +374,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-extension/endpoints.ts
@@ -233,6 +233,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -249,7 +251,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -480,6 +482,8 @@ export const useDeletePetByIdHook = () => {
   );
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const useDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -496,7 +500,7 @@ export const useDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios-with-second-parameter/endpoints.ts
@@ -248,6 +248,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -265,7 +267,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -516,6 +518,8 @@ export const useDeletePetByIdHook = () => {
   );
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const useDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -533,7 +537,7 @@ export const useDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/hook-mutator-axios/endpoints.ts
@@ -233,6 +233,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -249,7 +251,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -480,6 +482,8 @@ export const useDeletePetByIdHook = () => {
   );
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const useDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -496,7 +500,7 @@ export const useDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -334,6 +334,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -351,7 +353,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -612,6 +614,8 @@ export const deletePetById = async (
   });
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -629,7 +633,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -252,6 +252,8 @@ export const createPets = async (
   return data;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -269,7 +271,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -497,6 +499,8 @@ export const deletePetById = async (
   return data;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -514,7 +518,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -357,6 +357,8 @@ export const createPets = async (
   } as createPetsResponseSuccess;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = globalThis.Error & { info?: Error; status?: number },
   TContext = unknown,
@@ -374,7 +376,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -675,6 +677,8 @@ export const deletePetById = async (
   } as deletePetByIdResponseSuccess;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = globalThis.Error & { info?: Error; status?: number },
   TContext = unknown,
@@ -692,7 +696,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/importFromSubdirectory/endpoints.ts
+++ b/tests/__snapshots__/react-query/importFromSubdirectory/endpoints.ts
@@ -68,6 +68,8 @@ export const postPets = async (
   return { data, status: res.status, headers: res.headers } as postPetsResponse;
 };
 
+export const getPostPetsMutationKey = () => ['postPets'] as const;
+
 export const getPostPetsMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -85,7 +87,7 @@ export const getPostPetsMutationOptions = <
   void,
   TContext
 > => {
-  const mutationKey = ['postPets'];
+  const mutationKey = getPostPetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -342,6 +342,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -363,7 +365,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -342,6 +342,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -363,7 +365,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -662,6 +664,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -679,7 +683,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -342,6 +342,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -363,7 +365,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -662,6 +664,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -679,7 +683,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -342,6 +342,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -363,7 +365,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -664,6 +666,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -681,7 +685,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -342,6 +342,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -363,7 +365,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -664,6 +666,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -681,7 +685,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -359,7 +361,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -359,7 +361,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -709,6 +709,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -730,7 +732,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -359,7 +361,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -656,6 +658,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -673,7 +677,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -340,6 +340,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -361,7 +363,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -657,6 +659,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -674,7 +678,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -364,6 +364,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -385,7 +387,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -691,6 +693,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -712,7 +716,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -63,6 +63,8 @@ export const createEntity = async (
   } as createEntityResponse;
 };
 
+export const getCreateEntityMutationKey = () => ['createEntity'] as const;
+
 export const useCreateEntityMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -80,7 +82,7 @@ export const useCreateEntityMutationOptions = <
   CreateEntityMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createEntity'];
+  const mutationKey = getCreateEntityMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -82,6 +82,9 @@ export const postApiAppOssIdentityUserImportUsersFromFile = async (
   } as postApiAppOssIdentityUserImportUsersFromFileResponse;
 };
 
+export const getPostApiAppOssIdentityUserImportUsersFromFileMutationKey = () =>
+  ['postApiAppOssIdentityUserImportUsersFromFile'] as const;
+
 export const getPostApiAppOssIdentityUserImportUsersFromFileMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -99,7 +102,8 @@ export const getPostApiAppOssIdentityUserImportUsersFromFileMutationOptions = <
   PostApiAppOssIdentityUserImportUsersFromFileMutationVariables,
   TContext
 > => {
-  const mutationKey = ['postApiAppOssIdentityUserImportUsersFromFile'];
+  const mutationKey =
+    getPostApiAppOssIdentityUserImportUsersFromFileMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -222,6 +226,9 @@ export const postApiAppOssIdentityUserSignIn = async (
   } as postApiAppOssIdentityUserSignInResponse;
 };
 
+export const getPostApiAppOssIdentityUserSignInMutationKey = () =>
+  ['postApiAppOssIdentityUserSignIn'] as const;
+
 export const getPostApiAppOssIdentityUserSignInMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -239,7 +246,7 @@ export const getPostApiAppOssIdentityUserSignInMutationOptions = <
   PostApiAppOssIdentityUserSignInMutationVariables,
   TContext
 > => {
-  const mutationKey = ['postApiAppOssIdentityUserSignIn'];
+  const mutationKey = getPostApiAppOssIdentityUserSignInMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -234,6 +234,8 @@ export const createWidget = async (
   } as createWidgetResponse;
 };
 
+export const getCreateWidgetMutationKey = () => ['createWidget'] as const;
+
 export const getCreateWidgetMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -251,7 +253,7 @@ export const getCreateWidgetMutationOptions = <
   CreateWidgetMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createWidget'];
+  const mutationKey = getCreateWidgetMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/issue-607/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-607/endpoints.ts
@@ -45,6 +45,8 @@ export const petId = async (
 };
 
 const petIdRequestFn2 = petId;
+export const getPetIdMutationKey = () => ['petId'] as const;
+
 export const getPetIdMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -62,7 +64,7 @@ export const getPetIdMutationOptions = <
   PetIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['petId'];
+  const mutationKey = getPetIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -140,6 +142,8 @@ export const options = async (
 };
 
 const optionsRequestFn = options;
+export const getOptionsMutationKey = () => ['options'] as const;
+
 export const getOptionsMutationOptions = <
   TError = unknown,
   TContext = unknown,
@@ -157,7 +161,7 @@ export const getOptionsMutationOptions = <
   OptionsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['options'];
+  const mutationKey = getOptionsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -345,6 +345,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -362,7 +364,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -643,6 +645,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -660,7 +664,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -345,6 +345,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -362,7 +364,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -643,6 +645,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -660,7 +664,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/mutator/endpoints.ts
@@ -755,6 +755,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -771,7 +773,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1124,6 +1126,8 @@ export const deletePetById = (
   });
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -1140,7 +1144,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -368,6 +368,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -385,7 +387,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -681,6 +683,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -698,7 +702,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -456,6 +458,8 @@ export const showPetById = async (
   } as showPetByIdResponse;
 };
 
+export const getShowPetByIdMutationKey = () => ['showPetById'] as const;
+
 export const getShowPetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -473,7 +477,7 @@ export const getShowPetByIdMutationOptions = <
   ShowPetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['showPetById'];
+  const mutationKey = getShowPetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -573,6 +577,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -590,7 +596,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -304,6 +304,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -321,7 +323,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -601,6 +603,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -618,7 +622,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -635,6 +637,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -652,7 +656,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -499,6 +499,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -516,7 +518,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -952,6 +954,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -969,7 +973,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -332,6 +332,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -349,7 +351,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -636,6 +638,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -653,7 +657,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -338,6 +338,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -355,7 +357,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -636,6 +638,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -653,7 +657,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
@@ -236,6 +236,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -252,7 +254,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -483,6 +485,8 @@ export const useDeletePetByIdHook = () => {
   );
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const useDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -499,7 +503,7 @@ export const useDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -345,6 +345,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -362,7 +364,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -642,6 +644,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -659,7 +663,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -349,6 +349,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -366,7 +368,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -658,6 +660,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -675,7 +679,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -365,6 +365,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -382,7 +384,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -684,6 +686,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -701,7 +705,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -355,6 +355,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -372,7 +374,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -669,6 +671,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -686,7 +690,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -361,6 +361,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -378,7 +380,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -682,6 +684,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -699,7 +703,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-hook-mutator-axios/endpoints.ts
@@ -259,6 +259,8 @@ export const useCreatePetsHook = () => {
   );
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const useCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -275,7 +277,7 @@ export const useCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -532,6 +534,8 @@ export const useDeletePetByIdHook = () => {
   );
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const useDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -548,7 +552,7 @@ export const useDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -594,6 +594,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -611,7 +613,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -913,6 +915,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -930,7 +934,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -390,6 +390,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -407,7 +409,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -724,6 +726,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -741,7 +745,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -359,6 +359,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -376,7 +378,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -678,6 +680,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -695,7 +699,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -345,6 +345,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -362,7 +364,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -643,6 +645,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -660,7 +664,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -333,6 +333,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -350,7 +352,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -646,6 +648,8 @@ export const deletePetById = async (
   });
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -663,7 +667,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -251,6 +251,8 @@ export const createPets = async (
   return data;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -268,7 +270,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -531,6 +533,8 @@ export const deletePetById = async (
   return data;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -548,7 +552,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
@@ -337,6 +337,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -354,7 +356,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -669,6 +671,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -686,7 +690,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
@@ -546,6 +546,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -563,7 +565,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1087,6 +1089,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -1104,7 +1108,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
@@ -337,6 +337,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -354,7 +356,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -669,6 +671,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -686,7 +690,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/split/endpoints.ts
+++ b/tests/__snapshots__/solid-query/split/endpoints.ts
@@ -337,6 +337,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -354,7 +356,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -670,6 +672,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -687,7 +691,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/suspense/endpoints.ts
+++ b/tests/__snapshots__/solid-query/suspense/endpoints.ts
@@ -680,6 +680,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -697,7 +699,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -1150,6 +1152,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -1167,7 +1171,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/tags/pets.ts
+++ b/tests/__snapshots__/solid-query/tags/pets.ts
@@ -344,6 +344,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -361,7 +363,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -676,6 +678,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -693,7 +697,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
@@ -344,6 +344,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -361,7 +363,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -677,6 +679,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -694,7 +698,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -253,6 +253,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -270,7 +272,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -470,6 +472,8 @@ export const deletePetById = async (
   });
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -487,7 +491,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -171,6 +171,8 @@ export const createPets = async (
   return data;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -188,7 +190,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -355,6 +357,8 @@ export const deletePetById = async (
   return data;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -372,7 +376,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -257,6 +257,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -274,7 +276,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -493,6 +495,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -510,7 +514,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -287,6 +287,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -308,7 +310,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -547,6 +549,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -568,7 +572,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -285,6 +285,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -306,7 +308,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -545,6 +547,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -566,7 +570,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -257,6 +257,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -274,7 +276,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -493,6 +495,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -510,7 +514,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -257,6 +257,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -274,7 +276,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -494,6 +496,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -511,7 +515,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -264,6 +264,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -281,7 +283,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -500,6 +502,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -517,7 +521,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -264,6 +264,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -281,7 +283,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -501,6 +503,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -518,7 +522,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -274,6 +274,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -291,7 +293,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -517,6 +519,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -534,7 +538,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -274,6 +274,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -291,7 +293,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -517,6 +519,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -534,7 +538,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/form-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/form-data/endpoints.ts
@@ -151,6 +151,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -168,7 +170,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -263,6 +263,8 @@ export const createPets = async (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -280,7 +282,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -484,6 +486,8 @@ export const deletePetById = async (
   });
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -501,7 +505,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -181,6 +181,8 @@ export const createPets = async (
   return data;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -198,7 +200,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -369,6 +371,8 @@ export const deletePetById = async (
   return data;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -386,7 +390,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -267,6 +267,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -284,7 +286,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -507,6 +509,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -524,7 +528,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -294,6 +294,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -315,7 +317,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -563,6 +565,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -584,7 +588,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -292,6 +292,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -313,7 +315,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -561,6 +563,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -582,7 +586,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
@@ -138,6 +138,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -306,6 +308,8 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -323,7 +327,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/split/endpoints.ts
+++ b/tests/__snapshots__/vue-query/split/endpoints.ts
@@ -138,6 +138,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -155,7 +157,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -307,6 +309,8 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -324,7 +328,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/tags/pets.ts
+++ b/tests/__snapshots__/vue-query/tags/pets.ts
@@ -145,6 +145,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -162,7 +164,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -313,6 +315,8 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -330,7 +334,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -274,6 +274,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -291,7 +293,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -515,6 +517,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -532,7 +536,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -286,6 +286,8 @@ export const createPets = async (
   } as createPetsResponse;
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -303,7 +305,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -546,6 +548,8 @@ export const deletePetById = async (
   } as deletePetByIdResponse;
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = Error,
   TContext = unknown,
@@ -563,7 +567,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, fetch: fetchOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&

--- a/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
@@ -145,6 +145,8 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsMutationKey = () => ['createPets'] as const;
+
 export const getCreatePetsMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -162,7 +164,7 @@ export const getCreatePetsMutationOptions = <
   CreatePetsMutationVariables,
   TContext
 > => {
-  const mutationKey = ['createPets'];
+  const mutationKey = getCreatePetsMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&
@@ -314,6 +316,8 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
+
 export const getDeletePetByIdMutationOptions = <
   TError = AxiosError<Error>,
   TContext = unknown,
@@ -331,7 +335,7 @@ export const getDeletePetByIdMutationOptions = <
   DeletePetByIdMutationVariables,
   TContext
 > => {
-  const mutationKey = ['deletePetById'];
+  const mutationKey = getDeletePetByIdMutationKey();
   const { mutation: mutationOptions, axios: axiosOptions } = options
     ? options.mutation &&
       'mutationKey' in options.mutation &&


### PR DESCRIPTION
Fixes #3918

Mutation keys were computed inside the options factory, so getting one meant calling `getXxxMutationOptions()` and reading `.mutationKey` off the result — awkward in Vue, and it couples callers to the options shape instead of a stable key API.

This hoists the key into an exported getter next to the factory, same shape as `getXxxQueryKey`:

```ts
export const getCreatePetsMutationKey = () => ['createPets'] as const;

export const getCreatePetsMutationOptions = <...>(options?) => {
  const mutationKey = getCreatePetsMutationKey();
  ...
};
```

Main use case is matching a key outside a hook, e.g. a global `MutationCache` callback that receives `mutation.options.mutationKey`.

Notes:
- Gated on the existing `shouldExportQueryKey` option, no new config. Emission is skipped only when the getter would be both unexported and unused (`shouldExportQueryKey: false` + `requestOptions: false`).
- Unchanged behaviour: with `requestOptions: false` the factory still sets no `mutationKey` at all, so nothing new is wired there.
- Snapshots and samples regenerated; the only diff outside the two source files is the new getter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mutation keys can now be exported through dedicated getter helpers alongside mutation options.
  * Request-option configurations automatically use the generated mutation-key getters.
* **Documentation**
  * Updated English and Chinese configuration guides to document mutation-key exports and include a usage example.
* **Tests**
  * Added coverage confirming mutation-key getters are generated when enabled and omitted when request options are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->