### PR TITLE
ref(zod): render generated export blocks from a single emitter

### DIFF
--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -31,8 +31,8 @@ import {
   generateFormDataZodSchema,
   generateZodValidationSchemaDefinition,
   getZodImportSource,
-  getZodTypeName,
   parseZodValidationSchemaDefinition,
+  renderZodExport,
   resolveIsZodV4,
   type ZodValidationSchemaDefinition,
 } from '@orval/zod';
@@ -239,10 +239,15 @@ function generateZodSchemaFileContent(
     .map(({ schemaName, consts, zodExpression }) => {
       const schemaConsts = consts ? `${consts}\n` : '';
 
-      return `${schemaConsts}export const ${schemaName} = ${zodExpression}
-
-export type ${schemaName} = zod.input<typeof ${schemaName}>;
-export type ${schemaName}Output = zod.output<typeof ${schemaName}>;`;
+      return (
+        schemaConsts +
+        renderZodExport({
+          name: schemaName,
+          expression: zodExpression,
+          variant: zodVariant,
+          companionTypes: true,
+        })
+      );
     })
     .join('\n\n');
 
@@ -363,18 +368,32 @@ function renderReusableSchemaEntry(
 
     return {
       content:
-        `${consts}${subModelBlock}export type ${entry.name} = ${typeBody};\n\n` +
-        `export const ${entry.name}: zod.${getZodTypeName(zodVariant)}<${entry.name}> = ${entry.zod};\n\n` +
-        `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`,
+        consts +
+        subModelBlock +
+        renderZodExport({
+          name: entry.name,
+          expression: entry.zod,
+          variant: zodVariant,
+          recursivePin: { tsBody: typeBody },
+        }),
       extraImports,
     };
   }
 
   return {
     content:
-      `${consts}export const ${entry.name} = ${entry.zod};\n\n` +
-      `export type ${entry.name} = zod.input<typeof ${entry.name}>;\n` +
-      `export type ${entry.name}Output = zod.output<typeof ${entry.name}>;`,
+      consts +
+      renderZodExport({
+        name: entry.name,
+        // The trailing `;` is folded into the expression (rather than left
+        // for the emitter to add) to preserve this call site's pre-existing
+        // output byte-for-byte; the schema-file entry above passes its
+        // expression bare and emits none. See the module-drift note on
+        // `renderReusableSchemaEntry`.
+        expression: `${entry.zod};`,
+        variant: zodVariant,
+        companionTypes: true,
+      }),
     extraImports: [],
   };
 }

--- a/packages/zod/src/export-emitter.test.ts
+++ b/packages/zod/src/export-emitter.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { renderZodExport } from './export-emitter';
+
+describe('renderZodExport', () => {
+  it('renders a plain export const with no brand and no companion types', () => {
+    expect(
+      renderZodExport({
+        name: 'ListPetsParams',
+        expression: 'zod.object({ limit: zod.number() })',
+        variant: 'classic',
+      }),
+    ).toBe('export const ListPetsParams = zod.object({ limit: zod.number() })');
+  });
+
+  describe('brand', () => {
+    it('appends a Zod v4 brand call when isZodV4 is true', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsBody',
+          expression: 'zod.object({})',
+          variant: 'classic',
+          brand: { isZodV4: true },
+        }),
+      ).toBe(
+        'export const ListPetsBody = zod.object({}).brand("ListPetsBody")',
+      );
+    });
+
+    it('appends a Zod v3 brand call when isZodV4 is false', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsBody',
+          expression: 'zod.object({})',
+          variant: 'classic',
+          brand: { isZodV4: false },
+        }),
+      ).toBe(
+        'export const ListPetsBody = zod.object({}).brand<"ListPetsBody">()',
+      );
+    });
+
+    it('omits the brand call when brand is unset', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsBody',
+          expression: 'zod.object({})',
+          variant: 'classic',
+        }),
+      ).toBe('export const ListPetsBody = zod.object({})');
+    });
+  });
+
+  describe('companion types', () => {
+    it('adds zod.input/zod.output companion type aliases when enabled', () => {
+      expect(
+        renderZodExport({
+          name: 'Pet',
+          expression: 'zod.object({ name: zod.string() })',
+          variant: 'classic',
+          companionTypes: true,
+        }),
+      ).toBe(
+        'export const Pet = zod.object({ name: zod.string() })\n\n' +
+          'export type Pet = zod.input<typeof Pet>;\n' +
+          'export type PetOutput = zod.output<typeof Pet>;',
+      );
+    });
+
+    it('omits companion type aliases when disabled', () => {
+      expect(
+        renderZodExport({
+          name: 'Pet',
+          expression: 'zod.object({ name: zod.string() })',
+          variant: 'classic',
+        }),
+      ).toBe('export const Pet = zod.object({ name: zod.string() })');
+    });
+
+    it('reproduces the reusable-entry semicolon convention when the caller includes it in the expression', () => {
+      expect(
+        renderZodExport({
+          name: 'Pet',
+          expression: 'zod.object({ name: zod.string() });',
+          variant: 'classic',
+          companionTypes: true,
+        }),
+      ).toBe(
+        'export const Pet = zod.object({ name: zod.string() });\n\n' +
+          'export type Pet = zod.input<typeof Pet>;\n' +
+          'export type PetOutput = zod.output<typeof Pet>;',
+      );
+    });
+  });
+
+  describe('array Item split', () => {
+    it('splits into an Item schema and an unbounded array wrapper (classic)', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsResponse',
+          expression: 'zod.object({ id: zod.number() })',
+          variant: 'classic',
+          arrayItem: {},
+        }),
+      ).toBe(
+        'export const ListPetsResponseItem = zod.object({ id: zod.number() })\n' +
+          'export const ListPetsResponse = zod.array(ListPetsResponseItem)',
+      );
+    });
+
+    it('applies min/max bounds for the classic array wrapper', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsResponse',
+          expression: 'zod.object({ id: zod.number() })',
+          variant: 'classic',
+          arrayItem: { rules: { min: 1, max: 10 } },
+        }),
+      ).toBe(
+        'export const ListPetsResponseItem = zod.object({ id: zod.number() })\n' +
+          'export const ListPetsResponse = zod.array(ListPetsResponseItem).min(1).max(10)',
+      );
+    });
+
+    it('uses the Mini functional array call with no bounds', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsResponse',
+          expression: '/*#__PURE__*/ zod.object({ id: zod.number() })',
+          variant: 'mini',
+          arrayItem: {},
+        }),
+      ).toBe(
+        'export const ListPetsResponseItem = /*#__PURE__*/ zod.object({ id: zod.number() })\n' +
+          'export const ListPetsResponse = /*#__PURE__*/ zod.array(ListPetsResponseItem)',
+      );
+    });
+
+    it('uses Mini .check() calls for min/max bounds', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsResponse',
+          expression: '/*#__PURE__*/ zod.object({ id: zod.number() })',
+          variant: 'mini',
+          arrayItem: { rules: { min: 1, max: 10 } },
+        }),
+      ).toBe(
+        'export const ListPetsResponseItem = /*#__PURE__*/ zod.object({ id: zod.number() })\n' +
+          'export const ListPetsResponse = /*#__PURE__*/ zod.array(ListPetsResponseItem)' +
+          '.check(/*#__PURE__*/ zod.minLength(1)).check(/*#__PURE__*/ zod.maxLength(10))',
+      );
+    });
+
+    it('brands the array wrapper but never the Item schema', () => {
+      expect(
+        renderZodExport({
+          name: 'ListPetsResponse',
+          expression: 'zod.object({ id: zod.number() })',
+          variant: 'classic',
+          brand: { isZodV4: true },
+          arrayItem: {},
+        }),
+      ).toBe(
+        'export const ListPetsResponseItem = zod.object({ id: zod.number() })\n' +
+          'export const ListPetsResponse = zod.array(ListPetsResponseItem).brand("ListPetsResponse")',
+      );
+    });
+  });
+
+  describe('recursive pin', () => {
+    it('renders the TS type, the pinned const, and the Output companion type', () => {
+      expect(
+        renderZodExport({
+          name: 'Category',
+          expression: 'zod.lazy(() => CategorySchema)',
+          variant: 'classic',
+          recursivePin: { tsBody: '{ name: string; parent?: Category }' },
+        }),
+      ).toBe(
+        'export type Category = { name: string; parent?: Category };\n\n' +
+          'export const Category: zod.ZodType<Category> = zod.lazy(() => CategorySchema);\n\n' +
+          'export type CategoryOutput = zod.output<typeof Category>;',
+      );
+    });
+
+    it('uses ZodMiniType for the mini variant', () => {
+      expect(
+        renderZodExport({
+          name: 'Category',
+          expression: 'zod.lazy(() => CategorySchema)',
+          variant: 'mini',
+          recursivePin: { tsBody: '{ name: string }' },
+        }),
+      ).toBe(
+        'export type Category = { name: string };\n\n' +
+          'export const Category: zod.ZodMiniType<Category> = zod.lazy(() => CategorySchema);\n\n' +
+          'export type CategoryOutput = zod.output<typeof Category>;',
+      );
+    });
+  });
+});

--- a/packages/zod/src/export-emitter.ts
+++ b/packages/zod/src/export-emitter.ts
@@ -1,0 +1,109 @@
+import { type ZodVariantOption } from '@orval/core';
+
+import { getZodTypeName } from './compatible-v4';
+
+/** Marks a call as side-effect-free for bundlers' tree-shaking passes. */
+export const PURE_COMMENT = '/*#__PURE__*/ ';
+
+/** Renders a Zod Mini functional call, e.g. `zod.minLength(1)`, with the pure-call comment. */
+export const zodMiniCall = (fn: string, args = '') =>
+  `${PURE_COMMENT}zod.${fn}(${args})`;
+
+/**
+ * Descriptor for one generated Zod `export const` block. Everything on this
+ * type is already resolved by the caller (a chosen export name, a rendered
+ * zod expression) so this module can stay a pure string renderer: no
+ * `ContextSpec`, no OpenAPI, testable with plain objects.
+ *
+ * What this module does NOT own, and callers must resolve first:
+ * - name allocation (collision handling needs ref context)
+ * - the recursive TS type body (`recursivePin.tsBody`) — produced by the
+ *   caller's own model generator
+ * - hoisted consts (`…Default`, `…RegExp0`, …) — callers prepend these
+ *   themselves as pre-rendered strings
+ */
+export interface ZodExportBlock {
+  /** Already-allocated export name. */
+  name: string;
+  /** Already-rendered zod expression, the RHS of the `export const`. */
+  expression: string;
+  /** 'classic' zod calls vs the Zod Mini functional API. */
+  variant: ZodVariantOption;
+  /**
+   * Append a `.brand(...)` call to the wrapper (never to the `Item` schema).
+   * `isZodV4` selects the v4 vs v3 brand call syntax and is required here so
+   * a caller can't opt into branding without also saying which syntax it
+   * wants — omit the whole field at call sites that never brand (e.g.
+   * companion-type or recursive-pin blocks).
+   */
+  brand?: { isZodV4: boolean };
+  /** Emit `zod.input`/`zod.output` companion type aliases. */
+  companionTypes?: boolean;
+  /** Split into an `<name>Item` schema plus a bounded array wrapper. */
+  arrayItem?: { rules?: { min?: number; max?: number } };
+  /** Pin a recursive schema to a hand-written TS type instead of inferring it. */
+  recursivePin?: { tsBody: string };
+}
+
+const renderArrayWithBounds = (
+  itemName: string,
+  variant: ZodVariantOption,
+  rules: { min?: number; max?: number } | undefined,
+) => {
+  if (variant === 'mini') {
+    const checks = [
+      ...(rules?.min ? [zodMiniCall('minLength', `${rules.min}`)] : []),
+      ...(rules?.max ? [zodMiniCall('maxLength', `${rules.max}`)] : []),
+    ];
+    return `${zodMiniCall('array', itemName)}${checks
+      .map((check) => `.check(${check})`)
+      .join('')}`;
+  }
+
+  return `zod.array(${itemName})${rules?.min ? `.min(${rules.min})` : ''}${
+    rules?.max ? `.max(${rules.max})` : ''
+  }`;
+};
+
+const renderBrand = (block: ZodExportBlock) => {
+  if (!block.brand) return '';
+  return block.brand.isZodV4
+    ? `.brand("${block.name}")`
+    : `.brand<"${block.name}">()`;
+};
+
+/**
+ * Renders one generated Zod export block: the `export const`, its optional
+ * `Item` split, brand, and either `zod.input`/`zod.output` companion types
+ * or a recursive `zod.ZodType<X>` pin. See {@link ZodExportBlock} for what
+ * this deliberately leaves to the caller.
+ */
+export const renderZodExport = (block: ZodExportBlock): string => {
+  if (block.recursivePin) {
+    const typeName = getZodTypeName(block.variant);
+    return (
+      `export type ${block.name} = ${block.recursivePin.tsBody};\n\n` +
+      `export const ${block.name}: zod.${typeName}<${block.name}> = ${block.expression};\n\n` +
+      `export type ${block.name}Output = zod.output<typeof ${block.name}>;`
+    );
+  }
+
+  const constLine = block.arrayItem
+    ? `export const ${block.name}Item = ${block.expression}\n` +
+      `export const ${block.name} = ${renderArrayWithBounds(
+        `${block.name}Item`,
+        block.variant,
+        block.arrayItem.rules,
+      )}${renderBrand(block)}`
+    : `export const ${block.name} = ${block.expression}${renderBrand(block)}`;
+
+  if (!block.companionTypes) {
+    return constLine;
+  }
+
+  return (
+    `${constLine}\n\n` +
+    `export type ${block.name} = zod.input<typeof ${block.name}>;\n` +
+    `export type ${block.name}Output = zod.output<typeof ${block.name}>;`
+  );
+};

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -57,6 +57,7 @@ import {
   assertZodTarget,
   resolveIsZodV4,
 } from './compatible-v4';
+import { PURE_COMMENT, renderZodExport, zodMiniCall } from './export-emitter';
 
 export const getZodDependencies: ClientDependenciesBuilder = (
   _hasGlobalMutator,
@@ -164,11 +165,6 @@ const COERCIBLE_TYPES = new Set([
   'bigint',
   'date',
 ]);
-
-const PURE_COMMENT = '/*#__PURE__*/ ';
-
-const zodMiniCall = (fn: string, args = '') =>
-  `${PURE_COMMENT}zod.${fn}(${args})`;
 
 const zodMiniCoerceCall = (fn: string, args = '') =>
   `${PURE_COMMENT}zod.coerce.${fn}(${args})`;
@@ -3475,32 +3471,18 @@ const generateZodRoute = async (
   }
 
   const useBrandedTypes = override.zod.useBrandedTypes;
-  const brand = (name: string) =>
-    useBrandedTypes
-      ? isZodV4
-        ? `.brand("${name}")`
-        : `.brand<"${name}">()`
-      : '';
-
-  const zodArrayWithBounds = (
-    itemName: string,
-    rules: { min?: number; max?: number } | undefined,
-  ) => {
-    const checks = [
-      ...(rules?.min ? [zodMiniCall('minLength', `${rules.min}`)] : []),
-      ...(rules?.max ? [zodMiniCall('maxLength', `${rules.max}`)] : []),
-    ];
-
-    if (zodVariant === 'mini') {
-      return `${zodMiniCall('array', itemName)}${checks
-        .map((check) => `.check(${check})`)
-        .join('')}`;
-    }
-
-    return `zod.array(${itemName})${rules?.min ? `.min(${rules.min})` : ''}${
-      rules?.max ? `.max(${rules.max})` : ''
-    }`;
-  };
+  const renderExport = (
+    name: string,
+    expression: string,
+    arrayItem?: { rules?: { min?: number; max?: number } },
+  ) =>
+    renderZodExport({
+      name,
+      expression,
+      variant: zodVariant,
+      brand: useBrandedTypes ? { isZodV4 } : undefined,
+      arrayItem,
+    });
 
   // With `generateReusableSchemas`, operations import component schemas by
   // their PascalCase name from a sibling schemas module. When an operation's
@@ -3555,30 +3537,21 @@ const generateZodRoute = async (
   return {
     implementation: [
       ...(inputParams.consts ? [inputParams.consts] : []),
-      ...(inputParams.zod
-        ? [
-            `export const ${paramsName} = ${inputParams.zod}${brand(paramsName)}`,
-          ]
-        : []),
+      ...(inputParams.zod ? [renderExport(paramsName, inputParams.zod)] : []),
       ...(inputQueryParams.consts ? [inputQueryParams.consts] : []),
       ...(inputQueryParams.zod
-        ? [
-            `export const ${queryParamsName} = ${inputQueryParams.zod}${brand(queryParamsName)}`,
-          ]
+        ? [renderExport(queryParamsName, inputQueryParams.zod)]
         : []),
       ...(inputHeaders.consts ? [inputHeaders.consts] : []),
-      ...(inputHeaders.zod
-        ? [
-            `export const ${headerName} = ${inputHeaders.zod}${brand(headerName)}`,
-          ]
-        : []),
+      ...(inputHeaders.zod ? [renderExport(headerName, inputHeaders.zod)] : []),
       ...(inputBody.consts ? [inputBody.consts] : []),
       ...(inputBody.zod
         ? [
-            parsedBody.isArray
-              ? `export const ${bodyName}Item = ${inputBody.zod}
-export const ${bodyName} = ${zodArrayWithBounds(bodyName + 'Item', parsedBody.rules)}${brand(bodyName)}`
-              : `export const ${bodyName} = ${inputBody.zod}${brand(bodyName)}`,
+            renderExport(
+              bodyName,
+              inputBody.zod,
+              parsedBody.isArray ? { rules: parsedBody.rules } : undefined,
+            ),
           ]
         : []),
       ...inputResponses.flatMap((inputResponse, index) => {
@@ -3617,17 +3590,18 @@ export const ${bodyName} = ${zodArrayWithBounds(bodyName + 'Item', parsedBody.ru
               ? zodMiniCall('unknown')
               : 'zod.unknown()';
 
-          return [
-            `export const ${operationResponse} = ${noContentSchema}${brand(operationResponse)}`,
-          ];
+          return [renderExport(operationResponse, noContentSchema)];
         }
 
         return [
           ...(inputResponse.consts ? [inputResponse.consts] : []),
-          parsedResponses[index].isArray
-            ? `export const ${operationResponse}Item = ${inputResponse.zod}
-export const ${operationResponse} = ${zodArrayWithBounds(`${operationResponse}Item`, parsedResponses[index].rules)}${brand(operationResponse)}`
-            : `export const ${operationResponse} = ${inputResponse.zod}${brand(operationResponse)}`,
+          renderExport(
+            operationResponse,
+            inputResponse.zod,
+            parsedResponses[index].isArray
+              ? { rules: parsedResponses[index].rules }
+              : undefined,
+          ),
         ];
       }),
     ].join('\n\n'),
@@ -3687,5 +3661,6 @@ export {
   isZodVersionV4,
   resolveIsZodV4,
 } from './compatible-v4';
+export { renderZodExport, type ZodExportBlock } from './export-emitter';
 
 export default builder;


### PR DESCRIPTION
### Why
The shape of a generated Zod export block (the `export const`, its `Item` split, brand placement, the `zod.input`/`zod.output` companion aliases, the recursive `zod.ZodType<X>` pin) was not defined anywhere. It lived in eleven template literals across two packages, and the two sets had drifted: per-operation schemas got branding and an `Item` split but no companion types, component schemas got companion types and the recursive pin but no branding. Any change to export shape meant editing all eleven and reconciling both conventions by hand, and the smallest thing a test could assert against was the whole client builder. #3808 (companion types for per-operation schemas) is the first change that needs the two paths to agree, and this PR turns it into a one-line flag instead of a rewrite.

### What
adds `packages/zod/src/export-emitter.ts` with one pure renderer, `renderZodExport(block)`, and routes every generated Zod export block through it: the eight per-operation templates in `packages/zod/src/index.ts` (`Params`, `QueryParams`, `Header`, `Body` with and without `Item`, `Response` with and without `Item`, no-content `Response`) and the three schema-file templates in `packages/orval/src/write-zod-specs.ts` (plain entry, reusable acyclic, reusable recursive). The emitter owns the `export const` line, brand placement (on the wrapper, never on `Item`), the `Item` split with the classic vs Mini bounds syntax, the companion aliases, and the recursive pin. Name allocation, the recursive TS body and hoisted consts stay with the callers and cross as strings. It takes plain objects, so `export-emitter.test.ts` covers each shape without a spec or context.

This is a pure refactor. No snapshot or sample file changes; `test:snapshots` and `test:samples` pass with zero diff. Start review at `export-emitter.ts` and its test, then check each call site passes the same pieces the old literal concatenated.

One thing to know: the reusable acyclic entry passes its expression with a trailing `;` because that template had one and the plain schema-file template did not. The emitter keeps that drift instead of fixing it so output stays byte-identical; a comment marks the spot.

`PURE_COMMENT` and `zodMiniCall` moved into the emitter and are imported back into `index.ts`, so the Mini call syntax lives in one place. Branding is requested as `brand: { isZodV4 }`, so a caller cannot ask for a brand without saying which syntax it wants.

Closes #3810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
