### PR TITLE
fix(query): type runtime-validated angular-query responses with the schema's zod output alias

### DIFF
--- a/docs/content/docs/guides/angular-query.mdx
+++ b/docs/content/docs/guides/angular-query.mdx
@@ -376,7 +376,7 @@ export default defineConfig({
 This generates:
 
 ```ts
-const request$ = http.get<Pets>(url, { params: httpParams }).pipe(
+const request$ = http.get<PetsOutput>(url, { params: httpParams }).pipe(
   map((data) => {
     const result = Pets.safeParse(data);
     if (!result.success) {
@@ -391,6 +391,12 @@ const request$ = http.get<Pets>(url, { params: httpParams }).pipe(
 Use `runtimeValidation: true` to keep the existing `Schema.parse()` behavior.
 Validation is automatically skipped for primitive response types (`string`,
 `void`, etc.) and for operations using a custom mutator.
+
+A validated request function is typed with the schema's `zod.output` alias
+(`Promise<PetsOutput>` above), since that is what the parse returns at runtime —
+relevant when the schema transforms values through `coerce`, `useDates`,
+defaults or `.transform()`. Mutator operations keep the schema (input) type,
+as the generated parse never runs there.
 
 ## Full Example
 

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1592,6 +1592,8 @@ Force a specific version for generated hooks.
 
 Enable Zod runtime validation for Angular query responses. Requires `schemas: { type: 'zod' }`. When enabled, responses are validated in the RxJS pipeline according to the configured strategy (`Schema.parse()` for the default `throw`). Skipped for primitive types and custom mutators.
 
+A validated response is typed with the schema's `zod.output` alias (e.g. `PetsOutput`) instead of the input-typed schema name, since that is what the parse returns at runtime — relevant when the schema transforms values through `coerce`, `useDates`, defaults or `.transform()`. Operations using a custom mutator keep the schema (input) type: the mutator issues the request itself, so the generated parse never runs there.
+
 The boolean form is preserved for backward compatibility: `true` ≡ `{ strategy: 'throw' }`. With `{ strategy: 'both' }` an invalid response is first logged through `console.error('[orval] <operation> response validation failed', error)` with the raw `ZodError`, then re-thrown — so the failure still surfaces through the client's native error channel while giving production visibility into contract drift.
 
 ---
@@ -2549,7 +2551,7 @@ export const load = async ({ fetch }) => {
 | Client | Config key | Status | Notes |
 |--------|------------|--------|-------|
 | `angular` | `override.angular.runtimeValidation` | ✅ | Validates JSON body responses via `Schema.parse()`; skips primitive/`void`, `observe: 'events'/'response'`, and custom mutator paths |
-| `angular-query` | `override.query.runtimeValidation` | ✅ | Validates eligible responses via `Schema.parse()` in RxJS pipeline; skips primitive/`void` and custom mutator paths |
+| `angular-query` | `override.query.runtimeValidation` | ✅ | Validates eligible responses via `Schema.parse()` in RxJS pipeline; types them as the schema's `zod.output` alias; skips primitive/`void` and custom mutator paths |
 | `fetch` | `override.fetch.runtimeValidation` | ✅ | Validates JSON responses via `Schema.parse()`; types them as the schema's `zod.output` alias; skips primitive/`void`, ndjson and custom mutator paths |
 | any client with custom mutator | varies | ⚠️ | Runtime validation may be bypassed depending on mutator path and signature (see [#2858](https://github.com/orval-labs/orval/issues/2858)). For the `fetch` client, [`override.includeZodSchemaInArguments`](#includezodschemainarguments) passes the schema to the mutator so it can validate the response itself |
 

--- a/packages/query/src/client.test.ts
+++ b/packages/query/src/client.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import { createFrameworkAdapter } from './frameworks';
 import {
+  generateAngularHttpRequestFunction,
   generateAxiosRequestFunction,
   generateRequestOptionsArguments,
   getHookOptions,
@@ -842,5 +843,139 @@ describe('getHooksOptionImplementation', () => {
         'getCreatePetsMutationKey',
       ),
     ).toBe('');
+  });
+});
+
+describe('generateAngularHttpRequestFunction — zod runtimeValidation response typing (#3941)', () => {
+  const makeResponse = (successName = 'Pets') =>
+    ({
+      definition: { success: successName, errors: 'Error' },
+      imports: [{ name: successName, schemaName: successName, values: true }],
+      types: {
+        success: [
+          {
+            key: '200',
+            contentType: 'application/json',
+            value: successName,
+            hasReadonlyProps: false,
+            imports: [],
+            isEnum: false,
+            isRef: true,
+            schemas: [],
+            type: 'object',
+            dependencies: [],
+          },
+        ],
+        errors: [],
+      },
+      contentTypes: ['application/json'],
+      schemas: [],
+      isBlob: false,
+    }) as unknown as GeneratorVerbOptions['response'];
+
+  const makeVerbOptions = (
+    overrides: Partial<GeneratorVerbOptions> = {},
+  ): GeneratorVerbOptions =>
+    ({
+      verb: 'get',
+      route: '/pets',
+      pathRoute: '/pets',
+      operationId: 'listPets',
+      operationName: 'listPets',
+      doc: '',
+      tags: [],
+      response: makeResponse(),
+      body: {
+        definition: '',
+        implementation: '',
+        imports: [],
+        schemas: [],
+        formData: undefined,
+        formUrlEncoded: undefined,
+        contentType: '',
+        isOptional: true,
+        originalSchema: {},
+        isBlob: false,
+      },
+      params: [],
+      props: [],
+      override: {
+        formData: { disabled: false, arrayHandling: 'serialize' },
+        formUrlEncoded: false,
+        requestOptions: false,
+        query: {
+          runtimeValidation: { enabled: true, strategy: 'throw' },
+          shouldExportHttpClient: true,
+          signal: false,
+          version: 5,
+        },
+      },
+      ...overrides,
+    }) as unknown as GeneratorVerbOptions;
+
+  const makeAngularOptions = (
+    schemas: unknown = { path: './model', type: 'zod' },
+  ) =>
+    ({
+      route: '/pets',
+      pathRoute: '/pets',
+      override: {},
+      output: '',
+      context: {
+        target: '',
+        workspace: '',
+        spec: {},
+        output: { schemas, httpClient: 'angular' },
+      },
+    }) as unknown as GeneratorOptions;
+
+  it('declares the validated response as the zod output alias', () => {
+    const implementation = generateAngularHttpRequestFunction(
+      makeVerbOptions(),
+      makeAngularOptions(),
+    );
+
+    expect(implementation).toContain('): Promise<PetsOutput> =>');
+    expect(implementation).toContain('http.get<PetsOutput>(url)');
+    expect(implementation).toContain('Pets.parse(data)');
+    expect(implementation).not.toContain('Promise<Pets>');
+  });
+
+  it('references the ErrorSchema value alias for an `Error` response schema', () => {
+    const implementation = generateAngularHttpRequestFunction(
+      makeVerbOptions({ response: makeResponse('Error') }),
+      makeAngularOptions(),
+    );
+
+    expect(implementation).toContain('): Promise<ErrorOutput> =>');
+    expect(implementation).toContain('http.get<ErrorOutput>(url)');
+    expect(implementation).toContain('ErrorSchema.parse(data)');
+  });
+
+  it('keeps the schema (input) type when the schemas output is not zod', () => {
+    const implementation = generateAngularHttpRequestFunction(
+      makeVerbOptions(),
+      makeAngularOptions('./model'),
+    );
+
+    expect(implementation).toContain('): Promise<Pets> =>');
+    expect(implementation).not.toContain('PetsOutput');
+    expect(implementation).not.toContain('.parse(');
+  });
+
+  it('keeps the schema (input) type when validation is disabled', () => {
+    const verbOptions = makeVerbOptions();
+    verbOptions.override.query.runtimeValidation = {
+      enabled: false,
+      strategy: 'throw',
+    };
+
+    const implementation = generateAngularHttpRequestFunction(
+      verbOptions,
+      makeAngularOptions(),
+    );
+
+    expect(implementation).toContain('): Promise<Pets> =>');
+    expect(implementation).not.toContain('PetsOutput');
   });
 });

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -12,7 +12,11 @@ import {
   type GeneratorVerbOptions,
   getAngularFilteredParamsCallExpression,
   getAngularFilteredParamsHelperBody,
+  getSchemaOutputTypeRef,
+  getSchemaValueRef,
   getSuccessResponseType,
+  hasSchemaImport,
+  isPrimitiveResponseType,
   type GetterResponse,
   isObject,
   isOperationInTagBucket,
@@ -156,7 +160,22 @@ export const generateAngularHttpRequestFunction = (
     /,\s*$/,
     '',
   );
-  const dataType = response.definition.success || 'unknown';
+  // Detect if Zod runtime validation should be applied
+  const responseType = response.definition.success || 'unknown';
+  const isZodOutput =
+    isObject(context.output.schemas) && context.output.schemas.type === 'zod';
+  const shouldValidateResponse =
+    override.query.runtimeValidation?.enabled &&
+    isZodOutput &&
+    !isPrimitiveResponseType(responseType) &&
+    hasSchemaImport(response.imports, responseType);
+  // The generated parse returns the schema's zod output type, so the declared
+  // type (HttpClient generic and Promise return) references the `XOutput`
+  // alias — the bare schema name aliases `zod.input`, which diverges under
+  // `coerce`, `useDates`, defaults and transforms (#3941).
+  const dataType = shouldValidateResponse
+    ? getSchemaOutputTypeRef(responseType)
+    : responseType;
 
   // Build URL with query params - use httpParams to avoid shadowing the 'params' variable
   const hasQueryParams = queryParams?.schema.name;
@@ -224,28 +243,9 @@ export const generateAngularHttpRequestFunction = (
     }
   }
 
-  // Detect if Zod runtime validation should be applied
-  const responseType = response.definition.success;
-  const isPrimitiveType = [
-    'string',
-    'number',
-    'boolean',
-    'void',
-    'unknown',
-  ].includes(responseType);
-  const hasSchema = response.imports.some((imp) => imp.name === responseType);
-  const isZodOutput =
-    isObject(context.output.schemas) && context.output.schemas.type === 'zod';
-  const isValidateResponse =
-    override.query.runtimeValidation?.enabled &&
-    isZodOutput &&
-    !isPrimitiveType &&
-    hasSchema;
-
   // If validation is enabled, pipe through the shared runtime-validation emitter
-  if (isValidateResponse) {
-    const schemaValueRef =
-      responseType === 'Error' ? 'ErrorSchema' : responseType;
+  if (shouldValidateResponse) {
+    const schemaValueRef = getSchemaValueRef(responseType);
     httpCall = `${httpCall}${emitResponseValidation({
       schemaRef: schemaValueRef,
       operationName,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -3,10 +3,13 @@ import {
   type ClientDependenciesBuilder,
   type ClientHeaderBuilder,
   generateVerbImports,
+  hasSchemaImport,
+  isPrimitiveResponseType,
   mergeDeep,
   type NormalizedOutputOptions,
   OutputHttpClient,
   type QueryOptions,
+  rewriteImportsForResponseValidation,
 } from '@orval/core';
 
 import { getQueryHeader } from './client';
@@ -89,40 +92,41 @@ export const generateQuery: ClientBuilder = async (
   options,
   outputClient,
 ) => {
+  const adapter = createFrameworkAdapter({
+    outputClient,
+    packageJson: options.context.output.packageJson,
+    queryVersion: verbOptions.override.query.version,
+  });
+
   const isZodOutput =
     typeof options.context.output.schemas === 'object' &&
     options.context.output.schemas.type === 'zod';
   const responseType = verbOptions.response.definition.success;
-  const isPrimitiveResponse = [
-    'string',
-    'number',
-    'boolean',
-    'void',
-    'unknown',
-  ].includes(responseType);
+  // A custom mutator skips the generated parse entirely, so its schema
+  // import stays type-only and no rewrite is needed.
   const shouldUseRuntimeValidation =
-    verbOptions.override.query.runtimeValidation?.enabled && isZodOutput;
+    verbOptions.override.query.runtimeValidation?.enabled &&
+    isZodOutput &&
+    !verbOptions.mutator &&
+    !isPrimitiveResponseType(responseType) &&
+    hasSchemaImport(verbOptions.response.imports, responseType);
 
-  const normalizedVerbOptions =
-    shouldUseRuntimeValidation &&
-    !isPrimitiveResponse &&
-    verbOptions.response.imports.some((imp) => imp.name === responseType)
-      ? {
-          ...verbOptions,
-          response: {
-            ...verbOptions.response,
-            imports: verbOptions.response.imports.map((imp) =>
-              imp.name === responseType ? { ...imp, values: true } : imp,
-            ),
-          },
-        }
-      : verbOptions;
-
-  const adapter = createFrameworkAdapter({
-    outputClient,
-    packageJson: options.context.output.packageJson,
-    queryVersion: normalizedVerbOptions.override.query.version,
-  });
+  const normalizedVerbOptions = shouldUseRuntimeValidation
+    ? {
+        ...verbOptions,
+        response: {
+          ...verbOptions.response,
+          imports: rewriteImportsForResponseValidation(
+            verbOptions.response.imports,
+            responseType,
+            // Only the Angular HttpClient request function switches its
+            // declared type to the `XOutput` alias (#3941); other frameworks
+            // delegate to their http-client generator.
+            { includeOutputType: adapter.isAngularHttp },
+          ),
+        },
+      }
+    : verbOptions;
 
   const imports = generateVerbImports(normalizedVerbOptions);
   const functionImplementation = adapter.generateRequestFunction(

--- a/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/__snapshots__/api/endpoints-zod/pets/pets.ts
@@ -31,6 +31,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from '../../model-zod';
 
 type AngularHttpParamValue =
@@ -113,12 +116,12 @@ export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
   options?: { signal?: AbortSignal | null },
-): Promise<Pets> => {
+): Promise<PetsOutput> => {
   const httpParams = params
     ? new HttpParams({ fromObject: filterParams(params, new Set<string>([])) })
     : undefined;
   const url = `/pets`;
-  const request$ = http.get<Pets>(url, { params: httpParams }).pipe(
+  const request$ = http.get<PetsOutput>(url, { params: httpParams }).pipe(
     map((data) => {
       const result = Pets.safeParse(data);
       if (!result.success) {
@@ -225,13 +228,13 @@ export const createPets = (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
   options?: { signal?: AbortSignal | null },
-): Promise<Pet> => {
+): Promise<PetOutput> => {
   const httpParams = params
     ? new HttpParams({ fromObject: filterParams(params, new Set<string>([])) })
     : undefined;
   const url = `/pets`;
   const request$ = http
-    .post<Pet>(url, createPetsBody, { params: httpParams })
+    .post<PetOutput>(url, createPetsBody, { params: httpParams })
     .pipe(
       map((data) => {
         const result = Pet.safeParse(data);
@@ -332,9 +335,9 @@ export const showPetById = (
   http: HttpClient,
   petId: string,
   options?: { signal?: AbortSignal | null },
-): Promise<Pet> => {
+): Promise<PetOutput> => {
   const url = `/pets/${petId}`;
-  const request$ = http.get<Pet>(url).pipe(
+  const request$ = http.get<PetOutput>(url).pipe(
     map((data) => {
       const result = Pet.safeParse(data);
       if (!result.success) {
@@ -538,9 +541,9 @@ export const showPetWithOwner = (
   http: HttpClient,
   petId: string,
   options?: { signal?: AbortSignal | null },
-): Promise<PetWithTag> => {
+): Promise<PetWithTagOutput> => {
   const url = `/pets/${petId}/owner`;
-  const request$ = http.get<PetWithTag>(url).pipe(
+  const request$ = http.get<PetWithTagOutput>(url).pipe(
     map((data) => {
       const result = PetWithTag.safeParse(data);
       if (!result.success) {

--- a/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
+++ b/samples/angular-query/src/api/endpoints-zod/pets/pets.ts
@@ -31,6 +31,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from '../../model-zod';
 
 type AngularHttpParamValue =
@@ -113,12 +116,12 @@ export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
   options?: { signal?: AbortSignal | null },
-): Promise<Pets> => {
+): Promise<PetsOutput> => {
   const httpParams = params
     ? new HttpParams({ fromObject: filterParams(params, new Set<string>([])) })
     : undefined;
   const url = `/pets`;
-  const request$ = http.get<Pets>(url, { params: httpParams }).pipe(
+  const request$ = http.get<PetsOutput>(url, { params: httpParams }).pipe(
     map((data) => {
       const result = Pets.safeParse(data);
       if (!result.success) {
@@ -225,13 +228,13 @@ export const createPets = (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
   options?: { signal?: AbortSignal | null },
-): Promise<Pet> => {
+): Promise<PetOutput> => {
   const httpParams = params
     ? new HttpParams({ fromObject: filterParams(params, new Set<string>([])) })
     : undefined;
   const url = `/pets`;
   const request$ = http
-    .post<Pet>(url, createPetsBody, { params: httpParams })
+    .post<PetOutput>(url, createPetsBody, { params: httpParams })
     .pipe(
       map((data) => {
         const result = Pet.safeParse(data);
@@ -332,9 +335,9 @@ export const showPetById = (
   http: HttpClient,
   petId: string,
   options?: { signal?: AbortSignal | null },
-): Promise<Pet> => {
+): Promise<PetOutput> => {
   const url = `/pets/${petId}`;
-  const request$ = http.get<Pet>(url).pipe(
+  const request$ = http.get<PetOutput>(url).pipe(
     map((data) => {
       const result = Pet.safeParse(data);
       if (!result.success) {
@@ -538,9 +541,9 @@ export const showPetWithOwner = (
   http: HttpClient,
   petId: string,
   options?: { signal?: AbortSignal | null },
-): Promise<PetWithTag> => {
+): Promise<PetWithTagOutput> => {
   const url = `/pets/${petId}/owner`;
-  const request$ = http.get<PetWithTag>(url).pipe(
+  const request$ = http.get<PetWithTagOutput>(url).pipe(
     map((data) => {
       const result = PetWithTag.safeParse(data);
       if (!result.success) {

--- a/tests/__snapshots__/runtime-validation/angular-query-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/angular-query-both/endpoints.ts
@@ -31,6 +31,9 @@ import type {
   CreatePetsParams,
   Error,
   ListPetsParams,
+  PetOutput,
+  PetWithTagOutput,
+  PetsOutput,
 } from './model';
 
 type AngularHttpParamValue =
@@ -113,12 +116,12 @@ export const listPets = (
   http: HttpClient,
   params: ListPetsParams,
   options?: { signal?: AbortSignal | null },
-): Promise<Pets> => {
+): Promise<PetsOutput> => {
   const httpParams = params
     ? new HttpParams({ fromObject: filterParams(params, new Set<string>([])) })
     : undefined;
   const url = `/pets`;
-  const request$ = http.get<Pets>(url, { params: httpParams }).pipe(
+  const request$ = http.get<PetsOutput>(url, { params: httpParams }).pipe(
     map((data) => {
       const result = Pets.safeParse(data);
       if (!result.success) {
@@ -225,13 +228,13 @@ export const createPets = (
   createPetsBody: CreatePetsBody,
   params: CreatePetsParams,
   options?: { signal?: AbortSignal | null },
-): Promise<Pet> => {
+): Promise<PetOutput> => {
   const httpParams = params
     ? new HttpParams({ fromObject: filterParams(params, new Set<string>([])) })
     : undefined;
   const url = `/pets`;
   const request$ = http
-    .post<Pet>(url, createPetsBody, { params: httpParams })
+    .post<PetOutput>(url, createPetsBody, { params: httpParams })
     .pipe(
       map((data) => {
         const result = Pet.safeParse(data);
@@ -333,9 +336,9 @@ export const showPetById = (
   http: HttpClient,
   petId: string,
   options?: { signal?: AbortSignal | null },
-): Promise<Pet> => {
+): Promise<PetOutput> => {
   const url = `/pets/${petId}`;
-  const request$ = http.get<Pet>(url).pipe(
+  const request$ = http.get<PetOutput>(url).pipe(
     map((data) => {
       const result = Pet.safeParse(data);
       if (!result.success) {
@@ -631,9 +634,9 @@ export const showPetWithOwner = (
   http: HttpClient,
   petId: string,
   options?: { signal?: AbortSignal | null },
-): Promise<PetWithTag> => {
+): Promise<PetWithTagOutput> => {
   const url = `/pets/${petId}/owner`;
-  const request$ = http.get<PetWithTag>(url).pipe(
+  const request$ = http.get<PetWithTagOutput>(url).pipe(
     map((data) => {
       const result = PetWithTag.safeParse(data);
       if (!result.success) {


### PR DESCRIPTION
Sibling of #3943, which fixed this for the fetch client. With `runtimeValidation` on a zod-schemas output, the angular-query request function pipes the response through `Schema.safeParse` and returns `result.data`, so the runtime value is the schema's `zod.output` type. The declared TypeScript type still named the schema, which zod-schemas mode aliases to `zod.input`. Under `coerce`, `useDates`, defaults or transforms the two diverge: the runtime value is a `Date`, the declared type says `string | Date | unknown`.

The `HttpClient` generic and the `Promise` return type now reference the generated `XOutput` aliases, matching the angular `HttpClient` client:

```ts
// before
export const listPets = (...): Promise<Pets> => { ... http.get<Pets>(url) ... }
// after
export const listPets = (...): Promise<PetsOutput> => { ... http.get<PetsOutput>(url) ... }
```

The generated hooks pick the type up through `Awaited<ReturnType<typeof listPets>>`, so no hook code changes. Operations with a custom mutator keep the schema (input) type — the generated parse never runs there — and non-angular query flavors are byte-identical.

Both changes ride on the core helpers #3943 introduced:

- `packages/query/src/client.ts` resolves the declared type via `getSchemaOutputTypeRef` and the value ref via `getSchemaValueRef` (the `Error` → `ErrorSchema` rename, covered by a unit test asserting `ErrorSchema.parse` next to `Promise<ErrorOutput>`).
- `packages/query/src/index.ts` replaces its hand-rolled schema-import flip with `rewriteImportsForResponseValidation`, which also adds the missing `XOutput` type import. Adapter creation moves above the rewrite so `adapter.isAngularHttp` can gate the alias import to angular-query.

Review order: `packages/query/src/client.ts`, `packages/query/src/index.ts`. The snapshot changes (`runtime-validation/angular-query-both` plus the `samples/angular-query` zod sample) are mechanical: `Promise<X>` → `Promise<XOutput>` and the added type imports. Docs gain the same output-alias note the fetch pages got in #3943.

Per #3941's suggested order, the remaining step is refactoring `packages/angular` onto the core helpers with byte-identical snapshots — not part of this PR.

Fixes #3941
Refs #3943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdXNjYsbphgDxir14cZqXU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Angular Query runtime validation with accurate Zod output types for validated responses.
  * Added support for imported response schemas and shared validation behavior.
  * Preserved input types for custom mutators and non-Zod or disabled validation scenarios.

* **Documentation**
  * Clarified runtime-validation typing behavior and updated Angular Query support guidance.

* **Tests**
  * Added coverage for validated responses, error schemas, and validation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->