### PR TITLE
fix(zod): serialize nested object defaults as JSON (#3972, #3974)

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1006,28 +1006,69 @@ export const generateZodValidationSchemaDefinition = (
       // properties accept the emitted default (#3244). Whole-object/array
       // `as const` would make nested arrays `readonly`, which zod v4's
       // `.default()` rejects against its mutable parameter type (#3399).
+      // Recursively emit a default value as a TS expression. Strings get `as
+      // const` so zod.enum([...]) properties accept the emitted default (#3244);
+      // whole-object/array `as const` is avoided because it makes nested arrays
+      // readonly, which zod v4's `.default()` rejects (#3399).
+      const formatDefaultEntryValue = (
+        entryValue: unknown,
+      ): string | undefined => {
+        if (isString(entryValue)) {
+          return `${JSON.stringify(entryValue)} as const`;
+        }
+
+        if (Array.isArray(entryValue)) {
+          const arrayItems = entryValue.map((item) => {
+            if (isString(item)) {
+              return `${JSON.stringify(item)} as const`;
+            }
+            // Object items recurse so nested string values get `as const`
+            // (e.g. `{ value: 'active' as const }`), which JSON.stringify
+            // alone would drop (#3982 CodeRabbit).
+            if (isObject(item)) {
+              const formatted = formatDefaultEntryValue(item);
+              return formatted ?? 'null';
+            }
+            return `${JSON.stringify(item)}`;
+          });
+          return `[${arrayItems.join(', ')}]`;
+        }
+
+        // Nested objects recurse: emitting the raw value would stringify to
+        // `[object Object]` (#3972) and skipping it would leave a hole in the
+        // object literal `{ , , }` (#3974).
+        if (isObject(entryValue)) {
+          const nestedEntries = Object.entries(entryValue)
+            .map(([nestedKey, nestedValue]) => {
+              const formatted = formatDefaultEntryValue(nestedValue);
+              return formatted === undefined
+                ? undefined
+                : `${JSON.stringify(nestedKey)}: ${formatted}`;
+            })
+            .filter((entry) => entry !== undefined)
+            .join(', ');
+          return nestedEntries.length === 0 ? '{}' : `{ ${nestedEntries} }`;
+        }
+
+        if (
+          entryValue === null ||
+          entryValue === undefined ||
+          isNumber(entryValue) ||
+          isBoolean(entryValue)
+        )
+          return `${entryValue}`;
+
+        return undefined;
+      };
+
       const entries = Object.entries(schema.default)
         .map(([key, value]) => {
-          const safeKey = JSON.stringify(key);
-          if (isString(value)) {
-            return `${safeKey}: ${JSON.stringify(value)} as const`;
-          }
-
-          if (Array.isArray(value)) {
-            const arrayItems = value.map((item) =>
-              isString(item) ? `${JSON.stringify(item)} as const` : `${item}`,
-            );
-            return `${safeKey}: [${arrayItems.join(', ')}]`;
-          }
-
-          if (
-            value === null ||
-            value === undefined ||
-            isNumber(value) ||
-            isBoolean(value)
-          )
-            return `${safeKey}: ${value}`;
+          const formatted = formatDefaultEntryValue(value);
+          return formatted === undefined
+            ? undefined
+            : `${JSON.stringify(key)}: ${formatted}`;
         })
+        .filter((entry) => entry !== undefined)
         .join(', ');
       defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;
     } else {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2705,6 +2705,67 @@ describe('generateZodValidationSchemaDefinition`', () => {
       expect(secondParsed.consts).not.toContain('petAgeMaxOne');
       expect(secondParsed.consts).toBe(firstParsed.consts);
     });
+
+    it('serializes nested objects in object defaults (#3972)', () => {
+      // A $ref property whose default holds an array of objects used to
+      // stringify each non-string array item via template interpolation,
+      // emitting `[object Object]`.
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          default: { entries: [{ value: 1 }] },
+        },
+        context,
+        'parentChildren',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toEqual([
+        'export const parentChildrenDefault = { "entries": [{ "value": 1 }] };',
+      ]);
+    });
+
+    it('adds as const to strings inside array-of-object defaults', () => {
+      // Object items inside arrays recurse so nested strings keep `as const`,
+      // keeping zod.enum([...]) defaults assignable (#3982 CodeRabbit).
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          default: { entries: [{ value: 'active' }] },
+        },
+        context,
+        'parentEnumEntries',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toEqual([
+        'export const parentEnumEntriesDefault = { "entries": [{ "value": "active" as const }] };',
+      ]);
+    });
+
+    it('keeps nested object entries in parent defaults (#3974)', () => {
+      // Nested objects used to fall through the per-entry type checks, so the
+      // parent default emitted a literal with holes: { , , }.
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          default: { val1: { enabled: false }, val2: { enabled: true } },
+        },
+        context,
+        'parentState',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toEqual([
+        'export const parentStateDefault = { "val1": { "enabled": false }, "val2": { "enabled": true } };',
+      ]);
+    });
   });
 
   describe('default value template-literal injection', () => {


### PR DESCRIPTION
Fixes #3972
Fixes #3974.

Both bugs live in the object-default emitter in `packages/zod/src/index.ts` (`generateZodValidationSchemaDefinition`):

- **#3972**: array items that aren't strings were interpolated raw (`\`${item}\``), so a `$ref` default holding an array of objects emitted `[object Object]`.
- **#3974**: nested objects fell through the per-entry type checks and the entry was dropped, emitting `{ , , }` with holes.

The emitter now uses a recursive `formatDefaultEntryValue` that serializes nested objects/arrays via `JSON.stringify` (strings still get `as const` for the #3244 enum case, whole-object `as const` still avoided for the #3399 readonly case).

Two regression tests added in `zod.test.ts` asserting the exact emitted consts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated default values so nested objects are preserved as valid object literals.
  * Corrected serialization of arrays containing objects, preventing malformed output and missing entries.
  * Preserved string literal types at any nesting level and filtered unsupported default values.
  * Ensured empty nested objects are represented correctly.

* **Tests**
  * Added coverage for nested objects and arrays of objects in generated default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->