### PR TITLE
chore: add dev container development environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22.22.3-bookworm
+
+RUN apt-get update && apt-get install -y \
+  git \
+  vim \
+  curl \
+  unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Bun is required: package.json declares packageManager bun@1.3.14 and
+# postinstall runs `bun scripts/link-workspace-bins.mjs`.
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
+ENV BUN_INSTALL=/root/.bun
+ENV PATH="/root/.bun/bin:${PATH}"
+
+# Vite+ unified toolchain CLI (`vp`), pinned to the repo's catalog version.
+# The project-local vp (node_modules/.bin) must win over the global one:
+# the global copy resolves `typescript` from its own tree and fails dts builds.
+RUN npm install -g vite-plus@0.2.9
+ENV PATH="/app/node_modules/.bin:${PATH}"
+
+WORKDIR /app
+CMD ["bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,17 +7,38 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 
-# Bun is required: package.json declares packageManager bun@1.3.14 and
-# postinstall runs `bun scripts/link-workspace-bins.mjs`.
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
-ENV BUN_INSTALL=/root/.bun
-ENV PATH="/root/.bun/bin:${PATH}"
-
 # Vite+ unified toolchain CLI (`vp`), pinned to the repo's catalog version.
 # The project-local vp (node_modules/.bin) must win over the global one:
 # the global copy resolves `typescript` from its own tree and fails dts builds.
 RUN npm install -g vite-plus@0.2.9
-ENV PATH="/app/node_modules/.bin:${PATH}"
+
+USER node
+ENV BUN_INSTALL=/home/node/.bun
+ENV PATH="/app/node_modules/.bin:${BUN_INSTALL}/bin:${PATH}"
+
+# Bun is required: package.json declares packageManager bun@1.3.14 and
+# postinstall runs `bun scripts/link-workspace-bins.mjs`.
+# SHA-256 from https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/SHASUMS256.txt
+ARG TARGETARCH
+ARG BUN_VERSION=1.3.14
+ARG BUN_SHA256_AMD64=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+ARG BUN_SHA256_ARM64=a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b
+RUN set -eux; \
+  case "${TARGETARCH}" in \
+    amd64) BUN_ARCH=x64;     BUN_SHA256="${BUN_SHA256_AMD64}" ;; \
+    arm64) BUN_ARCH=aarch64; BUN_SHA256="${BUN_SHA256_ARM64}" ;; \
+    *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL -o /tmp/bun.zip \
+    "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip"; \
+  echo "${BUN_SHA256}  /tmp/bun.zip" | sha256sum -c -; \
+  mkdir -p "${BUN_INSTALL}/bin"; \
+  unzip -q /tmp/bun.zip -d /tmp; \
+  mv "/tmp/bun-linux-${BUN_ARCH}/bun" "${BUN_INSTALL}/bin/bun"; \
+  chmod +x "${BUN_INSTALL}/bin/bun"; \
+  ln -s bun "${BUN_INSTALL}/bin/bunx"; \
+  rm -rf /tmp/bun.zip "/tmp/bun-linux-${BUN_ARCH}"; \
+  bun --version
 
 WORKDIR /app
 CMD ["bash"]

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805",
+      "integrity": "sha256:7c409bf6316ffd85f04fd92fba85a744282639e603417dd4796409866bdb6805"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "orval",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",
+  "workspaceFolder": "/app",
+  "init": true,
+  // Host ports are intentionally uncommon to avoid clashing with other
+  // local development (container side keeps the standard ports), and are
+  // bound to localhost so they are not reachable from the local network.
+  "appPort": [
+    "127.0.0.1:43000:3000",
+    "127.0.0.1:45173:5173",
+    "127.0.0.1:48787:8787"
+  ],
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "vp install && vp run prepare",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "VoidZero.vite-plus-extension-pack",
+        "streetsidesoftware.code-spell-checker",
+        "unifiedjs.vscode-mdx",
+        "vitest.explorer",
+        "anthropic.claude-code",
+        "github.vscode-pull-request-github"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,14 +6,13 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",
   "workspaceFolder": "/app",
   "init": true,
-  // Host ports are intentionally uncommon to avoid clashing with other
-  // local development (container side keeps the standard ports), and are
-  // bound to localhost so they are not reachable from the local network.
-  "appPort": [
-    "127.0.0.1:43000:3000",
-    "127.0.0.1:45173:5173",
-    "127.0.0.1:48787:8787"
-  ],
+  "remoteUser": "node",
+  "forwardPorts": [3000, 5173, 8787],
+  "portsAttributes": {
+    "3000": { "label": "docs (vite dev)" },
+    "5173": { "label": "vite / vp dev" },
+    "8787": { "label": "wrangler dev" }
+  },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ vp install && vp run prepare
 
 If you use VS Code, you can skip the manual toolchain setup by reopening the repository in the provided [Dev Container](https://containers.dev/) ("Dev Containers: Reopen in Container"). The image (`.devcontainer/Dockerfile`) ships Node.js, Bun, Vite+ (`vp`) and the GitHub CLI at the versions the repository expects, and `vp install && vp run prepare` runs automatically on creation.
 
-Container ports are published to uncommon host ports to avoid clashing with other local development: 3000 → 43000, 5173 → 45173, 8787 → 48787.
+The container runs as the non-root `node` user. Ports 3000 (docs), 5173 (Vite) and 8787 (wrangler) are forwarded to your machine through VS Code, so dev servers work without `--host`; if a port is already in use locally, VS Code assigns another one and shows it in the **Ports** panel.
 
 ### Implement your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,12 @@ Install dependencies and set up Git hooks:
 vp install && vp run prepare
 ```
 
+### Develop in a Dev Container (optional)
+
+If you use VS Code, you can skip the manual toolchain setup by reopening the repository in the provided [Dev Container](https://containers.dev/) ("Dev Containers: Reopen in Container"). The image (`.devcontainer/Dockerfile`) ships Node.js, Bun, Vite+ (`vp`) and the GitHub CLI at the versions the repository expects, and `vp install && vp run prepare` runs automatically on creation.
+
+Container ports are published to uncommon host ports to avoid clashing with other local development: 3000 → 43000, 5173 → 45173, 8787 → 48787.
+
 ### Implement your changes
 
 When making commits, make sure to follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) guidelines, i.e. prepending the message with `feat:`, `fix:`, `chore:`, `docs:`, etc... You can use `git status` to double check which files have not yet been staged for commit:


### PR DESCRIPTION
Add a VS Code Dev Container so contributors get the expected toolchain (Node 22.22.3, Bun 1.3.14, Vite+ 0.2.9, GitHub CLI) without manual setup.

<!-- A few sentences describing the overall goals of the pull request's commits. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Dev Container with a preconfigured Node.js development environment and common command-line utilities.
  * Added support for running the container as a non-root user.
  * Configured convenient forwarding for documentation, development, and worker server ports, with labels in VS Code.
  * Added pinned GitHub CLI tooling for consistent container setup.

* **Documentation**
  * Updated contributing guidance for using the Dev Container, forwarded ports, and alternate-port behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->