### PR TITLE
fix(mock): don't force binary path from preferredContentType on structured schemas

### DIFF
--- a/docs/content/docs/guides/msw.mdx
+++ b/docs/content/docs/guides/msw.mdx
@@ -95,6 +95,8 @@ export default defineConfig({
 
 `preferredContentType` accepts common MIME literals and any custom string (via a loose `(string & {})` fallback), so vendor-specific types are supported too.
 
+`preferredContentType` only **selects** a declared media type — it does not convert the payload. If the chosen media type is not among the operation's responses, the preference is ignored and spec order is used. When the response schema is a structured object or array, prefer a JSON media type: pairing a non-JSON preference (for example, `text/plain` or `application/octet-stream`) with a structured schema serves a stringified or empty body instead of the structured mock.
+
 ### Array Item Factories
 
 Set `arrayItems: true` on the MSW generator entry to emit reusable mock factories for object-like array item schemas in operation responses (for example, `getTenantResponseModelDtoMock` for `value: TenantResponseModelDto[]`). The factories are written into the same `.msw.ts` / endpoints mock file as the handlers and response mocks. See the [Faker guide — Array Item Factories](/docs/guides/faker#array-item-factories) for configuration details and supported shapes.

--- a/docs/content/docs/guides/msw.mdx
+++ b/docs/content/docs/guides/msw.mdx
@@ -95,7 +95,7 @@ export default defineConfig({
 
 `preferredContentType` accepts common MIME literals and any custom string (via a loose `(string & {})` fallback), so vendor-specific types are supported too.
 
-`preferredContentType` only **selects** a declared media type — it does not convert the payload. If the chosen media type is not among the operation's responses, the preference is ignored and spec order is used. When the response schema is a structured object or array, prefer a JSON media type: pairing a non-JSON preference (for example, `text/plain` or `application/octet-stream`) with a structured schema serves a stringified or empty body instead of the structured mock.
+`preferredContentType` only **selects** a declared media type — it does not convert the payload. If the chosen media type is not among the operation's responses, the preference is ignored and spec order is used. When the response schema is a structured object or array, prefer a JSON media type: pairing a non-JSON preference (for example, `text/plain` or `application/xml`) with a structured schema serves a stringified body instead of the structured mock, and `application/octet-stream` falls back to JSON with the selected media type as the `Content-Type`.
 
 ### Array Item Factories
 

--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -612,6 +612,10 @@ describe('generateMSW', () => {
       expect(result.implementation.handler).not.toContain('new ArrayBuffer(0)');
       // Should use HttpResponse.json since no text-like content type is involved
       expect(result.implementation.handler).toContain('HttpResponse.json');
+      // The selected media type should be preserved on the json fallback header
+      expect(result.implementation.handler).toContain(
+        "headers: { 'Content-Type': 'application/octet-stream' }",
+      );
     });
 
     it('should ignore unmatched preferredContentType and use spec-order content types', () => {

--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -441,6 +441,220 @@ describe('generateMSW', () => {
       expect(result.implementation.handler).toContain('HttpResponse.json');
     });
 
+    it('should not force binary path when preferredContentType is text/plain for object schema', () => {
+      const mixedVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          imports: [],
+          definition: { success: 'Pet' },
+          types: {
+            success: [
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'application/json',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'text/plain',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+            ],
+          },
+          contentTypes: ['application/json', 'text/plain'],
+        },
+      } as unknown as GeneratorVerbOptions;
+
+      const result = generateMSW(mixedVerbOptions, {
+        ...baseOptions,
+        mock: { preferredContentType: 'text/plain' },
+      } as unknown as GeneratorOptions);
+
+      // Should NOT use HttpResponse.arrayBuffer — the schema is an object, not binary
+      expect(result.implementation.handler).not.toContain(
+        'HttpResponse.arrayBuffer',
+      );
+      // Should use the text path with JSON.stringify for the object payload
+      expect(result.implementation.handler).toContain('JSON.stringify');
+      expect(result.implementation.handler).toContain('HttpResponse.text');
+    });
+
+    it('should not force binary path when preferredContentType is application/xml for object schema', () => {
+      const mixedVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          imports: [],
+          definition: { success: 'Pet' },
+          types: {
+            success: [
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'application/json',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'application/xml',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+            ],
+          },
+          contentTypes: ['application/json', 'application/xml'],
+        },
+      } as unknown as GeneratorVerbOptions;
+
+      const result = generateMSW(mixedVerbOptions, {
+        ...baseOptions,
+        mock: { preferredContentType: 'application/xml' },
+      } as unknown as GeneratorOptions);
+
+      // Should NOT use HttpResponse.arrayBuffer — the schema is an object, not binary
+      expect(result.implementation.handler).not.toContain(
+        'HttpResponse.arrayBuffer',
+      );
+      // Should use the xml helper with JSON.stringify
+      expect(result.implementation.handler).toContain('HttpResponse.xml');
+    });
+
+    it('should not discard body when preferredContentType is application/octet-stream for object schema', () => {
+      const mixedVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          imports: [],
+          definition: { success: 'Pet' },
+          types: {
+            success: [
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'application/json',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'application/octet-stream',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+            ],
+          },
+          contentTypes: ['application/json', 'application/octet-stream'],
+        },
+      } as unknown as GeneratorVerbOptions;
+
+      const result = generateMSW(mixedVerbOptions, {
+        ...baseOptions,
+        mock: { preferredContentType: 'application/octet-stream' },
+      } as unknown as GeneratorOptions);
+
+      // Should NOT force binary path — the object schema is not binary (no format: binary)
+      expect(result.implementation.handler).not.toContain(
+        'HttpResponse.arrayBuffer',
+      );
+      expect(result.implementation.handler).not.toContain('new ArrayBuffer(0)');
+      // Should use HttpResponse.json since no text-like content type is involved
+      expect(result.implementation.handler).toContain('HttpResponse.json');
+    });
+
+    it('should ignore unmatched preferredContentType and use spec-order content types', () => {
+      const mixedVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          imports: [],
+          definition: { success: 'Pet' },
+          types: {
+            success: [
+              {
+                key: '200',
+                value: 'Pet',
+                contentType: 'application/json',
+                originalSchema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+                imports: [],
+                schemas: [],
+                type: 'object',
+                isEnum: false,
+                isRef: true,
+                hasReadonlyProps: false,
+              },
+            ],
+          },
+          contentTypes: ['application/json'],
+        },
+      } as unknown as GeneratorVerbOptions;
+
+      const result = generateMSW(mixedVerbOptions, {
+        ...baseOptions,
+        mock: { preferredContentType: 'text/csv' },
+      } as unknown as GeneratorOptions);
+
+      // Unmatched preference should be silently ignored — spec-order (application/json) wins
+      expect(result.implementation.handler).toContain('HttpResponse.json');
+      expect(result.implementation.handler).not.toContain(
+        'HttpResponse.arrayBuffer',
+      );
+    });
+
     it('should type the info parameter in the handler callback', () => {
       const result = generate({
         mock: { type: OutputMockType.MSW, delay: 100 },
@@ -736,13 +950,21 @@ describe('generateMSW', () => {
                 key: '200',
                 value: 'Blob',
                 contentType: 'application/octet-stream',
+                originalSchema: { type: 'string', format: 'binary' },
+                imports: [],
               },
-              { key: '200', value: 'Blob', contentType: 'image/png' },
+              {
+                key: '200',
+                value: 'Blob',
+                contentType: 'image/png',
+                originalSchema: { type: 'string', format: 'binary' },
+                imports: [],
+              },
             ],
           },
           contentTypes: ['application/octet-stream', 'image/png'],
         },
-      } as GeneratorVerbOptions;
+      } as unknown as GeneratorVerbOptions;
 
       const result = generateMSW(blobVerbOptions, {
         ...baseOptions,

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -351,7 +351,12 @@ function generateDefinition(
   const jsonCtHeaderSuffix =
     firstJsonCt && firstJsonCt !== 'application/json'
       ? `, headers: { 'Content-Type': '${firstJsonCt}' }`
-      : '';
+      : // When preferredContentType matched a non-JSON type (e.g. application/octet-stream)
+        // and the structured schema falls through to HttpResponse.json(), emit the
+        // selected media type as the Content-Type so the contract survives.
+        preferredContentTypeMatch && !preferredContentTypeMatch.includes('json')
+        ? `, headers: { 'Content-Type': '${preferredContentTypeMatch}' }`
+        : '';
   const textCtHeaderSuffix =
     firstTextCt && firstTextCt !== textHelperDefaultContentType
       ? `, headers: { 'Content-Type': '${firstTextCt}' }`

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -166,9 +166,16 @@ function generateDefinition(
     r.originalSchema?.format === 'binary' ||
     (r.originalSchema?.contentMediaType === 'application/octet-stream' &&
       !r.originalSchema.contentEncoding);
-  const isBinaryResponse =
-    contentTypesByPreference.some((ct) => isBinaryLikeContentType(ct)) ||
-    responsesByPreference.some((r) => isSchemaBinary(r));
+  // When preferredContentType matched, only use schema-binary metadata to decide
+  // the binary path — don't let the content-type name alone force it (issue #2962).
+  // A structured schema (e.g. Pet) paired with application/octet-stream via
+  // preference should not discard the body as new ArrayBuffer(0).
+  // When no preference matched, keep the content-type heuristic so binary-like
+  // types with no schema metadata still get the correct helper.
+  const isBinaryResponse = preferredContentTypeMatch
+    ? responsesByPreference.some((r) => isSchemaBinary(r))
+    : contentTypesByPreference.some((ct) => isBinaryLikeContentType(ct)) ||
+      responsesByPreference.some((r) => isSchemaBinary(r));
   // Bare ref names of schema-binary responses (include alias for collision-renamed imports).
   const binaryRefNames = responsesByPreference
     .filter((r) => isSchemaBinary(r))


### PR DESCRIPTION
Fixes #2962.

## What

`preferredContentType` narrowed the response selection to one media type, but `isBinaryResponse` still keyed off the content-type name alone, so a preference like `application/octet-stream` forced `HttpResponse.arrayBuffer()` even when the selected response schema was a structured object/array. The handler then discarded the mock body, sending an empty body while the signature still said `Pet`.

## Change

When `preferredContentType` matched a declared response, the binary path is now decided only from schema-binary metadata (`format: binary` / `contentMediaType: octet-stream` with no `contentEncoding`) on the matched responses. The content-type heuristic remains for the no-preference (spec order) path so binary-like types without schema metadata still work.

Also documents the selection-only semantics, the ignored-when-unmatched rule, and the structured-payload caveat in the MSW guide.

## Tests

- object schema + `text/plain` preference: text helper, no arrayBuffer
- object schema + `application/xml` preference: xml helper, no arrayBuffer
- object schema + `application/octet-stream` preference: json helper, no body discard
- unmatched preference (`text/csv`): ignored, spec order wins
- existing `preferredContentType: image/png` binary-header test updated with real schema metadata (`format: binary` + `imports`), still passes

@orval/mock: 348/348 pass, typecheck clean. No sample configs use `preferredContentType`, so no snapshot churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `preferredContentType` handling for mocked responses.
  * Declared media types are selected when they match the preference; unmatched preferences now fall back to the specification’s content-type order.
  * Non-JSON preferences with structured schemas produce appropriate string or empty response bodies.
  * Binary responses are generated only when the response schema indicates binary data.

* **Documentation**
  * Added guidance explaining content-type selection and response formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->