### PR TITLE
fix(hono): resolve the default schema module against the full extension

### DIFF
--- a/packages/core/src/utils/file.test.ts
+++ b/packages/core/src/utils/file.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { stripFileExtension } from './file';
+import { pathWithoutExtension, stripFileExtension } from './file';
 
 describe('stripFileExtension', () => {
   it('strips a multi-part fileExtension in one piece', () => {
@@ -34,5 +34,28 @@ describe('stripFileExtension', () => {
     expect(stripFileExtension('./v1.0/pets.ts', '.generated.ts')).toBe(
       './v1.0/pets',
     );
+  });
+
+  it('treats a backslash as a separator', () => {
+    // Windows paths reach this helper too. A character class that excludes
+    // only `/` lets the fallback eat back past a `\`, so a segment with no
+    // extension of its own takes the version dot with it.
+    expect(stripFileExtension('.\\v1.0\\pets', '.generated.ts')).toBe(
+      '.\\v1.0\\pets',
+    );
+    expect(stripFileExtension('.\\v1.0\\pets.ts', '.generated.ts')).toBe(
+      '.\\v1.0\\pets',
+    );
+  });
+});
+
+describe('pathWithoutExtension', () => {
+  it('removes the last extension', () => {
+    expect(pathWithoutExtension('./pets.ts')).toBe('./pets');
+  });
+
+  it('keeps a dot that belongs to a directory', () => {
+    expect(pathWithoutExtension('./v1.0/pets')).toBe('./v1.0/pets');
+    expect(pathWithoutExtension('.\\v1.0\\pets')).toBe('.\\v1.0\\pets');
   });
 });

--- a/packages/core/src/utils/file.test.ts
+++ b/packages/core/src/utils/file.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { stripFileExtension } from './file';
+
+describe('stripFileExtension', () => {
+  it('strips a multi-part fileExtension in one piece', () => {
+    // Regression: stripping only the last dot-segment leaves `.generated`
+    // behind, so appending an import extension doubles the suffix
+    // (`pets.generated.ts` -> `pets.generated` -> `pets.generated.generated`).
+    expect(stripFileExtension('./pets.generated.ts', '.generated.ts')).toBe(
+      './pets',
+    );
+  });
+
+  it('appends cleanly after stripping a multi-part extension', () => {
+    const withoutExt = stripFileExtension(
+      './pets.generated.ts',
+      '.generated.ts',
+    );
+    expect(withoutExt + '.js').toBe('./pets.js');
+  });
+
+  it('falls back to stripping the last segment for a plain extension', () => {
+    expect(stripFileExtension('./pets.ts', '.ts')).toBe('./pets');
+  });
+
+  it('falls back to stripping the last segment when the path does not end with the configured extension', () => {
+    expect(stripFileExtension('./pets.schemas.ts', '.generated.ts')).toBe(
+      './pets.schemas',
+    );
+  });
+
+  it('leaves a dot in a directory name alone', () => {
+    expect(stripFileExtension('./v1.0/pets.ts', '.generated.ts')).toBe(
+      './v1.0/pets',
+    );
+  });
+});

--- a/packages/core/src/utils/file.ts
+++ b/packages/core/src/utils/file.ts
@@ -5,6 +5,26 @@ import { escapePath, glob } from 'tinyglobby';
 
 import { isDirectory } from './assertion';
 
+/** Removes the last extension from a path. A dot in a directory name stays. */
+export function pathWithoutExtension(filePath: string) {
+  return filePath.replace(/\.[^/.]+$/, '');
+}
+
+/**
+ * Removes a configured file extension, which may have several parts. Stripping
+ * only the last segment would leave `pets.generated.ts` as `pets.generated`,
+ * and re-adding the extension then gives `pets.generated.generated`. Falls
+ * back to the last segment for a path that does not carry the full extension.
+ */
+export function stripFileExtension(
+  filePath: string,
+  fileExtension: string,
+): string {
+  return filePath.endsWith(fileExtension)
+    ? filePath.slice(0, -fileExtension.length)
+    : pathWithoutExtension(filePath);
+}
+
 /**
  * Escapes glob metacharacters (`*?()[]{}!`, a leading `!`, and a literal
  * backslash) in a path segment so it can be embedded in a glob pattern and
@@ -26,7 +46,6 @@ export function getFileInfo(
   const filePath = isDir
     ? path.join(target, backupFilename + extension)
     : target;
-  const pathWithoutExtension = filePath.replace(/\.[^/.]+$/, '');
   const dir = path.dirname(filePath);
   const filename = path.basename(
     filePath,
@@ -35,7 +54,7 @@ export function getFileInfo(
 
   return {
     path: filePath,
-    pathWithoutExtension,
+    pathWithoutExtension: pathWithoutExtension(filePath),
     extension,
     isDirectory: isDir,
     dirname: dir,

--- a/packages/core/src/utils/file.ts
+++ b/packages/core/src/utils/file.ts
@@ -5,9 +5,13 @@ import { escapePath, glob } from 'tinyglobby';
 
 import { isDirectory } from './assertion';
 
-/** Removes the last extension from a path. A dot in a directory name stays. */
+/**
+ * Removes the last extension from a path. A dot in a directory name stays,
+ * which is why `\` counts as a separator too: without it, `.\v1.0\pets` would
+ * lose everything after the version dot.
+ */
 export function pathWithoutExtension(filePath: string) {
-  return filePath.replace(/\.[^/.]+$/, '');
+  return filePath.replace(/\.[^\\/.]+$/, '');
 }
 
 /**

--- a/packages/hono/src/index.test.ts
+++ b/packages/hono/src/index.test.ts
@@ -2,10 +2,13 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import type { GeneratorVerbOptions } from '@orval/core';
+import type {
+  GeneratorVerbOptions,
+  NormalizedOutputOptions,
+} from '@orval/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
-import { generateHandlerFile } from './index';
+import { generateHandlerFile, resolveDefaultSchemaModule } from './index';
 
 const verb = (operationName: string): GeneratorVerbOptions =>
   ({
@@ -185,5 +188,71 @@ describe('generateHandlerFile — NodeNext module resolution', () => {
     });
 
     expect(result).toContain("from './endpoints.context';");
+  });
+});
+
+describe('resolveDefaultSchemaModule', () => {
+  const output = (overrides: Partial<NormalizedOutputOptions>) =>
+    ({
+      target: '/out/client.generated.ts',
+      fileExtension: '.generated.ts',
+      mode: 'split',
+      schemas: undefined,
+      ...overrides,
+    }) as unknown as NormalizedOutputOptions;
+
+  it('does not leave `.generated` behind for a multi-part fileExtension', () => {
+    // A naive last-extension strip on `/out/client.generated.ts` leaves
+    // `/out/client.generated`, which then produced
+    // `client.generated.schemas.generated.ts` instead of
+    // `client.schemas.generated.ts`.
+    expect(resolveDefaultSchemaModule(output({}))).toBe(
+      '/out/client.schemas.generated.ts',
+    );
+  });
+
+  it('still works for a single-part fileExtension', () => {
+    expect(
+      resolveDefaultSchemaModule(
+        output({ target: '/out/client.ts', fileExtension: '.ts' }),
+      ),
+    ).toBe('/out/client.schemas.ts');
+  });
+
+  it('strips the target extension when it differs from fileExtension', () => {
+    // `getFileInfo`'s `filename` only strips the extension it was handed, so a
+    // target that does not carry `fileExtension` kept its own `.ts` and
+    // produced `/out/client.ts.schemas.generated.ts`.
+    expect(
+      resolveDefaultSchemaModule(output({ target: '/out/client.ts' })),
+    ).toBe('/out/client.schemas.generated.ts');
+  });
+
+  it('keeps a dot that belongs to the filename', () => {
+    expect(
+      resolveDefaultSchemaModule(
+        output({ target: '/out/client.v1.ts', fileExtension: '.ts' }),
+      ),
+    ).toBe('/out/client.v1.schemas.ts');
+  });
+
+  it('returns the target path itself in single mode', () => {
+    expect(resolveDefaultSchemaModule(output({ mode: 'single' }))).toBe(
+      '/out/client.generated.ts',
+    );
+  });
+
+  it('returns the configured schemas directory when set', () => {
+    // Normalized `output.schemas` is a directory path; getFileInfo treats an
+    // extension-less path as a directory, so dirname resolves to the
+    // directory itself, not its parent.
+    expect(resolveDefaultSchemaModule(output({ schemas: '/out/model' }))).toBe(
+      '/out/model',
+    );
+    expect(
+      resolveDefaultSchemaModule(
+        output({ schemas: '/out/model/index.generated.ts' }),
+      ),
+    ).toBe('/out/model');
   });
 });

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -28,6 +28,7 @@ import {
   getKey,
   pascal,
   sanitizePathParamName,
+  stripFileExtension,
   getImportExtension,
   type Tsconfig,
   upath,
@@ -1115,28 +1116,48 @@ ${honoAppExport}
   ];
 };
 
-export const generateExtraFiles: ClientExtraFilesBuilder = async (
-  verbOptions,
-  output,
-  context,
-) => {
-  const { path, pathWithoutExtension, extension } = getFileInfo(output.target, {
+/**
+ * Path (or directory, when `output.schemas` names one explicitly) that the
+ * generated `.context` and `.zod` modules import shared schema types from.
+ *
+ * @remarks
+ * The configured `extension` may have several parts. Stripping only the last
+ * one leaves `.generated` behind for a `.generated.ts` extension and produces
+ * `client.generated.schemas.generated.ts` instead of
+ * `client.schemas.generated.ts`.
+ */
+export const resolveDefaultSchemaModule = (
+  output: NormalizedOutputOptions,
+): string => {
+  const { path, extension } = getFileInfo(output.target, {
     extension: output.fileExtension,
   });
-  const validator = generateZvalidator(output, context);
-  let schemaModule: string;
 
   if (output.schemas != undefined) {
     const schemasPath = (
       isObject(output.schemas) ? output.schemas.path : output.schemas
     ) as string;
-    const basePath = getFileInfo(schemasPath).dirname;
-    schemaModule = basePath;
-  } else if (output.mode === 'single') {
-    schemaModule = path;
-  } else {
-    schemaModule = `${pathWithoutExtension}.schemas${extension}`;
+    return upath.toUnix(getFileInfo(schemasPath).dirname);
   }
+
+  if (output.mode === 'single') {
+    return upath.toUnix(path);
+  }
+
+  // Strip the configured extension in one piece. `getFileInfo`'s `filename`
+  // only strips it when the target actually carries it, so a target named
+  // `client.ts` under `fileExtension: '.gen.ts'` would otherwise produce
+  // `client.ts.schemas.gen.ts`.
+  return `${upath.toUnix(stripFileExtension(path, extension))}.schemas${extension}`;
+};
+
+export const generateExtraFiles: ClientExtraFilesBuilder = async (
+  verbOptions,
+  output,
+  context,
+) => {
+  const validator = generateZvalidator(output, context);
+  const schemaModule = resolveDefaultSchemaModule(output);
 
   const contexts = generateContextFiles(
     verbOptions,

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -1117,14 +1117,8 @@ ${honoAppExport}
 };
 
 /**
- * Path (or directory, when `output.schemas` names one explicitly) that the
- * generated `.context` and `.zod` modules import shared schema types from.
- *
- * @remarks
- * The configured `extension` may have several parts. Stripping only the last
- * one leaves `.generated` behind for a `.generated.ts` extension and produces
- * `client.generated.schemas.generated.ts` instead of
- * `client.schemas.generated.ts`.
+ * Module (or directory, when `output.schemas` names one) that the generated
+ * `.context` and `.zod` files import shared schema types from.
  */
 export const resolveDefaultSchemaModule = (
   output: NormalizedOutputOptions,
@@ -1144,10 +1138,9 @@ export const resolveDefaultSchemaModule = (
     return upath.toUnix(path);
   }
 
-  // Strip the configured extension in one piece. `getFileInfo`'s `filename`
-  // only strips it when the target actually carries it, so a target named
-  // `client.ts` under `fileExtension: '.gen.ts'` would otherwise produce
-  // `client.ts.schemas.gen.ts`.
+  // The extension comes off in one piece, so `.generated.ts` leaves no
+  // `.generated` behind, and a target that carries a different extension
+  // (`client.ts` under `.gen.ts`) does not keep its own.
   return `${upath.toUnix(stripFileExtension(path, extension))}.schemas${extension}`;
 };
 


### PR DESCRIPTION
## What

`generateExtraFiles` derived the module that generated `.context` and `.zod` files import schemas from, using `pathWithoutExtension` — which strips a single dot-segment. Two configurations came out wrong:

```
fileExtension: '.generated.ts', target: 'client.generated.ts'
  ->  client.generated.schemas.generated.ts      # want client.schemas.generated.ts

fileExtension: '.gen.ts',       target: 'client.ts'
  ->  client.ts.schemas.gen.ts                   # want client.schemas.gen.ts
```

The first leaves the leading part of a multi-part extension behind. The second is the mirror image: `getFileInfo` strips only the extension it is handed, so a target that does not carry `fileExtension` keeps its own `.ts`.

## Why this fix

One helper, `stripFileExtension`, removes a configured extension whole and falls back to the last segment when the path does not carry it. It lives in `@orval/core` beside `pathWithoutExtension`, which it builds on.

The path logic moves out of `generateExtraFiles` into an exported `resolveDefaultSchemaModule`, so it is reachable from a unit test rather than only through file generation.

`upath.toUnix` now applies on every branch. The `output.schemas` branch previously returned `getFileInfo(...).dirname` unnormalised, so Windows emitted native separators inside a module specifier.

## User-visible changes

Hono projects with a multi-part `fileExtension`, or a `target` whose extension differs from it, now import schemas from the file that is actually written. On Windows, the generated specifier uses `/`.

## Tests

- `core/src/utils/file.test.ts` — `stripFileExtension` across multi-part, single-part, non-matching, and a dot that belongs to the filename.
- `hono/src/index.test.ts` — `resolveDefaultSchemaModule` across both broken configurations, single mode, and an explicit `schemas` directory.

## Verification

`build:release`, `typecheck`, `lint`, `format:check`, `test` — all green. Fixtures regenerated with no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45JnFEmPr7ocKckyjzuTd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-part file extensions when generating schema module paths.
  * Preserved dots in filenames and directory names during extension processing.
  * Standardized generated paths for consistent cross-platform behavior.
  * Improved fallback handling when configured extensions do not match the source path.

* **Refactor**
  * Centralized file-extension processing and schema-module path resolution for more reliable output generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->