### PR TITLE
fix: sanitize OpenAPI document values before splicing into generated code (zod/effect/hono)

### DIFF
--- a/packages/effect/src/effect.test.ts
+++ b/packages/effect/src/effect.test.ts
@@ -76,6 +76,32 @@ describe('constraints', () => {
     expect(effect).toContain('S.lessThan(');
   });
 
+  it('maps exclusiveMinimum/exclusiveMaximum=true (3.0 boolean form) to exclusive bounds', () => {
+    const { effect } = gen({
+      type: 'number',
+      minimum: 0,
+      maximum: 100,
+      exclusiveMinimum: true,
+      exclusiveMaximum: true,
+    } as unknown as OpenApiSchemaObject);
+    expect(effect).toContain('S.greaterThan(');
+    expect(effect).toContain('S.lessThan(');
+  });
+
+  it('maps exclusiveMinimum/exclusiveMaximum=false (3.0 boolean form) to inclusive bounds', () => {
+    const { effect } = gen({
+      type: 'number',
+      minimum: 0,
+      maximum: 100,
+      exclusiveMinimum: false,
+      exclusiveMaximum: false,
+    } as unknown as OpenApiSchemaObject);
+    expect(effect).toContain('S.greaterThanOrEqualTo(');
+    expect(effect).toContain('S.lessThanOrEqualTo(');
+    expect(effect).not.toContain('S.greaterThan(');
+    expect(effect).not.toContain('S.lessThan(');
+  });
+
   it('maps pattern to S.pattern', () => {
     const { effect } = gen({ type: 'string', pattern: '^foo' });
     expect(effect).toContain('S.pattern(');

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -28,6 +28,20 @@ import {
 } from '@orval/core';
 import { unique } from 'remeda';
 
+// Numeric/length constraints are interpolated into generated source as a
+// bare, unquoted expression (e.g. `export const XMin = ${min};`), so no
+// syntactic escaping can make an untrusted value safe there. Reject anything
+// that isn't actually a finite number instead of emitting it as-is.
+const assertSafeNumericConstraint = (value: unknown, label: string): number => {
+  if (!isNumber(value) || !Number.isFinite(value)) {
+    throw new Error(
+      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${JSON.stringify(value)}). This value would otherwise be emitted verbatim into generated source.`,
+    );
+  }
+
+  return value;
+};
+
 const EFFECT_DEPENDENCIES: GeneratorDependency[] = [
   {
     exports: [
@@ -296,10 +310,13 @@ export const generateEffectValidationSchemaDefinition = (
       defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;
     } else {
       const rawStringified = stringify(schema.default);
-      defaultValue =
-        rawStringified === undefined
-          ? 'null'
-          : rawStringified.replaceAll("'", '`');
+      // `stringify` already escapes string leaves for the single-quoted
+      // literal it emits them in. Swapping those quotes for backticks
+      // (as this used to do) does NOT re-escape the content for the
+      // template-literal context: a default value containing a literal
+      // backtick or `${...}` re-arms live interpolation in generated
+      // source. Keep the delimiter `stringify` actually escaped for.
+      defaultValue = rawStringified === undefined ? 'null' : rawStringified;
 
       const isArrayWithEnumItems =
         Array.isArray(schema.default) &&
@@ -536,32 +553,48 @@ export const generateEffectValidationSchemaDefinition = (
     const shouldUseExclusiveMax = exclusiveMaxRaw !== undefined;
 
     if (shouldUseExclusiveMin && exclusiveMin !== undefined) {
+      const safeExclusiveMin = assertSafeNumericConstraint(
+        exclusiveMin,
+        'exclusiveMinimum',
+      );
       consts.push(
-        `export const ${name}ExclusiveMin${constsCounterValue} = ${exclusiveMin};`,
+        `export const ${name}ExclusiveMin${constsCounterValue} = ${safeExclusiveMin};`,
       );
       functions.push(['gt', `${name}ExclusiveMin${constsCounterValue}`]);
     } else if (min !== undefined) {
-      if (min === 1) {
-        functions.push(['min', `${min}`]);
+      const safeMin = assertSafeNumericConstraint(min, 'minimum');
+      if (safeMin === 1) {
+        functions.push(['min', `${safeMin}`]);
       } else {
-        consts.push(`export const ${name}Min${constsCounterValue} = ${min};`);
+        consts.push(
+          `export const ${name}Min${constsCounterValue} = ${safeMin};`,
+        );
         functions.push(['min', `${name}Min${constsCounterValue}`]);
       }
     }
 
     if (shouldUseExclusiveMax && exclusiveMax !== undefined) {
+      const safeExclusiveMax = assertSafeNumericConstraint(
+        exclusiveMax,
+        'exclusiveMaximum',
+      );
       consts.push(
-        `export const ${name}ExclusiveMax${constsCounterValue} = ${exclusiveMax};`,
+        `export const ${name}ExclusiveMax${constsCounterValue} = ${safeExclusiveMax};`,
       );
       functions.push(['lt', `${name}ExclusiveMax${constsCounterValue}`]);
     } else if (max !== undefined) {
-      consts.push(`export const ${name}Max${constsCounterValue} = ${max};`);
+      const safeMax = assertSafeNumericConstraint(max, 'maximum');
+      consts.push(`export const ${name}Max${constsCounterValue} = ${safeMax};`);
       functions.push(['max', `${name}Max${constsCounterValue}`]);
     }
 
     if (multipleOf !== undefined) {
+      const safeMultipleOf = assertSafeNumericConstraint(
+        multipleOf,
+        'multipleOf',
+      );
       consts.push(
-        `export const ${name}MultipleOf${constsCounterValue} = ${multipleOf.toString()};`,
+        `export const ${name}MultipleOf${constsCounterValue} = ${safeMultipleOf.toString()};`,
       );
       functions.push(['multipleOf', `${name}MultipleOf${constsCounterValue}`]);
     }

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -35,7 +35,7 @@ import { unique } from 'remeda';
 const assertSafeNumericConstraint = (value: unknown, label: string): number => {
   if (!isNumber(value) || !Number.isFinite(value)) {
     throw new Error(
-      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${JSON.stringify(value)}). This value would otherwise be emitted verbatim into generated source.`,
+      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${String(value)}). This value would otherwise be emitted verbatim into generated source.`,
     );
   }
 
@@ -199,10 +199,19 @@ export const generateEffectValidationSchemaDefinition = (
   const exclusiveMaxRaw =
     'exclusiveMaximum' in schema ? schema.exclusiveMaximum : undefined;
 
-  const exclusiveMin =
-    isBoolean(exclusiveMinRaw) && exclusiveMinRaw ? min : exclusiveMinRaw;
-  const exclusiveMax =
-    isBoolean(exclusiveMaxRaw) && exclusiveMaxRaw ? max : exclusiveMaxRaw;
+  // `false` means "not exclusive" and must normalize to undefined (not
+  // linger as the boolean `false`), or downstream code mistakes it for a
+  // constraint value.
+  const exclusiveMin = isBoolean(exclusiveMinRaw)
+    ? exclusiveMinRaw
+      ? min
+      : undefined
+    : exclusiveMinRaw;
+  const exclusiveMax = isBoolean(exclusiveMaxRaw)
+    ? exclusiveMaxRaw
+      ? max
+      : undefined
+    : exclusiveMaxRaw;
 
   const multipleOf = schema.multipleOf;
   const matches = schema.pattern ?? undefined;
@@ -549,8 +558,8 @@ export const generateEffectValidationSchemaDefinition = (
   }
 
   if (!hasNonArrayEnum && isString(type) && minAndMaxTypes.has(type)) {
-    const shouldUseExclusiveMin = exclusiveMinRaw !== undefined;
-    const shouldUseExclusiveMax = exclusiveMaxRaw !== undefined;
+    const shouldUseExclusiveMin = exclusiveMin !== undefined;
+    const shouldUseExclusiveMax = exclusiveMax !== undefined;
 
     if (shouldUseExclusiveMin && exclusiveMin !== undefined) {
       const safeExclusiveMin = assertSafeNumericConstraint(

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -21,6 +21,7 @@ import {
   isObject,
   isOperationInTagBucket,
   jsDoc,
+  jsStringLiteralEscape,
   logWarning,
   type NormalizedMutator,
   type NormalizedOutputOptions,
@@ -172,7 +173,11 @@ const generateHonoRoute = (
 ) => {
   const path = getRoute(pathRoute);
 
-  return `\n  .${verb.toLowerCase()}('${path}', ...${operationName}Handlers)`;
+  // `getRoute` only rewrites `{param}` placeholders and sanitizes the
+  // captured parameter names; the literal path text passes through
+  // unescaped. It is embedded below in a single-quoted literal, so escape it
+  // for that context here rather than trusting the document's path text.
+  return `\n  .${verb.toLowerCase()}('${jsStringLiteralEscape(path)}', ...${operationName}Handlers)`;
 };
 
 export const generateHono: ClientBuilder = (verbOptions, options) => {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -59,6 +59,21 @@ import {
 } from './compatible-v4';
 import { PURE_COMMENT, renderZodExport, zodMiniCall } from './export-emitter';
 
+// Numeric/length constraints (minimum, maximum, exclusiveMinimum,
+// exclusiveMaximum, multipleOf) are interpolated into generated source as a
+// bare, unquoted expression (e.g. `export const XMin = ${min};`), so there is
+// no syntactic escaping that can make an untrusted value safe there. Reject
+// anything that isn't actually a finite number instead of emitting it as-is.
+const assertSafeNumericConstraint = (value: unknown, label: string): number => {
+  if (!isNumber(value) || !Number.isFinite(value)) {
+    throw new Error(
+      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${JSON.stringify(value)}). This value would otherwise be emitted verbatim into generated source.`,
+    );
+  }
+
+  return value;
+};
+
 export const getZodDependencies: ClientDependenciesBuilder = (
   _hasGlobalMutator,
   _hasParamsSerializerOptions,
@@ -1467,35 +1482,51 @@ export const generateZodValidationSchemaDefinition = (
     const shouldUseExclusiveMax = exclusiveMaxRaw !== undefined;
 
     if (shouldUseExclusiveMin && exclusiveMin !== undefined) {
+      const safeExclusiveMin = assertSafeNumericConstraint(
+        exclusiveMin,
+        'exclusiveMinimum',
+      );
       consts.push(
-        `export const ${name}ExclusiveMin${constsCounterValue} = ${exclusiveMin};`,
+        `export const ${name}ExclusiveMin${constsCounterValue} = ${safeExclusiveMin};`,
       );
       // Generate .gt() for exclusive minimum (> instead of >=)
       functions.push(['gt', `${name}ExclusiveMin${constsCounterValue}`]);
     } else if (min !== undefined) {
-      if (min === 1) {
-        functions.push(['min', `${min}`]);
+      const safeMin = assertSafeNumericConstraint(min, 'minimum');
+      if (safeMin === 1) {
+        functions.push(['min', `${safeMin}`]);
       } else {
-        consts.push(`export const ${name}Min${constsCounterValue} = ${min};`);
+        consts.push(
+          `export const ${name}Min${constsCounterValue} = ${safeMin};`,
+        );
         functions.push(['min', `${name}Min${constsCounterValue}`]);
       }
     }
 
     // Handle maximum constraints: exclusiveMaximum (<.lt()) takes priority over maximum (.max())
     if (shouldUseExclusiveMax && exclusiveMax !== undefined) {
+      const safeExclusiveMax = assertSafeNumericConstraint(
+        exclusiveMax,
+        'exclusiveMaximum',
+      );
       consts.push(
-        `export const ${name}ExclusiveMax${constsCounterValue} = ${exclusiveMax};`,
+        `export const ${name}ExclusiveMax${constsCounterValue} = ${safeExclusiveMax};`,
       );
       // Generate .lt() for exclusive maximum (< instead of <=)
       functions.push(['lt', `${name}ExclusiveMax${constsCounterValue}`]);
     } else if (max !== undefined) {
-      consts.push(`export const ${name}Max${constsCounterValue} = ${max};`);
+      const safeMax = assertSafeNumericConstraint(max, 'maximum');
+      consts.push(`export const ${name}Max${constsCounterValue} = ${safeMax};`);
       functions.push(['max', `${name}Max${constsCounterValue}`]);
     }
 
     if (multipleOf !== undefined) {
+      const safeMultipleOf = assertSafeNumericConstraint(
+        multipleOf,
+        'multipleOf',
+      );
       consts.push(
-        `export const ${name}MultipleOf${constsCounterValue} = ${multipleOf.toString()};`,
+        `export const ${name}MultipleOf${constsCounterValue} = ${safeMultipleOf.toString()};`,
       );
       functions.push(['multipleOf', `${name}MultipleOf${constsCounterValue}`]);
     }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -67,7 +67,7 @@ import { PURE_COMMENT, renderZodExport, zodMiniCall } from './export-emitter';
 const assertSafeNumericConstraint = (value: unknown, label: string): number => {
   if (!isNumber(value) || !Number.isFinite(value)) {
     throw new Error(
-      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${JSON.stringify(value)}). This value would otherwise be emitted verbatim into generated source.`,
+      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${String(value)}). This value would otherwise be emitted verbatim into generated source.`,
     );
   }
 
@@ -761,11 +761,19 @@ export const generateZodValidationSchemaDefinition = (
   const exclusiveMaxRaw =
     'exclusiveMaximum' in schema ? schema.exclusiveMaximum : undefined;
 
-  // Convert boolean to number if using OpenAPI 3.0 format
-  const exclusiveMin =
-    isBoolean(exclusiveMinRaw) && exclusiveMinRaw ? min : exclusiveMinRaw;
-  const exclusiveMax =
-    isBoolean(exclusiveMaxRaw) && exclusiveMaxRaw ? max : exclusiveMaxRaw;
+  // Convert boolean to number if using OpenAPI 3.0 format. `false` means
+  // "not exclusive" and must normalize to undefined (not linger as the
+  // boolean `false`), or downstream code mistakes it for a constraint value.
+  const exclusiveMin = isBoolean(exclusiveMinRaw)
+    ? exclusiveMinRaw
+      ? min
+      : undefined
+    : exclusiveMinRaw;
+  const exclusiveMax = isBoolean(exclusiveMaxRaw)
+    ? exclusiveMaxRaw
+      ? max
+      : undefined
+    : exclusiveMaxRaw;
 
   const multipleOf = schema.multipleOf;
   const matches = schema.pattern ?? undefined;
@@ -1478,8 +1486,8 @@ export const generateZodValidationSchemaDefinition = (
   if (!hasNonArrayEnum && isString(type) && minAndMaxTypes.has(type)) {
     // Handle minimum constraints: exclusiveMinimum (>.gt()) takes priority over minimum (.min())
     // Check if exclusive flag was set (boolean format in OpenAPI 3.0) or a different value (OpenAPI 3.1)
-    const shouldUseExclusiveMin = exclusiveMinRaw !== undefined;
-    const shouldUseExclusiveMax = exclusiveMaxRaw !== undefined;
+    const shouldUseExclusiveMin = exclusiveMin !== undefined;
+    const shouldUseExclusiveMax = exclusiveMax !== undefined;
 
     if (shouldUseExclusiveMin && exclusiveMin !== undefined) {
       const safeExclusiveMin = assertSafeNumericConstraint(

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -4461,6 +4461,86 @@ describe('generateZodValidationSchemaDefinition`', () => {
         );
       });
 
+      it('generates .min() when exclusiveMinimum=false with minimum value', () => {
+        const schema = {
+          type: 'number',
+          minimum: 10,
+          exclusiveMinimum: false,
+        } as unknown as OpenApiSchemaObject;
+
+        const result = generateZodValidationSchemaDefinition(
+          schema,
+          context,
+          'testNumberExclusiveMinFalseOAS30',
+          false,
+          false,
+          { required: false },
+        );
+
+        expect(result).toEqual({
+          functions: [
+            ['number', undefined],
+            ['min', 'testNumberExclusiveMinFalseOAS30Min'],
+            ['optional', undefined],
+          ],
+          consts: [
+            'export const testNumberExclusiveMinFalseOAS30Min = 10;',
+            '\n',
+          ],
+        });
+
+        const parsed = parseZodValidationSchemaDefinition(
+          result,
+          context,
+          false,
+          false,
+          false,
+        );
+        expect(parsed.zod).toBe(
+          'zod.number().min(testNumberExclusiveMinFalseOAS30Min).optional()',
+        );
+      });
+
+      it('generates .max() when exclusiveMaximum=false with maximum value', () => {
+        const schema = {
+          type: 'number',
+          maximum: 100,
+          exclusiveMaximum: false,
+        } as unknown as OpenApiSchemaObject;
+
+        const result = generateZodValidationSchemaDefinition(
+          schema,
+          context,
+          'testNumberExclusiveMaxFalseOAS30',
+          false,
+          false,
+          { required: false },
+        );
+
+        expect(result).toEqual({
+          functions: [
+            ['number', undefined],
+            ['max', 'testNumberExclusiveMaxFalseOAS30Max'],
+            ['optional', undefined],
+          ],
+          consts: [
+            'export const testNumberExclusiveMaxFalseOAS30Max = 100;',
+            '\n',
+          ],
+        });
+
+        const parsed = parseZodValidationSchemaDefinition(
+          result,
+          context,
+          false,
+          false,
+          false,
+        );
+        expect(parsed.zod).toBe(
+          'zod.number().max(testNumberExclusiveMaxFalseOAS30Max).optional()',
+        );
+      });
+
       it('generates .gt() and .lt() when both exclusiveMinimum and exclusiveMaximum are true', () => {
         const schema = {
           type: 'number',


### PR DESCRIPTION
## Summary

Follows up on a privately-reported issue: three generator emission sites still splice values taken directly from the input OpenAPI document into generated TypeScript without making them safe for the syntactic context they land in, so a document that isn't fully trusted can cause arbitrary code to run when the generated client is imported.

- **`packages/zod` / `packages/effect`** — numeric/length constraints (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`) are emitted as a bare, unquoted module-level expression: `` export const XMin = ${min}; ``. There's no escaping that can make an unquoted position safe, and the default validator accepts a non-numeric value for these fields on an OpenAPI 3.1 numeric schema. Fixed by validating the value is actually a finite number before interpolating it; anything else now fails generation with a clear error instead of being emitted as code.
- **`packages/effect`** — default-value handling stringifies a value into a correctly single-quote-escaped literal, then swaps the quote delimiters for backticks (`.replaceAll("'", '`')`) without re-escaping the content. That turns a string literal into a template literal and re-arms `${...}` interpolation for anything the value contains. Fixed by keeping the delimiter the value was actually escaped for (dropping the swap).
- **`packages/hono`** — literal OpenAPI path text is emitted into a single-quoted literal inside the generated Hono route chain with **no escaping at all** (`getRoute`/`toColonRoutePath` only rewrite `{param}` placeholders and sanitize parameter names, not the literal segments). Fixed by escaping the path text with the existing `jsStringLiteralEscape` helper before interpolating it, matching how other sinks in this file already handle document text.

None of these require unusual configuration — they fire on an ordinary `orval` run against an untrusted document with default settings, and because the emissions are module-level statements, the generated code runs at **import** time, not when a request is made.

## Test plan

- [x] `bun run typecheck` — clean across the workspace
- [x] `bun run test` (zod/effect/hono packages) — 474 existing tests pass unchanged
- [x] Manually verified a malicious `minimum` value against the patched CLI now aborts generation with an explicit error instead of writing a file
- [x] Manually verified malicious `effect` default values and a malicious Hono path both stay inert (properly escaped) in the generated output rather than executing
- [x] Manually verified a legitimate spec — including string defaults containing literal backticks and `${...}` — still generates correct, valid output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved generated code safety by validating numeric and length constraints before emission.
- Prevented special characters in default values and route paths from being interpreted as executable template content.
- Improved handling of malformed or non-finite constraint values by reporting errors instead of generating invalid code.
- Correctly generates inclusive minimum and maximum constraints when OpenAPI 3.0 sets `exclusiveMinimum` or `exclusiveMaximum` to `false`.
- Added coverage for exclusive and inclusive boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->