### PR TITLE
fix: autofix consistent-type-imports warnings in hand-written samples

### DIFF
--- a/samples/angular-app/src/app/app.config.ts
+++ b/samples/angular-app/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
+import type {
+  ApplicationConfig} from '@angular/core';
 import {
-  ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';

--- a/samples/angular-app/src/app/load-state.ts
+++ b/samples/angular-app/src/app/load-state.ts
@@ -1,4 +1,5 @@
-import { catchError, map, Observable, of, startWith } from 'rxjs';
+import type { Observable} from 'rxjs';
+import { catchError, map, of, startWith } from 'rxjs';
 
 export type LoadState<T> =
   | { status: 'loading'; data: T; error?: undefined }

--- a/samples/angular-app/src/app/zod-validation-demo.ts
+++ b/samples/angular-app/src/app/zod-validation-demo.ts
@@ -1,9 +1,10 @@
 import { HttpEventType } from '@angular/common/http';
+import type {
+  OnInit} from '@angular/core';
 import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  OnInit,
   signal,
 } from '@angular/core';
 import { JsonPipe } from '@angular/common';

--- a/samples/angular-app/src/orval/browser.ts
+++ b/samples/angular-app/src/orval/browser.ts
@@ -1,5 +1,6 @@
 import { setupWorker } from 'msw/browser';
-import { http, HttpResponse, RequestHandler } from 'msw';
+import type { RequestHandler } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 import * as httpBothMocks from '../api/http-both/index.msw';
 import * as httpClientMocks from '../api/http-client/index.msw';

--- a/samples/angular-app/src/orval/mutator/response-type.ts
+++ b/samples/angular-app/src/orval/mutator/response-type.ts
@@ -1,5 +1,5 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import type { HttpClient, HttpParams } from '@angular/common/http';
+import type { Observable } from 'rxjs';
 
 type QueryParamValue = string | number | boolean;
 

--- a/samples/angular-query/__snapshots__/api/mutator/custom-client-with-error.ts
+++ b/samples/angular-query/__snapshots__/api/mutator/custom-client-with-error.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import type { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { lastValueFrom } from 'rxjs';
 
 export interface ExtendedServerErrorResponse<Error> extends HttpErrorResponse {

--- a/samples/angular-query/src/api/mutator/custom-client-with-error.ts
+++ b/samples/angular-query/src/api/mutator/custom-client-with-error.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import type { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { lastValueFrom } from 'rxjs';
 
 export interface ExtendedServerErrorResponse<Error> extends HttpErrorResponse {

--- a/samples/angular-query/src/app/angular-query-generation.spec.ts
+++ b/samples/angular-query/src/app/angular-query-generation.spec.ts
@@ -18,12 +18,13 @@ import {
   uploadFormData,
 } from '../api/endpoints-no-transformer/pets/pets';
 
+import type {
+  ListPetsQueryError} from '../api/endpoints-custom-instance/pets/pets';
 import {
   listPets as listPetsCustom,
   getListPetsQueryOptions as getListPetsQueryOptionsCustom,
   injectListPets as injectListPetsCustom,
-  getListPetsQueryKey as getListPetsQueryKeyCustom,
-  ListPetsQueryError,
+  getListPetsQueryKey as getListPetsQueryKeyCustom
 } from '../api/endpoints-custom-instance/pets/pets';
 import {
   uploadFormData as uploadFormDataCustom,

--- a/samples/angular-query/src/app/app.config.ts
+++ b/samples/angular-query/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
+import type {
+  ApplicationConfig} from '@angular/core';
 import {
-  ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';

--- a/samples/basic/api/mutator/response-type.ts
+++ b/samples/basic/api/mutator/response-type.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
 
 export const getWithResponseType = <T>(
   config: AxiosRequestConfig,

--- a/samples/react-app-with-swr/basic/src/api/mutator/custom-instance.ts
+++ b/samples/react-app-with-swr/basic/src/api/mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/react-app-with-swr/basic/src/auth.context.tsx
+++ b/samples/react-app-with-swr/basic/src/auth.context.tsx
@@ -1,6 +1,7 @@
+import type {
+  ReactNode} from 'react';
 import React, {
   createContext,
-  ReactNode,
   useContext,
   useEffect,
   useState,

--- a/samples/react-app-with-swr/fetch-client/src/App.tsx
+++ b/samples/react-app-with-swr/fetch-client/src/App.tsx
@@ -2,7 +2,7 @@ import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
 
-import { Pet } from './api/models/pet';
+import type { Pet } from './api/models/pet';
 import { useListPets } from './api/endpoints/swaggerPetstore';
 import { useCreatePets } from './api/endpoints/swaggerPetstore';
 

--- a/samples/react-app/src/App.tsx
+++ b/samples/react-app/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Pets } from './api/model';
+import type { Pets } from './api/model';
 import { useApi } from './api/useApi';
 import './App.css';
 import { useAuthDispatch } from './auth.context';

--- a/samples/react-app/src/api/mutator/custom-instance.ts
+++ b/samples/react-app/src/api/mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/react-app/src/auth.context.tsx
+++ b/samples/react-app/src/auth.context.tsx
@@ -1,7 +1,8 @@
 import axios from 'axios';
+import type {
+  ReactNode} from 'react';
 import React, {
   createContext,
-  ReactNode,
   useContext,
   useEffect,
   useState,

--- a/samples/react-query/basic/src/api/mutator/custom-instance.ts
+++ b/samples/react-query/basic/src/api/mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/react-query/basic/src/auth.context.tsx
+++ b/samples/react-query/basic/src/auth.context.tsx
@@ -1,6 +1,7 @@
+import type {
+  ReactNode} from 'react';
 import React, {
   createContext,
-  ReactNode,
   useContext,
   useEffect,
   useState,

--- a/samples/react-query/custom-fetch/src/pets.tsx
+++ b/samples/react-query/custom-fetch/src/pets.tsx
@@ -1,5 +1,5 @@
 import { useListPets, useCreatePets } from './gen/pets/pets';
-import { Pet } from './gen/models';
+import type { Pet } from './gen/models';
 
 export default function Pets() {
   const { data } = useListPets();

--- a/samples/react-query/form-data-mutator/custom-instance.ts
+++ b/samples/react-query/form-data-mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/react-query/form-data/custom-instance.ts
+++ b/samples/react-query/form-data/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/react-query/form-url-encoded-mutator/custom-instance.ts
+++ b/samples/react-query/form-url-encoded-mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/react-query/form-url-encoded/custom-instance.ts
+++ b/samples/react-query/form-url-encoded/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/solid-query/basic/src/App.tsx
+++ b/samples/solid-query/basic/src/App.tsx
@@ -1,4 +1,5 @@
-import { Component, For, Show } from 'solid-js';
+import type { Component} from 'solid-js';
+import { For, Show } from 'solid-js';
 import { useListPets } from './api/endpoints/petstoreFromFileSpecWithTransformer';
 import './App.css';
 import logo from './logo.svg';

--- a/samples/solid-query/basic/src/api/mutator/custom-instance.ts
+++ b/samples/solid-query/basic/src/api/mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/solid-query/custom-fetch/src/App.tsx
+++ b/samples/solid-query/custom-fetch/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'solid-js';
+import type { Component } from 'solid-js';
 import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
 import Pets from './lib/Pets';
 import './App.css';

--- a/samples/solid-query/custom-fetch/src/lib/Pets.tsx
+++ b/samples/solid-query/custom-fetch/src/lib/Pets.tsx
@@ -1,4 +1,5 @@
-import { Component, For, Show } from 'solid-js';
+import type { Component} from 'solid-js';
+import { For, Show } from 'solid-js';
 import { useListPets, useCreatePets } from '../gen/pets/pets';
 
 const Pets: Component = () => {

--- a/samples/solid-start/basic/src/api/mutator/custom-instance.ts
+++ b/samples/solid-start/basic/src/api/mutator/custom-instance.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosRequestConfig } from 'axios';
 import { getPets, createPet, getPetById } from '~/server/pets';
 import type { CreatePetsBody } from '~/api/model';
 

--- a/samples/solid-start/basic/src/routes/index.tsx
+++ b/samples/solid-start/basic/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { Title } from '@solidjs/meta';
 import { createAsync, revalidate, useAction } from '@solidjs/router';
-import { Component, For, Show, createSignal } from 'solid-js';
+import type { Component} from 'solid-js';
+import { For, Show, createSignal } from 'solid-js';
 import { SwaggerPetstore } from '~/api/endpoints/petstore';
 
 const Home: Component = () => {

--- a/samples/swr-with-effect/src/App.tsx
+++ b/samples/swr-with-effect/src/App.tsx
@@ -1,7 +1,7 @@
 import { Schema as S } from 'effect';
 import './App.css';
 
-import { Pet } from './gen/models';
+import type { Pet } from './gen/models';
 import { useListPets, useCreatePets } from './gen/endpoints/pets/pets';
 import { CreatePetsBodyItem } from './gen/endpoints/pets/pets.effect';
 

--- a/samples/swr-with-zod/src/App.tsx
+++ b/samples/swr-with-zod/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css';
 
-import { Pet } from './gen/models';
+import type { Pet } from './gen/models';
 import { useListPets, useCreatePets } from './gen/endpoints/pets/pets';
 import { CreatePetsBodyItem } from './gen/endpoints/pets/pets.zod';
 

--- a/samples/vue-query/vue-query-basic/src/api/mutator/custom-instance.ts
+++ b/samples/vue-query/vue-query-basic/src/api/mutator/custom-instance.ts
@@ -1,4 +1,5 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
+import Axios from 'axios';
 
 export const AXIOS_INSTANCE = Axios.create({ baseURL: '' });
 

--- a/samples/vue-query/vue-query-basic/src/shims-vue.d.ts
+++ b/samples/vue-query/vue-query-basic/src/shims-vue.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
-  import { DefineComponent } from 'vue';
+  import type { DefineComponent } from 'vue';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
   const component: DefineComponent<{}, {}, any>;
   export default component;


### PR DESCRIPTION
Fixes part of #3931 (step 3: hand-written sample sources).

## Summary

32 sample source files were tripping oxlint's `typescript/consistent-type-imports` rule. All contained value imports of symbols that are only used in type positions (e.g. `import { MyType } from './types'` used only in `: MyType` annotations).

Auto-fixed with `vp lint --fix --no-ignore samples`:
- `import { Foo }` → `import type { Foo }` for type-only specifiers
- `import { type Foo }` → `import type { Foo }` (consolidated form)
- Namespace imports where all usages are type positions

## Result

**Before**: 33 `consistent-type-imports` warnings in `samples/`  
**After**: 0

Combined with the merged #3999 (hono 60 + mcp 9) and #3936 (source rule), the total `consistent-type-imports` warnings across the repo are now down to 2:
- `tests/__snapshots__/default/endpoint-parameters/endpoints.ts:10` — `CountryCode` used as a default parameter **value** (`country: CountryCode = 'UY'`). This is a false positive: the import must remain a value import because the enum is referenced in a value position.
- `tests/__snapshots__/angular-query/use-prefetch/endpoints.ts:11` — `QueryClient` is imported as a value because the angular mutation invalidation path emits `const queryClient = inject(QueryClient)`. Making it type-only would break that code path. See #3935 for the design discussion on conditional emission.

Both are expected and documented false positives; no generator change can fix them without regressing the generated code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated sample applications to clearly separate type-only imports from runtime imports.
  - Applied consistent import organization across Angular, React, Solid, Vue, and Axios-based examples.
  - No user-facing functionality or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->