### PR TITLE
fix(angular): add zodBaseName to httpResource alias imports for correct routing

### DIFF
--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -3756,6 +3756,50 @@ describe('angular httpResource generator', () => {
       );
       expect(petValueBlocks.length).toBeGreaterThan(0);
     });
+
+    it('resolves the Output alias through the base schema file, not a missing *-output module', async () => {
+      // #3968: with indexFiles false and a zod schemas output, the `PetOutput`
+      // alias must import from `pet.zod` (where the alias is declared), not
+      // `pet-output.zod` (a file nobody emits). The import needs `zodBaseName`
+      // so `resolveSchemaImportDependencies` routes it by the base schema.
+      const verb = createVerbOption({
+        response: baseResponse({
+          imports: [{ name: 'Pet' }],
+          definition: { success: 'Pet', errors: 'Error' },
+        }),
+      });
+
+      const output = createOutput({
+        target: '/tmp/pets.ts',
+        schemas: {
+          type: 'zod',
+          path: '/tmp/model',
+        } as NormalizedOutputOptions['schemas'],
+        schemaFileExtension: '.zod.ts',
+        indexFiles: false,
+      });
+
+      const context = createContextSpec(output, {
+        workspace: '/tmp',
+        target: '/tmp/pets.ts',
+        projectName: 'pets',
+      });
+
+      const extraFiles = await generateHttpResourceExtraFiles(
+        { getPetById: verb },
+        output,
+        context,
+      );
+
+      const content = extraFiles[0]?.content ?? '';
+
+      // The alias resolves through the base schema file.
+      expect(content).toMatch(
+        /import\s+type\s+\{[^}]*PetOutput[^}]*\}\s+from\s+'[^']*\/pet\.zod'/,
+      );
+      // Not through a missing `pet-output.zod` module.
+      expect(content).not.toMatch(/pet-output\.zod/);
+    });
   });
 
   // ── urlEncodeParameters ─────────────────────────────────────────────

--- a/packages/angular/src/http-resource.ts
+++ b/packages/angular/src/http-resource.ts
@@ -721,7 +721,10 @@ const getHttpResourceVerbImports = (
     ),
     ...parsedZodImports
       .filter((imp) => !isPrimitiveType(imp.name))
-      .map((imp) => ({ name: getSchemaOutputTypeRef(imp.name) })),
+      .map((imp) => ({
+        name: getSchemaOutputTypeRef(imp.name),
+        zodBaseName: imp.name,
+      })),
     ...body.imports,
     ...props.flatMap((prop) =>
       prop.type === GetterPropType.NAMED_PATH_PARAMS


### PR DESCRIPTION
Fixes #3968.

## What

Angular `httpResource` output with a Zod schema output (`schemas.type: 'zod'`) and `indexFiles: false` imported the `<Schema>Output` alias without `zodBaseName`. The per-file resolver then mapped `PetOutput` to `pet-output.zod` (a file nobody emits) instead of `pet.zod` where the alias is declared, so the generated resource file failed to compile with a missing module.

## Change

`getHttpResourceVerbImports` now sets `zodBaseName: imp.name` on the parsed-Zod alias imports, mirroring the plain-client fix in #3927 (`rewriteImportsForResponseValidation`). `resolveSchemaImportDependencies` routes by `zodBaseName ?? name`, so `PetOutput` now resolves to `pet.zod`.

## Tests

New test in `http-resource.test.ts` (`zod output-type-ref imports` block): with `indexFiles: false` and a zod schemas output, asserts `PetOutput` imports from `pet.zod` and never from `pet-output.zod`.

`@orval/angular`: 301/301 pass, typecheck clean. No sample config combines httpResource + zod + `indexFiles: false`, so no snapshot churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated Angular HTTP resource imports for Zod output types when schema index files are disabled.
  - Output type aliases now resolve from the base schema file instead of referencing a non-existent output module.

- **Tests**
  - Added coverage to verify correct Zod schema import resolution in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->