### PR TITLE
fix: escape single quotes in content type media keys (GHSA-rcpr-mq4m-…

### DIFF
--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -1356,6 +1356,39 @@ describe('angular HttpClient generator', () => {
       expect(impl).toContain("accept: GetPetFileAccept = 'application/json'");
     });
 
+    it('escapes single quotes in accept media type keys', () => {
+      const verbOption = createVerbOption({
+        operationId: 'getPetFile',
+        operationName: 'getPetFile',
+        typeName: 'getPetFile',
+        response: baseResponse({
+          definition: { success: 'Pet | string', errors: 'Error' },
+          types: {
+            success: [
+              createSuccessType(
+                'Pet',
+                "application/json', 'X-Evil': 'injected",
+              ),
+              createSuccessType('string', 'text/plain'),
+            ],
+            errors: [],
+          },
+          contentTypes: [
+            "application/json', 'X-Evil': 'injected",
+            'text/plain',
+          ],
+        }),
+      });
+      const options = createGeneratorOptions();
+
+      const impl = generateHttpClientImplementation(verbOption, options);
+
+      expect(impl).toContain(
+        "accept: 'application/json\\', \\'X-Evil\\': \\'injected'",
+      );
+      expect(impl).not.toContain("'X-Evil': 'injected'");
+    });
+
     it('omits text dispatch for JSON and Blob response types', () => {
       const verbOption = createVerbOption({
         operationId: 'getPetImage',

--- a/packages/angular/src/http-client.ts
+++ b/packages/angular/src/http-client.ts
@@ -23,6 +23,7 @@ import {
   type GetterProp,
   GetterPropType,
   isBoolean,
+  jsStringLiteralEscape,
   makeRouteSafe,
   pascal,
   toObjectString,
@@ -731,7 +732,7 @@ export const generateHttpClientImplementation = (
         const overloadParams = [
           requiredNonBodyPart,
           bodyOverloadPart,
-          `accept: '${contentType}'`,
+          `accept: '${jsStringLiteralEscape(contentType ?? '')}'`,
           optionalNonBodyPart,
         ]
           .filter(Boolean)
@@ -800,7 +801,9 @@ export const generateHttpClientImplementation = (
     const allParams = [
       requiredNonBodyImplPart,
       bodyImplPart,
-      `accept: ${acceptTypeName ?? 'string'} = '${defaultContentType}'`,
+      `accept: ${acceptTypeName ?? 'string'} = '${jsStringLiteralEscape(
+        defaultContentType,
+      )}'`,
       optionalNonBodyImplPart,
     ]
       .filter(Boolean)

--- a/packages/angular/src/http-resource.ts
+++ b/packages/angular/src/http-resource.ts
@@ -26,6 +26,7 @@ import {
   isObject,
   isSyntheticDefaultImportsAllow,
   jsDoc,
+  jsStringLiteralEscape,
   makeRouteSafe,
   type NormalizedOutputOptions,
   type OpenApiInfoObject,
@@ -1068,7 +1069,7 @@ const buildHttpResourceFunction = (
         const returnType = getBranchReturnType(type);
         const overloadArgs = [
           requiredPart,
-          `accept: '${type.contentType}'`,
+          `accept: '${jsStringLiteralEscape(type.contentType ?? '')}'`,
           optionalPart,
           `options?: ${buildBranchOptionsType(returnType, getBranchRawType(type), omitParse)}`,
         ]
@@ -1080,7 +1081,9 @@ const buildHttpResourceFunction = (
       .join('\n');
     const implementationArgsWithDefault = [
       requiredPart,
-      `accept: ${acceptTypeName} = '${defaultContentType}'`,
+      `accept: ${acceptTypeName} = '${jsStringLiteralEscape(
+        defaultContentType,
+      )}'`,
       optionalPart,
       `options?: ${implementationOptionsType}`,
     ]

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -1232,6 +1232,29 @@ describe('generateMutatorConfig', () => {
       expect(result).toContain('headers');
     });
 
+    it('should escape single quotes in the request body media type key', () => {
+      const result = generateMutatorConfig({
+        route: '/api/test',
+        body: {
+          ...minimalBody,
+          contentType: "application/json', 'X-Evil': 'injected",
+        },
+        headers: undefined,
+        queryParams: undefined,
+        response: minimalResponse,
+        verb: Verbs.POST,
+        isFormData: false,
+        isFormUrlEncoded: false,
+        hasSignal: false,
+        isExactOptionalPropertyTypes: false,
+      });
+
+      expect(result).toContain(
+        "'Content-Type': 'application/json\\', \\'X-Evil\\': \\'injected'",
+      );
+      expect(result).not.toContain("'X-Evil': 'injected'");
+    });
+
     it('should set Content-Type header for application/x-www-form-urlencoded', () => {
       const result = generateMutatorConfig({
         route: '/api/test',

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -8,7 +8,12 @@ import {
   type ParamsSerializerOptions,
   Verbs,
 } from '../types';
-import { getIsBodyVerb, isObject, stringify } from '../utils';
+import {
+  getIsBodyVerb,
+  isObject,
+  jsStringLiteralEscape,
+  stringify,
+} from '../utils';
 
 /**
  * Per-parameter Angular query-object serialization strategy, mirroring
@@ -975,9 +980,9 @@ export function generateMutatorConfig({
     body.contentType && !ignoreContentTypes.includes(body.contentType);
 
   const headerOptions = shouldSetContentType
-    ? `,\n      headers: {'Content-Type': '${body.contentType}', ${
-        headers ? '...headers' : ''
-      }}`
+    ? `,\n      headers: {'Content-Type': '${jsStringLiteralEscape(
+        body.contentType,
+      )}', ${headers ? '...headers' : ''}}`
     : headers
       ? ',\n      headers'
       : '';

--- a/packages/core/src/getters/res-req-types.test.ts
+++ b/packages/core/src/getters/res-req-types.test.ts
@@ -1105,3 +1105,37 @@ describe('getResReqTypes ($ref response without content)', () => {
     expect(result[0].originalSchema).toBeUndefined();
   });
 });
+
+describe('getResReqTypes (form-data part content type escaping)', () => {
+  it('escapes single quotes in an encoding content type', () => {
+    const reqBody: [string, OpenApiRequestBodyObject][] = [
+      [
+        'requestBody',
+        {
+          content: {
+            'multipart/form-data': {
+              schema: {
+                type: 'object',
+                properties: {
+                  note: { type: 'string' },
+                },
+                required: ['note'],
+              },
+              encoding: {
+                note: { contentType: "text/plain', evil: 'injected" },
+              },
+            },
+          },
+          required: true,
+        },
+      ],
+    ];
+
+    const result = getResReqTypes(reqBody, 'Body', context)[0];
+
+    expect(result.formData).toContain(
+      String.raw`new Blob([bodyRequestBody.note], { type: 'text/plain\', evil: \'injected' })`,
+    );
+    expect(result.formData).not.toContain("evil: 'injected'");
+  });
+});

--- a/packages/core/src/getters/res-req-types.ts
+++ b/packages/core/src/getters/res-req-types.ts
@@ -23,7 +23,7 @@ import {
   getFormDataFieldFileType,
   isBinaryContentType,
 } from '../utils/content-type';
-import { getNumberWord } from '../utils/string';
+import { getNumberWord, jsStringLiteralEscape } from '../utils/string';
 import type { FormDataContext } from './object';
 import { getKey, getPropertyNameCollisionKeys } from './keys';
 
@@ -815,7 +815,9 @@ function resolveSchemaPropertiesToFormData({
       formDataValue = `${variableName}.append(\`${keyPrefix}${escapedKey}\`, ${nonOptionalValueKey});\n`;
     } else if (fileType === 'text') {
       // Text file: value is Blob | string, check at runtime
-      formDataValue = `${variableName}.append(\`${keyPrefix}${escapedKey}\`, ${nonOptionalValueKey} instanceof Blob ? ${nonOptionalValueKey} : new Blob([${nonOptionalValueKey}], { type: '${effectiveContentType}' }));\n`;
+      formDataValue = `${variableName}.append(\`${keyPrefix}${escapedKey}\`, ${nonOptionalValueKey} instanceof Blob ? ${nonOptionalValueKey} : new Blob([${nonOptionalValueKey}], { type: '${jsStringLiteralEscape(
+        effectiveContentType ?? '',
+      )}' }));\n`;
     } else if (
       property.type === 'object' ||
       (Array.isArray(property.type) && property.type.includes('object'))

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -623,3 +623,33 @@ describe('generateRequestFunction — zod runtimeValidation response typing (#39
     expect(implementation).not.toContain('PetsOutput');
   });
 });
+
+describe('generateRequestFunction — Content-Type header escaping', () => {
+  it('escapes single quotes in the request body media type key', () => {
+    const verbOptions = makeVerbOptions({
+      verb: Verbs.POST,
+      body: {
+        definition: 'SubmitDataBody',
+        implementation: 'submitDataBody: SubmitDataBody',
+        imports: [],
+        schemas: [],
+        formData: undefined,
+        formUrlEncoded: undefined,
+        contentType: "application/json', 'X-Evil': 'injected",
+        isOptional: false,
+        originalSchema: {},
+        isBlob: false,
+      } as GeneratorVerbOptions['body'],
+    });
+
+    const implementation = generateImplementation(
+      verbOptions,
+      makeOptions(makeContext()),
+    );
+
+    expect(implementation).toContain(
+      String.raw`'Content-Type': 'application/json\', \'X-Evil\': \'injected'`,
+    );
+    expect(implementation).not.toContain("'X-Evil': 'injected'");
+  });
+});

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -12,6 +12,7 @@ import {
   getSchemaValueRef,
   hasSchemaImport,
   isPrimitiveResponseType,
+  jsStringLiteralEscape,
   rewriteImportsForResponseValidation,
   type GeneratorOptions,
   type GeneratorVerbOptions,
@@ -581,7 +582,7 @@ ${override.fetch.forceSuccessResponse && hasSuccess ? '' : `export type ${respon
 
   const headersToAdd: string[] = [
     ...(body.contentType && !ignoreContentTypes.includes(body.contentType)
-      ? [`'Content-Type': '${body.contentType}'`]
+      ? [`'Content-Type': '${jsStringLiteralEscape(body.contentType)}'`]
       : []),
     ...(isNdJson && response.contentTypes.length === 1
       ? [

--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -786,6 +786,34 @@ describe('generateMSW', () => {
       );
     });
 
+    it('should escape single quotes in the response media type key', () => {
+      const injectedVerbOptions = {
+        ...mockVerbOptions,
+        response: {
+          ...mockVerbOptions.response,
+          contentTypes: ["application/problem+json', 'X-Evil': 'injected"],
+        },
+      } as GeneratorVerbOptions;
+
+      const result = generateMSW(injectedVerbOptions, {
+        ...baseOptions,
+        override: {
+          ...baseOptions.override,
+          operations: {
+            ...baseOptions.override.operations,
+            getUser: { mock: { data: { id: 1, name: 'Milo' } } },
+          },
+        },
+      });
+
+      expect(result.implementation.handler).toContain(
+        String.raw`'Content-Type': 'application/problem+json\', \'X-Evil\': \'injected'`,
+      );
+      expect(result.implementation.handler).not.toContain(
+        "'X-Evil': 'injected'",
+      );
+    });
+
     it('should emit explicit Content-Type header for problem+json responses', () => {
       const problemJsonVerbOptions = {
         ...mockVerbOptions,

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -11,6 +11,7 @@ import {
   isFunction,
   isMswMock,
   isObject,
+  jsStringLiteralEscape,
   pascal,
   type ResReqTypesValue,
   type StrictMockSchemaKind,
@@ -350,16 +351,18 @@ function generateDefinition(
         : 'text/plain';
   const jsonCtHeaderSuffix =
     firstJsonCt && firstJsonCt !== 'application/json'
-      ? `, headers: { 'Content-Type': '${firstJsonCt}' }`
+      ? `, headers: { 'Content-Type': '${jsStringLiteralEscape(firstJsonCt)}' }`
       : // When preferredContentType matched a non-JSON type (e.g. application/octet-stream)
         // and the structured schema falls through to HttpResponse.json(), emit the
         // selected media type as the Content-Type so the contract survives.
         preferredContentTypeMatch && !preferredContentTypeMatch.includes('json')
-        ? `, headers: { 'Content-Type': '${preferredContentTypeMatch}' }`
+        ? `, headers: { 'Content-Type': '${jsStringLiteralEscape(
+            preferredContentTypeMatch,
+          )}' }`
         : '';
   const textCtHeaderSuffix =
     firstTextCt && firstTextCt !== textHelperDefaultContentType
-      ? `, headers: { 'Content-Type': '${firstTextCt}' }`
+      ? `, headers: { 'Content-Type': '${jsStringLiteralEscape(firstTextCt)}' }`
       : '';
 
   let responseBody: string;
@@ -388,7 +391,7 @@ function generateDefinition(
         ? binaryBody
         : new ArrayBuffer(0),
       { status: ${statusCode},
-        headers: { 'Content-Type': '${binaryContentType}' }
+        headers: { 'Content-Type': '${jsStringLiteralEscape(binaryContentType)}' }
       })`;
   } else if (isVoidUnionType) {
     // Runtime branching for void union types (e.g. 200 JSON + 204 No Content).

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -960,3 +960,41 @@ describe('generateSolidStartHeader namespace collision', () => {
     ).toBe('PetsApi');
   });
 });
+
+describe('generateSolidStart — Content-Type header escaping', () => {
+  it('escapes single quotes in the request body media type key', async () => {
+    const verbOptions = makeVerbOptions({
+      verb: Verbs.POST,
+      mutator: {
+        name: 'customInstance',
+        path: './custom-instance.ts',
+        default: false,
+        hasSecondArg: true,
+        hasThirdArg: false,
+        isHook: false,
+      } as GeneratorVerbOptions['mutator'],
+      body: {
+        definition: 'SubmitDataBody',
+        implementation: 'submitDataBody: SubmitDataBody',
+        imports: [],
+        schemas: [],
+        formData: undefined,
+        formUrlEncoded: undefined,
+        contentType: "application/json', 'X-Evil': 'injected",
+        isOptional: false,
+        originalSchema: {},
+        isBlob: false,
+      } as GeneratorVerbOptions['body'],
+    });
+
+    const implementation = await generateImplementation(
+      verbOptions,
+      makeOptions(makeContext()),
+    );
+
+    expect(implementation).toContain(
+      String.raw`'Content-Type': 'application/json\', \'X-Evil\': \'injected'`,
+    );
+    expect(implementation).not.toContain("'X-Evil': 'injected'");
+  });
+});

--- a/packages/solid-start/src/index.ts
+++ b/packages/solid-start/src/index.ts
@@ -14,6 +14,7 @@ import {
   getIsBodyVerb,
   isObject,
   isOperationInTagBucket,
+  jsStringLiteralEscape,
   logWarning,
   type OpenApiParameterObject,
   type OpenApiReferenceObject,
@@ -184,7 +185,7 @@ const generateImplementation = (
 
     const headersToAdd: string[] = [
       ...(body.contentType && !ignoreContentTypes.includes(body.contentType)
-        ? [`'Content-Type': '${body.contentType}'`]
+        ? [`'Content-Type': '${jsStringLiteralEscape(body.contentType)}'`]
         : []),
       ...overrideHeaders,
       ...(headers ? ['...headers'] : []),


### PR DESCRIPTION
…jx9j)

The OpenAPI requestBody.content / response media type key was interpolated into single-quoted string literals in generated code without escaping. A single quote in a media type terminated the literal, producing broken TypeScript or, with a crafted key, valid-but-backdoored code (e.g. an extra header silently injected into the generated request).

Applies the existing jsStringLiteralEscape (the same fix used for path segments in v8.21.0) at every site that embeds a spec-controlled media type in a generated string literal:

- @orval/core generateMutatorConfig Content-Type header (axios/angular/ solid-start mutator paths)
- @orval/fetch request headers
- @orval/solid-start mutator request headers
- @orval/core form-data Blob part content type
- @orval/mock msw response Content-Type headers
- @orval/angular http-client and http-resource accept media type literals

The advisory named the first three; the rest are the same class of bug reached through the same untrusted input.

Reported-by: SnailSploit

<!-- A few sentences describing the overall goals of the pull request's commits. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated client safety by properly escaping media type values in HTTP headers, `Accept` parameters, form-data MIME types, and mock responses.
  * Prevented specially crafted content-type values from injecting unintended code or headers into generated output.
  * Applied protections consistently across Angular, Fetch, Solid Start, MSW, and core-generated clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->