### PR TITLE
fix: escape operationId in query/mutation mutator options (GHSA-vv88-…

### DIFF
--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -27,7 +27,7 @@ import {
 import type { FrameworkAdapter } from './framework-adapter';
 import { getQueryKeyVerbPrefix } from './query-generator';
 import { getQueryOptionsDefinition } from './query-options';
-import { shouldUseOptionsHook } from './utils';
+import { getOperationMetaLiteral, shouldUseOptionsHook } from './utils';
 
 interface NormalizedTarget {
   query: string;
@@ -718,7 +718,10 @@ ${
                   : ''
               }${
                 mutationOptionsMutator.hasThirdArg
-                  ? `, { operationId: '${operationId}', operationName: '${operationName}' }`
+                  ? `, { ${getOperationMetaLiteral(
+                      operationId,
+                      operationName,
+                    )} }`
                   : ''
               });`
             : ''

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -33,7 +33,11 @@ import {
   QueryType,
   requiresUserSuppliedQueryOptions,
 } from './query-options';
-import { getHasSignal, shouldUseOptionsHook } from './utils';
+import {
+  getHasSignal,
+  getOperationMetaLiteral,
+  shouldUseOptionsHook,
+} from './utils';
 
 /**
  * Decide whether the current operation's configuration conflicts with a
@@ -829,7 +833,10 @@ ${hookOptions}
               queryOptionsMutator.hasSecondArg ? `, { ${queryProperties} }` : ''
             }${
               queryOptionsMutator.hasThirdArg
-                ? `, { url: \`${route}\`, operationId: '${operationId}', operationName: '${operationName}' }`
+                ? `, { url: \`${route}\`, ${getOperationMetaLiteral(
+                    operationId,
+                    operationName,
+                  )} }`
                 : ''
             });`
           : ''
@@ -911,7 +918,10 @@ export function ${queryHookName}<TData = ${TData}, TError = ${errorType}>(\n ${q
           queryOptionsMutator.hasSecondArg ? `, { ${queryProperties} }` : ''
         }${
           queryOptionsMutator.hasThirdArg
-            ? `, { url: \`${route}\`, operationId: '${operationId}', operationName: '${operationName}' }`
+            ? `, { url: \`${route}\`, ${getOperationMetaLiteral(
+                operationId,
+                operationName,
+              )} }`
             : ''
         }).queryKey`
       : baseExpr;

--- a/packages/query/src/utils.test.ts
+++ b/packages/query/src/utils.test.ts
@@ -1,8 +1,14 @@
+import vm from 'node:vm';
+
 import { describe, expect, it } from 'vite-plus/test';
 
 import type { GeneratorMutator } from '@orval/core';
 
-import { normalizeQueryOptions, shouldUseOptionsHook } from './utils';
+import {
+  getOperationMetaLiteral,
+  normalizeQueryOptions,
+  shouldUseOptionsHook,
+} from './utils';
 
 describe('normalizeQueryOptions', () => {
   it('preserves useHooks for options mutators', () => {
@@ -128,5 +134,49 @@ describe('shouldUseOptionsHook', () => {
         mutator: baseMutator,
       }),
     ).toBe(expected);
+  });
+});
+
+describe('getOperationMetaLiteral', () => {
+  // Evaluate the emitted fragment the way the generated hook would, so the
+  // assertions are about what the object actually becomes rather than about
+  // the escaping mechanics. `injected` records any code that broke out.
+  const evaluate = (literal: string) => {
+    const context = vm.createContext({ injected: false });
+    return vm.runInContext(`({ ${literal} })`, context) as Record<
+      string,
+      unknown
+    > & { injected?: unknown };
+  };
+
+  it('emits a plain operationId and operationName unchanged', () => {
+    expect(getOperationMetaLiteral('getPets', 'getPets')).toBe(
+      "operationId: 'getPets', operationName: 'getPets'",
+    );
+  });
+
+  it('escapes a quote in the operationId so it cannot inject object entries', () => {
+    const operationId = "getPets',x:(()=>{throw new Error('pwned')})(),y:'";
+    const parsed = evaluate(getOperationMetaLiteral(operationId, 'getPets'));
+
+    // The whole spec value has to stay inside the operationId string: an
+    // unescaped quote would add `x`/`y` keys and run the IIFE.
+    expect(Object.keys(parsed)).toEqual(['operationId', 'operationName']);
+    expect(parsed.operationId).toBe(operationId);
+  });
+
+  it('escapes a quote in the operationName', () => {
+    const operationName = "getPets','z':'";
+    const parsed = evaluate(getOperationMetaLiteral('getPets', operationName));
+
+    expect(Object.keys(parsed)).toEqual(['operationId', 'operationName']);
+    expect(parsed.operationName).toBe(operationName);
+  });
+
+  it('escapes a backslash so it cannot escape the closing quote', () => {
+    const parsed = evaluate(getOperationMetaLiteral('getPets\\', 'getPets'));
+
+    expect(Object.keys(parsed)).toEqual(['operationId', 'operationName']);
+    expect(parsed.operationId).toBe('getPets\\');
   });
 });

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -4,6 +4,7 @@ import { styleText } from 'node:util';
 import {
   isObject,
   isString,
+  jsStringLiteralEscape,
   type GeneratorMutator,
   type Mutator,
   type NormalizedMutator,
@@ -149,3 +150,19 @@ export const getHasSignal = ({
 }: {
   overrideQuerySignal?: boolean;
 }) => overrideQuerySignal;
+
+/**
+ * Builds the `operationId`/`operationName` pair passed as the third argument
+ * to a `queryOptions`/`mutationOptions` mutator.
+ *
+ * Both land in single-quoted literals inside an object that the generated hook
+ * evaluates at call time. `operationName` is already run through `sanitize`
+ * upstream, but `operationId` is the raw value from the OpenAPI document and
+ * nothing sanitizes it, so a quote in the spec would otherwise close the
+ * literal and inject entries — and expressions — into that object.
+ */
+export const getOperationMetaLiteral = (
+  operationId: string,
+  operationName: string,
+): string =>
+  `operationId: '${jsStringLiteralEscape(operationId)}', operationName: '${jsStringLiteralEscape(operationName)}'`;


### PR DESCRIPTION
…cm6j-665j)

getOperationId returns the OpenAPI operationId verbatim and nothing sanitizes it downstream, unlike operationName which goes through sanitize(). All three sites that pass the mutator its third argument emitted it into a single-quoted literal inside an object the generated hook builds at call time, so a quote in the spec closed the string and injected entries -- and expressions -- into that object:

  { url: `/pets`, operationId: 'getPets',x:(()=>{ ... })(),y:'', ... }

Route both values through a getOperationMetaLiteral helper that escapes for the literal they land in. operationName is escaped too: sanitize() covers the spec-derived path, but an override.operations[...].operationName function can return arbitrary text, and escaping at the emission site makes it correct regardless of what upstream does.

The sibling `url` in the same object was already escaped for its backtick context, and is unaffected.

Reported-by: manus-use

<!-- A few sentences describing the overall goals of the pull request's commits. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated query and mutation metadata handling.
  - Operation identifiers and names containing quotes or backslashes are now safely escaped, preventing malformed generated code.

- **Tests**
  - Added coverage validating metadata generation for standard and special-character values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->