### PR TITLE
docs: mention Vue Query mutation invalidation support

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1211,7 +1211,7 @@ Generate type-safe getQueryData helpers.
 
 **Type:** `Array`
 
-Automatically invalidate or reset queries on mutation success (Angular Query, React Query & Svelte Query):
+Automatically invalidate or reset queries on mutation success (Angular Query, React Query, Svelte Query & Vue Query v5):
 
 ```ts title="orval.config.ts"
 export default defineConfig({


### PR DESCRIPTION
Documents that `mutationInvalidates` supports Vue Query v5. Vue Query v4 remains excluded because the adapter enables mutation invalidation only for v5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `mutationInvalidates` documentation to include Vue Query v5 among the supported query libraries for automatic query invalidation and reset after successful mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->