### PR TITLE
feat(mcp): propagate tool call cancellation to downstream fetch requests

### DIFF
--- a/docs/content/docs/guides/mcp.mdx
+++ b/docs/content/docs/guides/mcp.mdx
@@ -144,7 +144,9 @@ The generated `server.ts` calls your function with a `createMcpServer` factory:
 ```ts title="src/server.ts (generated)"
 import { customServer } from '../custom-server';
 
-const createMcpServer = () => {
+const createMcpServer = (
+  options?: RequestInit,
+): { server: McpServer; tools: Record<string, RegisteredTool> } => {
   // ...tool registrations
 };
 
@@ -154,13 +156,21 @@ customServer(createMcpServer);
 Implement the custom server function to set up any transport. The following example uses [Hono](https://hono.dev) with [`@hono/mcp`](https://github.com/honojs/middleware/tree/main/packages/mcp) for Streamable HTTP:
 
 ```ts title="custom-server.ts"
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  McpServer,
+  RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPTransport } from '@hono/mcp';
 import { Hono } from 'hono';
 
-export const customServer = (createMcpServer: () => McpServer) => {
+export const customServer = (
+  createMcpServer: (options?: RequestInit) => {
+    server: McpServer;
+    tools: Record<string, RegisteredTool>;
+  },
+) => {
   const app = new Hono();
-  const server = createMcpServer();
+  const { server } = createMcpServer();
   const transport = new StreamableHTTPTransport();
 
   app.all('/mcp', async (c) => {

--- a/docs/content/docs/guides/mcp.mdx
+++ b/docs/content/docs/guides/mcp.mdx
@@ -76,6 +76,38 @@ For Cline:
 
 This allows your AI agent to interact with the API through the MCP protocol.
 
+## Request Cancellation
+
+When an MCP client cancels a tool call, the generated `server.ts` passes the cancellation signal of that call to the underlying HTTP request. The in-flight `fetch` is aborted with an `AbortError` instead of running to completion.
+
+```ts title="src/server.ts (generated)"
+tools.findPetsByStatus = server.registerTool(
+  'findPetsByStatus',
+  {
+    // ...
+  },
+  (args, ctx) =>
+    findPetsByStatusHandler(args, {
+      ...options,
+      signal: options?.signal
+        ? AbortSignal.any([options.signal, ctx.signal])
+        : ctx.signal,
+    }),
+);
+```
+
+If you pass a `signal` through `createMcpServer(options)`, for example from a custom server to abort every in-flight request on shutdown, it is combined with the per-call signal using `AbortSignal.any`. Either signal aborts the request.
+
+```ts title="custom-server.ts"
+const shutdown = new AbortController();
+const { server } = createMcpServer({ signal: shutdown.signal });
+process.on('SIGTERM', () => shutdown.abort());
+```
+
+<Callout type="info">
+`AbortSignal.any` requires Node.js 20.3 or later at runtime.
+</Callout>
+
 ## Custom Server
 
 By default, the generated `server.ts` connects via `StdioServerTransport`. To use a different transport (e.g., Streamable HTTP for container deployments), provide a custom server function via `override.mcp.server`.

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -2380,13 +2380,21 @@ Custom server function to use instead of the default `StdioServerTransport`. Whe
 Example implementation using `@hono/mcp`:
 
 ```ts title="custom-server.ts"
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  McpServer,
+  RegisteredTool,
+} from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPTransport } from '@hono/mcp';
 import { Hono } from 'hono';
 
-export const customServer = (createMcpServer: () => McpServer) => {
+export const customServer = (
+  createMcpServer: (options?: RequestInit) => {
+    server: McpServer;
+    tools: Record<string, RegisteredTool>;
+  },
+) => {
   const app = new Hono();
-  const server = createMcpServer();
+  const { server } = createMcpServer();
   const transport = new StreamableHTTPTransport();
 
   app.all('/mcp', async (c) => {

--- a/docs/content/docs/zh/guides/mcp.mdx
+++ b/docs/content/docs/zh/guides/mcp.mdx
@@ -44,6 +44,10 @@ export default defineConfig({
 
 在客户端配置中加入 MCP server 的启动命令或容器信息。
 
+## 请求取消
+
+当 MCP 客户端取消工具调用时，生成的 `server.ts` 会把该调用的取消信号传递给底层 HTTP 请求，正在进行的 `fetch` 会以 `AbortError` 中止。通过 `createMcpServer(options)` 传入的 `signal` 会与每次调用的信号用 `AbortSignal.any` 合并，任一信号触发都会中止请求。运行环境需要 Node.js 20.3 或更高版本。
+
 ## 自定义 Server
 
 你可以把生成的工具注册到自己的 server 中，统一加入鉴权、日志、限流或错误处理。

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -323,10 +323,14 @@ export const generateServer = (
         ? `\n    description: '${jsStringEscape(descriptionValue)}',`
         : '';
 
+      const requestInitWithSignal = `{
+    ...options,
+    signal: options?.signal ? AbortSignal.any([options.signal, ctx.signal]) : ctx.signal,
+  }`;
       const handlerCallImplementation =
         inputSchemaTypes.length > 0
-          ? `(args) => ${verbOption.operationName}Handler(args, options)`
-          : `() => ${verbOption.operationName}Handler(options)`;
+          ? `(args, ctx) => ${verbOption.operationName}Handler(args, ${requestInitWithSignal})`
+          : `(ctx) => ${verbOption.operationName}Handler(${requestInitWithSignal})`;
 
       const toolImplementation = `
 tools.${verbOption.operationName} = server.registerTool(

--- a/samples/mcp/custom-server/__snapshots__/server.ts
+++ b/samples/mcp/custom-server/__snapshots__/server.ts
@@ -81,7 +81,13 @@ const createMcpServer = (
       outputSchema: FindPetsByStatusResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => findPetsByStatusHandler(args, options),
+    (args, ctx) =>
+      findPetsByStatusHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.findPetsByTags = server.registerTool(
@@ -96,7 +102,13 @@ const createMcpServer = (
       outputSchema: FindPetsByTagsResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => findPetsByTagsHandler(args, options),
+    (args, ctx) =>
+      findPetsByTagsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getPetById = server.registerTool(
@@ -110,7 +122,13 @@ const createMcpServer = (
       outputSchema: GetPetByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getPetByIdHandler(args, options),
+    (args, ctx) =>
+      getPetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.updatePetWithForm = server.registerTool(
@@ -125,7 +143,13 @@ const createMcpServer = (
       outputSchema: UpdatePetWithFormResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => updatePetWithFormHandler(args, options),
+    (args, ctx) =>
+      updatePetWithFormHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deletePet = server.registerTool(
@@ -139,7 +163,13 @@ const createMcpServer = (
       outputSchema: DeletePetResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deletePetHandler(args, options),
+    (args, ctx) =>
+      deletePetHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getInventory = server.registerTool(
@@ -150,7 +180,13 @@ const createMcpServer = (
       outputSchema: GetInventoryResponse,
       annotations: { readOnlyHint: true },
     },
-    () => getInventoryHandler(options),
+    (ctx) =>
+      getInventoryHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getOrderById = server.registerTool(
@@ -165,7 +201,13 @@ const createMcpServer = (
       outputSchema: GetOrderByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getOrderByIdHandler(args, options),
+    (args, ctx) =>
+      getOrderByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteOrder = server.registerTool(
@@ -180,7 +222,13 @@ const createMcpServer = (
       outputSchema: DeleteOrderResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deleteOrderHandler(args, options),
+    (args, ctx) =>
+      deleteOrderHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.loginUser = server.registerTool(
@@ -194,7 +242,13 @@ const createMcpServer = (
       outputSchema: LoginUserResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => loginUserHandler(args, options),
+    (args, ctx) =>
+      loginUserHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.logoutUser = server.registerTool(
@@ -205,7 +259,13 @@ const createMcpServer = (
       outputSchema: LogoutUserResponse,
       annotations: { readOnlyHint: true },
     },
-    () => logoutUserHandler(options),
+    (ctx) =>
+      logoutUserHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getUserByName = server.registerTool(
@@ -219,7 +279,13 @@ const createMcpServer = (
       outputSchema: GetUserByNameResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getUserByNameHandler(args, options),
+    (args, ctx) =>
+      getUserByNameHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteUser = server.registerTool(
@@ -233,7 +299,13 @@ const createMcpServer = (
       outputSchema: DeleteUserResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deleteUserHandler(args, options),
+    (args, ctx) =>
+      deleteUserHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/samples/mcp/custom-server/src/server.ts
+++ b/samples/mcp/custom-server/src/server.ts
@@ -81,7 +81,13 @@ const createMcpServer = (
       outputSchema: FindPetsByStatusResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => findPetsByStatusHandler(args, options),
+    (args, ctx) =>
+      findPetsByStatusHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.findPetsByTags = server.registerTool(
@@ -96,7 +102,13 @@ const createMcpServer = (
       outputSchema: FindPetsByTagsResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => findPetsByTagsHandler(args, options),
+    (args, ctx) =>
+      findPetsByTagsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getPetById = server.registerTool(
@@ -110,7 +122,13 @@ const createMcpServer = (
       outputSchema: GetPetByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getPetByIdHandler(args, options),
+    (args, ctx) =>
+      getPetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.updatePetWithForm = server.registerTool(
@@ -125,7 +143,13 @@ const createMcpServer = (
       outputSchema: UpdatePetWithFormResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => updatePetWithFormHandler(args, options),
+    (args, ctx) =>
+      updatePetWithFormHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deletePet = server.registerTool(
@@ -139,7 +163,13 @@ const createMcpServer = (
       outputSchema: DeletePetResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deletePetHandler(args, options),
+    (args, ctx) =>
+      deletePetHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getInventory = server.registerTool(
@@ -150,7 +180,13 @@ const createMcpServer = (
       outputSchema: GetInventoryResponse,
       annotations: { readOnlyHint: true },
     },
-    () => getInventoryHandler(options),
+    (ctx) =>
+      getInventoryHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getOrderById = server.registerTool(
@@ -165,7 +201,13 @@ const createMcpServer = (
       outputSchema: GetOrderByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getOrderByIdHandler(args, options),
+    (args, ctx) =>
+      getOrderByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteOrder = server.registerTool(
@@ -180,7 +222,13 @@ const createMcpServer = (
       outputSchema: DeleteOrderResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deleteOrderHandler(args, options),
+    (args, ctx) =>
+      deleteOrderHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.loginUser = server.registerTool(
@@ -194,7 +242,13 @@ const createMcpServer = (
       outputSchema: LoginUserResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => loginUserHandler(args, options),
+    (args, ctx) =>
+      loginUserHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.logoutUser = server.registerTool(
@@ -205,7 +259,13 @@ const createMcpServer = (
       outputSchema: LogoutUserResponse,
       annotations: { readOnlyHint: true },
     },
-    () => logoutUserHandler(options),
+    (ctx) =>
+      logoutUserHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getUserByName = server.registerTool(
@@ -219,7 +279,13 @@ const createMcpServer = (
       outputSchema: GetUserByNameResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getUserByNameHandler(args, options),
+    (args, ctx) =>
+      getUserByNameHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteUser = server.registerTool(
@@ -233,7 +299,13 @@ const createMcpServer = (
       outputSchema: DeleteUserResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deleteUserHandler(args, options),
+    (args, ctx) =>
+      deleteUserHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/samples/mcp/petstore/src/server.ts
+++ b/samples/mcp/petstore/src/server.ts
@@ -86,7 +86,13 @@ const createMcpServer = (
       outputSchema: FilterPetsByStatusResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => filterPetsByStatusHandler(args, options),
+    (args, ctx) =>
+      filterPetsByStatusHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.findPetsByStatus = server.registerTool(
@@ -101,7 +107,13 @@ const createMcpServer = (
       outputSchema: FindPetsByStatusResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => findPetsByStatusHandler(args, options),
+    (args, ctx) =>
+      findPetsByStatusHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.findPetsByTags = server.registerTool(
@@ -116,7 +128,13 @@ const createMcpServer = (
       outputSchema: FindPetsByTagsResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => findPetsByTagsHandler(args, options),
+    (args, ctx) =>
+      findPetsByTagsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getPetById = server.registerTool(
@@ -130,7 +148,13 @@ const createMcpServer = (
       outputSchema: GetPetByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getPetByIdHandler(args, options),
+    (args, ctx) =>
+      getPetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.updatePetWithForm = server.registerTool(
@@ -145,7 +169,13 @@ const createMcpServer = (
       outputSchema: UpdatePetWithFormResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => updatePetWithFormHandler(args, options),
+    (args, ctx) =>
+      updatePetWithFormHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deletePet = server.registerTool(
@@ -159,7 +189,13 @@ const createMcpServer = (
       outputSchema: DeletePetResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deletePetHandler(args, options),
+    (args, ctx) =>
+      deletePetHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getInventory = server.registerTool(
@@ -170,7 +206,13 @@ const createMcpServer = (
       outputSchema: GetInventoryResponse,
       annotations: { readOnlyHint: true },
     },
-    () => getInventoryHandler(options),
+    (ctx) =>
+      getInventoryHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getOrderById = server.registerTool(
@@ -185,7 +227,13 @@ const createMcpServer = (
       outputSchema: GetOrderByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getOrderByIdHandler(args, options),
+    (args, ctx) =>
+      getOrderByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteOrder = server.registerTool(
@@ -200,7 +248,13 @@ const createMcpServer = (
       outputSchema: DeleteOrderResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deleteOrderHandler(args, options),
+    (args, ctx) =>
+      deleteOrderHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.loginUser = server.registerTool(
@@ -214,7 +268,13 @@ const createMcpServer = (
       outputSchema: LoginUserResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => loginUserHandler(args, options),
+    (args, ctx) =>
+      loginUserHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.logoutUser = server.registerTool(
@@ -225,7 +285,13 @@ const createMcpServer = (
       outputSchema: LogoutUserResponse,
       annotations: { readOnlyHint: true },
     },
-    () => logoutUserHandler(options),
+    (ctx) =>
+      logoutUserHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.getUserByName = server.registerTool(
@@ -239,7 +305,13 @@ const createMcpServer = (
       outputSchema: GetUserByNameResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => getUserByNameHandler(args, options),
+    (args, ctx) =>
+      getUserByNameHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteUser = server.registerTool(
@@ -253,7 +325,13 @@ const createMcpServer = (
       outputSchema: DeleteUserResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deleteUserHandler(args, options),
+    (args, ctx) =>
+      deleteUserHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/tests/__snapshots__/mcp/annotations-coverage/server.ts
+++ b/tests/__snapshots__/mcp/annotations-coverage/server.ts
@@ -49,7 +49,13 @@ const createMcpServer = (
       outputSchema: GetThingsResponse,
       annotations: { readOnlyHint: true },
     },
-    () => getThingsHandler(options),
+    (ctx) =>
+      getThingsHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.createThing = server.registerTool(
@@ -61,7 +67,13 @@ const createMcpServer = (
       outputSchema: CreateThingResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => createThingHandler(args, options),
+    (args, ctx) =>
+      createThingHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.replaceThing = server.registerTool(
@@ -73,7 +85,13 @@ const createMcpServer = (
       outputSchema: ReplaceThingResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => replaceThingHandler(args, options),
+    (args, ctx) =>
+      replaceThingHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.patchThing = server.registerTool(
@@ -85,7 +103,13 @@ const createMcpServer = (
       outputSchema: PatchThingResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => patchThingHandler(args, options),
+    (args, ctx) =>
+      patchThingHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deleteThing = server.registerTool(
@@ -94,7 +118,13 @@ const createMcpServer = (
       outputSchema: DeleteThingResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    () => deleteThingHandler(options),
+    (ctx) =>
+      deleteThingHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.optionsThings = server.registerTool(
@@ -103,7 +133,13 @@ const createMcpServer = (
       outputSchema: OptionsThingsResponse,
       annotations: { readOnlyHint: true },
     },
-    () => optionsThingsHandler(options),
+    (ctx) =>
+      optionsThingsHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.headThings = server.registerTool(
@@ -112,7 +148,13 @@ const createMcpServer = (
       outputSchema: HeadThingsResponse,
       annotations: { readOnlyHint: true },
     },
-    () => headThingsHandler(options),
+    (ctx) =>
+      headThingsHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/tests/__snapshots__/mcp/custom-server/server.ts
+++ b/tests/__snapshots__/mcp/custom-server/server.ts
@@ -55,7 +55,13 @@ const createMcpServer = (
       outputSchema: ListPetsResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => listPetsHandler(args, options),
+    (args, ctx) =>
+      listPetsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.createPets = server.registerTool(
@@ -70,7 +76,13 @@ const createMcpServer = (
       outputSchema: CreatePetsResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => createPetsHandler(args, options),
+    (args, ctx) =>
+      createPetsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.showPetById = server.registerTool(
@@ -84,7 +96,13 @@ const createMcpServer = (
       outputSchema: ShowPetByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => showPetByIdHandler(args, options),
+    (args, ctx) =>
+      showPetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deletePetById = server.registerTool(
@@ -98,7 +116,13 @@ const createMcpServer = (
       outputSchema: DeletePetByIdResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deletePetByIdHandler(args, options),
+    (args, ctx) =>
+      deletePetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.healthCheck = server.registerTool(
@@ -109,7 +133,13 @@ const createMcpServer = (
       outputSchema: HealthCheckResponse,
       annotations: { readOnlyHint: true },
     },
-    () => healthCheckHandler(options),
+    (ctx) =>
+      healthCheckHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.showPetWithOwner = server.registerTool(
@@ -123,7 +153,13 @@ const createMcpServer = (
       outputSchema: ShowPetWithOwnerResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => showPetWithOwnerHandler(args, options),
+    (args, ctx) =>
+      showPetWithOwnerHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/tests/__snapshots__/mcp/directory-target/server.gen.ts
+++ b/tests/__snapshots__/mcp/directory-target/server.gen.ts
@@ -33,7 +33,13 @@ const createMcpServer = (
       outputSchema: AddResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => addHandler(args, options),
+    (args, ctx) =>
+      addHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/tests/__snapshots__/mcp/inline-schemas/server.ts
+++ b/tests/__snapshots__/mcp/inline-schemas/server.ts
@@ -33,7 +33,13 @@ const createMcpServer = (
       outputSchema: AddResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => addHandler(args, options),
+    (args, ctx) =>
+      addHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/tests/__snapshots__/mcp/single/server.ts
+++ b/tests/__snapshots__/mcp/single/server.ts
@@ -55,7 +55,13 @@ const createMcpServer = (
       outputSchema: ListPetsResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => listPetsHandler(args, options),
+    (args, ctx) =>
+      listPetsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.createPets = server.registerTool(
@@ -70,7 +76,13 @@ const createMcpServer = (
       outputSchema: CreatePetsResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => createPetsHandler(args, options),
+    (args, ctx) =>
+      createPetsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.showPetById = server.registerTool(
@@ -84,7 +96,13 @@ const createMcpServer = (
       outputSchema: ShowPetByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => showPetByIdHandler(args, options),
+    (args, ctx) =>
+      showPetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deletePetById = server.registerTool(
@@ -98,7 +116,13 @@ const createMcpServer = (
       outputSchema: DeletePetByIdResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deletePetByIdHandler(args, options),
+    (args, ctx) =>
+      deletePetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.healthCheck = server.registerTool(
@@ -109,7 +133,13 @@ const createMcpServer = (
       outputSchema: HealthCheckResponse,
       annotations: { readOnlyHint: true },
     },
-    () => healthCheckHandler(options),
+    (ctx) =>
+      healthCheckHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.showPetWithOwner = server.registerTool(
@@ -123,7 +153,13 @@ const createMcpServer = (
       outputSchema: ShowPetWithOwnerResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => showPetWithOwnerHandler(args, options),
+    (args, ctx) =>
+      showPetWithOwnerHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };

--- a/tests/__snapshots__/mcp/zod-schema-response/server.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/server.ts
@@ -55,7 +55,13 @@ const createMcpServer = (
       outputSchema: ListPetsResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => listPetsHandler(args, options),
+    (args, ctx) =>
+      listPetsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.createPets = server.registerTool(
@@ -70,7 +76,13 @@ const createMcpServer = (
       outputSchema: CreatePetsResponse,
       annotations: { destructiveHint: true },
     },
-    (args) => createPetsHandler(args, options),
+    (args, ctx) =>
+      createPetsHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.showPetById = server.registerTool(
@@ -84,7 +96,13 @@ const createMcpServer = (
       outputSchema: ShowPetByIdResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => showPetByIdHandler(args, options),
+    (args, ctx) =>
+      showPetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.deletePetById = server.registerTool(
@@ -98,7 +116,13 @@ const createMcpServer = (
       outputSchema: DeletePetByIdResponse,
       annotations: { destructiveHint: true, idempotentHint: true },
     },
-    (args) => deletePetByIdHandler(args, options),
+    (args, ctx) =>
+      deletePetByIdHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.healthCheck = server.registerTool(
@@ -109,7 +133,13 @@ const createMcpServer = (
       outputSchema: HealthCheckResponse,
       annotations: { readOnlyHint: true },
     },
-    () => healthCheckHandler(options),
+    (ctx) =>
+      healthCheckHandler({
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   tools.showPetWithOwner = server.registerTool(
@@ -123,7 +153,13 @@ const createMcpServer = (
       outputSchema: ShowPetWithOwnerResponse,
       annotations: { readOnlyHint: true },
     },
-    (args) => showPetWithOwnerHandler(args, options),
+    (args, ctx) =>
+      showPetWithOwnerHandler(args, {
+        ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, ctx.signal])
+          : ctx.signal,
+      }),
   );
 
   return { server, tools };


### PR DESCRIPTION
Previously, even if the MCP client cancelled a tool call, the generated `server.ts` would continue the HTTP request.

With this improvement, the cancellation signal from the MCP client is propagated to the HTTP request. As a result, the ongoing `fetch` operation is aborted with an `AbortError` instead of running to completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP tool requests now support cancellation, stopping in-flight HTTP requests when a client cancels an operation.
  - Server-level and per-request cancellation signals are combined so either can abort the request.
  - Updated MCP server examples demonstrate cancellation handling, including custom server configuration.

- **Documentation**
  - Added English and Chinese guidance on request cancellation and the Node.js 20.3+ requirement.
  - Updated custom server configuration examples to reflect the current setup and returned server tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->