### PR TITLE
feat(query): rename shouldExportQueryKey to shouldExportKeys

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1460,14 +1460,18 @@ export async function loader(queryClient: QueryClient) {
 
 Export mutator hooks.
 
-### shouldExportQueryKey
+### shouldExportKeys
 
 **Type:** `Boolean`
 **Default:** `true`
 
-Export query keys. Also applies to mutation keys, which are emitted as a getter next to the mutation options factory:
+Export the generated cache key getters. This covers query keys and mutation keys, the latter emitted next to the mutation options factory:
 
 ```ts title="endpoints.ts"
+export const getShowPetByIdQueryKey = (petId: string) => {
+  return ['pets', petId] as const;
+};
+
 export const getCreatePetsMutationKey = () => ['createPets'] as const;
 ```
 

--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -495,9 +495,9 @@ export default defineConfig({
 
 控制是否导出 mutator 相关 hooks。
 
-### shouldExportQueryKey
+### shouldExportKeys
 
-控制是否导出 query key helper。该选项同样作用于 mutation key，会在 mutation options 工厂函数旁生成 `getXxxMutationKey()` 导出。
+控制是否导出生成的缓存 key helper。该选项同时作用于 query key 和 mutation key，后者会在 mutation options 工厂函数旁生成 `getXxxMutationKey()` 导出。
 
 ### shouldSplitQueryKey
 

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -91,7 +91,7 @@ export function createTestContextSpec({
         useGetQueryData: false,
         shouldExportMutatorHooks: false,
         shouldExportHttpClient: false,
-        shouldExportQueryKey: false,
+        shouldExportKeys: false,
         shouldFilterQueryKey: false,
         shouldSplitQueryKey: false,
         useOperationIdAsQueryKey: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1209,7 +1209,7 @@ export interface NormalizedQueryOptions {
   mutationOptions?: NormalizedMutator;
   shouldExportMutatorHooks?: boolean;
   shouldExportHttpClient?: boolean;
-  shouldExportQueryKey?: boolean;
+  shouldExportKeys?: boolean;
   shouldFilterQueryKey?: boolean;
   queryKeyFilter?: string;
   shouldSplitQueryKey?: boolean;
@@ -1238,6 +1238,15 @@ export interface QueryOptions {
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
   shouldExportHttpClient?: boolean;
+  /**
+   * Export the `getXxxQueryKey` and `getXxxMutationKey` getters. Defaults to
+   * `true`.
+   */
+  shouldExportKeys?: boolean;
+  /**
+   * @deprecated Renamed to `shouldExportKeys`, which is what it always did: it
+   * gates the mutation key getters too, not just the query key ones.
+   */
   shouldExportQueryKey?: boolean;
   shouldFilterQueryKey?: boolean;
   queryKeyFilter?: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1238,14 +1238,9 @@ export interface QueryOptions {
   mutationOptions?: Mutator;
   shouldExportMutatorHooks?: boolean;
   shouldExportHttpClient?: boolean;
-  /**
-   * Export the `getXxxQueryKey` and `getXxxMutationKey` getters. Defaults to
-   * `true`.
-   */
   shouldExportKeys?: boolean;
   /**
-   * @deprecated Renamed to `shouldExportKeys`, which is what it always did: it
-   * gates the mutation key getters too, not just the query key ones.
+   * @deprecated Renamed to `shouldExportKeys`, since it now also exports mutation keys
    */
   shouldExportQueryKey?: boolean;
   shouldFilterQueryKey?: boolean;

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -91,7 +91,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         useGetQueryData: false,
         shouldExportMutatorHooks: false,
         shouldExportHttpClient: false,
-        shouldExportQueryKey: false,
+        shouldExportKeys: false,
         shouldSplitQueryKey: false,
         useOperationIdAsQueryKey: false,
         signal: false,

--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -90,7 +90,7 @@ function createMockContext(): ContextSpec {
           useGetQueryData: false,
           shouldExportMutatorHooks: false,
           shouldExportHttpClient: false,
-          shouldExportQueryKey: false,
+          shouldExportKeys: false,
           shouldSplitQueryKey: false,
           useOperationIdAsQueryKey: false,
           signal: false,

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -484,7 +484,7 @@ export async function normalizeOptions(
     signal: true,
     shouldExportMutatorHooks: true,
     shouldExportHttpClient: true,
-    shouldExportQueryKey: true,
+    shouldExportKeys: true,
     shouldFilterQueryKey: false,
     shouldSplitQueryKey: false,
     ...normalizeQueryOptions(outputOptions.override?.query, outputWorkspace),
@@ -1374,6 +1374,17 @@ function normalizeQueryOptions(
     );
   }
 
+  if (!isNullish(queryOptions.shouldExportQueryKey)) {
+    logWarning(
+      '⚠️  shouldExportQueryKey is deprecated and will be removed in a future major release. Please use shouldExportKeys instead, which also gates the mutation key getters.',
+    );
+  }
+
+  // `shouldExportQueryKey` always gated the mutation key getters as well, so
+  // the rename is a pure alias.
+  const shouldExportKeys =
+    queryOptions.shouldExportKeys ?? queryOptions.shouldExportQueryKey;
+
   return {
     ...(isNullish(queryOptions.usePrefetch)
       ? {}
@@ -1442,14 +1453,12 @@ function normalizeQueryOptions(
           ),
         }
       : {}),
-    ...(isNullish(globalOptions.shouldExportQueryKey)
+    ...(isNullish(globalOptions.shouldExportKeys)
       ? {}
       : {
-          shouldExportQueryKey: globalOptions.shouldExportQueryKey,
+          shouldExportKeys: globalOptions.shouldExportKeys,
         }),
-    ...(isNullish(queryOptions.shouldExportQueryKey)
-      ? {}
-      : { shouldExportQueryKey: queryOptions.shouldExportQueryKey }),
+    ...(isNullish(shouldExportKeys) ? {} : { shouldExportKeys }),
     ...(isNullish(globalOptions.shouldFilterQueryKey)
       ? {}
       : {

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -1380,8 +1380,6 @@ function normalizeQueryOptions(
     );
   }
 
-  // `shouldExportQueryKey` always gated the mutation key getters as well, so
-  // the rename is a pure alias.
   const shouldExportKeys =
     queryOptions.shouldExportKeys ?? queryOptions.shouldExportQueryKey;
 

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -558,11 +558,11 @@ export const generateMutationHook = async ({
   const mutationKeyFnName = camel(`get-${operationName}-mutation-key`);
 
   // Hoisted out of the options factory so the key can be read without running
-  // it. Mirrors `getXxxQueryKey`, including its `shouldExportQueryKey` gate;
+  // it. Mirrors `getXxxQueryKey`, including its `shouldExportKeys` gate;
   // skipped only when it would be both unexported and unused.
   const mutationKeyFn =
-    query.shouldExportQueryKey || isRequestOptions
-      ? `${query.shouldExportQueryKey ? 'export ' : ''}const ${mutationKeyFnName} = () => ['${camel(operationName)}'] as const;`
+    query.shouldExportKeys || isRequestOptions
+      ? `${query.shouldExportKeys ? 'export ' : ''}const ${mutationKeyFnName} = () => ['${camel(operationName)}'] as const;`
       : '';
 
   const hooksOptionImplementation = getHooksOptionImplementation(

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -1258,7 +1258,7 @@ export const generateQueryHook = async (
 
         // Note: do not unref() params in Vue - this will make key lose reactivity
         queryKeyFns += `
-${override.query.shouldExportQueryKey ? 'export ' : ''}const ${queryOption.queryKeyFnName} = (${queryKeyProps}) => {
+${override.query.shouldExportKeys ? 'export ' : ''}const ${queryOption.queryKeyFnName} = (${queryKeyProps}) => {
     return [
     ${[
       queryOption.type === QueryType.INFINITE ||
@@ -1276,7 +1276,7 @@ ${override.query.shouldExportQueryKey ? 'export ' : ''}const ${queryOption.query
     }
 `;
       }
-    } else if (override.query.shouldExportQueryKey) {
+    } else if (override.query.shouldExportKeys) {
       // The factories call the mutator the same way the invalidate / set /
       // get helpers do (`{ url }` second arg). Query options keep their own
       // inline call — its second arg also carries `queryOptions` — so the

--- a/packages/query/src/utils.test.ts
+++ b/packages/query/src/utils.test.ts
@@ -40,6 +40,22 @@ describe('normalizeQueryOptions', () => {
     const result = normalizeQueryOptions({}, '/workspace');
     expect(result.useOperationIdAsQueryKey).toBeUndefined();
   });
+
+  it('accepts the deprecated shouldExportQueryKey alias', () => {
+    const result = normalizeQueryOptions(
+      { shouldExportQueryKey: true },
+      '/workspace',
+    );
+    expect(result.shouldExportKeys).toBe(true);
+  });
+
+  it('prefers shouldExportKeys over the deprecated alias', () => {
+    const result = normalizeQueryOptions(
+      { shouldExportKeys: true, shouldExportQueryKey: false },
+      '/workspace',
+    );
+    expect(result.shouldExportKeys).toBe(true);
+  });
 });
 
 describe('shouldUseOptionsHook', () => {

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -61,8 +61,9 @@ export const normalizeQueryOptions = (
     ...(queryOptions.shouldExportMutatorHooks
       ? { shouldExportMutatorHooks: true }
       : {}),
-    ...(queryOptions.shouldExportQueryKey
-      ? { shouldExportQueryKey: true }
+    // `shouldExportQueryKey` is the deprecated alias of `shouldExportKeys`.
+    ...((queryOptions.shouldExportKeys ?? queryOptions.shouldExportQueryKey)
+      ? { shouldExportKeys: true }
       : {}),
     ...(queryOptions.shouldFilterQueryKey
       ? { shouldFilterQueryKey: true }

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -93,7 +93,7 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         useGetQueryData: false,
         shouldExportMutatorHooks: false,
         shouldExportHttpClient: false,
-        shouldExportQueryKey: false,
+        shouldExportKeys: false,
         shouldSplitQueryKey: false,
         useOperationIdAsQueryKey: false,
         signal: false,

--- a/skills/orval/tanstack-query.md
+++ b/skills/orval/tanstack-query.md
@@ -16,7 +16,7 @@ output: {
       usePrefetch: true,
       useInvalidate: true,
       signal: true,
-      shouldExportQueryKey: true,
+      shouldExportKeys: true,
       shouldSplitQueryKey: false,       // Array vs string query keys
       useOperationIdAsQueryKey: false,  // Use operationId instead of route path
       options: { staleTime: 10000 },


### PR DESCRIPTION
Missed in #3919.

`shouldExportQueryKey` doesn't apply to query keys alone. It also gates the `getXxxMutationKey` getters, so the name misdescribes what the flag does:

**Alternitive:**
**I was also thinking maybe it shoudn't be a `boolean` but a `'query' | 'mutation' | 'both' | 'false'`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added `shouldExportKeys` to control generated query and mutation cache key helpers.
- Cache key exports are enabled by default.

## Bug Fixes
- Ensured query and mutation key exports consistently follow the same configuration.

## Documentation
- Deprecated `shouldExportQueryKey` in favor of `shouldExportKeys`.
- Existing configurations using the old option remain supported, with the new option taking precedence when both are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->