### PR TITLE
fix(zod): tuple item consts, inline tuple defaults, unescaped slashes in describe

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -576,7 +576,7 @@ export const generateZodValidationSchemaDefinition = (
       // break the generated string literal (TS1002).
       functions.push([
         'describe',
-        `'${jsStringEscape(siblingSchema.description)}'`,
+        `'${jsStringLiteralEscape(siblingSchema.description)}'`,
       ]);
     }
   };
@@ -738,7 +738,10 @@ export const generateZodValidationSchemaDefinition = (
       if (deprecated) meta.deprecated = true;
       functions.push(['meta', meta]);
     } else if (description !== undefined) {
-      functions.push(['describe', `'${jsStringEscape(description)}'`]);
+      // `.describe()` embeds the text in a plain string literal, so `/` and
+      // `*` carry no meaning and escaping them would trip ESLint's
+      // `no-useless-escape` in the generated code (#3985).
+      functions.push(['describe', `'${jsStringLiteralEscape(description)}'`]);
     }
   };
 
@@ -1120,6 +1123,23 @@ export const generateZodValidationSchemaDefinition = (
         defaultVarName = defaultValue;
         defaultValue = undefined;
       }
+
+      // A tuple (prefixItems) default must stay inline: hoisting it into a
+      // named const widens the array to `number[]` (mutable, unbounded) which
+      // is not assignable to the fixed-length `[number, number]` tuple that
+      // `zod.tuple()` expects (#3984). Inline, TypeScript contextually types
+      // the array literal as a tuple. `resolveZodType` maps prefixItems
+      // arrays to 'tuple', so match both.
+      const isTupleWithDefault =
+        Array.isArray(schema.default) &&
+        (type === 'array' || type === 'tuple') &&
+        'prefixItems' in schema &&
+        schema.default.length > 0;
+
+      if (isTupleWithDefault) {
+        defaultVarName = defaultValue;
+        defaultValue = undefined;
+      }
     }
     if (defaultValue) {
       consts.push(`export const ${defaultVarName} = ${defaultValue};`);
@@ -1199,8 +1219,8 @@ export const generateZodValidationSchemaDefinition = (
                   dereference(item, context),
                   context,
                   camel(`${name}-${idx}-item`),
-                  isZodV4,
                   strict,
+                  isZodV4,
                   {
                     required: true,
                     constNameRegistry,
@@ -1729,13 +1749,13 @@ export interface ZodMetaArgs {
 const buildMetaArgs = (args: ZodMetaArgs): string | undefined => {
   const parts: string[] = [];
   if (args.id !== undefined) {
-    parts.push(`id: '${jsStringEscape(args.id)}'`);
+    parts.push(`id: '${jsStringLiteralEscape(args.id)}'`);
   }
   if (args.title !== undefined) {
-    parts.push(`title: '${jsStringEscape(args.title)}'`);
+    parts.push(`title: '${jsStringLiteralEscape(args.title)}'`);
   }
   if (args.description !== undefined) {
-    parts.push(`description: '${jsStringEscape(args.description)}'`);
+    parts.push(`description: '${jsStringLiteralEscape(args.description)}'`);
   }
   if (args.deprecated) {
     parts.push('deprecated: true');
@@ -2478,14 +2498,25 @@ ${Object.entries(objectArgs)
           const value = x.functions
             .map((prop) => parseProperty(prop, fieldPath))
             .join('');
+          // Tuple-item consts (e.g. min/max on prefixItems, #3983) must be
+          // emitted just like `array` does above, or the generated code
+          // references undeclared constants.
+          if (Array.isArray(x.consts)) {
+            appendConstsChunk(x.consts.join('\n'));
+          }
           return `${value.startsWith('.') ? 'zod' : ''}${value}`;
         })
         .join(',\n')}])`;
     }
     if (fn === 'rest') {
-      return `.rest(zod${(args as ZodValidationSchemaDefinition).functions
+      const restArgs = args as ZodValidationSchemaDefinition;
+      const restValue = restArgs.functions
         .map((prop) => parseProperty(prop, fieldPath))
-        .join('')})`;
+        .join('');
+      if (Array.isArray(restArgs.consts)) {
+        appendConstsChunk(restArgs.consts.join('\n'));
+      }
+      return `.rest(zod${restValue})`;
     }
     const shouldCoerceType =
       coerceTypes &&

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2766,6 +2766,71 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'export const parentStateDefault = { "val1": { "enabled": false }, "val2": { "enabled": true } };',
       ]);
     });
+
+    it('keeps tuple (prefixItems) defaults inline for contextual tuple typing (#3984)', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'array',
+          minItems: 2,
+          maxItems: 2,
+          default: [0, 100],
+          prefixItems: [
+            { type: 'number', minimum: 0 },
+            { type: 'number', maximum: 100 },
+          ],
+        },
+        context,
+        'exampleRange',
+        false,
+        false,
+        { required: false },
+      );
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      // The default must be inline, not a hoisted const that TS widens to
+      // `number[]` (unassignable to the zod.tuple parameter).
+      expect(parsed.zod).toContain('.default([0, 100])');
+      expect(parsed.consts).not.toContain('exampleRangeDefault =');
+    });
+
+    it('emits tuple item min/max consts so generated code compiles (#3983)', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'array',
+          minItems: 2,
+          maxItems: 2,
+          prefixItems: [
+            { type: 'number', minimum: 0 },
+            { type: 'number', maximum: 100 },
+          ],
+        },
+        context,
+        'exampleRange',
+        false,
+        false,
+        { required: false },
+      );
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      expect(parsed.zod).toContain('.min(exampleRange0ItemMin)');
+      expect(parsed.zod).toContain('.max(exampleRange1ItemMax)');
+      expect(parsed.consts).toContain('export const exampleRange0ItemMin = 0;');
+      expect(parsed.consts).toContain(
+        'export const exampleRange1ItemMax = 100;',
+      );
+    });
   });
 
   describe('default value template-literal injection', () => {

--- a/tests/__snapshots__/zod/typed-arrays-tuples-v3-1/typed-arrays-tuples-v3-1.ts
+++ b/tests/__snapshots__/zod/typed-arrays-tuples-v3-1/typed-arrays-tuples-v3-1.ts
@@ -15,12 +15,10 @@ export const PostApiSampleResponse = zod.object({
   example_tuple_additional: zod.tuple([zod.string(), zod.unknown()]).optional(),
   example_tuple_with_object_item: zod
     .tuple([
-      zod
-        .object({
-          id: zod.string().uuid().optional(),
-        })
-        .strict(),
-      zod.string().uuid(),
+      zod.object({
+        id: zod.uuid().optional(),
+      }),
+      zod.uuid(),
     ])
     .optional(),
   example_const: zod.literal('this_is_a_const').optional(),


### PR DESCRIPTION
Fixes #3983
Fixes #3984
Fixes #3985

## Summary

Three fixes in the zod generator, all reachable from one spec shape (a `prefixItems` tuple property with min/max constraints, a default, and a description):

**#3983 — tuple item consts were dropped.** The classic `parseProperty` path emitted `zod.tuple([zod.number().min(exampleRange0ItemMin), ...])` but never appended the item definitions' `consts`, so the generated code referenced undeclared constants. The tuple (and `rest`) handlers now append item consts exactly like the `array` handler already does.

**#3984 — tuple defaults were hoisted into a widened const.** `default: [0, 100]` on a tuple schema became `export const xDefault = [0, 100];` — TypeScript widens that to `number[]`, which is not assignable to the fixed-length `[number, number]` tuple `zod.tuple()` expects. Tuple defaults now stay inline so TS contextually types the literal as a tuple (same pattern the generator already uses for arrays of enums).

**#3985 — `/` was escaped in `.describe()` text.** `.describe()` embeds the description in a plain string literal, where `/` and `*` carry no meaning; escaping them trips ESLint's `no-useless-escape`. Descriptions now use `jsStringLiteralEscape` (which leaves `/` alone) instead of `jsStringEscape`.

Generated output for the repro spec now compiles:

```ts
export const exampleRange0ItemMin = 0;
export const exampleRange1ItemMax = 100;
export const exampleApi = {
  range: zod.tuple([zod.number().min(exampleRange0ItemMin), zod.number().max(exampleRange1ItemMax)]).default([0, 100]).describe('A range represented by two numbers.'),
};
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated descriptions and metadata now avoid unnecessary escaping that could trigger linting errors.
  * Tuple defaults retain fixed-length typing in generated code.
  * Tuple item and rest constraints now generate valid references without undeclared constants.

* **Tests**
  * Added coverage for tuple defaults and generated tuple constraint declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->