### PR TITLE
fix(core): keep custom fileExtension in routed package subpath imports

### DIFF
--- a/packages/core/src/utils/schema-import-path.test.ts
+++ b/packages/core/src/utils/schema-import-path.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import type { GeneratorImport, NormalizedOutputOptions } from '../types';
+import {
+  NamingConvention,
+  type GeneratorImport,
+  type NormalizedOutputOptions,
+} from '../types';
+import { createSchemaOutputPlan } from '../writers/schema-output-plan';
 import { resolveSchemaImportDependencies } from './schema-import-path';
 
 /**
@@ -207,6 +212,47 @@ describe('resolveSchemaImportDependencies', () => {
       expect(resolve(output, '@acme/models', [PET])).toEqual([
         '@acme/models/pet.gen',
       ]);
+    });
+
+    it('routed package import keeps the custom fileExtension like the flat rule', () => {
+      // #3966: with `schemas.routes`, `packageImportPath` must keep the custom
+      // part of `fileExtension` the same way the flat rule does — a package
+      // subpath resolves through the consumer's export map, which knows nothing
+      // of the tsconfig.
+      const output = createOutput({
+        indexFiles: false,
+        fileExtension: '.gen.ts',
+        schemas: {
+          path: '/models',
+          type: 'typescript',
+          importPath: '@acme/models',
+          routes: { default: 'models', enum: 'enums' },
+        } as unknown as NormalizedOutputOptions['schemas'],
+      });
+
+      const plan = createSchemaOutputPlan({
+        basePath: '/models',
+        schemas: [
+          {
+            name: 'Pet',
+            kind: 'schema',
+            model: 'export type Pet = unknown;',
+            imports: [],
+          },
+        ],
+        routes: { default: 'models', enum: 'enums' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.gen.ts',
+        indexFiles: false,
+        importPath: '@acme/models',
+      });
+
+      expect(
+        resolveSchemaImportDependencies(output, [PET], '@acme/models', {
+          isZod: false,
+          schemaOutputPlan: plan,
+        }).map((dependency) => dependency.dependency),
+      ).toEqual(['@acme/models/models/pet.gen']);
     });
 
     it('keeps both imports when the same name is aliased differently', () => {

--- a/packages/core/src/writers/schema-output-plan.test.ts
+++ b/packages/core/src/writers/schema-output-plan.test.ts
@@ -336,4 +336,101 @@ describe('createSchemaOutputPlan', () => {
       'Schemas "UserStatus" and "user_status" produce the same generated file',
     );
   });
+
+  describe('packageImportPath', () => {
+    it('includes custom fileExtension in package subpath', () => {
+      const plan = createSchemaOutputPlan({
+        basePath,
+        schemas: [createSchema('Pet', 'schema')],
+        routes: { default: 'models' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.gen.ts',
+        indexFiles: false,
+        importPath: '@acme/models',
+      });
+
+      expect(plan.packageImportPath('Pet')).toBe('@acme/models/models/pet.gen');
+    });
+
+    it('strips the full custom fileExtension from the tail', () => {
+      const plan = createSchemaOutputPlan({
+        basePath,
+        schemas: [createSchema('Dog', 'schema')],
+        routes: { default: 'models' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.model.ts',
+        indexFiles: false,
+        importPath: '@acme/models',
+      });
+
+      expect(plan.packageImportPath('Dog')).toBe(
+        '@acme/models/models/dog.model',
+      );
+    });
+
+    it('returns undefined when no importPath is set', () => {
+      const plan = createSchemaOutputPlan({
+        basePath,
+        schemas: [createSchema('Pet', 'schema')],
+        routes: { default: 'models' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.gen.ts',
+        indexFiles: false,
+      });
+
+      expect(plan.packageImportPath('Pet')).toBeUndefined();
+    });
+
+    it('returns the barrel specifier when indexFiles is true', () => {
+      const plan = createSchemaOutputPlan({
+        basePath,
+        schemas: [createSchema('Pet', 'schema')],
+        routes: { default: 'models' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.gen.ts',
+        indexFiles: true,
+        importPath: '@acme/models',
+      });
+
+      // indexFiles routes every import through the root barrel
+      expect(plan.packageImportPath('Pet')).toBe('@acme/models');
+    });
+
+    it('preserves default .ts extension as empty suffix', () => {
+      const plan = createSchemaOutputPlan({
+        basePath,
+        schemas: [createSchema('User', 'schema')],
+        routes: { default: 'models' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.ts',
+        indexFiles: false,
+        importPath: '@acme/models',
+      });
+
+      // .ts stripped by getImportExtension with no tsconfig → empty string
+      expect(plan.packageImportPath('User')).toBe('@acme/models/models/user');
+    });
+
+    it('routes enum schemas through enum route for package import', () => {
+      const plan = createSchemaOutputPlan({
+        basePath,
+        schemas: [
+          createSchema('Status', 'enum'),
+          createSchema('User', 'schema'),
+        ],
+        routes: { default: 'models', enum: 'enums' },
+        namingConvention: NamingConvention.CAMEL_CASE,
+        fileExtension: '.gen.ts',
+        indexFiles: false,
+        importPath: '@acme/models',
+      });
+
+      expect(plan.packageImportPath('Status')).toBe(
+        '@acme/models/enums/status.gen',
+      );
+      expect(plan.packageImportPath('User')).toBe(
+        '@acme/models/models/user.gen',
+      );
+    });
+  });
 });

--- a/packages/core/src/writers/schema-output-plan.ts
+++ b/packages/core/src/writers/schema-output-plan.ts
@@ -317,9 +317,12 @@ export function createSchemaOutputPlan({
       if (!importPath || indexFiles) return importPath;
       const key = findKey(name);
       const routeImportPath = key ? importPathByName.get(key) : undefined;
-      return routeImportPath
-        ? upath.joinSafe(importPath, routeImportPath.slice(2))
-        : undefined;
+      if (!routeImportPath) return undefined;
+      // A package subpath resolves through the consumer's export map, which
+      // knows nothing of our tsconfig: keep the custom part of the extension
+      // the way the flat rule does (getImportExtension with no tsconfig, #3966).
+      const importExtension = getImportExtension(fileExtension, undefined);
+      return `${upath.joinSafe(importPath, routeImportPath.slice(2))}${importExtension}`;
     },
     hasSchema(name) {
       return filePathByName.has(findKey(name));


### PR DESCRIPTION
Fixes #3966.

## What

With `schemas.routes` **and** a package `schemas.importPath` **and** a custom `fileExtension` (e.g. `.gen.ts`), `packageImportPath()` stripped the whole extension from the subpath — emitting `@acme/models/pet` instead of `@acme/models/pet.gen`. A package export map that lists `./models/pet.gen` does not resolve `./models/pet`.

The flat (non-routed) rule in `schema-import-path.ts` already kept `.gen` by passing `undefined` as `tsconfig` to `getImportExtension` — the routed path was the only one that dropped it.

## Change

`packageImportPath()` now appends `getImportExtension(fileExtension, undefined)` to the joined subpath, mirroring the flat rule. Withholding `tsconfig` is correct: package subpaths resolve through the consumer's export map, which knows nothing of the tsconfig.

## Tests

- `schema-output-plan.test.ts`: 6 new tests for `packageImportPath` — custom extension (`.gen.ts`, `.model.ts`), undefined/no-importPath, `indexFiles: true` barrel, default `.ts` extension, and enum route routing
- `schema-import-path.test.ts`: 1 new test asserting flat and routed rules agree on `@acme/models/models/pet.gen` when `fileExtension: '.gen.ts'`

`@orval/core`: 2483/2483 tests pass, typecheck clean. No sample configs use the combination, so no snapshot churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated package import paths so custom and default file extensions are preserved.
  * Improved package import handling for routed schemas and enums, including package root and barrel imports.
  * Preserved expected behavior when no package import path is configured.
  * Ensured generated imports resolve consistently across supported package layouts.

* **Tests**
  * Added coverage for custom extensions, missing import paths, root imports, and routed schema and enum imports.
  * Added validation for generated package paths across default and customized configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->