### PR TITLE
fix(fetch): type deepObjectEntries as string[] to satisfy strict tsc

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -354,7 +354,7 @@ ${
 ${
   queryParams
     ? `  const normalizedParams = new URLSearchParams();
-${deepObjectParameters.length > 0 ? '  const deepObjectEntries = [];\n' : ''}
+${deepObjectParameters.length > 0 ? '  const deepObjectEntries: string[] = [];\n' : ''}
   Object.entries(params || {}).forEach(([key, value]) => {
     ${explodeArrayImplementation}${arrayFormatImplementation}${deepObjectImplementation}
     ${isExplodeParametersOnly ? '' : normalParamsImplementation}

--- a/packages/solid-start/src/index.ts
+++ b/packages/solid-start/src/index.ts
@@ -406,7 +406,7 @@ const generateImplementation = (
   // Build query params string
   const queryParamsCode = queryParams
     ? `const normalizedParams = new URLSearchParams();
-${deepObjectParameters.length > 0 ? '    const deepObjectEntries = [];\n' : ''}
+${deepObjectParameters.length > 0 ? '    const deepObjectEntries: string[] = [];\n' : ''}
     Object.entries(params || {}).forEach(([key, value]) => {
       ${explodeArrayImplementation}${deepObjectImplementation}
       ${


### PR DESCRIPTION
Added Type to deepObjectEntries

Fixes: https://github.com/orval-labs/orval/issues/4000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved type clarity in generated query-string handling by explicitly defining deep-object parameter collections as string arrays.
  - Generated URL-helper output remains functionally unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->