### PR TITLE
feat(query): add useSkipToken option to hold unresolved params

### DIFF
--- a/docs/content/docs/guides/react-query.mdx
+++ b/docs/content/docs/guides/react-query.mdx
@@ -205,7 +205,7 @@ export const getShowPetByIdQueryOptions = <...>(
 
 This matters in two cases the `enabled` guard does not cover:
 
-- `enabled` does not gate `refetch()`, so a retry button sends the request with the unresolved param in the URL. `skipToken` refuses instead.
+- `enabled` does not gate `refetch()`, so a retry button sends the request with the unresolved param in the URL. With `skipToken` no request is sent — the query rejects with `Missing queryFn` instead, which is the tradeoff to know about before enabling the option.
 - `enabled` is a single option and `...queryOptions` is spread last, so `useShowPetById(petId, { query: { enabled: isTabVisible } })` replaces the generated param check. With `skipToken` the two gates are independent.
 
 Pair it with [`allParamsOptional`](/reference/configuration/output#allparamsoptional) so callers can pass an unresolved param without a cast.

--- a/docs/content/docs/guides/react-query.mdx
+++ b/docs/content/docs/guides/react-query.mdx
@@ -183,6 +183,35 @@ export const useGetListPetsQueryData = () => {
 };
 ```
 
+## Skip Token
+
+When `useSkipToken: true` is set, a query whose params are not resolved yet is held with [`skipToken`](https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken) rather than the generated `enabled` guard:
+
+```ts
+export const getShowPetByIdQueryOptions = <...>(
+  petId: string,
+  options?: {...},
+) => {
+  const queryKey = queryOptions?.queryKey ?? getShowPetByIdQueryKey(petId);
+  const queryFn: QueryFunction<...> = ({ signal }) => showPetById(petId, signal);
+
+  return {
+    queryKey,
+    queryFn: petId === null || petId === undefined ? skipToken : queryFn,
+    ...queryOptions,
+  } as ...;
+};
+```
+
+This matters in two cases the `enabled` guard does not cover:
+
+- `enabled` does not gate `refetch()`, so a retry button sends the request with the unresolved param in the URL. `skipToken` refuses instead.
+- `enabled` is a single option and `...queryOptions` is spread last, so `useShowPetById(petId, { query: { enabled: isTabVisible } })` replaces the generated param check. With `skipToken` the two gates are independent.
+
+Pair it with [`allParamsOptional`](/reference/configuration/output#allparamsoptional) so callers can pass an unresolved param without a cast.
+
+Suspense queries are unaffected: TanStack excludes `SkipToken` from their `queryFn`, which is also why they get no `enabled` guard.
+
 ## Full Example
 
 See the [complete React Query example](https://github.com/orval-labs/orval/blob/master/samples/react-query/basic) on GitHub.

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1253,6 +1253,17 @@ Query keys are matched by prefix, so query params and body arguments are widened
 
 Generate type-safe getQueryData helpers.
 
+### useSkipToken
+
+**Type:** `Boolean`
+**Default:** `false`
+
+Hold a query whose params are not resolved yet with [`skipToken`](https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken) instead of the generated `enabled` guard.
+
+Unlike `enabled`, holding the query in `queryFn` also blocks `refetch()`, and it leaves `enabled` free for the caller — the caller's `...queryOptions` is spread last, so their own `enabled` would otherwise replace the generated param check.
+
+React Query v5 only. Suspense queries are unaffected — TanStack excludes `SkipToken` from their `queryFn`.
+
 ### mutationInvalidates
 
 **Type:** `Array`

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1260,7 +1260,7 @@ Generate type-safe getQueryData helpers.
 
 Hold a query whose params are not resolved yet with [`skipToken`](https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken) instead of the generated `enabled` guard.
 
-Unlike `enabled`, holding the query in `queryFn` also blocks `refetch()`, and it leaves `enabled` free for the caller — the caller's `...queryOptions` is spread last, so their own `enabled` would otherwise replace the generated param check.
+Unlike `enabled`, this also covers `refetch()`: no request is sent with an unresolved param, and the query rejects with `Missing queryFn` instead (TanStack also logs a console error in development). It leaves `enabled` free for the caller too — the caller's `...queryOptions` is spread last, so their own `enabled` would otherwise replace the generated param check.
 
 React Query v5 only. Suspense queries are unaffected — TanStack excludes `SkipToken` from their `queryFn`.
 

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -89,6 +89,7 @@ export function createTestContextSpec({
         useInvalidate: false,
         useSetQueryData: false,
         useGetQueryData: false,
+        useSkipToken: false,
         shouldExportMutatorHooks: false,
         shouldExportHttpClient: false,
         shouldExportKeys: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1268,6 +1268,12 @@ export interface NormalizedQueryOptions {
   useInvalidate?: boolean;
   useSetQueryData?: boolean;
   useGetQueryData?: boolean;
+  /**
+   * Hold a query whose params are not resolved yet with `skipToken` instead of
+   * the generated `enabled` guard, so a caller's own `enabled` cannot replace
+   * the check and `refetch()` cannot bypass it. TanStack Query v5 only.
+   */
+  useSkipToken?: boolean;
 
   options?: Record<string, unknown>;
   queryKey?: NormalizedMutator;
@@ -1297,6 +1303,12 @@ export interface QueryOptions {
   useInvalidate?: boolean;
   useSetQueryData?: boolean;
   useGetQueryData?: boolean;
+  /**
+   * Hold a query whose params are not resolved yet with `skipToken` instead of
+   * the generated `enabled` guard, so a caller's own `enabled` cannot replace
+   * the check and `refetch()` cannot bypass it. TanStack Query v5 only.
+   */
+  useSkipToken?: boolean;
 
   options?: Record<string, unknown>;
   queryKey?: Mutator;

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -1527,6 +1527,9 @@ function normalizeQueryOptions(
     ...(isNullish(queryOptions.useGetQueryData)
       ? {}
       : { useGetQueryData: queryOptions.useGetQueryData }),
+    ...(isNullish(queryOptions.useSkipToken)
+      ? {}
+      : { useSkipToken: queryOptions.useSkipToken }),
     ...(isNullish(queryOptions.useQuery)
       ? {}
       : { useQuery: queryOptions.useQuery }),

--- a/packages/query/src/dependencies.ts
+++ b/packages/query/src/dependencies.ts
@@ -148,6 +148,7 @@ const REACT_QUERY_DEPENDENCIES: GeneratorDependency[] = [
   {
     exports: [
       { name: 'useQuery', values: true },
+      { name: 'skipToken', values: true },
       { name: 'useSuspenseQuery', values: true },
       { name: 'useInfiniteQuery', values: true },
       { name: 'useSuspenseInfiniteQuery', values: true },

--- a/packages/query/src/query-generator.test.ts
+++ b/packages/query/src/query-generator.test.ts
@@ -3,10 +3,12 @@ import type {
   GetterBody,
   GetterParams,
   GetterProps,
+  OutputClient,
 } from '@orval/core';
 import { Verbs } from '@orval/core';
 import { describe, expect, it } from 'vite-plus/test';
 
+import { createFrameworkAdapter } from './frameworks';
 import {
   allowUndefinedParam,
   getMutationInvalidatesConflictWarning,
@@ -15,6 +17,7 @@ import {
   hasQueryParam,
   makeOptionalParam,
   resolveInfiniteQueryParam,
+  resolveUseSkipToken,
   widenOptionalPropsToUndefined,
   wrapPropsBodyWithMutatorBodyType,
 } from './query-generator';
@@ -647,5 +650,39 @@ describe('getQueryFnProperty', () => {
         type: QueryType.SUSPENSE_INFINITE,
       }),
     ).toBe('queryFn');
+  });
+});
+
+describe('resolveUseSkipToken', () => {
+  const adapterFor = (outputClient: OutputClient) =>
+    createFrameworkAdapter({ outputClient, queryVersion: 5 });
+
+  it('applies to react-query v5', () => {
+    expect(resolveUseSkipToken(true, adapterFor('react-query'))).toBe(true);
+  });
+
+  it('does not apply to react-query v4, which has no skipToken', () => {
+    const adapter = createFrameworkAdapter({
+      outputClient: 'react-query',
+      queryVersion: 4,
+    });
+    expect(resolveUseSkipToken(true, adapter)).toBe(false);
+  });
+
+  // The other v5 adapters set `hasQueryV5` too, but `skipToken` is a
+  // react-query export and their `enabled` guards differ (vue unwraps refs).
+  it.each<OutputClient>([
+    'vue-query',
+    'svelte-query',
+    'solid-query',
+    'angular-query',
+  ])('does not apply to %s v5', (outputClient) => {
+    expect(resolveUseSkipToken(true, adapterFor(outputClient))).toBe(false);
+  });
+
+  it('is off when the option is unset', () => {
+    expect(resolveUseSkipToken(undefined, adapterFor('react-query'))).toBe(
+      false,
+    );
   });
 });

--- a/packages/query/src/query-generator.test.ts
+++ b/packages/query/src/query-generator.test.ts
@@ -1,10 +1,16 @@
-import type { GeneratorMutator, GetterBody, GetterProps } from '@orval/core';
+import type {
+  GeneratorMutator,
+  GetterBody,
+  GetterParams,
+  GetterProps,
+} from '@orval/core';
 import { Verbs } from '@orval/core';
 import { describe, expect, it } from 'vite-plus/test';
 
 import {
   allowUndefinedParam,
   getMutationInvalidatesConflictWarning,
+  getQueryFnProperty,
   getQueryKeyVerbPrefix,
   hasQueryParam,
   makeOptionalParam,
@@ -12,6 +18,7 @@ import {
   widenOptionalPropsToUndefined,
   wrapPropsBodyWithMutatorBodyType,
 } from './query-generator';
+import { QueryType } from './query-options';
 
 const ruleFor = (op: string) => ({
   onMutations: [op],
@@ -555,5 +562,90 @@ describe('widenOptionalPropsToUndefined', () => {
     );
 
     expect(widened.implementation).toMatch(/^a\.b: undefined \|\s+string$/);
+  });
+});
+
+const skipParam = (name: string): GetterParams[number] => ({
+  name,
+  definition: `${name}: string`,
+  implementation: `${name}: string`,
+  default: undefined,
+  required: true,
+  imports: [],
+});
+
+describe('getQueryFnProperty', () => {
+  it('returns a plain queryFn when useSkipToken is off', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: false,
+        params: [skipParam('petId')],
+        type: QueryType.QUERY,
+      }),
+    ).toBe('queryFn');
+  });
+
+  it('returns a plain queryFn when the operation has no params to hold on', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: true,
+        params: [],
+        type: QueryType.QUERY,
+      }),
+    ).toBe('queryFn');
+  });
+
+  it('holds the query with skipToken until the param is resolved', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: true,
+        params: [skipParam('petId')],
+        type: QueryType.QUERY,
+      }),
+    ).toBe(
+      'queryFn: petId === null || petId === undefined ? skipToken : queryFn',
+    );
+  });
+
+  it('holds the query when any one of several params is unresolved', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: true,
+        params: [skipParam('version'), skipParam('petId')],
+        type: QueryType.QUERY,
+      }),
+    ).toBe(
+      'queryFn: version === null || version === undefined || petId === null || petId === undefined ? skipToken : queryFn',
+    );
+  });
+
+  it('holds an infinite query, which accepts skipToken', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: true,
+        params: [skipParam('petId')],
+        type: QueryType.INFINITE,
+      }),
+    ).toContain('skipToken');
+  });
+
+  it('never holds a suspense query, whose queryFn excludes SkipToken', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: true,
+        params: [skipParam('petId')],
+        type: QueryType.SUSPENSE_QUERY,
+      }),
+    ).toBe('queryFn');
+  });
+
+  it('never holds a suspense infinite query, for the same reason', () => {
+    expect(
+      getQueryFnProperty({
+        useSkipToken: true,
+        params: [skipParam('petId')],
+        type: QueryType.SUSPENSE_INFINITE,
+      }),
+    ).toBe('queryFn');
   });
 });

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -211,6 +211,20 @@ export const getQueryFnProperty = ({
 };
 
 /**
+ * Whether `useSkipToken` applies to this adapter. `skipToken` is exported by
+ * `@tanstack/react-query` v5 only: the other v5 adapters neither import it nor
+ * read their params the same way — vue unwraps refs in its `enabled` guard, for
+ * one — so they keep the guard.
+ */
+export const resolveUseSkipToken = (
+  useSkipToken: boolean | undefined,
+  adapter: FrameworkAdapter,
+) =>
+  !!useSkipToken &&
+  adapter.outputClient === OutputClient.REACT_QUERY &&
+  adapter.hasQueryV5;
+
+/**
  * Renders the `setXxxQueryData` helper as either a React hook (returns a
  * setter) or a plain function taking `queryClient`. Both shapes share the
  * same body and signature, so this collapses what would otherwise be two
@@ -1153,8 +1167,10 @@ export const generateQueryHook = async (
     isQuery = false;
   }
 
-  // `skipToken` does not exist before TanStack Query v5.
-  const useSkipToken = !!override.query.useSkipToken && adapter.hasQueryV5;
+  const useSkipToken = resolveUseSkipToken(
+    override.query.useSkipToken,
+    adapter,
+  );
 
   // Warn when an operation referenced by a `mutationInvalidates` rule's
   // `onMutations` list is generated as a Query (or no hook at all). The rule

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -29,6 +29,7 @@ import {
   generateQueryOptions,
   getQueryOptionsDefinition,
   isInfiniteQuery,
+  isSuspenseQuery,
   QueryType,
   requiresUserSuppliedQueryOptions,
 } from './query-options';
@@ -179,6 +180,34 @@ export const allowUndefinedParam = (impl: string) => {
   const optional = /^(\w+)\?:\s*(.+)$/.exec(impl);
   if (optional) return `${optional[1]}: ${optional[2]} | undefined`;
   return impl.replace(/^(\w+):\s*(.+)$/, '$1: $2 | undefined');
+};
+
+/**
+ * The `queryFn` entry of the emitted options literal. With `useSkipToken` a query
+ * whose params are not resolved is held by `skipToken`, so a caller's own
+ * `enabled` cannot replace the check and `refetch()` cannot bypass it.
+ *
+ * A suspense query is never held — TanStack excludes `SkipToken` from its
+ * `queryFn`, which is also why it gets no generated `enabled` guard.
+ */
+export const getQueryFnProperty = ({
+  useSkipToken,
+  params,
+  type,
+}: {
+  useSkipToken?: boolean;
+  params: GetterParams;
+  type: (typeof QueryType)[keyof typeof QueryType];
+}) => {
+  if (!useSkipToken || params.length === 0 || isSuspenseQuery(type)) {
+    return 'queryFn';
+  }
+
+  const isUnresolved = params
+    .map(({ name }) => `${name} === null || ${name} === undefined`)
+    .join(' || ');
+
+  return `queryFn: ${isUnresolved} ? skipToken : queryFn`;
 };
 
 /**
@@ -453,6 +482,7 @@ const generateQueryImplementation = ({
   useInvalidate,
   useSetQueryData,
   useGetQueryData,
+  useSkipToken,
   adapter,
 }: {
   queryOption: {
@@ -491,6 +521,7 @@ const generateQueryImplementation = ({
   useInvalidate?: boolean;
   useSetQueryData?: boolean;
   useGetQueryData?: boolean;
+  useSkipToken?: boolean;
   adapter: FrameworkAdapter;
 }) => {
   const {
@@ -693,7 +724,10 @@ const generateQueryImplementation = ({
     options,
     type,
     adapter,
+    useSkipToken,
   });
+
+  const queryFnProperty = getQueryFnProperty({ useSkipToken, params, type });
 
   const queryOptionsFnName = camel(
     shouldUseOptionsHook({
@@ -777,7 +811,7 @@ ${hookOptions}
             // operation. See #3153.
             `const customOptions = ${
               queryOptionsMutator.name
-            }({ queryKey, queryFn, ${queryOptionsImp}}${
+            }({ queryKey, ${queryFnProperty}, ${queryOptionsImp}}${
               queryOptionsMutator.hasSecondArg ? `, { ${queryProperties} }` : ''
             }${
               queryOptionsMutator.hasThirdArg
@@ -790,7 +824,7 @@ ${hookOptions}
    return  ${
      queryOptionsMutator
        ? 'customOptions'
-       : `{ queryKey, queryFn, ${queryOptionsImp}}`
+       : `{ queryKey, ${queryFnProperty}, ${queryOptionsImp}}`
    }${
      adapter.shouldCastQueryOptions?.() === false
        ? ''
@@ -1119,6 +1153,9 @@ export const generateQueryHook = async (
     isQuery = false;
   }
 
+  // `skipToken` does not exist before TanStack Query v5.
+  const useSkipToken = !!override.query.useSkipToken && adapter.hasQueryV5;
+
   // Warn when an operation referenced by a `mutationInvalidates` rule's
   // `onMutations` list is generated as a Query (or no hook at all). The rule
   // is wired up in mutation-generator and only fires for Mutation hooks, so
@@ -1347,6 +1384,7 @@ ${queryKeyFns}`;
           operationQueryOptions?.useSetQueryData ?? query.useSetQueryData,
         useGetQueryData:
           operationQueryOptions?.useGetQueryData ?? query.useGetQueryData,
+        useSkipToken,
         adapter,
       });
     }

--- a/packages/query/src/query-options.test.ts
+++ b/packages/query/src/query-options.test.ts
@@ -279,3 +279,43 @@ describe('getQueryOptionsDefinition: mutation variables alias (issue #3782)', ()
     expect(out).toContain('void, TContext>');
   });
 });
+
+describe('generateQueryOptions with useSkipToken', () => {
+  it('does not emit the enabled guard, because skipToken replaces it', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = generateQueryOptions({
+      params: [param('petId')],
+      options: undefined,
+      type: QueryType.QUERY,
+      adapter,
+      useSkipToken: true,
+    });
+    expect(out).not.toContain('enabled:');
+    expect(out).toContain('...queryOptions');
+  });
+
+  it('keeps the configured query options alongside it', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = generateQueryOptions({
+      params: [param('petId')],
+      options: { staleTime: 10000 },
+      type: QueryType.QUERY,
+      adapter,
+      useSkipToken: true,
+    });
+    expect(out).not.toContain('enabled:');
+    expect(out).toContain('staleTime: 10000');
+  });
+
+  it('still emits the enabled guard when the option is off', () => {
+    const adapter = createFrameworkAdapter({ outputClient: 'react-query' });
+    const out = generateQueryOptions({
+      params: [param('petId')],
+      options: undefined,
+      type: QueryType.QUERY,
+      adapter,
+      useSkipToken: false,
+    });
+    expect(out).toContain('enabled: petId !== null && petId !== undefined,');
+  });
+});

--- a/packages/query/src/query-options.ts
+++ b/packages/query/src/query-options.ts
@@ -37,11 +37,14 @@ export const generateQueryOptions = ({
   options,
   type,
   adapter,
+  useSkipToken,
 }: {
   params: GetterParams;
   options?: object | boolean;
   type: QueryType;
   adapter?: FrameworkAdapter;
+  /** `skipToken` holds the query instead, so the `enabled` guard is redundant. */
+  useSkipToken?: boolean;
 }) => {
   if (options === false) {
     return '';
@@ -59,6 +62,10 @@ export const generateQueryOptions = ({
     }
 
     return '...queryOptions';
+  }
+
+  if (useSkipToken) {
+    return `${queryConfig} ...queryOptions`;
   }
 
   const enabledOption = adapter


### PR DESCRIPTION
Closes #3993.

`enabled` cannot carry "the param has not arrived yet":

- it does not gate `refetch()`, so a retry button or pull-to-refresh sends `GET /pets/undefined`;
- it is a single option and the caller's `...queryOptions` is spread last, so `useShowPetById(petId, { query: { enabled: isTabVisible } })` silently replaces the generated param check.

This adds an opt-in `override.query.useSkipToken` (default `false`) that holds the query in `queryFn` with TanStack's [`skipToken`](https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken) instead of emitting the `enabled` guard:

```ts
return {
  queryKey,
  queryFn: petId === null || petId === undefined ? skipToken : queryFn,
  ...queryOptions,
};
```

`enabled` then stays free for the caller, and `refetch()` cannot bypass the check.


### Scope

- React Query v5 only (`adapter.hasQueryV5`) — `skipToken` does not exist before v5. The other v5 adapters (solid/svelte/vue) each have their own `generateEnabledOption`; I don't work in those frameworks enough to be confident about the equivalent, so they are left alone.
- Replaces the `enabled` guard wherever that guard is emitted.
- Suspense queries are untouched: TanStack excludes `SkipToken` from their `queryFn` type, which is also why they get no `enabled` guard today.
- Query keys are unchanged.

### Behaviour change to be aware of

With the option on, `refetch()` before the params resolve puts the query into the error state (`Missing queryFn`) instead of firing a request with `undefined` in the URL. I think the error is the better outcome, but it is a visible difference for anyone enabling the option.

### Verification

- `@orval/query` unit tests: 193 pass, including new cases for `getQueryFnProperty` (multi-param, infinite, both suspense types) and `generateQueryOptions` (guard dropped, configured options kept, guard still emitted when off).
- `vp run test:snapshots`: 7350 pass, and regenerating every sample leaves no diff — with the default off this is a no-op.
- `vp fmt --check`, `vp run typecheck` and `vp lint --type-aware --type-check packages` are clean.
- Generated `samples/react-query/basic/petstore.yaml` with `useSkipToken: true` + `allParamsOptional: true`: the `showPetById` factory emits the `skipToken` branch and no `enabled` guard, the suspense factory is unchanged, and a probe calling `useShowPetById(petId, { query: { enabled: true } })` with `petId?: string` typechecks (`tsc --noEmit`). The scratch config and output were not committed.

### Docs

`docs/content/docs/guides/react-query.mdx` gets a short "Skip Token" section (what it emits and the two cases `enabled` does not cover), and `output.mdx` gets the `useSkipToken` reference entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional TanStack Query v5 `skipToken` support for generated queries with unresolved parameters.
  * Unresolved queries send no request; early `refetch()` rejects with a `Missing queryFn` error.
  * Caller-provided query options remain supported.
  * Support is limited to React Query v5; other adapters and React Query v4 retain existing behavior.
  * Suspense queries remain unaffected.

* **Documentation**
  * Added guidance on configuration, behavior differences from `enabled`, parameter requirements, and usage recommendations.

* **Tests**
  * Added coverage for adapter compatibility and generated query options with and without `skipToken`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->