### PR TITLE
fix(fetch): type runtime-validated responses with the schema's zod output alias

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -2403,6 +2403,8 @@ Enable Zod runtime validation for fetch client responses. Requires `schemas: { t
 
 The boolean form is preserved for backward compatibility: `true` ≡ `{ strategy: 'throw' }`. With `{ strategy: 'both' }` an invalid response is first logged through `console.error('[orval] <operation> response validation failed', error)` with the raw `ZodError`, then re-thrown (rejecting the returned promise) — giving production visibility into contract drift while still failing fast.
 
+A validated response is typed with the schema's `zod.output` alias (e.g. `PetsOutput`) instead of the input-typed schema name, since that is what the parse returns at runtime — relevant when the schema transforms values through `coerce`, `useDates`, defaults or `.transform()`. Operations using a custom mutator keep the schema (input) type: the mutator issues the request itself, so the generated parse never runs there.
+
 ### arrayFormat
 
 **Type:** `'repeat' | 'brackets' | 'comma'`
@@ -2503,7 +2505,7 @@ export const load = async ({ fetch }) => {
 |--------|------------|--------|-------|
 | `angular` | `override.angular.runtimeValidation` | ✅ | Validates JSON body responses via `Schema.parse()`; skips primitive/`void`, `observe: 'events'/'response'`, and custom mutator paths |
 | `angular-query` | `override.query.runtimeValidation` | ✅ | Validates eligible responses via `Schema.parse()` in RxJS pipeline; skips primitive/`void` and custom mutator paths |
-| `fetch` | `override.fetch.runtimeValidation` | ✅ | Validates JSON responses via `Schema.parse()` |
+| `fetch` | `override.fetch.runtimeValidation` | ✅ | Validates JSON responses via `Schema.parse()`; types them as the schema's `zod.output` alias; skips primitive/`void`, ndjson and custom mutator paths |
 | any client with custom mutator | varies | ⚠️ | Runtime validation may be bypassed depending on mutator path and signature (see [#2858](https://github.com/orval-labs/orval/issues/2858)). For the `fetch` client, [`override.includeZodSchemaInArguments`](#includezodschemainarguments) passes the schema to the mutator so it can validate the response itself |
 
 Runtime validation is **disabled by default** (`false`). When enabled, all three supporting clients accept the object form `{ strategy: 'throw' | 'both' }`, and `true` is shorthand for `{ strategy: 'throw' }`. The `throw` strategy parses and throws; `both` additionally `console.error`s the raw `ZodError` before re-throwing, for production observability without giving up fail-fast behaviour.

--- a/packages/core/src/generators/runtime-validation.test.ts
+++ b/packages/core/src/generators/runtime-validation.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import {
   emitResponseValidation,
+  getSchemaOutputTypeRef,
+  getSchemaValueRef,
+  hasSchemaImport,
+  isPrimitiveResponseType,
   normalizeRuntimeValidation,
+  rewriteImportsForResponseValidation,
 } from './runtime-validation';
 
 describe('emitResponseValidation', () => {
@@ -177,5 +182,77 @@ describe('normalizeRuntimeValidation', () => {
     expect(
       normalizeRuntimeValidation({ enabled: true, strategy: 'both' }),
     ).toEqual({ enabled: true, strategy: 'both' });
+  });
+});
+
+describe('isPrimitiveResponseType', () => {
+  it('treats primitives, void and unknown as primitive', () => {
+    for (const t of ['string', 'number', 'boolean', 'void', 'unknown']) {
+      expect(isPrimitiveResponseType(t)).toBe(true);
+    }
+  });
+
+  it('treats schema names and undefined as non-primitive', () => {
+    expect(isPrimitiveResponseType('Pets')).toBe(false);
+    expect(isPrimitiveResponseType(undefined)).toBe(false);
+  });
+});
+
+describe('hasSchemaImport', () => {
+  const imports = [{ name: 'Pets' }, { name: 'Error' }];
+
+  it('finds an import by exact name', () => {
+    expect(hasSchemaImport(imports, 'Pets')).toBe(true);
+  });
+
+  it('misses absent names and undefined', () => {
+    expect(hasSchemaImport(imports, 'Pet')).toBe(false);
+    expect(hasSchemaImport(imports, undefined)).toBe(false);
+  });
+});
+
+describe('getSchemaValueRef', () => {
+  it('renames Error to ErrorSchema, leaves other names untouched', () => {
+    expect(getSchemaValueRef('Error')).toBe('ErrorSchema');
+    expect(getSchemaValueRef('Pets')).toBe('Pets');
+  });
+});
+
+describe('getSchemaOutputTypeRef', () => {
+  it('appends the Output suffix', () => {
+    expect(getSchemaOutputTypeRef('Pets')).toBe('PetsOutput');
+    expect(getSchemaOutputTypeRef('PetsSchema')).toBe('PetsSchemaOutput');
+  });
+});
+
+describe('rewriteImportsForResponseValidation', () => {
+  const imports = [
+    { name: 'Pets', schemaName: 'Pets' },
+    { name: 'Error', schemaName: 'Error' },
+  ];
+
+  it('flips the schema import to a value import and appends the Output alias', () => {
+    expect(rewriteImportsForResponseValidation(imports, 'Pets')).toEqual([
+      { name: 'Pets', schemaName: 'Pets', values: true },
+      { name: 'Error', schemaName: 'Error' },
+      { name: 'PetsOutput', zodBaseName: 'Pets' },
+    ]);
+  });
+
+  it('skips the Output alias when includeOutputType is false', () => {
+    expect(
+      rewriteImportsForResponseValidation(imports, 'Pets', {
+        includeOutputType: false,
+      }),
+    ).toEqual([
+      { name: 'Pets', schemaName: 'Pets', values: true },
+      { name: 'Error', schemaName: 'Error' },
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = structuredClone(imports);
+    rewriteImportsForResponseValidation(imports, 'Pets');
+    expect(imports).toEqual(before);
   });
 });

--- a/packages/core/src/generators/runtime-validation.ts
+++ b/packages/core/src/generators/runtime-validation.ts
@@ -1,4 +1,5 @@
 import type {
+  GeneratorImport,
   NormalizedRuntimeValidation,
   RuntimeValidation,
   RuntimeValidationStrategy,
@@ -130,3 +131,80 @@ export const normalizeRuntimeValidation = (
   }
   return { enabled: true, strategy: value.strategy ?? 'throw' };
 };
+
+/**
+ * Response types the runtime-validation generators never validate: primitives
+ * and `void`/`unknown` have no generated Zod schema to parse against.
+ */
+const RESPONSE_PRIMITIVE_TYPES = new Set([
+  'string',
+  'number',
+  'boolean',
+  'void',
+  'unknown',
+]);
+
+/**
+ * Indicates whether a response definition names a primitive (non-schema) type,
+ * which runtime validation skips.
+ */
+export const isPrimitiveResponseType = (t: string | undefined): boolean =>
+  t !== undefined && RESPONSE_PRIMITIVE_TYPES.has(t);
+
+/**
+ * Indicates whether the response imports carry a schema for the given type
+ * name — the precondition for emitting a `Schema.parse`/`safeParse` call.
+ */
+export const hasSchemaImport = (
+  imports: readonly { name: string }[],
+  typeName: string | undefined,
+): boolean =>
+  typeName !== undefined && imports.some((imp) => imp.name === typeName);
+
+/**
+ * Maps a response type name to the identifier its Zod schema value is bound to
+ * at the call site. `Error` collides with the global constructor, so validated
+ * call sites reference that schema as `ErrorSchema`.
+ */
+export const getSchemaValueRef = (typeName: string): string =>
+  typeName === 'Error' ? 'ErrorSchema' : typeName;
+
+/**
+ * Maps a schema type name to its Zod output-type alias (`${typeName}Output`),
+ * emitted next to every schema in zod-schemas mode. A validated response
+ * returns `zod.output` at runtime, so its declared type must reference this
+ * alias — the bare schema name aliases `zod.input`, which diverges under
+ * `coerce`, `useDates`, defaults and transforms.
+ */
+export const getSchemaOutputTypeRef = (typeName: string): string =>
+  `${typeName}Output`;
+
+/**
+ * Rewrites a verb's response imports for a runtime-validated response: the
+ * schema import becomes a value import (the generated code calls
+ * `parse`/`safeParse` on it), and the schema's `Output` type alias is imported
+ * for the declared response type. `zodBaseName` routes the alias import to the
+ * base schema's `.zod` file in per-file (`indexFiles: false`) layouts.
+ *
+ * `includeOutputType: false` keeps the value-import flip but skips the alias —
+ * for call sites where validation is delegated (e.g. a custom mutator handed
+ * the schema via `includeZodSchemaInArguments`) and the declared type is
+ * intentionally left as the schema (input) name.
+ */
+export const rewriteImportsForResponseValidation = (
+  imports: readonly GeneratorImport[],
+  responseType: string,
+  { includeOutputType = true }: { includeOutputType?: boolean } = {},
+): GeneratorImport[] => [
+  ...imports.map((imp) =>
+    imp.name === responseType ? { ...imp, values: true } : imp,
+  ),
+  ...(includeOutputType
+    ? [
+        {
+          name: getSchemaOutputTypeRef(responseType),
+          zodBaseName: responseType,
+        },
+      ]
+    : []),
+];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1702,6 +1702,11 @@ export interface GeneratorImport {
   // (e.g. `getPetMock`). The mock-file writer routes it to
   // `<schemas-dir>/index.faker` instead of `<schemas-dir>/<schemaName>`.
   readonly schemaFactory?: boolean;
+  // Zod-schemas mode: the base schema identifier whose `.zod` file declares
+  // this binding. Set on `${name}Output` type-alias imports so per-file
+  // (`indexFiles: false`) layouts route them to the base schema's file
+  // instead of a nonexistent `<name>.zod` one.
+  readonly zodBaseName?: string;
 }
 
 export interface GeneratorDependency {

--- a/packages/core/src/writers/generate-imports-for-builder.test.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.test.ts
@@ -643,5 +643,34 @@ describe('generateImportsForBuilder', () => {
       const deps = result.map((r) => r.dependency).sort();
       expect(deps).toEqual(['../models/error', '../models/pets/pet']);
     });
+
+    it('routes an Output alias into the same tag subdir as its base schema', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        schemas: { path: './schemas', type: 'zod', splitByTags: true },
+      });
+      const imports: GeneratorImport[] = [
+        { name: 'Pets', schemaName: 'Pets', values: true },
+        { name: 'PetsOutput', zodBaseName: 'Pets' },
+      ];
+      const schemaTagMap = new Map<string, string>([['Pets', 'pets']]);
+
+      const result = generateImportsForBuilder(
+        output,
+        imports,
+        '../models',
+        schemaTagMap,
+      );
+
+      expect(result).toEqual([
+        {
+          exports: [
+            { name: 'Pets', schemaName: 'Pets', values: true },
+            { name: 'PetsOutput', zodBaseName: 'Pets' },
+          ],
+          dependency: '../models/pets/pets.zod',
+        },
+      ]);
+    });
   });
 });

--- a/packages/core/src/writers/generate-imports-for-builder.test.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.test.ts
@@ -163,6 +163,30 @@ describe('generateImportsForBuilder', () => {
         },
       ]);
     });
+
+    it('routes an Output type alias to its base schema zod file via zodBaseName', () => {
+      const output = createMockOutput({
+        indexFiles: false,
+        fileExtension: '.ts',
+        schemas: { path: './schemas', type: 'zod', splitByTags: false },
+      });
+      const imports: GeneratorImport[] = [
+        { name: 'Pets', schemaName: 'Pets', values: true },
+        { name: 'PetsOutput', zodBaseName: 'Pets' },
+      ];
+
+      const result = generateImportsForBuilder(output, imports, '../models');
+
+      expect(result).toEqual([
+        {
+          exports: [
+            { name: 'Pets', schemaName: 'Pets', values: true },
+            { name: 'PetsOutput', zodBaseName: 'Pets' },
+          ],
+          dependency: '../models/pets.zod',
+        },
+      ]);
+    });
   });
 
   describe('with indexFiles', () => {

--- a/packages/core/src/writers/generate-imports-for-builder.ts
+++ b/packages/core/src/writers/generate-imports-for-builder.ts
@@ -90,7 +90,9 @@ export function generateImportsForBuilder(
     const importsByDependency = new Map<string, GeneratorImport[]>();
 
     for (const schemaImport of imports.filter((i) => !i.importPath)) {
-      const baseName = schemaImport.name;
+      // `Output` type aliases live in their base schema's file
+      // (`zodBaseName`); everything else is named after the TS identifier.
+      const baseName = schemaImport.zodBaseName ?? schemaImport.name;
       const normalizedName = conventionName(baseName, output.namingConvention);
       const suffix = isZodSchemaOutput ? '.zod' : '';
       const importExtension = isPackageImport
@@ -105,7 +107,10 @@ export function generateImportsForBuilder(
       // including the `Response`/`Body`/`Parameter` suffix added for
       // component refs), so `schemaName` (the bare ref name) would produce
       // import paths that point at files that are never written (#2912).
-      const tagDir = schemaTagMap?.get(schemaImport.name);
+      // `Output` aliases again resolve via their base schema's identifier.
+      const tagDir = schemaTagMap?.get(
+        schemaImport.zodBaseName ?? schemaImport.name,
+      );
       const tagSegment = tagDir && tagDir !== '.' ? `${tagDir}/` : '';
       const dependency = upath.joinSafe(
         relativeSchemasPath,

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -513,3 +513,112 @@ describe('generateRequestFunction — deepObject query parameters', () => {
     expect(implementation).toContain('deepObjectEntries.push(');
   });
 });
+
+describe('generateRequestFunction — zod runtimeValidation response typing (#3938)', () => {
+  const ZOD_RESPONSE = {
+    definition: { success: 'Pets', errors: 'Error' },
+    imports: [{ name: 'Pets', schemaName: 'Pets', values: true }],
+    types: {
+      success: [
+        {
+          key: '200',
+          contentType: 'application/json',
+          value: 'Pets',
+          hasReadonlyProps: false,
+          imports: [],
+          isEnum: false,
+          isRef: true,
+          schemas: [],
+          type: 'object',
+          dependencies: [],
+        },
+      ],
+      errors: [],
+    },
+    contentTypes: ['application/json'],
+    schemas: [],
+    isBlob: false,
+  } as unknown as GeneratorVerbOptions['response'];
+
+  function makeZodValidationVerbOptions(
+    overrides: Partial<GeneratorVerbOptions> = {},
+  ): GeneratorVerbOptions {
+    const base = makeVerbOptions({ response: ZOD_RESPONSE });
+    return {
+      ...base,
+      typeName: 'listPets',
+      override: {
+        ...base.override,
+        fetch: {
+          includeHttpResponseReturnType: false,
+          forceSuccessResponse: false,
+          runtimeValidation: { enabled: true, strategy: 'throw' },
+        },
+      } as GeneratorVerbOptions['override'],
+      ...overrides,
+    } as GeneratorVerbOptions;
+  }
+
+  function makeZodContext(): ContextSpec {
+    const context = makeContext();
+    (context.output as { schemas: unknown }).schemas = {
+      path: './model',
+      type: 'zod',
+    };
+    return context;
+  }
+
+  it('declares the parsed response as the zod output alias', () => {
+    const implementation = generateRequestFunction(
+      makeZodValidationVerbOptions(),
+      makeOptions(makeZodContext()),
+    );
+
+    expect(implementation).toContain('): Promise<PetsOutput> =>');
+    expect(implementation).toContain('Pets.parse(parsedBody)');
+    expect(implementation).not.toContain('Promise<Pets>');
+  });
+
+  it('uses the output alias for the data field with includeHttpResponseReturnType', () => {
+    const verbOptions = makeZodValidationVerbOptions();
+    (
+      verbOptions.override.fetch as { includeHttpResponseReturnType: boolean }
+    ).includeHttpResponseReturnType = true;
+
+    const implementation = generateRequestFunction(
+      verbOptions,
+      makeOptions(makeZodContext()),
+    );
+
+    expect(implementation).toContain('data: PetsOutput');
+    expect(implementation).toContain('): Promise<listPetsResponse> =>');
+  });
+
+  it('keeps the schema (input) type when a custom mutator owns the request', () => {
+    const verbOptions = makeZodValidationVerbOptions({
+      mutator: {
+        name: 'customFetch',
+        path: './mutator.ts',
+        default: false,
+      } as GeneratorVerbOptions['mutator'],
+    });
+
+    const implementation = generateRequestFunction(
+      verbOptions,
+      makeOptions(makeZodContext()),
+    );
+
+    expect(implementation).toContain('): Promise<Pets> =>');
+    expect(implementation).not.toContain('PetsOutput');
+  });
+
+  it('keeps the schema (input) type when the schemas output is not zod', () => {
+    const implementation = generateRequestFunction(
+      makeZodValidationVerbOptions(),
+      makeOptions(makeContext()),
+    );
+
+    expect(implementation).toContain('): Promise<Pets> =>');
+    expect(implementation).not.toContain('PetsOutput');
+  });
+});

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -8,6 +8,11 @@ import {
   generateFormDataAndUrlEncodedFunction,
   generateVerbImports,
   type GeneratorDependency,
+  getSchemaOutputTypeRef,
+  getSchemaValueRef,
+  hasSchemaImport,
+  isPrimitiveResponseType,
+  rewriteImportsForResponseValidation,
   type GeneratorOptions,
   type GeneratorVerbOptions,
   type GeneratorMutator,
@@ -418,20 +423,22 @@ ${deepObjectParameters.length > 0 ? '  const deepObjectEntries = [];\n' : ''}
   const responseType = response.definition.success;
   const isVoidResponse = responseType === 'void';
 
-  const isPrimitiveType = [
-    'string',
-    'number',
-    'boolean',
-    'void',
-    'unknown',
-  ].includes(responseType);
-  const hasSchema = response.imports.some((imp) => imp.name === responseType);
+  const isPrimitiveType = isPrimitiveResponseType(responseType);
+  const hasSchema = hasSchemaImport(response.imports, responseType);
 
   const isValidateResponse =
     override.fetch.runtimeValidation.enabled &&
     !isPrimitiveType &&
     hasSchema &&
     !isNdJson;
+  const isZodSchemasOutput =
+    isObject(context.output.schemas) && context.output.schemas.type === 'zod';
+  // The generated parse returns the schema's zod output type, so the declared
+  // response type must reference the `XOutput` alias. A custom mutator issues
+  // the request itself — the generated parse never runs there — so its
+  // declared types keep the schema (input) name.
+  const useValidatedOutputType =
+    isValidateResponse && isZodSchemasOutput && !mutator;
 
   const allResponses = [...response.types.success, ...response.types.errors];
   if (allResponses.length === 0) {
@@ -460,11 +467,24 @@ ${deepObjectParameters.length > 0 ? '  const deepObjectEntries = [];\n' : ''}
     )
     .map((r) => {
       const name = `${responseTypeName}${pascal(r.key)}${'suffix' in r ? r.suffix : ''}`;
-      const dataType = r.value || 'unknown';
+      const isSuccessEntry = response.types.success.some(
+        (s) => s.key === r.key,
+      );
+      const rawDataType = r.value || 'unknown';
+      // An empty contentType falls back to JSON parsing at runtime, so it is
+      // validated too (matching `successAlwaysJson`).
+      const dataType =
+        useValidatedOutputType &&
+        isSuccessEntry &&
+        rawDataType === responseType &&
+        !isContentTypeNdJson(r.contentType) &&
+        (r.contentType === '' || isContentTypeJson(r.contentType))
+          ? getSchemaOutputTypeRef(responseType)
+          : rawDataType;
 
       return {
         name,
-        success: response.types.success.some((s) => s.key === r.key),
+        success: isSuccessEntry,
         value: `export type ${name} = {
   ${isContentTypeNdJson(r.contentType) ? `stream: TypedResponse<${dataType}>` : `data: ${dataType}`}
   status: ${
@@ -539,7 +559,12 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
     hasSuccess &&
     override.fetch.includeHttpResponseReturnType
       ? `Promise<${successName}>`
-      : `Promise<${responseTypeName}>`;
+      : `Promise<${
+          useValidatedOutputType &&
+          !override.fetch.includeHttpResponseReturnType
+            ? getSchemaOutputTypeRef(responseType)
+            : responseTypeName
+        }>`;
 
   const fetchMethodOption = `method: '${verb.toUpperCase()}'`;
   const ignoreContentTypes = ['multipart/form-data'];
@@ -601,8 +626,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
       ? `body: ${requestBodyParams}`
       : `body: JSON.stringify(${requestBodyParams})`
     : '';
-  const schemaValueRef =
-    responseType === 'Error' ? 'ErrorSchema' : responseType;
+  const schemaValueRef = getSchemaValueRef(responseType);
   const responseValidationExpression = emitResponseValidation({
     schemaRef: schemaValueRef,
     operationName,
@@ -814,30 +838,33 @@ export const generateClient: ClientBuilder = (verbOptions, options) => {
     typeof options.context.output.schemas === 'object' &&
     options.context.output.schemas.type === 'zod';
   const responseType = verbOptions.response.definition.success;
-  const isPrimitiveResponse = [
-    'string',
-    'number',
-    'boolean',
-    'void',
-    'unknown',
-  ].includes(responseType);
+  const isNdJsonResponse = verbOptions.response.contentTypes.some(
+    (contentType) =>
+      contentType === 'application/nd-json' ||
+      contentType === 'application/x-ndjson',
+  );
   const shouldUseRuntimeValidation =
-    verbOptions.override.fetch.runtimeValidation.enabled && isZodOutput;
+    verbOptions.override.fetch.runtimeValidation.enabled &&
+    isZodOutput &&
+    !isPrimitiveResponseType(responseType) &&
+    hasSchemaImport(verbOptions.response.imports, responseType);
 
-  const normalizedVerbOptions =
-    shouldUseRuntimeValidation &&
-    !isPrimitiveResponse &&
-    verbOptions.response.imports.some((imp) => imp.name === responseType)
-      ? {
-          ...verbOptions,
-          response: {
-            ...verbOptions.response,
-            imports: verbOptions.response.imports.map((imp) =>
-              imp.name === responseType ? { ...imp, values: true } : imp,
-            ),
-          },
-        }
-      : verbOptions;
+  const normalizedVerbOptions = shouldUseRuntimeValidation
+    ? {
+        ...verbOptions,
+        response: {
+          ...verbOptions.response,
+          imports: rewriteImportsForResponseValidation(
+            verbOptions.response.imports,
+            responseType,
+            // A mutator (or an ndjson stream) skips the generated parse, so
+            // the declared types keep the schema (input) name and no Output
+            // alias import is needed.
+            { includeOutputType: !verbOptions.mutator && !isNdJsonResponse },
+          ),
+        },
+      }
+    : verbOptions;
 
   const imports = generateVerbImports(normalizedVerbOptions);
   const functionImplementation = generateRequestFunction(

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -843,9 +843,12 @@ export const generateClient: ClientBuilder = (verbOptions, options) => {
       contentType === 'application/nd-json' ||
       contentType === 'application/x-ndjson',
   );
+  // ndjson streams skip the generated parse entirely, so their schema import
+  // stays type-only and no Output alias is needed.
   const shouldUseRuntimeValidation =
     verbOptions.override.fetch.runtimeValidation.enabled &&
     isZodOutput &&
+    !isNdJsonResponse &&
     !isPrimitiveResponseType(responseType) &&
     hasSchemaImport(verbOptions.response.imports, responseType);
 
@@ -857,10 +860,11 @@ export const generateClient: ClientBuilder = (verbOptions, options) => {
           imports: rewriteImportsForResponseValidation(
             verbOptions.response.imports,
             responseType,
-            // A mutator (or an ndjson stream) skips the generated parse, so
-            // the declared types keep the schema (input) name and no Output
-            // alias import is needed.
-            { includeOutputType: !verbOptions.mutator && !isNdJsonResponse },
+            // A mutator skips the generated parse (it issues the request
+            // itself), so the declared types keep the schema (input) name and
+            // no Output alias import is needed — but the schema value import
+            // stays, for `includeZodSchemaInArguments`.
+            { includeOutputType: !verbOptions.mutator },
           ),
         },
       }

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -10,6 +10,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from './model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
@@ -55,7 +58,7 @@ export type HTTPStatusCodes =
   | HTTPStatusCode5xx;
 
 export type listPetsResponse200 = {
-  data: Pets;
+  data: PetsOutput;
   status: 200;
 };
 
@@ -114,7 +117,7 @@ export const listPets = async (
 };
 
 export type createPetsResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -193,7 +196,7 @@ export const createPets = async (
 };
 
 export type showPetByIdResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -348,7 +351,7 @@ export const healthCheck = async (
 };
 
 export type showPetWithOwnerResponse200 = {
-  data: PetWithTag;
+  data: PetWithTagOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -13,10 +13,13 @@ import type { Error } from './model/error.zod';
 import type { ListPetsParams } from './model/listPetsParams.zod';
 
 import { Pet } from './model/pet.zod';
+import type { PetOutput } from './model/pet.zod';
 
 import { PetWithTag } from './model/petWithTag.zod';
+import type { PetWithTagOutput } from './model/petWithTag.zod';
 
 import { Pets } from './model/pets.zod';
+import type { PetsOutput } from './model/pets.zod';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
 export type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;
@@ -61,7 +64,7 @@ export type HTTPStatusCodes =
   | HTTPStatusCode5xx;
 
 export type listPetsResponse200 = {
-  data: Pets;
+  data: PetsOutput;
   status: 200;
 };
 
@@ -120,7 +123,7 @@ export const listPets = async (
 };
 
 export type createPetsResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -199,7 +202,7 @@ export const createPets = async (
 };
 
 export type showPetByIdResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -354,7 +357,7 @@ export const healthCheck = async (
 };
 
 export type showPetWithOwnerResponse200 = {
-  data: PetWithTag;
+  data: PetWithTagOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-single/endpoints.ts
@@ -5,9 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 import { PortfolioResponseSchema } from './model';
+import type { PortfolioResponseSchemaOutput } from './model';
 
 export type getPortfolioResponse200 = {
-  data: PortfolioResponseSchema;
+  data: PortfolioResponseSchemaOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-split/endpoints.ts
@@ -5,9 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 import { PortfolioResponseSchema } from './model/portfolioResponseSchema.zod';
+import type { PortfolioResponseSchemaOutput } from './model/portfolioResponseSchema.zod';
 
 export type getPortfolioResponse200 = {
-  data: PortfolioResponseSchema;
+  data: PortfolioResponseSchemaOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/default/default.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags-split/default/default.ts
@@ -5,9 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 import { PortfolioResponseSchema } from '../model';
+import type { PortfolioResponseSchemaOutput } from '../model';
 
 export type getPortfolioResponse200 = {
-  data: PortfolioResponseSchema;
+  data: PortfolioResponseSchemaOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/default.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-suffix-tags/default.ts
@@ -5,9 +5,10 @@
  * OpenAPI spec version: 1.0.0
  */
 import { PortfolioResponseSchema } from './model';
+import type { PortfolioResponseSchemaOutput } from './model';
 
 export type getPortfolioResponse200 = {
-  data: PortfolioResponseSchema;
+  data: PortfolioResponseSchemaOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -10,6 +10,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from '../model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
@@ -55,7 +58,7 @@ export type HTTPStatusCodes =
   | HTTPStatusCode5xx;
 
 export type listPetsResponse200 = {
-  data: Pets;
+  data: PetsOutput;
   status: 200;
 };
 
@@ -114,7 +117,7 @@ export const listPets = async (
 };
 
 export type createPetsResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -193,7 +196,7 @@ export const createPets = async (
 };
 
 export type showPetByIdResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -297,7 +300,7 @@ export const deletePetById = async (
 };
 
 export type showPetWithOwnerResponse200 = {
-  data: PetWithTag;
+  data: PetWithTagOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -10,6 +10,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from './model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
@@ -55,7 +58,7 @@ export type HTTPStatusCodes =
   | HTTPStatusCode5xx;
 
 export type listPetsResponse200 = {
-  data: Pets;
+  data: PetsOutput;
   status: 200;
 };
 
@@ -114,7 +117,7 @@ export const listPets = async (
 };
 
 export type createPetsResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -193,7 +196,7 @@ export const createPets = async (
 };
 
 export type showPetByIdResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -297,7 +300,7 @@ export const deletePetById = async (
 };
 
 export type showPetWithOwnerResponse200 = {
-  data: PetWithTag;
+  data: PetWithTagOutput;
   status: 200;
 };
 

--- a/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
@@ -10,6 +10,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from './model';
 
 export type HTTPStatusCode1xx = 100 | 101 | 102 | 103;
@@ -55,7 +58,7 @@ export type HTTPStatusCodes =
   | HTTPStatusCode5xx;
 
 export type listPetsResponse200 = {
-  data: Pets;
+  data: PetsOutput;
   status: 200;
 };
 
@@ -124,7 +127,7 @@ export const listPets = async (
 };
 
 export type createPetsResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -213,7 +216,7 @@ export const createPets = async (
 };
 
 export type showPetByIdResponse200 = {
-  data: Pet;
+  data: PetOutput;
   status: 200;
 };
 
@@ -378,7 +381,7 @@ export const healthCheck = async (
 };
 
 export type showPetWithOwnerResponse200 = {
-  data: PetWithTag;
+  data: PetWithTagOutput;
   status: 200;
 };
 


### PR DESCRIPTION
With `runtimeValidation` on a zod-schemas output, the fetch client parses the response through the Zod schema at runtime, so the value it returns is the schema's `zod.output` type. The declared TypeScript type still named the schema, which zod-schemas mode aliases to `zod.input`. Under `coerce`, `useDates`, defaults or transforms the two diverge: the runtime value is a `Date`, the declared type says `string | Date | unknown`.

The declared types now reference the generated `XOutput` aliases instead:

```ts
// before
export type listPetsResponse200 = { data: Pets; status: 200 };
// after
export type listPetsResponse200 = { data: PetsOutput; status: 200 };
```

Same for the function return type when `includeHttpResponseReturnType` is off (`Promise<PetsOutput>`). Operations with a custom mutator, and ndjson streams, keep the schema (input) type: the generated parse never runs on those paths, so typing them as output would be the opposite lie. The `zod-schema-response-mutator` snapshot is byte-identical.

Two pieces land in `@orval/core` rather than the fetch package:

- The type-side helpers (`getSchemaOutputTypeRef`, `getSchemaValueRef`, `hasSchemaImport`, `isPrimitiveResponseType`, `rewriteImportsForResponseValidation`) sit next to `emitResponseValidation`, which #3650 already centralized for the value side. The angular-query client has the same bug (#3941) and `packages/angular` carries private copies of these helpers; both can move onto the shared ones next.
- `GeneratorImport` gains `zodBaseName`, and the import writer routes an `XOutput` alias import to its base schema's `.zod` file. Without it, `indexFiles: false` layouts would import `PetsOutput` from a nonexistent `petsOutput.zod` — a gap the angular implementation never hit because its fixtures all use barrel imports. The `zod-schema-response-split` snapshot now covers it: `import type { PetOutput } from './model/pet.zod'`.

Review order: `packages/core/src/generators/runtime-validation.ts`, `packages/fetch/src/index.ts`, `packages/core/src/writers/generate-imports-for-builder.ts`. The snapshot changes are mechanical (`data: X` → `data: XOutput` plus the added type imports) and limited to the eight fixtures with validation enabled; the `*-no-runtime-validation` fixtures are untouched.

Fixes #3938
Refs #3941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch responses using Zod runtime validation now use the schema’s output type, including transformed, coerced, defaulted, or date-converted values.
  * Response validation skips primitive responses and ndjson streams.
  * Custom mutators continue using the original schema input type.

* **Bug Fixes**
  * Improved generated imports so output types resolve correctly in per-file Zod schema layouts.

* **Documentation**
  * Updated runtime validation guidance and support details for fetch responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->