### PR TITLE
fix(query): link invalidate helpers to queries in jsdocs

### DIFF
--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -446,6 +446,7 @@ const generateQueryImplementation = ({
   forceSuccessResponse,
   route,
   doc,
+  deprecated,
   usePrefetch,
   useQuery,
   useInfinite,
@@ -483,6 +484,7 @@ const generateQueryImplementation = ({
   forceSuccessResponse?: boolean;
   route: string;
   doc?: string;
+  deprecated?: boolean;
   usePrefetch?: boolean;
   useQuery?: boolean;
   useInfinite?: boolean;
@@ -803,6 +805,10 @@ ${hookOptions}
   const optionalQueryClientArgument = adapter.getOptionalQueryClientArgument();
 
   const queryHookName = camel(`${operationPrefix}-${name}`);
+  const invalidateDoc = jsDoc({
+    summary: `Invalidates the {@link ${queryHookName}} query`,
+    deprecated,
+  });
 
   const overrideTypes = `
 export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${definedInitialDataQueryPropsDefinitions} ${definedInitialDataQueryArguments} ${optionalQueryClientArgument}\n  ): ${definedInitialDataReturnType}
@@ -971,7 +977,7 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${w
 ${prefetch}
 ${
   shouldGenerateInvalidate
-    ? `${doc}export const ${invalidateFnName} = async (\n queryClient: QueryClient, ${queryProps} options?: InvalidateOptions\n  ): Promise<QueryClient> => {
+    ? `${invalidateDoc}export const ${invalidateFnName} = async (\n queryClient: QueryClient, ${queryProps} options?: InvalidateOptions\n  ): Promise<QueryClient> => {
 
   await queryClient.invalidateQueries({ queryKey: ${invalidateQueryKeyExpr} }, options);
 
@@ -1332,6 +1338,7 @@ ${queryKeyFns}`;
         queryKeyMutator,
         route,
         doc,
+        deprecated,
         usePrefetch: query.usePrefetch,
         useQuery: effectiveUseQuery,
         useInfinite: effectiveUseInfinite,

--- a/samples/angular-app/__snapshots__/api/endpoints-zod-both/pets/pets.service.ts
+++ b/samples/angular-app/__snapshots__/api/endpoints-zod-both/pets/pets.service.ts
@@ -106,13 +106,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -122,6 +127,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-app/src/api/endpoints-zod-both/pets/pets.service.ts
+++ b/samples/angular-app/src/api/endpoints-zod-both/pets/pets.service.ts
@@ -106,13 +106,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -122,6 +127,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints/pets/pets.ts
@@ -236,7 +236,7 @@ export function injectSearchPets<
 }
 
 /**
- * @summary search by query params
+ * @summary Invalidates the {@link injectSearchPets} query
  */
 export const invalidateSearchPets = async (
   queryClient: QueryClient,
@@ -361,7 +361,7 @@ export function injectListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link injectListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,
@@ -599,7 +599,7 @@ export function injectShowPetById<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link injectShowPetById} query
  */
 export const invalidateShowPetById = async (
   queryClient: QueryClient,
@@ -1060,7 +1060,7 @@ export function injectShowPetText<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link injectShowPetText} query
  */
 export const invalidateShowPetText = async (
   queryClient: QueryClient,
@@ -1414,7 +1414,7 @@ export function injectDownloadFile<
 }
 
 /**
- * @summary Download an image.
+ * @summary Invalidates the {@link injectDownloadFile} query
  */
 export const invalidateDownloadFile = async (
   queryClient: QueryClient,
@@ -1532,7 +1532,7 @@ export function injectHealthCheck<
 }
 
 /**
- * @summary Health check
+ * @summary Invalidates the {@link injectHealthCheck} query
  */
 export const invalidateHealthCheck = async (
   queryClient: QueryClient,

--- a/samples/angular-query/src/api/endpoints/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints/pets/pets.ts
@@ -236,7 +236,7 @@ export function injectSearchPets<
 }
 
 /**
- * @summary search by query params
+ * @summary Invalidates the {@link injectSearchPets} query
  */
 export const invalidateSearchPets = async (
   queryClient: QueryClient,
@@ -361,7 +361,7 @@ export function injectListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link injectListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,
@@ -599,7 +599,7 @@ export function injectShowPetById<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link injectShowPetById} query
  */
 export const invalidateShowPetById = async (
   queryClient: QueryClient,
@@ -1060,7 +1060,7 @@ export function injectShowPetText<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link injectShowPetText} query
  */
 export const invalidateShowPetText = async (
   queryClient: QueryClient,
@@ -1414,7 +1414,7 @@ export function injectDownloadFile<
 }
 
 /**
- * @summary Download an image.
+ * @summary Invalidates the {@link injectDownloadFile} query
  */
 export const invalidateDownloadFile = async (
   queryClient: QueryClient,
@@ -1532,7 +1532,7 @@ export function injectHealthCheck<
 }
 
 /**
- * @summary Health check
+ * @summary Invalidates the {@link injectHealthCheck} query
  */
 export const invalidateHealthCheck = async (
   queryClient: QueryClient,

--- a/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -297,7 +297,7 @@ export function useListPetsInfinite<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPetsInfinite} query
  */
 export const invalidateListPetsInfinite = async (
   queryClient: QueryClient,
@@ -440,7 +440,7 @@ export function useListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,

--- a/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-query/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -297,7 +297,7 @@ export function useListPetsInfinite<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPetsInfinite} query
  */
 export const invalidateListPetsInfinite = async (
   queryClient: QueryClient,
@@ -440,7 +440,7 @@ export function useListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/angular/http-resource-zod-output-ref/endpoints.resource.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-output-ref/endpoints.resource.ts
@@ -32,6 +32,10 @@ import type {
   Signal
 } from '@angular/core';
 
+import {
+  map
+} from 'rxjs';
+
 
 export interface OrvalHttpResourceRequestExtension {
   /** Extra headers merged over generated headers. Pass a function to read signals reactively. */
@@ -144,13 +148,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -160,6 +169,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/angular/http-resource-zod-output-ref/endpoints.ts
+++ b/tests/__snapshots__/angular/http-resource-zod-output-ref/endpoints.ts
@@ -134,13 +134,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -150,6 +155,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -276,7 +276,7 @@ export function useListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,
@@ -630,7 +630,7 @@ export function useShowPetById<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link useShowPetById} query
  */
 export const invalidateShowPetById = async (
   queryClient: QueryClient,
@@ -955,7 +955,7 @@ export function useHealthCheck<
 }
 
 /**
- * @summary health check
+ * @summary Invalidates the {@link useHealthCheck} query
  */
 export const invalidateHealthCheck = async (
   queryClient: QueryClient,
@@ -1188,7 +1188,7 @@ export function useShowPetWithOwner<
 }
 
 /**
- * @summary combinate nullable and $ref
+ * @summary Invalidates the {@link useShowPetWithOwner} query
  */
 export const invalidateShowPetWithOwner = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -234,7 +234,7 @@ export const prefetchMusclesControllerFindAllInfiniteQuery = async <
 };
 
 /**
- * @summary Return all muscles
+ * @summary Invalidates the {@link useMusclesControllerFindAllInfinite} query
  */
 export const invalidateMusclesControllerFindAllInfinite = async (
   queryClient: QueryClient,
@@ -411,7 +411,7 @@ export const prefetchMusclesControllerFindAllQuery = async <
 };
 
 /**
- * @summary Return all muscles
+ * @summary Invalidates the {@link useMusclesControllerFindAll} query
  */
 export const invalidateMusclesControllerFindAll = async (
   queryClient: QueryClient,
@@ -640,7 +640,7 @@ export const prefetchMusclesControllerCreateQuery = async <
 };
 
 /**
- * @summary Create muscle
+ * @summary Invalidates the {@link useMusclesControllerCreate} query
  */
 export const invalidateMusclesControllerCreate = async (
   queryClient: QueryClient,
@@ -865,7 +865,7 @@ export const prefetchMusclesControllerFindOneInfiniteQuery = async <
 };
 
 /**
- * @summary Return one muscle
+ * @summary Invalidates the {@link useMusclesControllerFindOneInfinite} query
  */
 export const invalidateMusclesControllerFindOneInfinite = async (
   queryClient: QueryClient,
@@ -1057,7 +1057,7 @@ export const prefetchMusclesControllerFindOneQuery = async <
 };
 
 /**
- * @summary Return one muscle
+ * @summary Invalidates the {@link useMusclesControllerFindOne} query
  */
 export const invalidateMusclesControllerFindOne = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -224,7 +224,7 @@ export const prefetchMusclesControllerFindAllQuery = async <
 };
 
 /**
- * @summary Return all muscles
+ * @summary Invalidates the {@link useMusclesControllerFindAll} query
  */
 export const invalidateMusclesControllerFindAll = async (
   queryClient: QueryClient,
@@ -453,7 +453,7 @@ export const prefetchMusclesControllerCreateQuery = async <
 };
 
 /**
- * @summary Create muscle
+ * @summary Invalidates the {@link useMusclesControllerCreate} query
  */
 export const invalidateMusclesControllerCreate = async (
   queryClient: QueryClient,
@@ -666,7 +666,7 @@ export const prefetchMusclesControllerFindOneQuery = async <
 };
 
 /**
- * @summary Return one muscle
+ * @summary Invalidates the {@link useMusclesControllerFindOne} query
  */
 export const invalidateMusclesControllerFindOne = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -276,7 +276,7 @@ export function useListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,
@@ -619,7 +619,7 @@ export function useShowPetById<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link useShowPetById} query
  */
 export const invalidateShowPetById = async (
   queryClient: QueryClient,
@@ -933,7 +933,7 @@ export function useHealthCheck<
 }
 
 /**
- * @summary health check
+ * @summary Invalidates the {@link useHealthCheck} query
  */
 export const invalidateHealthCheck = async (
   queryClient: QueryClient,
@@ -1151,7 +1151,7 @@ export function useShowPetWithOwner<
 }
 
 /**
- * @summary combinate nullable and $ref
+ * @summary Invalidates the {@link useShowPetWithOwner} query
  */
 export const invalidateShowPetWithOwner = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -269,7 +269,7 @@ export function useListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,
@@ -607,7 +607,7 @@ export function useShowPetById<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link useShowPetById} query
  */
 export const invalidateShowPetById = async (
   queryClient: QueryClient,
@@ -912,7 +912,7 @@ export function useHealthCheck<
 }
 
 /**
- * @summary health check
+ * @summary Invalidates the {@link useHealthCheck} query
  */
 export const invalidateHealthCheck = async (
   queryClient: QueryClient,
@@ -1125,7 +1125,7 @@ export function useShowPetWithOwner<
 }
 
 /**
- * @summary combinate nullable and $ref
+ * @summary Invalidates the {@link useShowPetWithOwner} query
  */
 export const invalidateShowPetWithOwner = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/runtime-validation/angular-http-client-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/angular-http-client-both/endpoints.ts
@@ -107,13 +107,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -123,6 +128,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/runtime-validation/angular-http-resource-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/angular-http-resource-both/endpoints.ts
@@ -160,13 +160,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -176,6 +181,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/runtime-validation/angular-query-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/angular-query-both/endpoints.ts
@@ -73,13 +73,18 @@ function filterParams(
       continue;
     }
     if (Array.isArray(value)) {
-      const filtered = value.filter(
-        (item) =>
-          item != null &&
-          (typeof item === 'string' ||
-            typeof item === 'number' ||
-            typeof item === 'boolean'),
-      ) as Array<string | number | boolean>;
+      const filtered = value
+        .filter(
+          (item) =>
+            item != null &&
+            (typeof item === 'string' ||
+              typeof item === 'number' ||
+              typeof item === 'boolean' ||
+              (item instanceof Date && !Number.isNaN(item.getTime()))),
+        )
+        .map((item) =>
+          item instanceof Date ? item.toISOString() : item,
+        ) as Array<string | number | boolean>;
       if (filtered.length) {
         filteredParams[key] = filtered;
       }
@@ -89,6 +94,10 @@ function filterParams(
       // string so the required key still reaches the wire as `?key=`
       // instead of being silently dropped. See #3712.
       filteredParams[key] = preserveRequiredNullables ? null : '';
+    } else if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      // useDates produces Date query params; serialize to ISO so they reach
+      // the wire instead of being dropped by the primitive check below. See #3856.
+      filteredParams[key] = value.toISOString();
     } else if (
       value != null &&
       (typeof value === 'string' ||

--- a/tests/__snapshots__/solid-query/infinite-invalidate/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-invalidate/endpoints.ts
@@ -356,7 +356,7 @@ export function useListHouseCatsInfinite<
 }
 
 /**
- * @summary List all cats of a house
+ * @summary Invalidates the {@link useListHouseCatsInfinite} query
  */
 export const invalidateListHouseCatsInfinite = async (
   queryClient: QueryClient,
@@ -540,7 +540,7 @@ export function useListHouseCats<
 }
 
 /**
- * @summary List all cats of a house
+ * @summary Invalidates the {@link useListHouseCats} query
  */
 export const invalidateListHouseCats = async (
   queryClient: QueryClient,

--- a/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
+++ b/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
@@ -336,7 +336,7 @@ export function useListPetsInfinite<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPetsInfinite} query
  */
 export const invalidateListPetsInfinite = async (
   queryClient: QueryClient,
@@ -489,7 +489,7 @@ export function useListPets<
 }
 
 /**
- * @summary List all pets
+ * @summary Invalidates the {@link useListPets} query
  */
 export const invalidateListPets = async (
   queryClient: QueryClient,
@@ -734,7 +734,7 @@ export function useCreatePets<
 }
 
 /**
- * @summary Create a pet
+ * @summary Invalidates the {@link useCreatePets} query
  */
 export const invalidateCreatePets = async (
   queryClient: QueryClient,
@@ -965,7 +965,7 @@ export function useShowPetById<
 }
 
 /**
- * @summary Info for a specific pet
+ * @summary Invalidates the {@link useShowPetById} query
  */
 export const invalidateShowPetById = async (
   queryClient: QueryClient,
@@ -1197,7 +1197,7 @@ export function useDeletePetById<
 }
 
 /**
- * @summary Deletes a specific pet
+ * @summary Invalidates the {@link useDeletePetById} query
  */
 export const invalidateDeletePetById = async (
   queryClient: QueryClient,
@@ -1414,7 +1414,7 @@ export function useHealthCheck<
 }
 
 /**
- * @summary health check
+ * @summary Invalidates the {@link useHealthCheck} query
  */
 export const invalidateHealthCheck = async (
   queryClient: QueryClient,
@@ -1643,7 +1643,7 @@ export function useShowPetWithOwner<
 }
 
 /**
- * @summary combinate nullable and $ref
+ * @summary Invalidates the {@link useShowPetWithOwner} query
  */
 export const invalidateShowPetWithOwner = async (
   queryClient: QueryClient,


### PR DESCRIPTION
Invalidate helpers reused the endpoint JSDoc, which incorrectly described the request instead of the invalidation. They now use helper-specific JSDoc linking to the query they invalidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date values in Angular query parameters are now correctly serialized to ISO strings.
  * Invalid dates and unsupported array values are excluded from query parameters.

* **Documentation**
  * Improved descriptions for query invalidation helpers so generated documentation clearly explains which query each helper invalidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->