### PR TITLE
fix(core): pass schemaOutputPlan to mock imports so schemas.routes are respected

### DIFF
--- a/packages/core/src/writers/single-mode.test.ts
+++ b/packages/core/src/writers/single-mode.test.ts
@@ -24,6 +24,7 @@ import {
   OutputMode,
 } from '../types';
 import { writeSingleMode } from './single-mode';
+import { createSchemaOutputPlanForOutput } from './schema-output-plan';
 
 describe('writeSingleMode — separated mocks import inline schemas from the target file', () => {
   let tmpDir: string;
@@ -94,6 +95,84 @@ describe('writeSingleMode — separated mocks import inline schemas from the tar
       ]),
     );
   });
+
+  it('routes mock schema imports through schemaOutputPlan (#3967)', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const importsMockCalls: Array<{ imports: readonly GeneratorDependency[] }> =
+      [];
+    const baseProps = createSplitModeProps(target);
+    const props = {
+      ...baseProps,
+      builder: {
+        ...baseProps.builder,
+        schemas: [petSchema, petTypeSchema],
+        operations: {
+          listPets: createSplitModeOperation({
+            mockOutputs: [
+              {
+                type: OutputMockType.MSW,
+                implementation: {
+                  function: '',
+                  handler: '',
+                  handlerName: 'mockHandler',
+                },
+                imports: [{ name: 'Pet' }, { name: 'PetType' }],
+              },
+            ],
+          }),
+        },
+        importsMock: (args: { imports: readonly GeneratorDependency[] }) => {
+          importsMockCalls.push(args);
+          return '';
+        },
+      },
+      output: createSplitModeOutput(target, {
+        mode: OutputMode.SINGLE,
+        indexFiles: false,
+        schemas: {
+          path: path.join(tmpDir, 'model'),
+          type: 'typescript',
+          splitByTags: false,
+          routes: { default: 'models', enum: 'enums' },
+        },
+        mock: {
+          indexMockFiles: false,
+          inline: false,
+          path: path.join(tmpDir, 'mocks'),
+          generators: [{ type: OutputMockType.MSW }],
+        },
+      }),
+    };
+
+    await writeSingleMode({
+      ...props,
+      needSchema: true,
+      schemaTagMap: undefined,
+      schemaOutputPlan: createSchemaOutputPlanForOutput(
+        [petSchema, petTypeSchema],
+        props.output,
+        undefined,
+      ),
+    });
+
+    // The mock file's Pet import must use the routed subpath (`models/pet`),
+    // same as the client file — not the flat `../model/pet`. PetType is an
+    // enum schema, so it must route through the `enums` route dir instead.
+    const petImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'Pet'));
+    expect(petImports.length).toBeGreaterThan(0);
+    for (const dep of petImports) {
+      expect(dep.dependency).toContain('models/pet');
+    }
+    const petTypeImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'PetType'));
+    expect(petTypeImports.length).toBeGreaterThan(0);
+    for (const dep of petTypeImports) {
+      expect(dep.dependency).toContain('enums/petType');
+    }
+  });
 });
 
 // Regression coverage for https://github.com/orval-labs/orval/issues/3627
@@ -103,6 +182,13 @@ describe('writeSingleMode — separated mocks import inline schemas from the tar
 // split-mode, tags-mode, and split-tags-mode all recover these by scanning
 // the finalized mock implementation. single-mode was the only writer missing
 // this recovery — both the inline branch and the de-inlined branch.
+
+const petTypeSchema: GeneratorSchema = {
+  name: 'PetType',
+  model: "export type PetType = 'dog' | 'cat' | 'bird';",
+  imports: [],
+  schema: { type: 'string', enum: ['dog', 'cat', 'bird'] },
+};
 
 const petSchema: GeneratorSchema = {
   name: 'Pet',

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -220,6 +220,7 @@ export async function writeSingleMode({
               filteredMockImports,
               relativeSchemasPath,
               schemaTagMap,
+              schemaOutputPlan,
             )
           : generateImportsForBuilder(
               output,
@@ -369,6 +370,7 @@ export async function writeSingleMode({
                 ),
                 mockRelativeSchemasPath,
                 schemaTagMap,
+                schemaOutputPlan,
               )
             : generateImportsForBuilder(
                 output,

--- a/packages/core/src/writers/split-mode.test.ts
+++ b/packages/core/src/writers/split-mode.test.ts
@@ -17,6 +17,7 @@ import {
   OutputMode,
 } from '../types';
 import { writeSplitMode } from './split-mode';
+import { createSchemaOutputPlanForOutput } from './schema-output-plan';
 
 // Regression coverage for https://github.com/orval-labs/orval/issues/2309
 //
@@ -509,5 +510,105 @@ describe('writeSplitMode — schemas import extension follows tsconfig module', 
 
     expect(mockContent).toContain("from './petstore.schemas'");
     expect(mockContent).not.toContain("from '..");
+  });
+});
+
+describe('writeSplitMode — routes mock schema imports through schemaOutputPlan (#3967)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orval-split-mode-'));
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpDir);
+  });
+
+  it('mock file schema imports match the routed client imports', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const importsMockCalls: Array<{ imports: readonly GeneratorDependency[] }> =
+      [];
+    const builder = createSplitModeBuilder(target);
+    builder.schemas = [
+      {
+        name: 'Pet',
+        model: 'export type Pet = { id: number };',
+        imports: [],
+        schema: { type: 'object', properties: { id: { type: 'integer' } } },
+      },
+      {
+        name: 'PetType',
+        model: "export type PetType = 'dog' | 'cat' | 'bird';",
+        imports: [],
+        schema: { type: 'string', enum: ['dog', 'cat', 'bird'] },
+      },
+    ];
+    builder.operations = {
+      listPets: createSplitModeOperation({
+        mockOutputs: [
+          {
+            type: OutputMockType.MSW,
+            implementation: {
+              function: '',
+              handler: '',
+              handlerName: 'mockHandler',
+            },
+            imports: [{ name: 'Pet' }, { name: 'PetType' }],
+          },
+        ],
+      }),
+    };
+    builder.importsMock = (args: {
+      imports: readonly GeneratorDependency[];
+    }) => {
+      importsMockCalls.push(args);
+      return '';
+    };
+
+    const output = createSplitModeOutput(target, {
+      mode: OutputMode.SPLIT,
+      indexFiles: false,
+      schemas: {
+        path: path.join(tmpDir, 'model'),
+        type: 'typescript',
+        splitByTags: false,
+        routes: { default: 'models', enum: 'enums' },
+      },
+      mock: {
+        indexMockFiles: false,
+        inline: false,
+        generators: [{ type: OutputMockType.MSW }],
+      },
+    });
+    const props = {
+      ...createSplitModeProps(target),
+      builder,
+      output,
+    };
+
+    await writeSplitMode({
+      ...props,
+      needSchema: true,
+      schemaOutputPlan: createSchemaOutputPlanForOutput(
+        builder.schemas,
+        output,
+        undefined,
+      ),
+    });
+
+    const petImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'Pet'));
+    expect(petImports.length).toBeGreaterThan(0);
+    for (const dep of petImports) {
+      expect(dep.dependency).toContain('models/pet');
+    }
+    const petTypeImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'PetType'));
+    expect(petTypeImports.length).toBeGreaterThan(0);
+    for (const dep of petTypeImports) {
+      expect(dep.dependency).toContain('enums/petType');
+    }
   });
 });

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -322,6 +322,7 @@ export async function writeSplitMode({
         ),
         mockRelativeSchemasPath,
         schemaTagMap,
+        schemaOutputPlan,
       );
       let mockData = header;
       mockData += builder.importsMock({

--- a/packages/core/src/writers/split-tags-mode.test.ts
+++ b/packages/core/src/writers/split-tags-mode.test.ts
@@ -20,10 +20,12 @@ import {
 import {
   OutputClient,
   type GeneratorDependency,
+  type GeneratorSchema,
   OutputMockType,
   OutputMode,
 } from '../types';
 import { writeSplitTagsMode } from './split-tags-mode';
+import { createSchemaOutputPlanForOutput } from './schema-output-plan';
 
 // Regression coverage for https://github.com/orval-labs/orval/issues/2309
 //
@@ -744,5 +746,107 @@ describe('writeSplitTagsMode — client extra files in the barrel', () => {
     const barrel = readBarrel().join('\n');
     expect(barrel).not.toContain('server');
     expect(barrel).toContain("export * from './pets/pets.resource';");
+  });
+});
+
+describe('writeSplitTagsMode — routes mock schema imports through schemaOutputPlan (#3967)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orval-split-tags-'));
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpDir);
+  });
+
+  it('mock file schema imports match the routed client imports', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const importsMockCalls: Array<{ imports: readonly GeneratorDependency[] }> =
+      [];
+    const petSchemaLocal: GeneratorSchema = {
+      name: 'Pet',
+      model: 'export type Pet = { id: number };',
+      imports: [],
+      schema: { type: 'object', properties: { id: { type: 'integer' } } },
+    };
+    const petTypeSchemaLocal: GeneratorSchema = {
+      name: 'PetType',
+      model: "export type PetType = 'dog' | 'cat' | 'bird';",
+      imports: [],
+      schema: { type: 'string', enum: ['dog', 'cat', 'bird'] },
+    };
+
+    const builder = createSplitModeBuilder(target);
+    builder.schemas = [petSchemaLocal, petTypeSchemaLocal];
+    builder.operations = {
+      listPets: createSplitModeOperation({
+        tags: ['pets'],
+        operationName: 'listPets',
+        mockOutputs: [
+          {
+            type: OutputMockType.MSW,
+            implementation: {
+              function: '',
+              handler: '',
+              handlerName: 'mockHandler',
+            },
+            imports: [{ name: 'Pet' }, { name: 'PetType' }],
+          },
+        ],
+      }),
+    };
+    builder.importsMock = (args: {
+      imports: readonly GeneratorDependency[];
+    }) => {
+      importsMockCalls.push(args);
+      return '';
+    };
+
+    const output = createSplitModeOutput(target, {
+      mode: OutputMode.TAGS_SPLIT,
+      indexFiles: false,
+      schemas: {
+        path: path.join(tmpDir, 'model'),
+        type: 'typescript',
+        splitByTags: false,
+        routes: { default: 'models', enum: 'enums' },
+      },
+      mock: {
+        indexMockFiles: false,
+        inline: false,
+        generators: [{ type: OutputMockType.MSW }],
+      },
+    });
+    const props = {
+      ...createSplitModeProps(target),
+      builder,
+      output,
+    };
+
+    await writeSplitTagsMode({
+      ...props,
+      needSchema: true,
+      schemaOutputPlan: createSchemaOutputPlanForOutput(
+        [petSchemaLocal, petTypeSchemaLocal],
+        output,
+        undefined,
+      ),
+    });
+
+    const petImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'Pet'));
+    expect(petImports.length).toBeGreaterThan(0);
+    for (const dep of petImports) {
+      expect(dep.dependency).toContain('models/pet');
+    }
+    const petTypeImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'PetType'));
+    expect(petTypeImports.length).toBeGreaterThan(0);
+    for (const dep of petTypeImports) {
+      expect(dep.dependency).toContain('enums/petType');
+    }
   });
 });

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -421,6 +421,7 @@ export async function writeSplitTagsMode({
             ),
             mockRelativeSchemasPath,
             schemaTagMap,
+            schemaOutputPlan,
           );
 
           let mockData = header;

--- a/packages/core/src/writers/tags-mode.test.ts
+++ b/packages/core/src/writers/tags-mode.test.ts
@@ -16,8 +16,14 @@ import {
   createSplitModeOutput,
   createSplitModeProps,
 } from '../test-utils/split-modes';
-import { type GeneratorDependency, OutputMockType, OutputMode } from '../types';
+import {
+  type GeneratorDependency,
+  type GeneratorSchema,
+  OutputMockType,
+  OutputMode,
+} from '../types';
 import { writeTagsMode } from './tags-mode';
+import { createSchemaOutputPlanForOutput } from './schema-output-plan';
 
 // Regression: the index mock barrel must emit tags in locale-sorted order
 // regardless of I/O completion order inside Promise.all. Without an
@@ -268,6 +274,96 @@ describe('writeTagsMode — index mock barrel re-exports get<PascalledTag>Mock',
     expect(content).toMatch(
       /export \{ getPetsMock \} from '\.\/pets\/pets\.msw'/,
     );
+  });
+
+  it('routes mock schema imports through schemaOutputPlan (#3967)', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const mockDir = path.join(tmpDir, 'mocks');
+    const importsMockCalls: Array<{ imports: readonly GeneratorDependency[] }> =
+      [];
+    const baseProps = createSplitModeProps(target);
+    const petSchemaLocal: GeneratorSchema = {
+      name: 'Pet',
+      model: 'export type Pet = { id: number };',
+      imports: [],
+      schema: { type: 'object', properties: { id: { type: 'integer' } } },
+    };
+    const petTypeSchemaLocal: GeneratorSchema = {
+      name: 'PetType',
+      model: "export type PetType = 'dog' | 'cat' | 'bird';",
+      imports: [],
+      schema: { type: 'string', enum: ['dog', 'cat', 'bird'] },
+    };
+
+    const props = {
+      ...baseProps,
+      builder: {
+        ...baseProps.builder,
+        schemas: [petSchemaLocal, petTypeSchemaLocal],
+        operations: {
+          listPets: createSplitModeOperation({
+            tags: ['pets'],
+            operationName: 'listPets',
+            mockOutputs: [
+              {
+                type: OutputMockType.MSW,
+                implementation: {
+                  function: '',
+                  handler: '',
+                  handlerName: 'mockHandler',
+                },
+                imports: [{ name: 'Pet' }, { name: 'PetType' }],
+              },
+            ],
+          }),
+        },
+        importsMock: (args: { imports: readonly GeneratorDependency[] }) => {
+          importsMockCalls.push(args);
+          return '';
+        },
+      },
+      output: createSplitModeOutput(target, {
+        mode: OutputMode.TAGS,
+        indexFiles: false,
+        schemas: {
+          path: path.join(tmpDir, 'model'),
+          type: 'typescript',
+          splitByTags: false,
+          routes: { default: 'models', enum: 'enums' },
+        },
+        mock: {
+          indexMockFiles: false,
+          inline: false,
+          path: mockDir,
+          generators: [{ type: OutputMockType.MSW }],
+        },
+      }),
+    };
+
+    await writeTagsMode({
+      ...props,
+      needSchema: true,
+      schemaOutputPlan: createSchemaOutputPlanForOutput(
+        [petSchemaLocal, petTypeSchemaLocal],
+        props.output,
+        undefined,
+      ),
+    });
+
+    const petImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'Pet'));
+    expect(petImports.length).toBeGreaterThan(0);
+    for (const dep of petImports) {
+      expect(dep.dependency).toContain('models/pet');
+    }
+    const petTypeImports = importsMockCalls
+      .flatMap((call) => call.imports)
+      .filter((dep) => dep.exports.some((entry) => entry.name === 'PetType'));
+    expect(petTypeImports.length).toBeGreaterThan(0);
+    for (const dep of petTypeImports) {
+      expect(dep.dependency).toContain('enums/petType');
+    }
   });
 });
 

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -206,6 +206,7 @@ export async function writeTagsMode({
               ),
               schemasPathRelative,
               schemaTagMap,
+              schemaOutputPlan,
             );
 
             data += builder.importsMock({
@@ -364,6 +365,7 @@ export async function writeTagsMode({
               ),
               mockRelativeSchemasPath,
               schemaTagMap,
+              schemaOutputPlan,
             );
 
             let mockData = header;


### PR DESCRIPTION
Fixes #3967.

## What

With `schemas.routes` (#3942) and `indexFiles: false`, client files import routed schemas through `schemaOutputPlan.clientImportPath`, but mock files did not — every writer passed the plan to the client `generateImportsForBuilder` call and omitted it from the mock call. A mock file could then import `../model/pet` while the schema writer emitted `../model/models/pet`, producing an unresolvable module.

## Change

Pass `schemaOutputPlan` at the five mock `generateImportsForBuilder` call sites that were missing it:

- `single-mode.ts` (de-inlined mock branch)
- `tags-mode.ts` (inline mock branch + de-inlined mock branch)
- `split-mode.ts` (mock branch)
- `split-tags-mode.ts` (mock branch)

The argument already existed and was forwarded into `resolveSchemaImportDependencies`, which prefers the plan's routed path whenever `hasSchema(name)` is true. No signature changes.

## Tests

One regression test per writer with distinct `default`/`enum` routes and `indexFiles: false`, asserting the mock file's `Pet` import uses the routed subpath (`models/pet`) exactly as the client file does.

`@orval/core`: 2480/2480 pass, typecheck clean. No sample config combines `schemas.routes` with `mock: true`, so no snapshot churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated mock files so schema imports consistently follow configured schema routes across supported output modes.
  - Ensured model and enum schemas use their configured paths, such as `models/pet` and `enums/petType`.
  - Prevented mock imports from falling back to automatically derived paths when custom routes are configured.

- **Tests**
  - Added regression coverage for routed schema imports across single, split, split-tags, and tags output modes.
  - Verified behavior for both standard model and enum schema imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->