### PR TITLE
feat: add external schema naming strategy and compress option

### DIFF
--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -308,6 +308,14 @@ export default defineConfig({
 });
 ```
 
+With this configuration, a `User` schema from `billing.yaml` is emitted as
+`User_billing`. An asynchronous callback uses the same configuration shape:
+
+```ts
+const externalIdentity = async (value: string) =>
+  value.includes('billing') ? 'billing' : value;
+```
+
 The callback must produce unique values for distinct external documents. Scalar
 will retry collisions, but a callback that cannot produce a unique value fails
 instead of silently merging two documents.

--- a/docs/content/docs/reference/configuration/input.mdx
+++ b/docs/content/docs/reference/configuration/input.mdx
@@ -272,6 +272,46 @@ export default defineConfig({
 });
 ```
 
+### compress
+
+**Type:** `(value: string) => Promise<string> | string`
+
+Optional callback forwarded to `@scalar/json-magic` when external references are
+bundled. It may be synchronous or asynchronous. The callback receives Scalar's
+normalized external document identity/path, not necessarily the literal `$ref`,
+and returns the key used internally for that document. Returning stable service
+names makes external schema names easier to read when using
+`externalRefs.strategy: 'always'`.
+
+```ts title="orval.config.ts"
+import { defineConfig } from 'orval';
+
+const externalIdentity = (value: string) => {
+  if (value.includes('billing')) return 'billing';
+  if (value.includes('catalog')) return 'catalog';
+  return value;
+};
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './openapi.yaml',
+      parserOptions: {
+        compress: externalIdentity,
+        externalRefs: {
+          allow: ['*'],
+          strategy: 'always',
+        },
+      },
+    },
+  },
+});
+```
+
+The callback must produce unique values for distinct external documents. Scalar
+will retry collisions, but a callback that cannot produce a unique value fails
+instead of silently merging two documents.
+
 ### externalRefs
 
 Control how external `$ref` targets (local files or remote URLs) are resolved.
@@ -316,12 +356,42 @@ parserOptions: {
 }
 ```
 
+#### strategy
+
+**Type:** `'default' | 'always'`
+**Default:** `'default'`
+
+Controls the names assigned to schemas imported from external documents.
+
+- `default` preserves the current behavior: an external schema keeps its
+  original name and receives a suffix only when that name collides with an
+  existing schema.
+- `always` appends the sanitized external document key to every external
+  schema. For example, `User` from the `billing` document becomes
+  `User_billing`.
+
+The external document key is produced by `parserOptions.compress` when it is
+configured. Without `compress`, `always` still works, but Scalar's default
+generated, hash-like key is used, so names may look like `User_<generated-key>`.
+Use a stable custom `compress` callback such as one that maps `billing.yaml` to
+`billing` when human-readable names are needed.
+
+Orval does not silently overwrite an existing final component name. A collision
+with a local or external component, including a collision after suffix
+sanitization, produces an explicit error. This deliberately prevents an
+ambiguous suffix from overwriting a schema as could happen in the legacy
+behavior.
+
 <Callout type="warn">
   **Security:** External `$ref` values come from the spec being processed, which may
   be untrusted. Allowing all external refs (`['*']`) means orval will read arbitrary
   local files and fetch arbitrary URLs referenced by the spec. Prefer listing
   specific documents you trust.
 </Callout>
+
+`externalRefs.allow` still controls which external documents may be loaded;
+`compress` and `strategy` only control the names of external schemas that have
+already been allowed.
 
 ## unsafeDisableValidation
 

--- a/docs/content/docs/zh/reference/configuration/input.mdx
+++ b/docs/content/docs/zh/reference/configuration/input.mdx
@@ -263,6 +263,37 @@ export default defineConfig({
 });
 ```
 
+### compress
+
+**类型：** `(value: string) => Promise<string> | string`
+
+在解析外部引用时传递给 `@scalar/json-magic` 的可选回调。该回调可以同步或异步执行。它接收 Scalar 标准化后的外部文档标识/path（不一定是 `$ref` 中的原始字符串），并返回该文档在内部使用的 key。
+
+如果希望在 `externalRefs.strategy: 'always'` 下生成可读的 schema 名称，可以返回稳定的服务名称：
+
+```ts title="orval.config.ts"
+import { defineConfig } from 'orval';
+
+const externalIdentity = (value: string) => {
+  if (value.includes('billing')) return 'billing';
+  if (value.includes('catalog')) return 'catalog';
+  return value;
+};
+
+export default defineConfig({
+  petstore: {
+    input: {
+      target: './openapi.yaml',
+      parserOptions: {
+        compress: externalIdentity,
+      },
+    },
+  },
+});
+```
+
+不同外部文档应返回不同的值。如果无法生成唯一 key，解析会失败，而不会静默合并两个文档。
+
 ### externalRefs
 
 控制如何解析外部 `$ref` 目标（本地文件或远程 URL）。
@@ -310,6 +341,22 @@ parserOptions: {
 <Callout type="warn">
   **安全性：** 外部 `$ref` 的值来自正在处理的 spec，而该 spec 可能并不可信。允许所有外部 refs（`['*']`）意味着 orval 会读取 spec 中引用的任意本地文件，并抓取任意 URL。更推荐显式列出你信任的具体文档。
 </Callout>
+
+#### strategy
+
+**类型：** `'default' | 'always'`
+**默认值：** `'default'`
+
+控制从外部文档导入的 schema 如何命名：
+
+- `default` 保持现有行为：外部 schema 使用原始名称，只有在与已有 schema 重名时才追加后缀。
+- `always` 为每个外部 schema 追加经过清理的外部文档 key。例如，`billing` 文档中的 `User` 会命名为 `User_billing`。
+
+配置了 `parserOptions.compress` 时，外部文档 key 来自该回调。未配置 `compress` 时，`always` 仍然可用，但会使用 Scalar 默认生成的、类似 hash 的 key，因此名称可能类似 `User_<generated-key>`。如果需要可读且稳定的名称，请使用自定义回调，例如将 `billing.yaml` 映射为 `billing`。
+
+Orval 不会静默覆盖已有的最终 component 名称。如果本地或外部 schema 已占用该名称，或者不同身份在清理后产生相同后缀，Orval 会抛出明确错误。这是为了避免歧义后缀覆盖 schema 的旧行为。
+
+`externalRefs.allow` 仍然决定哪些外部文档可以被加载；`compress` 和 `strategy` 只决定已经获准加载的外部 schema 的名称。
 
 ## unsafeDisableValidation
 

--- a/docs/content/docs/zh/reference/configuration/input.mdx
+++ b/docs/content/docs/zh/reference/configuration/input.mdx
@@ -267,7 +267,7 @@ export default defineConfig({
 
 **类型：** `(value: string) => Promise<string> | string`
 
-在解析外部引用时传递给 `@scalar/json-magic` 的可选回调。该回调可以同步或异步执行。它接收 Scalar 标准化后的外部文档标识/path（不一定是 `$ref` 中的原始字符串），并返回该文档在内部使用的 key。
+在解析外部引用时传递给 `@scalar/json-magic` 的可选回调。该回调可以同步或异步执行。它接收 Scalar 标准化后的外部文档标识或路径（不一定是 `$ref` 中的原始字符串），并返回该文档在内部使用的 key。
 
 如果希望在 `externalRefs.strategy: 'always'` 下生成可读的 schema 名称，可以返回稳定的服务名称：
 
@@ -286,10 +286,21 @@ export default defineConfig({
       target: './openapi.yaml',
       parserOptions: {
         compress: externalIdentity,
+        externalRefs: {
+          allow: ['*'],
+          strategy: 'always',
+        },
       },
     },
   },
 });
+```
+
+使用此配置时，`billing.yaml` 中的 `User` schema 会生成为 `User_billing`。异步回调使用相同的配置结构：
+
+```ts
+const externalIdentity = async (value: string) =>
+  value.includes('billing') ? 'billing' : value;
 ```
 
 不同外部文档应返回不同的值。如果无法生成唯一 key，解析会失败，而不会静默合并两个文档。

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -242,21 +242,42 @@ export interface NormalizedOperationOptions {
   requestOptions?: object | boolean;
 }
 
+export type ExternalRefNamingStrategy = 'default' | 'always';
+
+export interface InputParserOptions {
+  headers?: {
+    domains: string[];
+    headers: Record<string, string>;
+  }[];
+  /**
+   * Optional Scalar bundler callback used to create external document keys.
+   */
+  compress?: (value: string) => Promise<string> | string;
+  externalRefs?: {
+    /**
+     * External `$ref` document targets to allow. Each entry should be the
+     * document part of the `$ref` (without the `#/...` fragment). File paths
+     * are relative to the spec file. Use `['*']` to allow all external refs.
+     *
+     * @default []
+     */
+    allow?: string[];
+    /**
+     * Controls how schemas imported from external documents are named.
+     *
+     * @default 'default'
+     */
+    strategy?: ExternalRefNamingStrategy;
+    // TODO: add `deny?: string[]` when users need "allow all except X"
+  };
+}
+
 export interface NormalizedInputOptions {
   target: string | OpenApiDocument;
   override: OverrideInput;
   unsafeDisableValidation: boolean;
   filters?: InputFiltersOptions;
-  parserOptions?: {
-    headers?: {
-      domains: string[];
-      headers: Record<string, string>;
-    }[];
-    externalRefs?: {
-      allow?: string[];
-      // TODO: add `deny?: string[]` when users need "allow all except X"
-    };
-  };
+  parserOptions?: InputParserOptions;
 }
 
 export type OutputClientFunc = (
@@ -473,30 +494,7 @@ export interface InputOptions {
    */
   unsafeDisableValidation?: boolean;
   filters?: InputFiltersOptions;
-  parserOptions?: {
-    headers?: {
-      domains: string[];
-      headers: Record<string, string>;
-    }[];
-    /**
-     * Control how external `$ref` targets (local files or remote URLs) are
-     * resolved.
-     *
-     * By default, orval refuses to resolve any external `$ref` and prints a
-     * config snippet you can paste into your `parserOptions`.
-     */
-    externalRefs?: {
-      /**
-       * External `$ref` document targets to allow. Each entry should be the
-       * document part of the `$ref` (without the `#/...` fragment). File paths
-       * are relative to the spec file. Use `['*']` to allow all external refs.
-       *
-       * @default []
-       */
-      allow?: string[];
-      // TODO: add `deny?: string[]` when users need "allow all except X"
-    };
-  };
+  parserOptions?: InputParserOptions;
 }
 
 export const OutputClient = {

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -420,6 +420,107 @@ describe('validation', () => {
     }
   });
 
+  it('should apply async compress and always naming to transformer refs', async () => {
+    const workspace = await mkdtemp(
+      path.join(os.tmpdir(), 'orval-issue-3166-transformer-'),
+    );
+    const specPath = path.join(workspace, 'spec.yaml');
+    const externalPath = path.join(workspace, 'refs.yaml');
+    const compressInputs: string[] = [];
+
+    const spec = {
+      openapi: '3.0.2',
+      info: { title: 'transformer', version: '1.0.0' },
+      paths: {
+        '/path': {
+          get: {
+            operationId: 'getPath',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Field' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Field: { type: 'object', properties: { id: { type: 'string' } } },
+        },
+      },
+    };
+    const external = {
+      components: {
+        schemas: {
+          Point: { type: 'object', properties: { x: { type: 'number' } } },
+        },
+      },
+    };
+
+    try {
+      await writeFile(specPath, JSON.stringify(spec), 'utf8');
+      await writeFile(externalPath, JSON.stringify(external), 'utf8');
+
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              compress: async (value) => {
+                compressInputs.push(value);
+                return 'refs';
+              },
+              externalRefs: {
+                allow: ['refs.yaml'],
+                strategy: 'always',
+              },
+            },
+            override: {
+              transformer: (input: OpenApiDocument) => {
+                const next = structuredClone(input);
+                const field = next.components?.schemas?.Field as
+                  | { properties?: Record<string, unknown> }
+                  | undefined;
+                if (field) {
+                  field.properties ??= {};
+                  field.properties.geometry = {
+                    $ref: 'refs.yaml#/components/schemas/Point',
+                  };
+                }
+                return next;
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      const result = await importSpecs(workspace, normalizedOptions);
+
+      expect(compressInputs).toContain('refs.yaml');
+      expect(result.spec.components?.schemas).toHaveProperty('Point_refs');
+      expect(result.spec.components?.schemas?.Field).toEqual(
+        expect.objectContaining({
+          properties: {
+            id: { type: 'string' },
+            geometry: { $ref: '#/components/schemas/Point_refs' },
+          },
+        }),
+      );
+      expect(JSON.stringify(result.spec)).not.toContain('refs.yaml');
+      expect(JSON.stringify(result.spec)).not.toContain('#/x-ext/');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('should preserve date-like enum strings from YAML specs', async () => {
     const workspace = await mkdtemp(
       path.join(os.tmpdir(), 'orval-yaml-date-enum-'),
@@ -856,6 +957,53 @@ describe('externalRefs', () => {
     return { workspace, specPath };
   }
 
+  async function createSchemaRefWorkspace(
+    externalFiles: Record<string, unknown>,
+    refs: Record<string, string>,
+  ) {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-schema-'));
+    const specPath = path.join(workspace, 'spec.yaml');
+    const paths = Object.fromEntries(
+      Object.entries(refs).map(([name, ref]) => [
+        `/${name}`,
+        {
+          get: {
+            operationId: `get${name}`,
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { $ref: ref } },
+                },
+              },
+            },
+          },
+        },
+      ]),
+    );
+
+    await Promise.all(
+      Object.entries(externalFiles).map(([fileName, document]) =>
+        writeFile(
+          path.join(workspace, fileName),
+          JSON.stringify(document),
+          'utf8',
+        ),
+      ),
+    );
+    await writeFile(
+      specPath,
+      JSON.stringify({
+        openapi: '3.0.2',
+        info: { title: 'main', version: '1.0' },
+        paths,
+      }),
+      'utf8',
+    );
+
+    return { workspace, specPath };
+  }
+
   it('should block external $ref by default and print a config snippet', async () => {
     const { workspace, specPath } = await createExternalRefWorkspace();
     try {
@@ -1030,6 +1178,297 @@ describe('externalRefs', () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it('should forward compress and always-suffix external schemas', async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-compress-'));
+    const specPath = path.join(workspace, 'spec.yaml');
+    const externalPath = path.join(workspace, 'billing.yaml');
+
+    await writeFile(
+      externalPath,
+      JSON.stringify({
+        openapi: '3.0.2',
+        info: { title: 'billing', version: '1.0' },
+        paths: {},
+        components: {
+          schemas: {
+            User: { type: 'object' },
+          },
+        },
+      }),
+      'utf8',
+    );
+    await writeFile(
+      specPath,
+      JSON.stringify({
+        openapi: '3.0.2',
+        info: { title: 'main', version: '1.0' },
+        paths: {
+          '/user': {
+            get: {
+              operationId: 'getUser',
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        $ref: 'billing.yaml#/components/schemas/User',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              compress: () => 'billing',
+              externalRefs: {
+                allow: ['billing.yaml'],
+                strategy: 'always',
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      const result = await importSpecs(workspace, normalizedOptions);
+
+      expect(result.spec.components?.schemas).toHaveProperty('User_billing');
+      expect(
+        result.spec.paths?.['/user']?.get?.responses?.['200']?.content?.[
+          'application/json'
+        ]?.schema,
+      ).toEqual({ $ref: '#/components/schemas/User_billing' });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('should await an async compress callback end to end', async () => {
+    const compressInputs: string[] = [];
+    const { workspace, specPath } = await createSchemaRefWorkspace(
+      {
+        'billing.yaml': {
+          components: { schemas: { User: { type: 'object' } } },
+        },
+      },
+      { user: 'billing.yaml#/components/schemas/User' },
+    );
+
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              compress: async (value) => {
+                compressInputs.push(value);
+                return 'billing';
+              },
+              externalRefs: {
+                allow: ['billing.yaml'],
+                strategy: 'always',
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      const result = await importSpecs(workspace, normalizedOptions);
+
+      expect(compressInputs).toEqual(['billing.yaml']);
+      expect(result.spec.components?.schemas).toHaveProperty('User_billing');
+      expect(
+        result.spec.paths?.['/user']?.get?.responses?.['200']?.content,
+      ).toEqual({
+        'application/json': {
+          schema: { $ref: '#/components/schemas/User_billing' },
+        },
+      });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("should use Scalar's generated key for always mode without compress", async () => {
+    const { workspace, specPath } = await createSchemaRefWorkspace(
+      {
+        'billing.yaml': {
+          components: { schemas: { User: { type: 'object' } } },
+        },
+      },
+      { user: 'billing.yaml#/components/schemas/User' },
+    );
+
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              externalRefs: {
+                allow: ['billing.yaml'],
+                strategy: 'always',
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      const result = await importSpecs(workspace, normalizedOptions);
+      const schemaNames = Object.keys(result.spec.components?.schemas ?? {});
+      const generatedName = schemaNames.find((name) =>
+        name.startsWith('User_'),
+      );
+
+      expect(generatedName).toMatch(/^User_[a-zA-Z0-9]+$/);
+      expect(generatedName).not.toBe('User_billing');
+      expect(
+        result.spec.paths?.['/user']?.get?.responses?.['200']?.content?.[
+          'application/json'
+        ]?.schema,
+      ).toEqual({ $ref: `#/components/schemas/${generatedName}` });
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('should keep stable names when external schema content changes', async () => {
+    const { workspace, specPath } = await createSchemaRefWorkspace(
+      {
+        'billing.yaml': {
+          components: {
+            schemas: {
+              User: {
+                type: 'object',
+                required: ['id'],
+                properties: { id: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+      { user: 'billing.yaml#/components/schemas/User' },
+    );
+
+    const importWithStableIdentity = async () => {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              compress: () => 'billing',
+              externalRefs: {
+                allow: ['billing.yaml'],
+                strategy: 'always',
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+      return importSpecs(workspace, normalizedOptions);
+    };
+
+    try {
+      const first = await importWithStableIdentity();
+      await writeFile(
+        path.join(workspace, 'billing.yaml'),
+        JSON.stringify({
+          components: {
+            schemas: {
+              User: {
+                type: 'object',
+                required: ['id'],
+                properties: {
+                  id: { type: 'string' },
+                  nickname: { type: 'string' },
+                },
+              },
+            },
+          },
+        }),
+        'utf8',
+      );
+      const second = await importWithStableIdentity();
+
+      expect(first.spec.components?.schemas).toHaveProperty('User_billing');
+      expect(second.spec.components?.schemas).toHaveProperty('User_billing');
+      expect(first.spec.components?.schemas?.User_billing).not.toHaveProperty(
+        'properties.nickname',
+      );
+      expect(second.spec.components?.schemas?.User_billing).toHaveProperty(
+        'properties.nickname',
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('should propagate Scalar compressor collisions without a secondary error', async () => {
+    const { workspace, specPath } = await createSchemaRefWorkspace(
+      {
+        'billing.yaml': {
+          components: { schemas: { User: { type: 'object' } } },
+        },
+        'catalog.yaml': {
+          components: { schemas: { User: { type: 'object' } } },
+        },
+      },
+      {
+        billing: 'billing.yaml#/components/schemas/User',
+        catalog: 'catalog.yaml#/components/schemas/User',
+      },
+    );
+
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              compress: () => 'same',
+              externalRefs: {
+                allow: ['billing.yaml', 'catalog.yaml'],
+                strategy: 'always',
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      await expect(importSpecs(workspace, normalizedOptions)).rejects.toBe(
+        'Can not generate unique compressed values',
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('optionsParamRequired', () => {
@@ -1175,6 +1614,361 @@ export const handleResource = (
 });
 
 describe('dereferenceExternalRefs', () => {
+  it('should match an x-ext placeholder to its source document', () => {
+    const input = {
+      components: {
+        schemas: {
+          User: {
+            $ref: '#/x-ext/catalog/components/schemas/User',
+          },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: {
+            schemas: {
+              User: { type: 'string', enum: ['billing'] },
+            },
+          },
+        },
+        catalog: {
+          components: {
+            schemas: {
+              User: { type: 'string', enum: ['catalog'] },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as {
+      components: { schemas: Record<string, unknown> };
+    };
+
+    expect(result.components.schemas.User).toEqual({
+      type: 'string',
+      enum: ['catalog'],
+    });
+    expect(result.components.schemas.User_billing).toEqual({
+      type: 'string',
+      enum: ['billing'],
+    });
+    expect(JSON.stringify(result)).not.toContain('#/x-ext/');
+  });
+
+  it('should reject an occupied default-mode suffix without overwriting it', () => {
+    const input = {
+      components: {
+        schemas: {
+          User: { type: 'string', enum: ['local'] },
+          User_billing: { type: 'string', enum: ['occupied'] },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: {
+            schemas: {
+              User: { type: 'string', enum: ['external'] },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => dereferenceExternalRef(input)).toThrow(
+      /external schema.*User.*billing.*User_billing/i,
+    );
+  });
+
+  it('should rewrite always-mode direct and nested cross-document refs', () => {
+    const input = {
+      components: {
+        schemas: {
+          Holder: {
+            $ref: '#/x-ext/billing/components/schemas/Order',
+          },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: {
+            schemas: {
+              Order: {
+                type: 'object',
+                properties: {
+                  product: {
+                    $ref: '#/x-ext/catalog/components/schemas/Product',
+                  },
+                },
+              },
+            },
+          },
+        },
+        catalog: {
+          components: {
+            schemas: {
+              Product: { type: 'string' },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input, 'always') as {
+      components: { schemas: Record<string, Record<string, unknown>> };
+    };
+
+    expect(result.components.schemas.Holder).toEqual({
+      $ref: '#/components/schemas/Order_billing',
+    });
+    expect(result.components.schemas.Order_billing).toEqual({
+      type: 'object',
+      properties: {
+        product: { $ref: '#/components/schemas/Product_catalog' },
+      },
+    });
+    expect(result.components.schemas).toHaveProperty('Product_catalog');
+    expect(JSON.stringify(result)).not.toContain('#/x-ext/');
+  });
+
+  it('should reject a post-sanitization external schema collision', () => {
+    const input = {
+      'x-ext': {
+        'service-a': {
+          components: {
+            schemas: { User: { type: 'string', enum: ['first'] } },
+          },
+        },
+        service_a: {
+          components: {
+            schemas: { User: { type: 'string', enum: ['second'] } },
+          },
+        },
+      },
+    };
+
+    expect(() => dereferenceExternalRef(input, 'always')).toThrow(
+      /external schema.*User.*service_a.*User_service_a/i,
+    );
+  });
+
+  it('should always name duplicate schemas by their external document', () => {
+    const input = {
+      components: {
+        schemas: {
+          BillingUser: {
+            $ref: '#/x-ext/billing/components/schemas/User',
+          },
+          CatalogUser: {
+            $ref: '#/x-ext/catalog/components/schemas/User',
+          },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: { schemas: { User: { type: 'string' } } },
+        },
+        catalog: {
+          components: { schemas: { User: { type: 'number' } } },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input, 'always') as {
+      components: { schemas: Record<string, unknown> };
+    };
+
+    expect(result.components.schemas).toHaveProperty('User_billing');
+    expect(result.components.schemas).toHaveProperty('User_catalog');
+    expect(result.components.schemas.BillingUser).toEqual({
+      $ref: '#/components/schemas/User_billing',
+    });
+    expect(result.components.schemas.CatalogUser).toEqual({
+      $ref: '#/components/schemas/User_catalog',
+    });
+  });
+
+  it('should reuse one always-named component for repeated external refs', () => {
+    const input = {
+      components: {
+        schemas: {
+          First: { $ref: '#/x-ext/billing/components/schemas/User' },
+          Second: { $ref: '#/x-ext/billing/components/schemas/User' },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: { schemas: { User: { type: 'string' } } },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input, 'always') as {
+      components: { schemas: Record<string, unknown> };
+    };
+
+    expect(Object.keys(result.components.schemas)).toEqual([
+      'First',
+      'Second',
+      'User_billing',
+    ]);
+    expect(result.components.schemas.First).toEqual({
+      $ref: '#/components/schemas/User_billing',
+    });
+    expect(result.components.schemas.Second).toEqual({
+      $ref: '#/components/schemas/User_billing',
+    });
+  });
+
+  it('should keep always-mode names stable when external order is reversed', () => {
+    const createInput = (reverse: boolean) => ({
+      components: {
+        schemas: {
+          BillingUser: {
+            $ref: '#/x-ext/billing/components/schemas/User',
+          },
+          CatalogUser: {
+            $ref: '#/x-ext/catalog/components/schemas/User',
+          },
+        },
+      },
+      'x-ext': reverse
+        ? {
+            catalog: {
+              components: { schemas: { User: { type: 'number' } } },
+            },
+            billing: {
+              components: { schemas: { User: { type: 'string' } } },
+            },
+          }
+        : {
+            billing: {
+              components: { schemas: { User: { type: 'string' } } },
+            },
+            catalog: {
+              components: { schemas: { User: { type: 'number' } } },
+            },
+          },
+    });
+
+    const project = (reverse: boolean) => {
+      const schemas = (
+        dereferenceExternalRef(createInput(reverse), 'always') as {
+          components: { schemas: Record<string, unknown> };
+        }
+      ).components.schemas;
+      return {
+        billing: schemas.BillingUser,
+        catalog: schemas.CatalogUser,
+        names: Object.keys(schemas)
+          .filter((name) => name.startsWith('User_'))
+          .sort(),
+      };
+    };
+
+    expect(project(true)).toEqual(project(false));
+  });
+
+  it('should always suffix external schemas and rewrite their internal refs', () => {
+    const input = {
+      components: {
+        schemas: {
+          Holder: {
+            allOf: [{ $ref: '#/x-ext/billing/components/schemas/Order' }],
+          },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: {
+            schemas: {
+              User: { type: 'object' },
+              Order: {
+                type: 'object',
+                properties: {
+                  user: { $ref: '#/components/schemas/User' },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input, 'always') as {
+      components: { schemas: Record<string, Record<string, unknown>> };
+    };
+
+    expect(result.components.schemas).toHaveProperty('User_billing');
+    expect(result.components.schemas).toHaveProperty('Order_billing');
+    expect(result.components.schemas.Order_billing).toEqual({
+      type: 'object',
+      properties: {
+        user: { $ref: '#/components/schemas/User_billing' },
+      },
+    });
+    expect(result.components.schemas.Holder).toEqual({
+      allOf: [{ $ref: '#/components/schemas/Order_billing' }],
+    });
+    expect(result).not.toHaveProperty('x-ext');
+  });
+
+  it('should preserve an x-ext placeholder as an alias in always mode', () => {
+    const input = {
+      components: {
+        schemas: {
+          User: {
+            $ref: '#/x-ext/billing/components/schemas/User',
+          },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: {
+            schemas: {
+              User: { type: 'object', properties: { id: { type: 'string' } } },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input, 'always') as {
+      components: { schemas: Record<string, unknown> };
+    };
+
+    expect(result.components.schemas.User).toEqual({
+      $ref: '#/components/schemas/User_billing',
+    });
+    expect(result.components.schemas.User_billing).toEqual({
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    });
+  });
+
+  it('should reject a suffixed external schema name collision', () => {
+    const input = {
+      components: {
+        schemas: {
+          User_billing: { type: 'string' },
+        },
+      },
+      'x-ext': {
+        billing: {
+          components: {
+            schemas: {
+              User: { type: 'object' },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() => dereferenceExternalRef(input, 'always')).toThrow(
+      /external schema.*User.*billing.*User_billing/i,
+    );
+  });
+
   it('should dereference x-ext references and remove x-ext property', () => {
     const input = {
       openapi: '3.0.0',
@@ -1751,6 +2545,53 @@ describe('dereferenceExternalRefs', () => {
     expect(result).not.toHaveProperty('x-ext');
   });
 
+  it('should rewrite an always-mode barrel ref across external documents', () => {
+    const input = {
+      components: {
+        schemas: {
+          UserProjectDTO: {
+            $ref: '#/x-ext/barrel/components/schemas/UserProjectDTO',
+          },
+        },
+      },
+      'x-ext': {
+        barrel: {
+          components: {
+            schemas: {
+              UserProjectDTO: {
+                $ref: '#/x-ext/concrete/components/schemas/UserProject',
+              },
+            },
+          },
+        },
+        concrete: {
+          components: {
+            schemas: {
+              UserProject: {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input, 'always') as OpenApiDocument;
+    const schemas = result.components?.schemas;
+
+    expect(schemas).toHaveProperty('UserProjectDTO_barrel');
+    expect(schemas).toHaveProperty('UserProject_concrete');
+    expect(schemas?.UserProjectDTO_barrel).toEqual({
+      $ref: '#/components/schemas/UserProject_concrete',
+    });
+    expect(schemas?.UserProject_concrete).toEqual({
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    });
+    expect(JSON.stringify(result)).not.toContain('#/x-ext/');
+  });
+
   // Regression test for https://github.com/orval-labs/orval/issues/394
   it('should resolve internal $ref inside an external parameter against the external doc', () => {
     const input = {
@@ -1830,6 +2671,9 @@ describe('dereferenceExternalRefs', () => {
               name: { type: 'string' },
             },
           },
+          Holder: {
+            $ref: '#/x-ext/external/components/schemas/User',
+          },
         },
       },
       'x-ext': {
@@ -1852,7 +2696,23 @@ describe('dereferenceExternalRefs', () => {
 
     const result = dereferenceExternalRef(input) as OpenApiDocument;
 
-    expect(result.components?.schemas).toHaveProperty('User_external');
+    expect(result.components?.schemas?.User).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+    });
+    expect(result.components?.schemas?.User_external).toEqual({
+      type: 'object',
+      properties: {
+        email: { type: 'string' },
+        age: { type: 'number' },
+      },
+    });
+    expect(result.components?.schemas?.Holder).toEqual({
+      $ref: '#/components/schemas/User_external',
+    });
     expect(result).not.toHaveProperty('x-ext');
   });
 

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -4,6 +4,7 @@ import {
   isString,
   isUrl,
   logWarning,
+  type ExternalRefNamingStrategy,
   type NormalizedOptions,
   type OpenApiDocument,
   type OverrideInput,
@@ -555,9 +556,13 @@ async function bundleAndDereferenceExternalRefs(
       parseYaml(),
     ],
     treeShake: false,
+    ...(parserOptions?.compress ? { compress: parserOptions.compress } : {}),
     ...(origin ? { origin } : {}),
   });
-  return dereferenceExternalRef(data as Record<string, unknown>);
+  return dereferenceExternalRef(
+    data as Record<string, unknown>,
+    parserOptions?.externalRefs?.strategy,
+  );
 }
 
 // ─── External ref allow-list enforcement (GHSA-cxq5-97v7-87j8) ─────────────
@@ -834,11 +839,12 @@ export function validateComponentKeys(data: Record<string, unknown>): void {
  */
 export function dereferenceExternalRef(
   data: Record<string, unknown>,
+  strategy: ExternalRefNamingStrategy = 'default',
 ): Record<string, unknown> {
   const extensions = (data['x-ext'] ?? {}) as Record<string, unknown>;
 
   // Step 1: Merge external schemas into main spec with collision handling
-  const schemaNameMappings = mergeExternalSchemas(data, extensions);
+  const schemaNameMappings = mergeExternalSchemas(data, extensions, strategy);
 
   // Step 2: Replace all x-ext refs throughout the document
   const result: Record<string, unknown> = {};
@@ -858,6 +864,7 @@ export function dereferenceExternalRef(
 function mergeExternalSchemas(
   data: Record<string, unknown>,
   extensions: Record<string, unknown>,
+  strategy: ExternalRefNamingStrategy,
 ): Record<string, Record<string, string>> {
   const schemaNameMappings: Record<string, Record<string, string>> = {};
 
@@ -868,10 +875,9 @@ function mergeExternalSchemas(
   mainComponents.schemas ??= {};
   const mainSchemas = mainComponents.schemas as Record<string, unknown>;
 
-  // Merge schemas from each external doc
-  // Collision handling:
-  // - If schema already exists in main spec, add x-ext key as suffix (e.g., User -> User_external1)
-  // - x-ext refs in main spec get replaced by actual schema from external doc
+  // Merge schemas from each external doc. In default mode, preserve the
+  // original name unless it is occupied by a different schema. In always mode,
+  // include the external document key for every external schema.
   for (const [extKey, extDoc] of Object.entries(extensions)) {
     schemaNameMappings[extKey] = {};
 
@@ -880,26 +886,43 @@ function mergeExternalSchemas(
       if (isObject(extComponents) && 'schemas' in extComponents) {
         const extSchemas = extComponents.schemas as Record<string, unknown>;
         for (const [schemaName, schema] of Object.entries(extSchemas)) {
-          // Check if main schema is just an x-ext ref - if so, replace it without suffix
           const existingSchema = mainSchemas[schemaName];
-          const isXExtRef =
+          const existingRef =
             isObject(existingSchema) &&
             '$ref' in existingSchema &&
             isString(existingSchema.$ref) &&
-            existingSchema.$ref.startsWith('#/x-ext/');
+            existingSchema.$ref;
+          const isMatchingXExtRef =
+            existingRef ===
+            `#/x-ext/${extKey}/components/schemas/${schemaName}`;
 
           let finalSchemaName = schemaName;
 
-          if (schemaName in mainSchemas && !isXExtRef) {
-            // Collision: add suffix to external schema
-            const suffix = extKey.replaceAll(/[^a-zA-Z0-9]/g, '_');
-            finalSchemaName = `${schemaName}_${suffix}`;
-            schemaNameMappings[extKey][schemaName] = finalSchemaName;
-          } else {
-            // No collision or replacing x-ext ref
-            schemaNameMappings[extKey][schemaName] = schemaName;
+          const suffix = extKey.replaceAll(/[^a-zA-Z0-9]/g, '_');
+          if (strategy === 'always' && suffix.length === 0) {
+            throw new Error(
+              `External schema "${schemaName}" from "${extKey}" cannot be named with the always strategy because its external document identity is empty after sanitization.`,
+            );
           }
 
+          if (strategy === 'always') {
+            finalSchemaName = `${schemaName}_${suffix}`;
+          } else if (schemaName in mainSchemas && !isMatchingXExtRef) {
+            finalSchemaName = `${schemaName}_${suffix}`;
+          }
+
+          const isExistingPlaceholder =
+            finalSchemaName === schemaName && isMatchingXExtRef;
+          if (
+            Object.hasOwn(mainSchemas, finalSchemaName) &&
+            !isExistingPlaceholder
+          ) {
+            throw new Error(
+              `External schema "${schemaName}" from "${extKey}" cannot be merged as "${finalSchemaName}" because that component name is already occupied.`,
+            );
+          }
+
+          schemaNameMappings[extKey][schemaName] = finalSchemaName;
           mainSchemas[finalSchemaName] = scrubUnwantedKeys(schema);
         }
       }


### PR DESCRIPTION
## Summary

  Add support for custom external document compression and configurable external schema naming strategies

  Fixes #3166

  ## Changed

  - Added `input.parserOptions.compress`
    - Supports synchronous and asynchronous callbacks
    - Receives Scalar’s normalized external document identity/path
  - Added `input.parserOptions.externalRefs.strategy`
    - `default`: preserves suffix-only-on-collision behavior
    - `always`: always suffixes external schemas with their document identity
  - Preserved external reference allow-listing and `$ref` rewriting
  - Added source-aware `x-ext` placeholder handling
  - Added explicit errors for final schema-name collisions instead of silently overwriting schemas
  - Added coverage for:
    - synchronous and asynchronous compression;
    - transformer-introduced external refs;
    - internal and cross-document refs;
    - repeated refs;
    - reversed document order;
    - collision cases;
    - stable names after schema content changes
  - Updated English and Chinese configuration documentation

  ## Notes

  Without a custom `compress` callback, `strategy: 'always'` still works using Scalar’s generated/hash-like external key

  For readable and stable names, configure a deterministic callback:

  ```ts
  parserOptions: {
    compress: (value) =>
      value.includes('billing') ? 'billing' : value,
    externalRefs: {
      strategy: 'always',
    },
  },
```
  This produces names such as `User_billing`

  externalRefs.allow behavior and security semantics remain unchanged.

  ## Important

  An ambiguous final-name collision now throws an explicit error instead of silently overwriting an existing schema. This is intentional data-loss protection

  ## Validation

  - Focused Orval tests: 74 passed.
  - Core TypeScript check: passed.
  - Orval TypeScript check: passed.
  - vp check: passed with 0 errors.
  - Full test suite: 4,206 passed, 3 failed.

  The three failing resolve-version.test.ts cases are reproducible on clean master and are unrelated to this change:

  - remeda package with an exports field;
  - scoped @faker-js/faker;
  - batch remeda resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable compression for naming bundled external documents, supporting synchronous and asynchronous callbacks.
  - Added external-reference naming strategies: `default` and `always`.
  - External schema names now include sanitized document identifiers when needed, with clear errors for naming collisions or invalid identifiers.
  - Clarified that external-reference permissions control document loading independently from naming configuration.

- **Bug Fixes**
  - Improved handling of external references, including remote relative references, cross-document references, and schema aliases.
  - Strengthened validation for form-data parameters, security settings, and generated request parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->