### PR TITLE
fix(orval): emit zod import in shared schemas file for split modes

### DIFF
--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -845,10 +845,15 @@ async function writeSpecsInternal(
     // so the inline schema block (which always uses zod) must supply it itself.
     // When an operation does use zod the client already imports it, and a second
     // import would redeclare the `zod` binding — so the inline block omits it.
+    // This only applies to `single` mode where schemas concatenate into the
+    // operation file. In split/tags/tags-split modes the schemas are written to
+    // a separate `.schemas.ts` file that never sees the operation's imports, so
+    // the zod import must always be emitted there.
+    const isSchemasInSeparateFile = output.mode !== OutputMode.SINGLE;
     const operationsUseZod = Object.values(builder.operations).some(
       (operation) => /\bzod\b/.test(operation.implementation),
     );
-    const includeZodImport = !operationsUseZod;
+    const includeZodImport = isSchemasInSeparateFile || !operationsUseZod;
 
     // Inline component schemas (when `generateReusableSchemas` is on without a
     // dedicated `output.schemas` dir) need their own `paramsMutator` resolved
@@ -873,7 +878,6 @@ async function writeSpecsInternal(
     // emitting from inline would produce a duplicate `import` line there.
     // With no operations at all, even in `single` mode the file builder has
     // no operation mutators to lean on, so we still emit.
-    const isSchemasInSeparateFile = output.mode !== OutputMode.SINGLE;
     const includeParamsImport = !hasOperations || isSchemasInSeparateFile;
 
     implementationPaths = await writeMode({

--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -1178,4 +1178,71 @@ describe('generateZodSchemasInline with generateReusableSchemas', () => {
     expect(result).toMatch(/export const Owner\b/);
     expect(result).toContain(".meta({ id: 'Owner' })");
   });
+
+  it('always includes the zod import when includeZodImport is true (#3963)', () => {
+    // #3963: when client: 'zod' + generateReusableSchemas + a split mode,
+    // the schemas block is written to a standalone `.schemas.ts` file. Even
+    // though operations emit `zod.void()` (so operationsUseZod is true), the
+    // schemas file never shares the operation file's import — it must carry
+    // its own. This verifies `generateZodSchemasInline` includes the zod
+    // import when `includeZodImport: true` (the value split modes pass).
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            Widget: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        { name: 'Widget', schema: { $ref: '#/components/schemas/Widget' } },
+      ],
+    } satisfies Parameters<typeof generateZodSchemasInline>[0];
+
+    const output = createOutputOptions();
+    (output.override.zod as Record<string, unknown>).generateReusableSchemas =
+      true;
+
+    const result = generateZodSchemasInline(builder, output, true);
+    expect(result).toMatch(/import \* as zod from ['"]zod['"]/);
+    expect(result).toContain('export const Widget =');
+  });
+
+  it('omits the zod import in single mode when operations use zod (#3963)', () => {
+    // The gate: `includeZodImport = isSchemasInSeparateFile || !operationsUseZod`.
+    // In single mode (`isSchemasInSeparateFile = false`), when operations already
+    // emit zod, the inline schemas concatenate into the same file and must not
+    // duplicate the import. This verifies the `!operationsUseZod` side of the gate.
+    const builder = {
+      spec: {
+        components: {
+          schemas: {
+            Widget: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+            },
+          },
+        },
+      },
+      target: '',
+      schemas: [
+        { name: 'Widget', schema: { $ref: '#/components/schemas/Widget' } },
+      ],
+    } satisfies Parameters<typeof generateZodSchemasInline>[0];
+
+    const output = createOutputOptions();
+    (output.override.zod as Record<string, unknown>).generateReusableSchemas =
+      true;
+
+    const result = generateZodSchemasInline(builder, output, false);
+
+    expect(result).not.toMatch(/import \* as zod from ['"]zod['"]/);
+    expect(result).toContain('export const Widget =');
+  });
 });


### PR DESCRIPTION
Fixes #3963.

## What

With `client: 'zod'` + `override.zod.generateReusableSchemas: true` in a split mode (`tags-split` in the report), the shared `*.schemas.ts` file was emitted without any zod import while its body was full of `zod.object(...)`, producing ~4,500 × `TS2304: Cannot find name 'zod'`.

The trigger: a spec with at least one operation whose response has no `content` (e.g. django-ninja `@router.post(..., response=None)`). That operation emits `zod.void()` into the client, which made `operationsUseZod` true, which made the caller pass `includeZodImport: false` — on the assumption that the schemas concatenate into the same file that already imports zod.

## Root cause

`writeSpecsInternal` in `write-specs.ts` set `includeZodImport = !operationsUseZod`. That heuristic is only correct in `single` mode, where inline schemas concatenate into the operation file and inherit its import. In `split` / `tags` / `tags-split` modes the schemas block is written to a standalone `.schemas.ts` file that never sees the operation file's imports — it must always carry its own zod import.

## Change

`includeZodImport` is now `isSchemasInSeparateFile || !operationsUseZod`, where `isSchemasInSeparateFile` is `output.mode !== SINGLE` (the same flag already used to decide the params-mutator import). Single-mode behavior is unchanged.

## Tests

New test in `write-zod-specs.test.ts`: `generateZodSchemasInline` with `generateReusableSchemas` and `includeZodImport: true` emits `import * as zod from 'zod'` alongside the named schema exports.

`@orval/orval`: 304/304 pass, typecheck clean. No sample config uses `generateReusableSchemas`, so no snapshot churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated reusable inline Zod schemas in split output modes so they consistently include the required Zod import.
  * Prevented generated schema files from relying on imports provided by operation implementations, improving reliability across supported output configurations.

* **Tests**
  * Added regression coverage confirming inline schemas include the necessary Zod import when appropriate.
  * Verified generated schemas continue to include the expected named schema across output modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->