### PR TITLE
fix: use JSON_SCHEMA in parseSpec to prevent date coercion

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -429,26 +429,26 @@ describe('validation', () => {
     // Write raw YAML (not JSON) so js-yaml actually parses the content.
     // Without JSON_SCHEMA, js-yaml coerces `2026-01-27` into a Date object.
     const yamlContent = `
-openapi: "3.0.3"
-info:
-  title: DateEnumRepro
-  version: "1.0.0"
-paths:
-  /test:
-    get:
-      operationId: getTest
-      parameters:
-        - name: Accept-Version
-          in: header
-          schema:
-            type: string
-            enum:
-              - latest
-              - 2026-01-27
-      responses:
-        "200":
-          description: OK
-`;
+      openapi: "3.0.3"
+      info:
+        title: DateEnumRepro
+        version: "1.0.0"
+      paths:
+        /test:
+          get:
+            operationId: getTest
+            parameters:
+              - name: Accept-Version
+                in: header
+                schema:
+                  type: string
+                  enum:
+                    - latest
+                    - 2026-01-27
+            responses:
+              "200":
+                description: OK
+      `;
 
     try {
       await writeFile(specPath, yamlContent, 'utf8');

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -428,27 +428,30 @@ describe('validation', () => {
 
     // Write raw YAML (not JSON) so js-yaml actually parses the content.
     // Without JSON_SCHEMA, js-yaml coerces `2026-01-27` into a Date object.
-    const yamlContent = `
-      openapi: "3.0.3"
-      info:
-        title: DateEnumRepro
-        version: "1.0.0"
-      paths:
-        /test:
-          get:
-            operationId: getTest
-            parameters:
-              - name: Accept-Version
-                in: header
-                schema:
-                  type: string
-                  enum:
-                    - latest
-                    - 2026-01-27
-            responses:
-              "200":
-                description: OK
-      `;
+    const yamlContent = [
+      'openapi: "3.0.3"',
+      'info:',
+      '  title: DateEnumRepro',
+      '  version: "1.0.0"',
+      'paths:',
+      '  /test:',
+      '    get:',
+      '      operationId: getTest',
+      '      responses:',
+      '        "200":',
+      '          description: OK',
+      '          content:',
+      '            application/json:',
+      '              schema:',
+      '                $ref: "#/components/schemas/ApiVersion"',
+      'components:',
+      '  schemas:',
+      '    ApiVersion:',
+      '      type: string',
+      '      enum:',
+      '        - latest',
+      '        - 2026-01-27',
+    ].join('\n');
 
     try {
       await writeFile(specPath, yamlContent, 'utf8');
@@ -461,12 +464,12 @@ describe('validation', () => {
 
       const result = await importSpecs(workspace, normalizedOptions);
 
-      const versionParam = result.schemas.find(
-        (s) => s.name === 'GetTestHeaderAcceptVersionParameter',
+      const apiVersion = result.schemas.find(
+        (s) => s.name === 'ApiVersion',
       );
-      expect(versionParam).toBeDefined();
-      expect(versionParam?.model).toContain("'2026-01-27'");
-      expect(versionParam?.model).not.toContain('GMT');
+      expect(apiVersion).toBeDefined();
+      expect(apiVersion?.model).toContain("'2026-01-27'");
+      expect(apiVersion?.model).not.toContain('GMT');
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -419,6 +419,58 @@ describe('validation', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+
+  it('should preserve date-like enum strings from YAML specs', async () => {
+    const workspace = await mkdtemp(
+      path.join(os.tmpdir(), 'orval-yaml-date-enum-'),
+    );
+    const specPath = path.join(workspace, 'spec.yaml');
+
+    // Write raw YAML (not JSON) so js-yaml actually parses the content.
+    // Without JSON_SCHEMA, js-yaml coerces `2026-01-27` into a Date object.
+    const yamlContent = `
+openapi: "3.0.3"
+info:
+  title: DateEnumRepro
+  version: "1.0.0"
+paths:
+  /test:
+    get:
+      operationId: getTest
+      parameters:
+        - name: Accept-Version
+          in: header
+          schema:
+            type: string
+            enum:
+              - latest
+              - 2026-01-27
+      responses:
+        "200":
+          description: OK
+`;
+
+    try {
+      await writeFile(specPath, yamlContent, 'utf8');
+
+      const normalizedOptions = await normalizeOptions(
+        { output: { target: '' }, input: { target: specPath } },
+        workspace,
+        {},
+      );
+
+      const result = await importSpecs(workspace, normalizedOptions);
+
+      const versionParam = result.schemas.find(
+        (s) => s.name === 'GetTestHeaderAcceptVersionParameter',
+      );
+      expect(versionParam).toBeDefined();
+      expect(versionParam?.model).toContain("'2026-01-27'");
+      expect(versionParam?.model).not.toContain('GMT');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('swagger2FormData', () => {

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -464,9 +464,7 @@ describe('validation', () => {
 
       const result = await importSpecs(workspace, normalizedOptions);
 
-      const apiVersion = result.schemas.find(
-        (s) => s.name === 'ApiVersion',
-      );
+      const apiVersion = result.schemas.find((s) => s.name === 'ApiVersion');
       expect(apiVersion).toBeDefined();
       expect(apiVersion?.model).toContain("'2026-01-27'");
       expect(apiVersion?.model).not.toContain('GMT');

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -569,7 +569,10 @@ async function bundleAndDereferenceExternalRefs(
  * untrusted.
  */
 function parseSpec(text: string): Record<string, unknown> {
-  const result = jsYaml.load(text, { schema: jsYaml.JSON_SCHEMA });
+  const schema = jsYaml.JSON_SCHEMA.extend({
+    implicit: [jsYaml.types.merge],
+  });
+  const result = jsYaml.load(text, { schema });
   if (!isObject(result)) {
     throw new Error('OpenAPI spec must be a valid JSON/YAML object.');
   }

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -569,10 +569,7 @@ async function bundleAndDereferenceExternalRefs(
  * untrusted.
  */
 function parseSpec(text: string): Record<string, unknown> {
-  const schema = jsYaml.JSON_SCHEMA.extend({
-    implicit: [jsYaml.types.merge],
-  });
-  const result = jsYaml.load(text, { schema });
+  const result = jsYaml.load(text, { schema: jsYaml.JSON_SCHEMA });
   if (!isObject(result)) {
     throw new Error('OpenAPI spec must be a valid JSON/YAML object.');
   }

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -569,7 +569,7 @@ async function bundleAndDereferenceExternalRefs(
  * untrusted.
  */
 function parseSpec(text: string): Record<string, unknown> {
-  const result = jsYaml.load(text);
+  const result = jsYaml.load(text, { schema: jsYaml.JSON_SCHEMA });
   if (!isObject(result)) {
     throw new Error('OpenAPI spec must be a valid JSON/YAML object.');
   }


### PR DESCRIPTION
## Summary

- `parseSpec` calls `jsYaml.load(text)` without specifying a schema. js-yaml's default schema (YAML 1.1) auto-converts date-like strings (`2026-01-27`) into JavaScript `Date` objects.
- This causes enum values that look like dates to be emitted as `Date.toString()` output (e.g. `Tue Jan 27 2026 01:00:00 GMT+0100...`) instead of the original string literal, producing invalid TypeScript.
- Fix: pass `{ schema: jsYaml.JSON_SCHEMA }` which only recognizes JSON-native types and leaves everything else as a string.

## Example

Given this OpenAPI spec:

```yaml
enum:
  - latest
  - 2026-01-27
```

**Before (broken):**

```typescript
export const HeaderAcceptVersionParameter = {
  latest: 'latest',
  'Tue_Jan_27_2026_01:00:00_GMT+0100_(Central_European_Standard_Time)':
    Tue Jan 27 2026 01:00:00 GMT+0100 (Central European Standard Time),
} as const;
```

**After (fixed):**

```typescript
export const HeaderAcceptVersionParameter = {
  latest: 'latest',
  '2026-01-27': '2026-01-27',
} as const;
```

## Test plan

- [x] Run existing test suite
- [ ] Generate code from a spec with date-like enum values and verify they stay as strings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API specification parsing by limiting YAML interpretation to JSON-compatible values.
  * Preserved date-like values in specifications as strings instead of converting them into dates.
  * Prevented unsupported YAML features, including custom tags and timestamps, from being processed unexpectedly.
  * Improved reliability when importing specifications containing date-formatted enum values, ensuring they remain unchanged in generated API definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->