### PR TITLE
fix(msw): honor useExamples for property examples

### DIFF
--- a/packages/mock/src/msw/mocks.test.ts
+++ b/packages/mock/src/msw/mocks.test.ts
@@ -97,6 +97,60 @@ describe('getResponsesMockDefinition (useExamples + transformer)', () => {
   });
 });
 
+describe('getResponsesMockDefinition (generator useExamples for property examples)', () => {
+  const propertyExampleResponse = {
+    key: '200',
+    value: 'Patient',
+    contentType: 'application/json',
+    originalSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', example: 'abc-123' },
+        category: { type: 'string', example: 'cardiology' },
+      },
+      required: ['id', 'category'],
+    },
+    imports: [],
+    schemas: [],
+    type: 'object',
+    isEnum: false,
+    isRef: false,
+    hasReadonlyProps: false,
+    dependencies: [],
+  } satisfies ResReqTypesValue;
+
+  const baseOptions = {
+    operationId: 'getPatient',
+    tags: [],
+    returnType: 'Patient',
+    responses: [propertyExampleResponse],
+    mockOptionsWithoutFunc: {},
+    context: createTestContextSpec(),
+    splitMockImplementations: [],
+  };
+
+  it('uses property-level schema examples when generator useExamples is true', () => {
+    const { definitions } = getResponsesMockDefinition({
+      ...baseOptions,
+      mockOptions: { type: 'msw', useExamples: true },
+    });
+
+    expect(definitions[0]).toContain('id: "abc-123"');
+    expect(definitions[0]).toContain('category: "cardiology"');
+  });
+
+  it('keeps faker-generated values when generator useExamples is false', () => {
+    const { definitions } = getResponsesMockDefinition({
+      ...baseOptions,
+      mockOptions: { type: 'msw', useExamples: false },
+    });
+
+    expect(definitions[0]).not.toContain('id: "abc-123"');
+    expect(definitions[0]).not.toContain('category: "cardiology"');
+    expect(definitions[0]).toContain('faker.string.alpha()');
+  });
+});
+
 describe('getMockWithoutFunc (override.mock.schemas)', () => {
   const spec = {} as OpenApiDocument;
 

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -226,6 +226,13 @@ export function getResponsesMockDefinition({
     definitions: [] as string[],
     imports: [] as GeneratorImport[],
   };
+  const scalarMockOptions =
+    mockOptions?.useExamples === undefined
+      ? mockOptionsWithoutFunc
+      : {
+          ...mockOptionsWithoutFunc,
+          useExamples: mockOptions.useExamples,
+        };
 
   for (const response of responses) {
     const { value: definition, example, examples, imports, isRef } = response;
@@ -280,7 +287,7 @@ export function getResponsesMockDefinition({
           : {}),
       },
       imports: responseImports,
-      mockOptions: mockOptionsWithoutFunc,
+      mockOptions: scalarMockOptions,
       operationId,
       tags,
       context,


### PR DESCRIPTION
## Summary

Fix MSW mock generation so generator-level `useExamples: true` is honored for property-level schema examples.

Previously, whole-response examples worked correctly, but object responses built property-by-property still fell back to Faker instead of using the schema property `example` values.

This change forwards only `useExamples` into the MSW scalar/property generation path, keeping the fix narrowly scoped to `packages/mock/src/msw`.

Closes #3976

## Changes

* Forward generator-level `useExamples` to the property-level `getMockScalar` path in MSW response generation.
* Add a regression test covering property-level schema examples with `useExamples: true`.
* Add a control test confirming `useExamples: false` continues to use Faker.

## Verification

```bash
vp test packages/mock/src/msw/mocks.test.ts
```

* 7 passed

```bash
vp run -F @orval/mock test
```

* Test Files: 13 passed (13)
* Tests: 350 passed (350)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mock generation now respects the `useExamples` option for property-level examples.
  * When enabled, generated mock responses use defined example values; when disabled, they continue using generated placeholder values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->