### PR TITLE
docs(core): per-generator mock path no longer forces separate files

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -589,9 +589,9 @@ export interface MswMockOptions extends CommonMockOptions {
   // Execute the `delay` function at runtime rather than build time
   delayFunctionLazyExecute?: boolean;
   // Custom output directory for MSW mock files. Overrides the shared
-  // `OutputMocksConfig.path` when set. When provided in `single` or `tags`
-  // modes, mock code is written to separate files instead of being inlined
-  // into the implementation file.
+  // `OutputMocksConfig.path` when set. Only picks where deinlined mock files
+  // land; `OutputMocksConfig.inline: true` keeps mocks in the implementation
+  // file in `single`/`tags` modes even when this path is set.
   path?: string;
 }
 
@@ -613,9 +613,9 @@ export interface FakerMockOptions extends CommonMockOptions {
   // only the consolidated schema factories.
   operationResponses?: boolean;
   // Custom output directory for faker mock files. Overrides the shared
-  // `OutputMocksConfig.path` when set. When provided in `single` or `tags`
-  // modes, mock code is written to separate files instead of being inlined
-  // into the implementation file.
+  // `OutputMocksConfig.path` when set. Only picks where deinlined mock files
+  // land; `OutputMocksConfig.inline: true` keeps mocks in the implementation
+  // file in `single`/`tags` modes even when this path is set.
   path?: string;
 }
 


### PR DESCRIPTION
## Summary

Comment-only follow-up to #3928. `MswMockOptions.path` and `FakerMockOptions.path` in `packages/core/src/types.ts` still said that setting a path in `single` or `tags` mode writes mocks to separate files. Since #3928 the writers key on `mock.inline` alone; a per-generator path only picks the destination of already de-inlined mock files, and `inline: true` keeps mocks in the implementation file even when a path is set.

Flagged by CodeRabbit on #3928 (outside-diff finding); the PR merged before the fix landed on its branch.

## Changes

- Rewrite the two `path` doc comments to match `OutputMocksConfig.path` and `OutputMocksConfig.inline`, which already describe the current behaviour.

No code change. `vp fmt --check` and `tsc --noEmit` in `packages/core` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AK2XJuDxg7UzZGrrSnLXT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the mock output path controls where deinlined mock files are generated.
  - Documented that enabling inline mocks keeps them in the implementation file in `single` and `tags` modes, even when an output path is configured.
  - No functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->