### PR TITLE
fix: emit type-only imports in hono handlers and mcp http-client

### DIFF
--- a/packages/hono/src/handler-merge.test.ts
+++ b/packages/hono/src/handler-merge.test.ts
@@ -103,7 +103,7 @@ export const getFooHandlers = factory.createHandlers(
     });
 
     expect(result).toContain(
-      "import { Get$FooContext } from '../endpoints.context';",
+      "import type { Get$FooContext } from '../endpoints.context';",
     );
     // user body untouched
     expect(result).toContain('async (c: Get$FooContext) =>');
@@ -719,7 +719,7 @@ export const listPetsHandlers = factory.createHandlers(
     expect(result).toContain('somethingCustom'); // user name preserved
     expect(result).toContain('export const createPetsHandlers'); // new op appended
     expect(result).toContain(
-      "import { CreatePetsContext } from '../endpoints.context';",
+      "import type { CreatePetsContext } from '../endpoints.context';",
     ); // new op's context added via a separate import
   });
 
@@ -854,7 +854,7 @@ export const listPetsHandlers = factory.createHandlers(
     expect(result).toContain("import * as Ctx from '../endpoints.context';"); // namespace kept
     expect(result).toContain('export const createPetsHandlers'); // new op appended
     expect(result).toContain(
-      "import { CreatePetsContext } from '../endpoints.context';",
+      "import type { CreatePetsContext } from '../endpoints.context';",
     ); // new op's bare context imported
     // the namespace-qualified existing context is not duplicated bare
     expect(result).not.toContain('import { ListPetsContext }');

--- a/packages/hono/src/handler-merge.ts
+++ b/packages/hono/src/handler-merge.ts
@@ -193,10 +193,16 @@ const localNameFor = (
   return undefined;
 };
 
-const renderImport = ({ names, module }: OrvalImport): string =>
-  names.length <= 1
-    ? `import { ${names.join('')} } from '${module}';`
-    : `import {\n  ${names.join(',\n  ')}\n} from '${module}';`;
+const renderImport = ({
+  names,
+  module,
+  typeOnly,
+}: OrvalImport & { typeOnly?: boolean }): string => {
+  const keyword = typeOnly ? 'import type ' : 'import ';
+  return names.length <= 1
+    ? `${keyword}{ ${names.join('')} } from '${module}';`
+    : `${keyword}{\n  ${names.join(',\n  ')}\n} from '${module}';`;
+};
 
 const lineStart = (source: string, position: number): number =>
   source.lastIndexOf('\n', position - 1) + 1;
@@ -277,6 +283,7 @@ export const reconcileHandlerFile = async (
     isOrvalName: (name: string) => boolean,
     augment?: (name: string) => boolean,
     collectRenames?: Map<string, string>,
+    typeOnly?: boolean,
   ) => {
     if (!existing) {
       // Never insert a name that is already bound bare elsewhere (e.g. a default
@@ -286,7 +293,9 @@ export const reconcileHandlerFile = async (
         augment ? names.filter((name) => augment(name)) : names
       ).filter((name) => !isImportedBare(name));
       if (toInsert.length > 0) {
-        pendingInsertions.push(renderImport({ names: toInsert, module }));
+        pendingInsertions.push(
+          renderImport({ names: toInsert, module, typeOnly }),
+        );
       }
       return;
     }
@@ -300,7 +309,9 @@ export const reconcileHandlerFile = async (
           (name) => augment(name) && !isImportedBare(name),
         );
         if (missing.length > 0) {
-          pendingInsertions.push(renderImport({ names: missing, module }));
+          pendingInsertions.push(
+            renderImport({ names: missing, module, typeOnly }),
+          );
         }
       }
       return;
@@ -313,7 +324,8 @@ export const reconcileHandlerFile = async (
 
     if (
       setEquals(importedNames(existing), names) &&
-      moduleText(existing) === module
+      moduleText(existing) === module &&
+      (existing.importClause?.isTypeOnly ?? false) === Boolean(typeOnly)
     ) {
       return;
     }
@@ -333,7 +345,7 @@ export const reconcileHandlerFile = async (
     edits.push({
       start: existing.getStart(sourceFile),
       end: existing.getEnd(),
-      text: renderImport({ names, module }),
+      text: renderImport({ names, module, typeOnly }),
     });
   };
 
@@ -434,6 +446,11 @@ export const reconcileHandlerFile = async (
     desired.imports.context.module,
     (name) => desired.imports.context.names.includes(name),
     needsBareContext,
+    undefined,
+    // Context identifiers only appear in type positions (the typed
+    // `async (c: XContext) => {}` handler callback), so the import is
+    // emitted type-only.
+    true,
   );
 
   const zodModule = desired.imports.zod?.module ?? '';

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -476,7 +476,7 @@ const generateFreshHandlerFile = ({
   }
 
   imports.push(
-    `import { ${verbList
+    `import type { ${verbList
       .map((verb) => `${pascal(verb.typeName)}Context`)
       .join(
         ',\n',

--- a/packages/hono/src/zValidator.ts
+++ b/packages/hono/src/zValidator.ts
@@ -1,9 +1,9 @@
 // based on https://github.com/honojs/middleware/blob/main/packages/zod-validator/src/index.ts
 import { zValidator as zValidatorBase } from '@hono/zod-validator'
 import type { Context, Env, Input, MiddlewareHandler, TypedResponse, ValidationTargets } from 'hono'
-import * as v3 from 'zod/v3'
+import type * as v3 from 'zod/v3'
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4'
-import * as v4 from 'zod/v4/core'
+import type * as v4 from 'zod/v4/core'
 
 type Awaitable<T> = T | Promise<T>
 type HasUndefined<T> = undefined extends T ? true : false

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -134,7 +134,7 @@ export const getMcpHeader: ClientHeaderBuilder = ({ verbOptions, output }) => {
     .toArray();
 
   const importSchemasImplementation = schemasPath
-    ? `import {\n  ${importSchemaNames.join(
+    ? `import type {\n  ${importSchemaNames.join(
         ',\n  ',
       )}\n} from '${relativeSchemaImportPath}';
 `
@@ -559,7 +559,10 @@ const generateHttpClientFiles = async (
     .map((imp) => imp.name);
   const uniqueImportNames = new Set(importNames).values().toArray();
 
-  const importImplementation = `import { ${uniqueImportNames.join(
+  // Type-only schemas — the http-client references them in type positions
+  // (response/params/body type aliases and function signatures), so the
+  // import is type-only.
+  const importImplementation = `import type { ${uniqueImportNames.join(
     ',\n',
   )} } from '${relativeSchemasPath}';`;
 

--- a/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/pets/pets.handlers.ts
+++ b/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/pets/pets.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   UpdatePetsContext,

--- a/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/validator.ts
+++ b/samples/hono/composite-routes-with-tags-split/__snapshots__/endpoints/validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/samples/hono/composite-routes-with-tags-split/src/endpoints/pets/pets.handlers.ts
+++ b/samples/hono/composite-routes-with-tags-split/src/endpoints/pets/pets.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   UpdatePetsContext,

--- a/samples/hono/composite-routes-with-tags-split/src/endpoints/validator.ts
+++ b/samples/hono/composite-routes-with-tags-split/src/endpoints/validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/createPets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { CreatePetsContext } from '../petstore.context';
+import type { CreatePetsContext } from '../petstore.context';
 import { CreatePetsBody, CreatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/listPets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ListPetsContext } from '../petstore.context';
+import type { ListPetsContext } from '../petstore.context';
 import { ListPetsQueryParams, ListPetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/showPetById.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ShowPetByIdContext } from '../petstore.context';
+import type { ShowPetByIdContext } from '../petstore.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/updatePets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/handlers/updatePets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { UpdatePetsContext } from '../petstore.context';
+import type { UpdatePetsContext } from '../petstore.context';
 import { UpdatePetsBody, UpdatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.validator.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/hono-app/petstore.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/samples/hono/hono-with-fetch-client/hono-app/src/handlers/createPets.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { CreatePetsContext } from '../petstore.context';
+import type { CreatePetsContext } from '../petstore.context';
 import { CreatePetsBody, CreatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/hono-app/src/handlers/listPets.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ListPetsContext } from '../petstore.context';
+import type { ListPetsContext } from '../petstore.context';
 import { ListPetsQueryParams, ListPetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/hono-app/src/handlers/showPetById.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ShowPetByIdContext } from '../petstore.context';
+import type { ShowPetByIdContext } from '../petstore.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/hono-app/src/handlers/updatePets.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/handlers/updatePets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { UpdatePetsContext } from '../petstore.context';
+import type { UpdatePetsContext } from '../petstore.context';
 import { UpdatePetsBody, UpdatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-fetch-client/hono-app/src/petstore.validator.ts
+++ b/samples/hono/hono-with-fetch-client/hono-app/src/petstore.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/samples/hono/hono-with-zod/__snapshots__/handlers/createPets.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { CreatePetsContext } from '../petstore.context';
+import type { CreatePetsContext } from '../petstore.context';
 import { CreatePetsBody, CreatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/__snapshots__/handlers/listPets.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ListPetsContext } from '../petstore.context';
+import type { ListPetsContext } from '../petstore.context';
 import { ListPetsQueryParams, ListPetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/__snapshots__/handlers/showPetById.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ShowPetByIdContext } from '../petstore.context';
+import type { ShowPetByIdContext } from '../petstore.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/__snapshots__/handlers/updatePets.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/handlers/updatePets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { UpdatePetsContext } from '../petstore.context';
+import type { UpdatePetsContext } from '../petstore.context';
 import { UpdatePetsBody, UpdatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/__snapshots__/petstore.validator.ts
+++ b/samples/hono/hono-with-zod/__snapshots__/petstore.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/samples/hono/hono-with-zod/src/handlers/createPets.ts
+++ b/samples/hono/hono-with-zod/src/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { CreatePetsContext } from '../petstore.context';
+import type { CreatePetsContext } from '../petstore.context';
 import { CreatePetsBody, CreatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/src/handlers/listPets.ts
+++ b/samples/hono/hono-with-zod/src/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ListPetsContext } from '../petstore.context';
+import type { ListPetsContext } from '../petstore.context';
 import { ListPetsQueryParams, ListPetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/src/handlers/showPetById.ts
+++ b/samples/hono/hono-with-zod/src/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { ShowPetByIdContext } from '../petstore.context';
+import type { ShowPetByIdContext } from '../petstore.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/src/handlers/updatePets.ts
+++ b/samples/hono/hono-with-zod/src/handlers/updatePets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../petstore.validator';
-import { UpdatePetsContext } from '../petstore.context';
+import type { UpdatePetsContext } from '../petstore.context';
 import { UpdatePetsBody, UpdatePetsResponse } from '../petstore.zod';
 
 const factory = createFactory();

--- a/samples/hono/hono-with-zod/src/petstore.validator.ts
+++ b/samples/hono/hono-with-zod/src/petstore.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/samples/mcp/custom-server/__snapshots__/handlers.ts
+++ b/samples/mcp/custom-server/__snapshots__/handlers.ts
@@ -12,7 +12,7 @@
  * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
-import {
+import type {
   FindPetsByStatusParams,
   FindPetsByTagsParams,
   UpdatePetWithFormParams,

--- a/samples/mcp/custom-server/src/handlers.ts
+++ b/samples/mcp/custom-server/src/handlers.ts
@@ -12,7 +12,7 @@
  * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
-import {
+import type {
   FindPetsByStatusParams,
   FindPetsByTagsParams,
   UpdatePetWithFormParams,

--- a/samples/mcp/custom-server/src/http-client.ts
+++ b/samples/mcp/custom-server/src/http-client.ts
@@ -13,7 +13,7 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-import {
+import type {
   Pet,
   FindPetsByStatusParams,
   FindPetsByTagsParams,

--- a/samples/mcp/petstore/__snapshots__/handlers.ts
+++ b/samples/mcp/petstore/__snapshots__/handlers.ts
@@ -12,7 +12,7 @@
  * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
-import {
+import type {
   FilterPetsByStatusParams,
   Pet,
   FindPetsByStatusParams,

--- a/samples/mcp/petstore/src/handlers.ts
+++ b/samples/mcp/petstore/src/handlers.ts
@@ -12,7 +12,7 @@
  * - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
-import {
+import type {
   FilterPetsByStatusParams,
   Pet,
   FindPetsByStatusParams,

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -13,7 +13,7 @@
  * OpenAPI spec version: 1.0.27-SNAPSHOT
  */
 
-import {
+import type {
   Pet,
   FilterPetsByStatusParams,
   FindPetsByStatusParams,

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.handlers.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from './endpoints.validator';
-import {
+import type {
   ListPetsByCountryContext,
   ListPetsByAgeContext,
 } from './endpoints.context';

--- a/tests/__snapshots__/hono/endpoint-parameters/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/endpoint-parameters/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/issue-3634/src/ab-widget/ab-widget.handlers.ts
+++ b/tests/__snapshots__/hono/issue-3634/src/ab-widget/ab-widget.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../endpoints/validator';
-import { ListAbWidgetsContext } from './ab-widget.context';
+import type { ListAbWidgetsContext } from './ab-widget.context';
 import {
   ListAbWidgetsQueryParams,
   ListAbWidgetsResponse,

--- a/tests/__snapshots__/hono/issue-3634/src/endpoints/validator.ts
+++ b/tests/__snapshots__/hono/issue-3634/src/endpoints/validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/issue-3634/src/widget/widget.handlers.ts
+++ b/tests/__snapshots__/hono/issue-3634/src/widget/widget.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../endpoints/validator';
-import { ListWidgetsContext } from './widget.context';
+import type { ListWidgetsContext } from './widget.context';
 import { ListWidgetsQueryParams, ListWidgetsResponse } from './widget.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-single-with-companion-types/endpoints.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-single-with-companion-types/endpoints.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from './endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/petstore-single-with-companion-types/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-single-with-companion-types/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-single/endpoints.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from './endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/petstore-single/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-single/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/create-pets.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/create-pets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { CreatePetsContext } from '../../endpoints.context';
+import type { CreatePetsContext } from '../../endpoints.context';
 import {
   CreatePetsQueryParams,
   CreatePetsBody,

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/delete-pet-by-id.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/delete-pet-by-id.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { DeletePetByIdContext } from '../../endpoints.context';
+import type { DeletePetByIdContext } from '../../endpoints.context';
 import { DeletePetByIdParams } from '../../endpoints.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/health-check.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/health-check.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from '../../endpoints.context';
+import type { HealthCheckContext } from '../../endpoints.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/list-pets.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/list-pets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ListPetsContext } from '../../endpoints.context';
+import type { ListPetsContext } from '../../endpoints.context';
 import { ListPetsQueryParams } from '../../endpoints.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/show-pet-by-id.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/show-pet-by-id.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetByIdContext } from '../../endpoints.context';
+import type { ShowPetByIdContext } from '../../endpoints.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../../endpoints.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/show-pet-with-owner.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers-kebab/src/handlers/show-pet-with-owner.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetWithOwnerContext } from '../../endpoints.context';
+import type { ShowPetWithOwnerContext } from '../../endpoints.context';
 import {
   ShowPetWithOwnerParams,
   ShowPetWithOwnerResponse,

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/createPets.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { CreatePetsContext } from '../../endpoints.context';
+import type { CreatePetsContext } from '../../endpoints.context';
 import {
   CreatePetsQueryParams,
   CreatePetsBody,

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/deletePetById.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/deletePetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { DeletePetByIdContext } from '../../endpoints.context';
+import type { DeletePetByIdContext } from '../../endpoints.context';
 import { DeletePetByIdParams } from '../../endpoints.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/healthCheck.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/healthCheck.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from '../../endpoints.context';
+import type { HealthCheckContext } from '../../endpoints.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/listPets.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ListPetsContext } from '../../endpoints.context';
+import type { ListPetsContext } from '../../endpoints.context';
 import { ListPetsQueryParams } from '../../endpoints.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/showPetById.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetByIdContext } from '../../endpoints.context';
+import type { ShowPetByIdContext } from '../../endpoints.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../../endpoints.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/showPetWithOwner.ts
+++ b/tests/__snapshots__/hono/petstore-split-with-handlers/src/handlers/showPetWithOwner.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetWithOwnerContext } from '../../endpoints.context';
+import type { ShowPetWithOwnerContext } from '../../endpoints.context';
 import {
   ShowPetWithOwnerParams,
   ShowPetWithOwnerResponse,

--- a/tests/__snapshots__/hono/petstore-split/endpoints.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from './endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/petstore-split/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-split/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/createPets.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { CreatePetsContext } from '../../pets/pets.context';
+import type { CreatePetsContext } from '../../pets/pets.context';
 import {
   CreatePetsQueryParams,
   CreatePetsBody,

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/deletePetById.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/deletePetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { DeletePetByIdContext } from '../../pets/pets.context';
+import type { DeletePetByIdContext } from '../../pets/pets.context';
 import { DeletePetByIdParams } from '../../pets/pets.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/healthCheck.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/healthCheck.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from '../../health/health.context';
+import type { HealthCheckContext } from '../../health/health.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/listPets.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ListPetsContext } from '../../pets/pets.context';
+import type { ListPetsContext } from '../../pets/pets.context';
 import { ListPetsQueryParams } from '../../pets/pets.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/showPetById.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetByIdContext } from '../../pets/pets.context';
+import type { ShowPetByIdContext } from '../../pets/pets.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../../pets/pets.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/showPetWithOwner.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-handlers/src/handlers/showPetWithOwner.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetWithOwnerContext } from '../../pets/pets.context';
+import type { ShowPetWithOwnerContext } from '../../pets/pets.context';
 import {
   ShowPetWithOwnerParams,
   ShowPetWithOwnerResponse,

--- a/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/health/health.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/health/health.handlers.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from './health.context';
+import type { HealthCheckContext } from './health.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/pets/pets.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split-with-zod-mutator/pets/pets.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/petstore-tags-split/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-tags-split/health/health.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/health/health.handlers.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from './health.context';
+import type { HealthCheckContext } from './health.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-tags-split/pets/pets.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-tags-split/pets/pets.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/createPets.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/createPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { CreatePetsContext } from '../../pets.context';
+import type { CreatePetsContext } from '../../pets.context';
 import {
   CreatePetsQueryParams,
   CreatePetsBody,

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/deletePetById.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/deletePetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { DeletePetByIdContext } from '../../pets.context';
+import type { DeletePetByIdContext } from '../../pets.context';
 import { DeletePetByIdParams } from '../../pets.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/healthCheck.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/healthCheck.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from '../../health.context';
+import type { HealthCheckContext } from '../../health.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/listPets.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/listPets.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ListPetsContext } from '../../pets.context';
+import type { ListPetsContext } from '../../pets.context';
 import { ListPetsQueryParams } from '../../pets.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/showPetById.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/showPetById.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetByIdContext } from '../../pets.context';
+import type { ShowPetByIdContext } from '../../pets.context';
 import { ShowPetByIdParams, ShowPetByIdResponse } from '../../pets.zod';
 
 const factory = createFactory();

--- a/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/showPetWithOwner.ts
+++ b/tests/__snapshots__/hono/petstore-tags-with-handlers/src/handlers/showPetWithOwner.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from '../../endpoints.validator';
-import { ShowPetWithOwnerContext } from '../../pets.context';
+import type { ShowPetWithOwnerContext } from '../../pets.context';
 import {
   ShowPetWithOwnerParams,
   ShowPetWithOwnerResponse,

--- a/tests/__snapshots__/hono/petstore-tags/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/petstore-tags/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/hono/petstore-tags/health.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-tags/health.handlers.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 import { createFactory } from 'hono/factory';
-import { HealthCheckContext } from './health.context';
+import type { HealthCheckContext } from './health.context';
 
 const factory = createFactory();
 export const healthCheckHandlers = factory.createHandlers(

--- a/tests/__snapshots__/hono/petstore-tags/pets.handlers.ts
+++ b/tests/__snapshots__/hono/petstore-tags/pets.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from './endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.handlers.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.handlers.ts
@@ -6,7 +6,7 @@
  */
 import { createFactory } from 'hono/factory';
 import { zValidator } from './endpoints.validator';
-import {
+import type {
   ListPetsContext,
   CreatePetsContext,
   ShowPetByIdContext,

--- a/tests/__snapshots__/hono/zod-schema-response/endpoints.validator.ts
+++ b/tests/__snapshots__/hono/zod-schema-response/endpoints.validator.ts
@@ -14,9 +14,9 @@ import type {
   TypedResponse,
   ValidationTargets,
 } from 'hono';
-import * as v3 from 'zod/v3';
+import type * as v3 from 'zod/v3';
 import type { ZodSafeParseResult as ZodSafeParseResult$1 } from 'zod/v4';
-import * as v4 from 'zod/v4/core';
+import type * as v4 from 'zod/v4/core';
 
 type Awaitable<T> = T | Promise<T>;
 type HasUndefined<T> = undefined extends T ? true : false;

--- a/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
+++ b/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
@@ -5,7 +5,11 @@
  * OpenAPI spec version: 1
  */
 
-import { CreateThingBody, ReplaceThingBody, PatchThingBody } from './handlers';
+import type {
+  CreateThingBody,
+  ReplaceThingBody,
+  PatchThingBody,
+} from './handlers';
 
 export type getThingsResponse200 = {
   data: string[];

--- a/tests/__snapshots__/mcp/custom-server/handlers.ts
+++ b/tests/__snapshots__/mcp/custom-server/handlers.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import {
+import type {
   ListPetsParams,
   CreatePetsParams,
   CreatePetsBody,

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 
-import {
+import type {
   Pets,
   Error,
   ListPetsParams,

--- a/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
+++ b/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1
  */
 
-import { Form } from './sample.gen';
+import type { Form } from './sample.gen';
 
 export type addResponseDefault = {
   data: unknown;

--- a/tests/__snapshots__/mcp/inline-schemas/http-client.ts
+++ b/tests/__snapshots__/mcp/inline-schemas/http-client.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1
  */
 
-import { Form } from './custom-handlers';
+import type { Form } from './custom-handlers';
 
 export type addResponseDefault = {
   data: unknown;

--- a/tests/__snapshots__/mcp/single/handlers.ts
+++ b/tests/__snapshots__/mcp/single/handlers.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import {
+import type {
   ListPetsParams,
   CreatePetsParams,
   CreatePetsBody,

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 
-import {
+import type {
   Pets,
   Error,
   ListPetsParams,

--- a/tests/__snapshots__/mcp/zod-schema-response/handlers.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/handlers.ts
@@ -4,7 +4,7 @@
  * Swagger Petstore
  * OpenAPI spec version: 1.0.0
  */
-import {
+import type {
   ListPetsParams,
   CreatePetsParams,
   CreatePetsBody,

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -5,7 +5,7 @@
  * OpenAPI spec version: 1.0.0
  */
 
-import {
+import type {
   Pets,
   Error,
   ListPetsParams,


### PR DESCRIPTION
Fixes #3933, fixes #3934. Part of #3931.

## Summary

Two generators emitted value imports for symbols their output only uses as types, tripping `consistent-type-imports` in every generated hono/mcp file.

**hono** (`packages/hono/src/index.ts`, `packages/hono/src/handler-merge.ts`, `packages/hono/src/zValidator.ts`):

- Handler-file context imports are now `import type { ...Context } from '...context'` — context identifiers only appear in the typed handler callback (`async (c: XContext) => {}`). Both the fresh-file emission and the handler-merge reconciler (via a new `typeOnly` flag on `renderImport`) are covered.
- The zValidator template's `import * as v3 from 'zod/v3'` / `import * as v4 from 'zod/v4/core'` are now `import type *` — every usage is a type position (`schema as v3.ZodType` is an assertion, the rest are conditional types).

One deliberate deviation from the issue: the zod **schema** imports (`ShowPetWithOwnerParams`, etc.) stay value imports. `zValidator('param', ShowPetWithOwnerParams)` passes them to the validator at runtime, so making them type-only would break the generated code. The lint warnings on those lines were false positives from the rule's perspective of the file, but the emitted code compiles and runs correctly either way — the fix targets only genuinely type-only symbols.

**mcp** (`packages/mcp/src/index.ts`):

- The http-client's schema import (line ~562, `importImplementation`) is now `import type` — `Pets`, `ListPetsParams`, `CreatePetsBody`, etc. are referenced only in type aliases and function signatures.
- The server file's schemas import (`importSchemasImplementation`) is now `import type` — body/param type names used only as handler parameter types.

## Verification

- `vp lint --no-ignore tests/__snapshots__/hono tests/__snapshots__/mcp` — 0 `consistent-type-imports` warnings (previously 60 + 9)
- Snapshot/samples regenerated: 59 snapshot files + 14 sample files updated, all diffs are exactly the `import` → `import type` transitions
- hono package tests: 59/59 pass

## Scope note

#3935 (angular `QueryClient`) is intentionally **not** included. `QueryClient` is imported with `values: true` because the angular mutation invalidation path emits `const queryClient = inject(QueryClient);` — a genuine value use (see `samples/angular-query/src/api/endpoints/pets/pets.ts`). The static dependency list can't express "value only when invalidation is used", so flipping the flag would break real output. That one needs conditional emission, which is a design decision rather than a mechanical fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Hono and MCP code now emits type-only imports for context, schema, and validation types.
  * Updated generated samples and handlers to use type-only imports consistently.
* **Refactor**
  * Import generation now distinguishes type-only imports from runtime imports.
  * Type-only imports are excluded from compiled runtime code, with no runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->