### PR TITLE
chore(lint): enforce consistent-type-imports for source, warn for generated output

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Lint samples
         run: vp run -w lint:samples
 
+      - name: Lint snapshots
+        run: vp run -w lint:snapshots
+
       - name: Typecheck packages
         run: vp run -w typecheck
 

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "test:snapshots:update": "vp run -F './packages/*' build:release && vp run -F './samples/**' -F orval-tests generate-api && vp run -F './samples/**' -F orval-tests test:snapshots:update",
     "lint": "vp lint --type-aware --type-check packages",
     "lint:samples": "vp lint samples",
-    "lint:snapshots": "vp lint --no-ignore tests/__snapshots__",
+    "lint:snapshots": "vp lint tests/__snapshots__",
     "lint:all": "vp run -w lint && vp run -w lint:samples && vp run -w lint:snapshots",
     "clean": "vp cache clean",
     "clean:all": "vp run -r clean",
     "nuke:all": "vp run -r nuke && rimraf node_modules"
   },
   "devDependencies": {
-    "@commitlint/cli": "^21.2.1",
-    "@commitlint/config-conventional": "^21.2.0",
+    "@commitlint/cli": "^21.2.2",
+    "@commitlint/config-conventional": "^21.2.2",
     "@socketsecurity/bun-security-scanner": "^1.1.2",
     "@types/node": "catalog:",
     "pkg-pr-new": "^0.0.86",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:snapshots:update": "vp run -F './packages/*' build:release && vp run -F './samples/**' -F orval-tests generate-api && vp run -F './samples/**' -F orval-tests test:snapshots:update",
     "lint": "vp lint --type-aware --type-check packages",
     "lint:samples": "vp lint samples",
-    "lint:all": "vp run -w lint && vp run -w lint:samples",
+    "lint:snapshots": "vp lint --no-ignore tests/__snapshots__",
+    "lint:all": "vp run -w lint && vp run -w lint:samples && vp run -w lint:snapshots",
     "clean": "vp cache clean",
     "clean:all": "vp run -r clean",
     "nuke:all": "vp run -r nuke && rimraf node_modules"

--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -1,6 +1,7 @@
 import { isNullish, prop, unique } from 'remeda';
 
 import { resolveExampleRefs, resolveObject } from '../resolvers';
+import type { SchemaType } from '../types';
 import {
   type ContextSpec,
   EnumGeneration,
@@ -9,7 +10,6 @@ import {
   type OpenApiReferenceObject,
   type OpenApiSchemaObject,
   type ScalarValue,
-  SchemaType,
 } from '../types';
 import {
   dedupeUnionType,

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -1,10 +1,7 @@
 import { keyword } from 'esutils';
 
-import {
-  EnumGeneration,
-  NamingConvention,
-  type OpenApiSchemaObject,
-} from '../types';
+import type { NamingConvention } from '../types';
+import { EnumGeneration, type OpenApiSchemaObject } from '../types';
 import {
   conventionName,
   isNumeric,

--- a/packages/core/src/getters/object.ts
+++ b/packages/core/src/getters/object.ts
@@ -1,5 +1,6 @@
 import { resolveExampleRefs, resolveValue } from '../resolvers';
 import { resolveObject } from '../resolvers/object';
+import type { SchemaType } from '../types';
 import {
   type ContextSpec,
   type GeneratorImport,
@@ -7,7 +8,6 @@ import {
   type OpenApiSchemaObject,
   PropertySortOrder,
   type ScalarValue,
-  SchemaType,
 } from '../types';
 import {
   compareNatural,

--- a/packages/core/src/getters/operation.ts
+++ b/packages/core/src/getters/operation.ts
@@ -1,4 +1,4 @@
-import { type OpenApiOperationObject, Verbs } from '../types';
+import type { OpenApiOperationObject, Verbs } from '../types';
 import { isString, pascal, sanitize } from '../utils';
 
 export function getOperationId(

--- a/packages/core/src/utils/is-body-verb.ts
+++ b/packages/core/src/utils/is-body-verb.ts
@@ -1,5 +1,5 @@
 import { VERBS_WITH_BODY } from '../constants';
-import { Verbs } from '../types';
+import type { Verbs } from '../types';
 
 export function getIsBodyVerb(verb: Verbs) {
   return VERBS_WITH_BODY.includes(verb);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,12 +64,19 @@ export default defineConfig({
       'typescript/no-require-imports': 'error',
       'typescript/no-unnecessary-type-constraint': 'error',
       'typescript/no-unsafe-function-type': 'error',
+      // `disallowTypeAnnotations: false` keeps `typeof import('x')` legal; the
+      // test files need it for `vi.importOriginal<typeof import('@orval/core')>()`.
+      'typescript/consistent-type-imports': [
+        'error',
+        { disallowTypeAnnotations: false },
+      ],
     },
     overrides: [
       {
-        // Samples are generated orval output — relax the rules generated code
-        // legitimately trips so `lint:samples` stays a useful, looser gate.
-        files: ['samples/**'],
+        // Samples and snapshots are generated orval output — relax the rules
+        // generated code legitimately trips so `lint:samples` and
+        // `lint:snapshots` stay useful, looser gates.
+        files: ['samples/**', 'tests/__snapshots__/**'],
         rules: {
           'eslint/no-unused-vars': 'off',
           'eslint/no-extra-boolean-cast': 'off',
@@ -79,6 +86,17 @@ export default defineConfig({
           'typescript/no-require-imports': 'off',
           'unicorn/no-useless-spread': 'off',
           'unicorn/no-useless-fallback-in-spread': 'off',
+          // Generators emit empty files on purpose (e.g. a client with no
+          // operations for a tag).
+          'unicorn/no-empty-file': 'off',
+          // Generated output must not trip a consumer's linter. Stays `warn`
+          // until every generator emits `import type` for type-only imports
+          // (tracked per generator from #3931); then it flips to `error`
+          // and this entry goes away.
+          'typescript/consistent-type-imports': [
+            'warn',
+            { disallowTypeAnnotations: false },
+          ],
         },
       },
     ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,12 +44,18 @@ export default defineConfig({
     },
     ignorePatterns: [
       '**/dist',
-      '**/__snapshots__',
+      'packages/**/__snapshots__',
+      'samples/**/__snapshots__',
       '**/.bun',
       '**/*.timestamp*',
       '**/node_modules',
       'docs',
-      'tests',
+      // Everything under `tests` is ignored except the committed generated
+      // output, which `lint:snapshots` lints. Gitignore semantics: a negation
+      // can only re-include a child of a directory whose *children* are
+      // ignored, hence `tests/*` rather than `tests`.
+      'tests/*',
+      '!tests/__snapshots__',
       'packages/hono/src/zValidator.ts',
       // Committed TypeDoc bundles: minified vendor output, not lintable source.
       'samples/react-app/docs-html/assets',


### PR DESCRIPTION
Generated code must not trip a consumer's linter. oxlint's `typescript/consistent-type-imports` currently finds 147 value imports of type-only symbols in `tests/__snapshots__` and 66 in `samples`. None fail `tsc`; all fail for a consumer who runs the rule as `error`. #3926 fixed the one case that was a compile error; this PR makes the rest visible and enforces it where we can already comply.

## What changes

- `vite.config.ts`: `typescript/consistent-type-imports` is `error` for `packages/**`, with `disallowTypeAnnotations: false` so `vi.importOriginal<typeof import('@orval/core')>()` in tests stays legal. The generated-code override (`samples/**`) now also covers `tests/__snapshots__/**` and sets the rule to `warn` there, plus `unicorn/no-empty-file: off` because generators emit empty files on purpose.
- `packages/core`: the five source hits fixed (`combine.ts`, `enum.ts`, `object.ts`, `operation.ts`, `is-body-verb.ts`). Import-only changes.
- `package.json` + `pr-checks.yaml`: new `lint:snapshots` script (`vp lint --no-ignore tests/__snapshots__`, since `tests` is in `ignorePatterns`) and a CI step after `Lint samples`. Warnings don't fail the step; the count is visible in the log.

## What does not change

No generated output. Snapshot warnings are fixed per generator in #3932 (Angular, 77), #3933 (Hono, 60), #3934 (MCP, 9), #3935 (angular-query, 1); the hand-written sample sources are a separate sweep. When the count reaches zero the `warn` entry is removed and the rule is `error` workspace-wide. Tracking: #3931.

## Verification

```
vp lint --type-aware --type-check packages   # clean
vp lint samples                              # 66 warnings, exit 0
vp lint --no-ignore tests/__snapshots__      # 147 warnings, exit 0
vp run -F @orval/core typecheck              # clean
```

Refs #3931

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting coverage for committed snapshot files, including pull request checks.
  * Refined lint configuration to ensure intended test snapshots are validated.

* **Chores**
  * Standardized internal type imports without changing runtime behavior.
  * Expanded the all-in-one lint workflow to include snapshots.
  * Updated development tooling configuration for more consistent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->