### PR TITLE
fix(core): collect enum members from nested anyOf/oneOf branches

### DIFF
--- a/packages/core/src/getters/enum.test.ts
+++ b/packages/core/src/getters/enum.test.ts
@@ -330,6 +330,71 @@ describe('getEnumMembers', () => {
     ]);
   });
 
+  it('should not widen a null-only branch with its nested composition', () => {
+    // `type: 'null'` admits no value but `null`, so a nested composition under
+    // it cannot contribute additional values to the enum.
+    const schema = {
+      anyOf: [
+        {
+          type: 'null',
+          anyOf: [
+            {
+              type: 'string',
+              enum: ['a', 'b'],
+            },
+          ],
+        },
+      ],
+    } as unknown as OpenApiSchemaObject;
+
+    expect(getEnumMembers(schema)).toEqual([{ value: null }]);
+  });
+
+  it('should still walk a branch that allows a type besides null', () => {
+    const schema = {
+      anyOf: [
+        {
+          type: ['string', 'null'],
+          anyOf: [
+            {
+              const: 'ACTIVE',
+            },
+          ],
+        },
+      ],
+    } as unknown as OpenApiSchemaObject;
+
+    expect(getEnumMembers(schema)).toEqual([
+      { value: null },
+      {
+        value: 'ACTIVE',
+        name: undefined,
+        description: undefined,
+        deprecated: undefined,
+      },
+    ]);
+  });
+
+  it('should collect members from a deeply nested acyclic composition', () => {
+    // Traversal stops on real cycles, not at a fixed depth, so an innermost
+    // enum stays reachable however many redundant wrappers precede it.
+    let schema = { enum: ['deep'] } as unknown as OpenApiSchemaObject;
+    for (let i = 0; i < 64; i++) {
+      schema = { anyOf: [schema] } as unknown as OpenApiSchemaObject;
+    }
+
+    expect(getEnumMembers(schema)).toEqual([{ value: 'deep' }]);
+  });
+
+  it('should stop on a self-referential branch', () => {
+    const schema = {
+      anyOf: [{ enum: ['a'] }],
+    } as unknown as OpenApiSchemaObject;
+    (schema.anyOf as unknown[]).push(schema);
+
+    expect(getEnumMembers(schema)).toEqual([{ value: 'a' }]);
+  });
+
   it('should preserve const null branches', () => {
     const schema = {
       oneOf: [

--- a/packages/core/src/getters/enum.test.ts
+++ b/packages/core/src/getters/enum.test.ts
@@ -264,6 +264,72 @@ describe('getEnumMembers', () => {
     ]);
   });
 
+  it('should collect enum members from a nested anyOf branch', () => {
+    // Some generators emit a redundant but valid nesting where the inner
+    // composition already carries the null branch. See #3951.
+    const schema = {
+      anyOf: [
+        {
+          anyOf: [
+            {
+              type: 'string',
+              enum: ['a', 'b'],
+            },
+            {
+              type: 'null',
+            },
+          ],
+        },
+        {
+          type: 'null',
+        },
+      ],
+    } as unknown as OpenApiSchemaObject;
+
+    expect(getEnumMembers(schema)).toEqual([
+      { value: 'a' },
+      { value: 'b' },
+      { value: null },
+    ]);
+  });
+
+  it('should collect enum members from a nested oneOf branch', () => {
+    const schema = {
+      anyOf: [
+        {
+          oneOf: [
+            {
+              const: 'ACTIVE',
+              title: 'Active',
+            },
+            {
+              const: 'INACTIVE',
+            },
+          ],
+        },
+        {
+          type: 'null',
+        },
+      ],
+    } as unknown as OpenApiSchemaObject;
+
+    expect(getEnumMembers(schema)).toEqual([
+      {
+        value: 'ACTIVE',
+        name: 'Active',
+        description: undefined,
+        deprecated: undefined,
+      },
+      {
+        value: 'INACTIVE',
+        name: undefined,
+        description: undefined,
+        deprecated: undefined,
+      },
+      { value: null },
+    ]);
+  });
+
   it('should preserve const null branches', () => {
     const schema = {
       oneOf: [

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -377,21 +377,17 @@ ${getEnumImplementation(members, {
   };
 }
 
-/**
- * Guards against a self-referential branch (a `oneOf`/`anyOf` member that is
- * the same object as one of its ancestors) sending the walk into an infinite
- * loop. Plain specs cannot express such a cycle, but a spec object built or
- * mutated in memory can.
- */
-const MAX_ENUM_BRANCH_DEPTH = 32;
-
 function getEnumMembersFromBranches(
   schemaObject: OpenApiSchemaObject | undefined,
-  depth = 0,
+  seen = new Set<object>(),
 ): EnumMember[] {
-  if (!schemaObject || depth > MAX_ENUM_BRANCH_DEPTH) {
+  // A spec cannot express a branch that contains itself, but a spec object
+  // built or mutated in memory can. Stop on a real cycle rather than at an
+  // arbitrary depth, so deeply nested acyclic compositions stay complete.
+  if (!schemaObject || seen.has(schemaObject)) {
     return [];
   }
+  seen.add(schemaObject);
 
   const branches = [
     ...(schemaObject.oneOf ?? []),
@@ -421,25 +417,35 @@ function getEnumMembersFromBranches(
       })),
     );
 
-    if (
+    const isNullBranch =
       branch.type === 'null' ||
-      (Array.isArray(branch.type) && branch.type.includes('null'))
-    ) {
+      (Array.isArray(branch.type) && branch.type.includes('null'));
+
+    if (isNullBranch) {
       members.push({
         value: null,
       });
     }
 
+    // `type: 'null'` (or `type: ['null']`) admits no value but `null`, so a
+    // nested composition under it cannot contribute anything else. A branch
+    // that allows other types still can, so keep walking multi-type arrays.
+    const isNullOnlyBranch =
+      branch.type === 'null' ||
+      (Array.isArray(branch.type) &&
+        branch.type.length > 0 &&
+        branch.type.every((type) => type === 'null'));
+
     // A branch can itself be a composition, e.g. the redundant but valid
     // `anyOf: [{anyOf: [{enum}, {null}]}, {null}]` emitted by some generators.
     // Without descending, only the outer `{type: 'null'}` is collected and the
-    // generated const ends up empty. Only walk branches that contribute no
-    // members of their own so an annotated `const`/`enum` branch keeps its own
+    // generated const ends up empty. Only walk branches that contributed no
+    // members of their own: an annotated `const`/`enum` branch keeps its own
     // metadata. See #3951.
-    if (enumValues.length === 0) {
+    if (enumValues.length === 0 && !isNullOnlyBranch) {
       const nestedBranch = branch as OpenApiSchemaObject;
       if (nestedBranch.oneOf || nestedBranch.anyOf) {
-        members.push(...getEnumMembersFromBranches(nestedBranch, depth + 1));
+        members.push(...getEnumMembersFromBranches(nestedBranch, seen));
       }
     }
   }

--- a/packages/core/src/getters/enum.ts
+++ b/packages/core/src/getters/enum.ts
@@ -377,10 +377,19 @@ ${getEnumImplementation(members, {
   };
 }
 
+/**
+ * Guards against a self-referential branch (a `oneOf`/`anyOf` member that is
+ * the same object as one of its ancestors) sending the walk into an infinite
+ * loop. Plain specs cannot express such a cycle, but a spec object built or
+ * mutated in memory can.
+ */
+const MAX_ENUM_BRANCH_DEPTH = 32;
+
 function getEnumMembersFromBranches(
   schemaObject: OpenApiSchemaObject | undefined,
+  depth = 0,
 ): EnumMember[] {
-  if (!schemaObject) {
+  if (!schemaObject || depth > MAX_ENUM_BRANCH_DEPTH) {
     return [];
   }
 
@@ -419,6 +428,19 @@ function getEnumMembersFromBranches(
       members.push({
         value: null,
       });
+    }
+
+    // A branch can itself be a composition, e.g. the redundant but valid
+    // `anyOf: [{anyOf: [{enum}, {null}]}, {null}]` emitted by some generators.
+    // Without descending, only the outer `{type: 'null'}` is collected and the
+    // generated const ends up empty. Only walk branches that contribute no
+    // members of their own so an annotated `const`/`enum` branch keeps its own
+    // metadata. See #3951.
+    if (enumValues.length === 0) {
+      const nestedBranch = branch as OpenApiSchemaObject;
+      if (nestedBranch.oneOf || nestedBranch.anyOf) {
+        members.push(...getEnumMembersFromBranches(nestedBranch, depth + 1));
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #3951.

## The problem

`getEnumMembersFromBranches` walks `oneOf`/`anyOf` members and pulls enum values out of each one, but it only looks one level deep. A branch that is itself a composition contributes nothing, so for the spec in the issue:

```yaml
anyOf:
  - anyOf:
      - type: string
        enum: [a, b]
      - type: 'null'
  - type: 'null'
```

only the outer `{type: 'null'}` branch is collected. `combineSchemas` still takes the combined-enum path (the union type resolves correctly to `'a' | 'b' | null`), so the type alias is emitted referencing `keyof typeof PostRootBody` while the const it points at is empty:

```ts
export type PostRootBody = typeof PostRootBody[keyof typeof PostRootBody] | null;

export const PostRootBody = {
} as const;
```

This nesting is redundant — the inner composition already carries the null branch — but it is valid, and as the reporter notes some OpenAPI generators emit it. It worked up to v8.24.0.

## The fix

Descend into a branch when it is a composition and contributed no members of its own. The `enumValues.length === 0` guard keeps annotated `const`/`enum` branches on their existing path, so title/description/deprecated metadata handling is unchanged. A depth cap guards against a self-referential branch in an in-memory spec object; a plain spec cannot express that cycle.

Output with the fix, matching v8.24.0:

```ts
export type PostRootBody = typeof PostRootBody[keyof typeof PostRootBody] | null;

export const PostRootBody = {
  a: 'a',
  b: 'b',
} as const;
```

## Validation

- Two regression tests in `packages/core/src/getters/enum.test.ts` covering a nested `anyOf` and a nested `oneOf` of `const` branches (the latter pins that nested metadata still survives).
- Verified end-to-end by generating the issue's exact spec against a local `build:release`, before and after the change.
- `vp run -F './packages/*' test` — 11 files, all passing (core: 2451 tests).
- `vp run -F './packages/*' typecheck`, `vp lint --type-aware --type-check packages`, `vp fmt --check` — all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enum detection across deeply nested `oneOf` and `anyOf` schemas.
  * Correctly preserves enum and constant values, metadata, and valid null options in complex schemas.
  * Excludes values from branches that only allow `null`.
  * Added protection against infinite processing for self-referential schemas while supporting deeply nested, acyclic schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->