### PR TITLE
fix: escape single quotes in generated route literals (GHSA-g4mf-q5hw…

### DIFF
--- a/packages/hono/src/index.test.ts
+++ b/packages/hono/src/index.test.ts
@@ -3,12 +3,19 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type {
+  GeneratorClient,
   GeneratorVerbOptions,
   NormalizedOutputOptions,
 } from '@orval/core';
+import { OutputClient } from '@orval/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
-import { generateHandlerFile, resolveDefaultSchemaModule } from './index';
+import {
+  generateHandlerFile,
+  generateHono,
+  getContext,
+  resolveDefaultSchemaModule,
+} from './index';
 
 const verb = (operationName: string): GeneratorVerbOptions =>
   ({
@@ -254,5 +261,67 @@ describe('resolveDefaultSchemaModule', () => {
         output({ schemas: '/out/model/index.generated.ts' }),
       ),
     ).toBe('/out/model');
+  });
+});
+
+describe('single-quote escaping in generated route literals', () => {
+  const contextVerb = (
+    overrides: Partial<GeneratorVerbOptions> = {},
+  ): GeneratorVerbOptions =>
+    ({
+      operationName: 'getItem',
+      typeName: 'getItem',
+      verb: 'get',
+      pathRoute: "/api/v1/it's-endpoint/{id}",
+      params: [
+        {
+          name: 'id',
+          definition: 'id: string',
+          required: true,
+          imports: [],
+          implementation: 'id: string',
+        },
+      ],
+      queryParams: undefined,
+      body: { definition: '', imports: [] },
+      response: { originalSchema: {} },
+      ...overrides,
+    }) as unknown as GeneratorVerbOptions;
+
+  it('escapes a quote in the path of the generated context type', () => {
+    const context = getContext(contextVerb());
+
+    expect(context).toContain(
+      String.raw`Context<E, '/api/v1/it\'s-endpoint/:id'`,
+    );
+  });
+
+  it('escapes an injected type declaration in the path of the context type', () => {
+    const context = getContext(
+      contextVerb({
+        pathRoute: "/api/v1/'; type Injected = any //",
+        params: [],
+      }),
+    );
+
+    expect(context).toContain(
+      String.raw`Context<E, '/api/v1/\'; type Injected = any //'`,
+    );
+    expect(context).not.toContain('type Injected = any //<');
+  });
+
+  it('escapes a quote in the path of the generated route registration', () => {
+    const client = generateHono(
+      contextVerb(),
+      {
+        pathRoute: "/api/v1/it's-endpoint/{id}",
+        override: { hono: { compositeRoute: '' } },
+      } as unknown as Parameters<typeof generateHono>[1],
+      OutputClient.HONO,
+    ) as GeneratorClient;
+
+    expect(client.implementation).toContain(
+      String.raw`.get('/api/v1/it\'s-endpoint/:id', ...getItemHandlers)`,
+    );
   });
 });

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -734,7 +734,7 @@ const generateHandlerFiles = async (
   ];
 };
 
-const getContext = (verbOption: GeneratorVerbOptions) => {
+export const getContext = (verbOption: GeneratorVerbOptions) => {
   let paramType = '';
   if (verbOption.params.length > 0) {
     const params = getParamsInPath(verbOption.pathRoute).map((name) => {
@@ -762,10 +762,14 @@ const getContext = (verbOption: GeneratorVerbOptions) => {
     : '';
   const hasIn = !!paramType || !!queryType || !!bodyType;
 
+  // `getRoute` only rewrites `{param}` placeholders and sanitizes the captured
+  // parameter names; the literal path text passes through unescaped. It is
+  // embedded below in a single-quoted type literal, so escape it for that
+  // context here rather than trusting the document's path text.
   return `export type ${pascal(
     verbOption.typeName,
-  )}Context<E extends Env = any> = Context<E, '${getRoute(
-    verbOption.pathRoute,
+  )}Context<E extends Env = any> = Context<E, '${jsStringLiteralEscape(
+    getRoute(verbOption.pathRoute),
   )}'${
     hasIn
       ? `, { in: { ${paramType}${queryType}${bodyType} }, out: { ${paramType}${queryType}${bodyType} } }`

--- a/packages/mock/src/faker/getters/route.test.ts
+++ b/packages/mock/src/faker/getters/route.test.ts
@@ -49,3 +49,21 @@ describe('getRoute getter', () => {
     );
   });
 });
+
+describe('getRouteMSW single-quote escaping', () => {
+  it('escapes a quote in a static path segment', () => {
+    expect(getRouteMSW("/api/v1/it's-endpoint/{id}", '')).toBe(
+      String.raw`/api/v1/it\'s-endpoint/:id`,
+    );
+  });
+
+  it('escapes a backslash so it cannot escape the closing quote', () => {
+    expect(getRouteMSW('/api/v1/trailing\\', '')).toBe('/api/v1/trailing\\\\');
+  });
+
+  it('escapes a quote in the base URL', () => {
+    expect(getRouteMSW('/pets/{petId}', "https://api.example.com/it's")).toBe(
+      String.raw`https://api.example.com/it\'s/pets/:petId`,
+    );
+  });
+});

--- a/packages/mock/src/faker/getters/route.ts
+++ b/packages/mock/src/faker/getters/route.ts
@@ -1,5 +1,19 @@
-import { camelPathParamName, toColonRoutePath } from '@orval/core';
+import {
+  camelPathParamName,
+  jsStringLiteralEscape,
+  toColonRoutePath,
+} from '@orval/core';
 
 // MSW route params are camelized to match the generated mock function args.
+//
+// The result is a *source fragment*, not a plain value: the `\\:` below is two
+// literal backslashes so the emitted single-quoted literal compiles to MSW's
+// `\:` escape for a colon that is not a param. Because of that, the spec text
+// has to be escaped for the literal here — before the colon escape is spliced
+// in — rather than at the emit site, where escaping again would double these
+// intentional backslashes.
 export const getRouteMSW = (route: string, baseUrl = '*') =>
-  `${baseUrl}${toColonRoutePath(route.replaceAll(':', String.raw`\\:`), camelPathParamName)}`;
+  `${jsStringLiteralEscape(baseUrl)}${toColonRoutePath(
+    jsStringLiteralEscape(route).replaceAll(':', String.raw`\\:`),
+    camelPathParamName,
+  )}`;


### PR DESCRIPTION
…-f9j9)

getRoute() rewrites {param} placeholders but passes static path text through unchanged. Two sites embedded that result in single-quoted literals without escaping, so a single quote in a static path segment terminated the literal -- producing broken TypeScript or, with a crafted path, an injected top-level type declaration in the generated *.context.ts file.

- @orval/hono getContext: escape the path in the Context<E, '...'> type literal. generateHonoRoute was already fixed in source; a test now locks that in.
- @orval/mock getRouteMSW: escape the spec path and base URL for the http.get('...') literal in generated msw handlers. The escape happens inside getRouteMSW, before the intentional source-level colon escape is spliced in, so the emitted \: is not doubled.

getContext is exported so it can be tested directly, matching the existing generateHandlerFile / resolveDefaultSchemaModule test exports.

The advisory named the hono sites; the msw handler is the same class of bug reached through the same untrusted input.

Reported-by: SnailSploit

<!-- A few sentences describing the overall goals of the pull request's commits. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated route and context code when paths, URLs, or type declarations contain quotes or backslashes.
  - Fixed relative handler imports for NodeNext projects by adding the required `.js` extension.
  - Improved schema resolution for multi-part extensions, custom schema directories, and filenames containing dots.
- **Compatibility**
  - Preserved extensionless imports for projects that do not use NodeNext module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->