### PR TITLE
fix(zod): preserve numeric literals in object defaults

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1073,10 +1073,13 @@ export const generateZodValidationSchemaDefinition = (
           return nestedEntries.length === 0 ? '{}' : `{ ${nestedEntries} }`;
         }
 
+        if (isNumber(entryValue)) {
+          return `${entryValue} as const`;
+        }
+
         if (
           entryValue === null ||
           entryValue === undefined ||
-          isNumber(entryValue) ||
           isBoolean(entryValue)
         )
           return `${entryValue}`;

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1045,6 +1045,13 @@ export const generateZodValidationSchemaDefinition = (
             if (isString(item)) {
               return `${JSON.stringify(item)} as const`;
             }
+            if (isNumber(item)) {
+              return `${item} as const`;
+            }
+            if (Array.isArray(item)) {
+              const formatted = formatDefaultEntryValue(item);
+              return formatted ?? '[]';
+            }
             // Object items recurse so nested string values get `as const`
             // (e.g. `{ value: 'active' as const }`), which JSON.stringify
             // alone would drop (#3982 CodeRabbit).

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -3977,6 +3977,111 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
     });
 
+    it('narrows numeric enum array items in object defaults', () => {
+      const schemaWithNumericEnumArrayDefault: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          codes: {
+            type: 'array',
+            items: { type: 'integer', enum: [1, 2, 3] },
+          },
+          negative_codes: {
+            type: 'array',
+            items: { type: 'integer', enum: [-2, -1] },
+          },
+          decimal_codes: {
+            type: 'array',
+            items: { type: 'number', enum: [-3.5, 2.1] },
+          },
+        },
+        default: {
+          codes: [1, 2],
+          negative_codes: [-2],
+          decimal_codes: [2.1, -3.5],
+        },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithNumericEnumArrayDefault,
+        context,
+        'NumericArrayExample',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toContain(
+        'export const NumericArrayExampleDefault = { "codes": [1 as const, 2 as const], "negative_codes": [-2 as const], "decimal_codes": [2.1 as const, -3.5 as const] };',
+      );
+      expect(result.functions).toContainEqual([
+        'default',
+        'NumericArrayExampleDefault',
+      ]);
+    });
+
+    it('narrows numeric enum array items in nested object defaults', () => {
+      const schemaWithNestedNumericEnumArrayDefault: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          groups: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                codes: {
+                  type: 'array',
+                  items: { type: 'integer', enum: [-2, 1, 2] },
+                },
+              },
+            },
+          },
+        },
+        default: { groups: [{ codes: [-2, 1] }] },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithNestedNumericEnumArrayDefault,
+        context,
+        'NestedNumericArrayExample',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toContain(
+        'export const NestedNumericArrayExampleDefault = { "groups": [{ "codes": [-2 as const, 1 as const] }] };',
+      );
+    });
+
+    it('narrows numeric enum values in nested arrays in object defaults', () => {
+      const schemaWithNestedNumericArrayDefault: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          matrix: {
+            type: 'array',
+            items: {
+              type: 'array',
+              items: { type: 'integer', enum: [1, 2, 3] },
+            },
+          },
+        },
+        default: { matrix: [[2]] },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithNestedNumericArrayDefault,
+        context,
+        'MatrixExample',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toContain(
+        'export const MatrixExampleDefault = { "matrix": [[2 as const]] };',
+      );
+    });
+
     it('keeps array values mutable in object defaults so zod.default() accepts them (#3399)', () => {
       const schemaWithArrayInObjectDefault: OpenApiSchemaObject = {
         type: 'object',

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2533,7 +2533,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
           ['default', 'testObjectDefaultDefault'],
         ],
         consts: [
-          'export const testObjectDefaultDefault = { "name": "Fluffy" as const, "age": 3 };',
+          'export const testObjectDefaultDefault = { "name": "Fluffy" as const, "age": 3 as const };',
         ],
       });
 
@@ -2548,7 +2548,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'zod.object({\n  "name": zod.string().optional(),\n  "age": zod.number().optional()\n}).default(testObjectDefaultDefault)',
       );
       expect(parsed.consts).toBe(
-        'export const testObjectDefaultDefault = { "name": "Fluffy" as const, "age": 3 };',
+        'export const testObjectDefaultDefault = { "name": "Fluffy" as const, "age": 3 as const };',
       );
     });
 
@@ -2723,7 +2723,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
 
       expect(result.consts).toEqual([
-        'export const parentChildrenDefault = { "entries": [{ "value": 1 }] };',
+        'export const parentChildrenDefault = { "entries": [{ "value": 1 as const }] };',
       ]);
     });
 
@@ -3886,6 +3886,95 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'default',
         'enumPropertiesObjectDefault',
       ]);
+    });
+
+    it('narrows numeric literals in object defaults so enum properties keep literal types (#3992)', () => {
+      const schemaWithNumericEnumDefault: OpenApiSchemaObject = {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          example_value: {
+            type: 'integer',
+            enum: [0, 1, 2],
+            default: 2,
+          },
+        },
+        default: { example_value: 2 },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithNumericEnumDefault,
+        context,
+        'Example',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toContain(
+        'export const ExampleDefault = { "example_value": 2 as const };',
+      );
+      expect(result.functions).toContainEqual(['default', 'ExampleDefault']);
+    });
+
+    it('narrows numeric literals in nested object defaults', () => {
+      const schemaWithNestedNumericEnumDefault: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          settings: {
+            type: 'object',
+            properties: {
+              example_value: { type: 'integer', enum: [0, 1, 2] },
+            },
+          },
+        },
+        default: { settings: { example_value: 2 } },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithNestedNumericEnumDefault,
+        context,
+        'NestedExample',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toContain(
+        'export const NestedExampleDefault = { "settings": { "example_value": 2 as const } };',
+      );
+    });
+
+    it('preserves decimal and negative numeric literals in object defaults', () => {
+      const schemaWithDecimalAndNegativeDefaults: OpenApiSchemaObject = {
+        type: 'object',
+        properties: {
+          decimal_value: {
+            type: 'number',
+            enum: [-2.1, 0, 2.1],
+            default: 2.1,
+          },
+          negative_value: {
+            type: 'number',
+            enum: [-2.1, -1, 0],
+            default: -2.1,
+          },
+        },
+        default: { decimal_value: 2.1, negative_value: -2.1 },
+      };
+
+      const result = generateZodValidationSchemaDefinition(
+        schemaWithDecimalAndNegativeDefaults,
+        context,
+        'NumericExample',
+        false,
+        false,
+        { required: false },
+      );
+
+      expect(result.consts).toContain(
+        'export const NumericExampleDefault = { "decimal_value": 2.1 as const, "negative_value": -2.1 as const };',
+      );
     });
 
     it('keeps array values mutable in object defaults so zod.default() accepts them (#3399)', () => {


### PR DESCRIPTION
## Summary

Fixes #3992

Numeric values in OpenAPI object-level defaults were previously emitted as widened `number` types, causing generated Zod defaults to fail TypeScript typechecking when property schemas expected numeric literal or enum types.

The default serializer now preserves numeric literals by appending `as const` at the individual value level instead of applying `as const` to the whole object or array. This also resolves the nested-array case where numeric array items previously bypassed scalar numeric literal serialization, while preserving existing array mutability (#3399 / #3400).

## Examples

### Scalar and Negative/Decimal Values
```ts
export const ExampleDefault = {
  "example_value": 2 as const,
  "rate": 2.1 as const,
  "offset": -2.1 as const,
};

```

### Arrays and Nested Arrays

```ts
// OpenAPI: default: { codes: [2], matrix: [[2]] }
export const ExampleDefault = {
  "codes": [2 as const],
  "matrix": [[2 as const]],
};

```

## Changes

* Preserve numeric literals with `as const` in scalar object defaults.
* Recursively apply `as const` to numeric literals inside arrays and nested arrays.
* Support negative and decimal numeric literals (e.g., `-2.1 as const`).
* Preserve array mutability by scoping `as const` strictly to individual numeric literals rather than root objects or arrays.
* Maintain existing serialization behavior for strings, booleans, objects, and null values.
* Add regression test coverage for numeric enums, negative/decimal numbers, and nested array structures.

## Validation

* `vp test run packages/zod/src/zod.test.ts`
* `vp exec tsc --noEmit -p packages/zod/tsconfig.json`
* `git diff --check`

## Documentation

No documentation updates required; this is an internal TypeScript emission fix with no public API or configuration changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Generated object defaults now preserve numeric literal types with `as const`, including nested objects, arrays, numeric enums, and multi-dimensional arrays.
  - Integer, decimal, and negative numeric values retain their literal types at every array depth.
  - Invalid numeric and length constraints are now rejected instead of being emitted.
  - OpenAPI 3.0 `exclusiveMinimum` and `exclusiveMaximum` values set to `false` now correctly generate inclusive minimum and maximum constraints.
  - Improves type accuracy and constraint handling in generated schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->