### PR TITLE
fix(zod): resolve $ref parameters before filtering by location

### DIFF
--- a/packages/orval/src/write-zod-specs.test.ts
+++ b/packages/orval/src/write-zod-specs.test.ts
@@ -992,6 +992,74 @@ describe('writeZodSchemasFromVerbs with generateReusableSchemas', () => {
   });
 });
 
+describe('writeZodSchemasFromVerbs $ref parameter resolution', () => {
+  it('includes $ref parameters in generated query param schemas', async () => {
+    const root = await fs.mkdtemp(path.join(tmpdir(), 'orval-zod-ref-param-'));
+    const schemasPath = path.join(root, 'schemas');
+
+    const verbOptions = {
+      listPets: {
+        operationName: 'listPets',
+        typeName: 'listPets',
+        originalOperation: {
+          parameters: [
+            { $ref: '#/components/parameters/pageQuery' },
+            {
+              name: 'status',
+              in: 'query',
+              required: false,
+              schema: { type: 'string' },
+            },
+          ],
+        },
+        response: { types: { success: [], errors: [] } },
+      },
+    } as never;
+
+    const ctx = {
+      output: {
+        override: {
+          useDates: false,
+          zod: { dateTimeOptions: {}, timeOptions: {} },
+        },
+      },
+      spec: {
+        components: {
+          parameters: {
+            pageQuery: {
+              name: 'page',
+              in: 'query',
+              required: false,
+              schema: { type: 'number', minimum: 1, default: 1 },
+            },
+          },
+        },
+      } as never,
+      target: '',
+      workspace: '',
+    } satisfies MinimalVerbsContext;
+
+    await writeZodSchemasFromVerbs(
+      verbOptions,
+      schemasPath,
+      '.ts',
+      '',
+      createOutputOptions(),
+      ctx,
+    );
+
+    const content = await fs.readFile(
+      path.join(schemasPath, 'ListPetsParams.ts'),
+      'utf8',
+    );
+
+    expect(content).toContain('"page"');
+    expect(content).toContain('"status"');
+
+    await fs.remove(root);
+  });
+});
+
 describe('generateZodSchemasInline with generateReusableSchemas', () => {
   it('emits one named schema per reachable component ref', () => {
     const builder = {

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -9,6 +9,7 @@ import {
   getImportExtension,
   getRefInfo,
   isComponentRef,
+  isReference,
   kebab,
   type NamingConvention,
   type NormalizedOutputOptions,
@@ -17,6 +18,7 @@ import {
   type OpenApiRequestBodyObject,
   type OpenApiSchemaObject,
   pascal,
+  resolveRef,
   resolveValue,
   type SchemaOutputPlan,
   type Tsconfig,
@@ -1275,7 +1277,13 @@ export async function writeZodSchemasFromVerbs(
 
     const parameters = operation.parameters;
 
-    const pathParams = parameters?.filter(
+    const resolvedParameters = parameters?.map((p) =>
+      isReference(p) && typeof p.$ref === 'string'
+        ? resolveRef<OpenApiParameterObject>(p, zodContext).schema
+        : p,
+    );
+
+    const pathParams = resolvedParameters?.filter(
       (p): p is OpenApiParameterObject => 'in' in p && p.in === 'path',
     );
 
@@ -1314,7 +1322,7 @@ export async function writeZodSchemasFromVerbs(
           ]
         : [];
 
-    const queryParams = parameters?.filter(
+    const queryParams = resolvedParameters?.filter(
       (p): p is OpenApiParameterObject => 'in' in p && p.in === 'query',
     );
 
@@ -1347,7 +1355,7 @@ export async function writeZodSchemasFromVerbs(
           ]
         : [];
 
-    const headerParams = parameters?.filter(
+    const headerParams = resolvedParameters?.filter(
       (p): p is OpenApiParameterObject => 'in' in p && p.in === 'header',
     );
 


### PR DESCRIPTION
## What

The Zod schema generation path silently drops `$ref` parameter entries from `operation.parameters`, producing incomplete schemas for operations that reference shared parameters via `$ref`.

## Why

`writeZodSchemasFromVerbs` filters parameters by location (`path`, `query`, `header`) using `"in" in p && p.in === "..."`. `$ref` objects have no `in` property, so the filter drops them entirely. 

This surfaces when:
- The spec uses `$ref` in operation-level `parameters` arrays (e.g. `{"$ref": "#/components/parameters/pageQuery"}`)
- A bundler preserves internal `$ref` pointers (Redocly `bundle`, for example)
- `schemas.type` is `"zod"`, making Zod schemas the sole type source

## Changes

- **`packages/orval/src/write-zod-specs.ts`**: resolve `$ref` entries in `operation.parameters` via `isReference` + `resolveRef` before filtering by location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated Zod schemas so operation parameters defined through OpenAPI `$ref` references are included correctly.
  - Referenced path, query, and header parameters are now recognized and grouped appropriately in generated schemas.
  - Referenced parameters with nested schemas are now resolved correctly before schema generation.
  - Inline and referenced parameters are now represented together in generated schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->