### PR TITLE
fix(core): leave allOf-wrapped ref discriminator properties untouched

### DIFF
--- a/packages/core/src/getters/discriminators.test.ts
+++ b/packages/core/src/getters/discriminators.test.ts
@@ -741,4 +741,65 @@ describe('resolveDiscriminators getter', () => {
       enum: ['cat'],
     });
   });
+
+  it('leaves allOf-wrapped $ref discriminator properties untouched (#3991)', () => {
+    // A member whose discriminator property is an `allOf` wrapping a single
+    // `$ref` to a shared enum (drf-spectacular emits this when a member
+    // accepts multiple discriminator values). Merging mapping keys into the
+    // `allOf` wrapper produces `SharedEnum.enum([...])` in zod output, where
+    // `.enum` on ZodEnum is the values object, not callable (TS2349). The
+    // shared schema already carries the full value set, so the property must
+    // stay exactly as declared.
+    const schemas: OpenApiSchemasObject = {
+      AnyEventRef: {
+        oneOf: [
+          { $ref: '#/components/schemas/SessionEventRef' },
+          { $ref: '#/components/schemas/OtherEventRef' },
+        ],
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            Pause: '#/components/schemas/SessionEventRef',
+            Session: '#/components/schemas/SessionEventRef',
+            Other: '#/components/schemas/OtherEventRef',
+          },
+        },
+      },
+      SessionEventRef: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          type: {
+            allOf: [{ $ref: '#/components/schemas/EventTypeEnum' }],
+            title: 'Type',
+          },
+        },
+        required: ['id', 'type'],
+      },
+      OtherEventRef: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          type: { type: 'string', const: 'Other' },
+        },
+        required: ['id', 'type'],
+      },
+      EventTypeEnum: {
+        type: 'string',
+        enum: ['Session', 'Pause'],
+      },
+    };
+
+    const result = resolveDiscriminators(structuredClone(schemas), context);
+    const sessionProps = result.SessionEventRef.properties as
+      | Record<string, OpenApiSchemaObject | OpenApiReferenceObject>
+      | undefined;
+
+    // The allOf-wrapped ref survives untouched: no injected `enum`, no
+    // injected `type`.
+    expect(sessionProps?.type).toEqual({
+      allOf: [{ $ref: '#/components/schemas/EventTypeEnum' }],
+      title: 'Type',
+    });
+  });
 });

--- a/packages/core/src/getters/discriminators.ts
+++ b/packages/core/src/getters/discriminators.ts
@@ -66,6 +66,22 @@ export function resolveDiscriminators(
           continue;
         }
 
+        // When the discriminator property is an `allOf` wrapping a single
+        // `$ref` to a shared enum, the referenced schema already carries the
+        // full set of valid values. Merging mapping keys into the `allOf`
+        // wrapper itself produces a chimera (e.g. `EventTypeEnum.enum([...])`
+        // where `.enum` on ZodEnum is the values object, not callable —
+        // #3991). Leave the property as declared so the generator emits a
+        // plain reference to the shared schema.
+        const isAllOfRef =
+          property &&
+          Array.isArray(property.allOf) &&
+          property.allOf.length === 1 &&
+          isReference(property.allOf[0]);
+        if (isAllOfRef) {
+          continue;
+        }
+
         const schemaProperty =
           property && !isReference(property) ? property : undefined;
 


### PR DESCRIPTION
Fixes #3991

## Summary

When a `oneOf` discriminator `mapping` targets a member whose discriminator property is an `allOf` wrapping a single `$ref` to a shared enum component (the shape drf-spectacular emits when a member accepts multiple discriminator values), `resolveDiscriminators` merged the mapping keys into the `allOf` wrapper itself. The zod generator then rendered the chimera as `EventTypeEnum.enum(['Pause', 'Session'])` — `.enum` on a `ZodEnum` is its values object, not callable, so the generated code failed with TS2349.

`resolveDiscriminators` now skips the merge entirely for `allOf`-wrapped single-`$ref` properties: the referenced shared schema already carries the full set of valid values, so the property stays exactly as declared.

## Output after the fix (from the issue's repro)

```ts
export const SessionEventRef = zod.object({
  "id": zod.string(),
  "type": EventTypeEnum
});
```

Verified end-to-end by running orval on the issue's spec with `client: 'zod'` and `generateReusableSchemas: true`.

## Notes

A bare `$ref` discriminator property already took a different (safe) path via the `isReference` short-circuit; this fix gives the `allOf`-wrapped variant the same leave-it-alone treatment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved discriminator properties wrapped in a single reference without adding unintended `enum` or `type` values.
  - Improved schema resolution for shared discriminator definitions.

- **Tests**
  - Added regression coverage to verify discriminator properties remain unchanged in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->