### PR TITLE
fix(mock): don't mutate shared response imports during mock generation

### DIFF
--- a/packages/mock/src/msw/mocks.test.ts
+++ b/packages/mock/src/msw/mocks.test.ts
@@ -45,21 +45,42 @@ describe('getResponsesMockDefinition', () => {
   });
 
   it('does not mutate the response imports it is given (#3931)', () => {
+    // An array of objects whose property is a `const` enum: the array branch
+    // resolves its items with the array it was handed, and the item's value
+    // import is merged back into it.
     const context = createTestContextSpec({
-      override: { enumGenerationType: EnumGeneration.ENUM },
+      override: { enumGenerationType: EnumGeneration.CONST },
+      spec: {
+        components: {
+          schemas: {
+            Pets: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/Pet' },
+            },
+            Pet: {
+              type: 'object',
+              required: ['countryCode'],
+              properties: {
+                countryCode: { $ref: '#/components/schemas/CountryCode' },
+              },
+            },
+            CountryCode: { type: 'string', enum: ['CN', 'UY'] },
+          },
+        },
+      },
     });
     // Core shares this array between every operation that resolves the same
     // schema, so it must come back untouched.
-    const sharedImports = [{ name: 'Color', schemaName: 'Color' }];
+    const sharedImports = [{ name: 'Pets', schemaName: 'Pets' }];
 
     const result = getResponsesMockDefinition({
-      operationId: 'listColors',
+      operationId: 'listPets',
       tags: [],
-      returnType: 'Color',
+      returnType: 'Pets',
       responses: [
         {
-          value: 'Color',
-          originalSchema: { type: 'string', enum: ['RED', 'GREEN'] },
+          value: 'Pets',
+          originalSchema: { $ref: '#/components/schemas/Pets' },
           contentType: 'application/json',
           imports: sharedImports,
           isRef: true,
@@ -70,13 +91,11 @@ describe('getResponsesMockDefinition', () => {
       splitMockImplementations: [],
     });
 
-    expect(result.definitions).toEqual([
-      'faker.helpers.arrayElement(Object.values(Color))',
-    ]);
-    // The mock needs `Color` at runtime, so the value import is reported...
-    expect(result.imports).toContainEqual({ name: 'Color', values: true });
+    expect(result.definitions[0]).toContain('Object.values(CountryCode)');
+    // The mock needs `CountryCode` at runtime, so the value import is reported...
+    expect(result.imports).toContainEqual({ name: 'CountryCode', values: true });
     // ...without being written back into the caller's array.
-    expect(sharedImports).toEqual([{ name: 'Color', schemaName: 'Color' }]);
+    expect(sharedImports).toEqual([{ name: 'Pets', schemaName: 'Pets' }]);
   });
 });
 

--- a/packages/mock/src/msw/mocks.test.ts
+++ b/packages/mock/src/msw/mocks.test.ts
@@ -1,7 +1,8 @@
-import type {
-  NormalizedOverrideOutput,
-  OpenApiDocument,
-  ResReqTypesValue,
+import {
+  EnumGeneration,
+  type NormalizedOverrideOutput,
+  type OpenApiDocument,
+  type ResReqTypesValue,
 } from '@orval/core';
 import { describe, expect, it } from 'vite-plus/test';
 
@@ -41,6 +42,41 @@ describe('getResponsesMockDefinition', () => {
     expect(result.imports).toEqual([
       { name: 'PointInFutureAbsolute', values: false },
     ]);
+  });
+
+  it('does not mutate the response imports it is given (#3931)', () => {
+    const context = createTestContextSpec({
+      override: { enumGenerationType: EnumGeneration.ENUM },
+    });
+    // Core shares this array between every operation that resolves the same
+    // schema, so it must come back untouched.
+    const sharedImports = [{ name: 'Color', schemaName: 'Color' }];
+
+    const result = getResponsesMockDefinition({
+      operationId: 'listColors',
+      tags: [],
+      returnType: 'Color',
+      responses: [
+        {
+          value: 'Color',
+          originalSchema: { type: 'string', enum: ['RED', 'GREEN'] },
+          contentType: 'application/json',
+          imports: sharedImports,
+          isRef: true,
+        } as unknown as ResReqTypesValue,
+      ],
+      mockOptionsWithoutFunc: {},
+      context,
+      splitMockImplementations: [],
+    });
+
+    expect(result.definitions).toEqual([
+      'faker.helpers.arrayElement(Object.values(Color))',
+    ]);
+    // The mock needs `Color` at runtime, so the value import is reported...
+    expect(result.imports).toContainEqual({ name: 'Color', values: true });
+    // ...without being written back into the caller's array.
+    expect(sharedImports).toEqual([{ name: 'Color', schemaName: 'Color' }]);
   });
 });
 

--- a/packages/mock/src/msw/mocks.ts
+++ b/packages/mock/src/msw/mocks.ts
@@ -276,7 +276,13 @@ export function getResponsesMockDefinition({
 
     const resolvedSchema = resolveRef(originalSchema, context).schema;
 
-    const responseImports = imports ?? [];
+    // `imports` belongs to the response type entry, which core shares across
+    // operations that resolve the same schema. Mock resolution appends the
+    // value imports it needs (`Object.values(Enum)`), and only the delta is
+    // reported below, so work on a copy: mutating the shared array would leak
+    // mock-only value imports into every later client that imports the same
+    // schema, turning its `import type` into a value import (#3931).
+    const responseImports = imports ? [...imports] : [];
     const importsBefore = responseImports.length;
     const scalar = getMockScalar({
       item: {

--- a/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
+++ b/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
@@ -7,8 +7,8 @@
 import axios from 'axios';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
-import { CountryCode } from './model';
 import type {
+  CountryCode,
   ListPetsByAgeParams,
   ListPetsByCountryParams,
   Pets,


### PR DESCRIPTION
Fix #3931.

## Problem

`tests/__snapshots__/default/endpoint-parameters/endpoints.ts` imports `CountryCode` as a value although the file only uses it as a type (`country: CountryCode = 'UY'`), which trips `consistent-type-imports`. The same spec generated without `mock: true` emits `import type { CountryCode }`, so the value import comes from mock generation.

`getResponsesMockDefinition` hands the response type's own `imports` array to `getMockScalar`. For an array response the array branch resolves its items with that same array, and `resolveMockValue` merges the item's imports back into it, including the `{ name: 'CountryCode', values: true }` the mock needs for `Object.values(CountryCode)`. `getResponsesMockDefinition` only reports the delta, but the array itself has been mutated. Core shares that array between every operation that resolves the same response schema, so the next operation's client generation sees the value flag in its response imports and `generateImportsForBuilder` promotes the binding to a value import ("a value import satisfies both uses").

## Fix

Copy the array before mock resolution appends to it. The reported delta is unchanged; the caller's array is left alone.

## Verification

- New unit test: an array-of-objects response whose property is a `const` enum. The `imports` passed in comes back untouched while the result still reports `{ name: 'CountryCode', values: true }`. On `master` it fails with the value import written into the caller's array; it passes with the fix.
- Regenerated every fixture (`generate-api`) and ran `test:snapshots`: exactly one of 6764 files changes, `default/endpoint-parameters/endpoints.ts`, where `CountryCode` moves into the existing `import type` block. `endpoints.msw.ts` and `endpoints.faker.ts` keep their value import. Regenerating the samples changes nothing.
- `lint:snapshots` goes from 2 warnings to 1; the remaining one is the angular-query `QueryClient` case from #3935.
- `@orval/mock` tests: 355 passed. Typecheck, lint and format on the changed files are clean.


<details>
<summary>Verification output (local, Windows, bun 1.4.2)</summary>

**Regression test, with the fix** (`packages/mock`, `vp test run src/msw/mocks.test.ts`):

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**Same test with `mocks.ts` from `master`** – the caller's array gains the mock-only value import:

```
     × does not mutate the response imports it is given (#3931) 13ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected [ { name: 'Pets', …(1) }, …(1) ] to deeply equal [ Array(1) ]
- Expected
+ Received
+   {
+     "name": "CountryCode",
+     "values": true,
+   },
 Test Files  1 failed (1)
      Tests  1 failed | 7 passed (8)
```

**`lint:snapshots` before:**

```
tests/__snapshots__/default/endpoint-parameters/endpoints.ts:10:1: warning typescript(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
tests/__snapshots__/angular-query/use-prefetch/endpoints.ts:11:1: warning typescript(consistent-type-imports): Imports QueryClient are only used as type.
```

**`lint:snapshots` after** (the remaining one is #3935):

```
tests/__snapshots__/angular-query/use-prefetch/endpoints.ts:11:1: warning typescript(consistent-type-imports): Imports QueryClient are only used as type.
```

**`test:snapshots` after regenerating every fixture** (one file updated, diff below):

```
 Test Files  4 passed (4)
      Tests  6764 passed (6764)
```

```diff
diff --git a/tests/__snapshots__/default/endpoint-parameters/endpoints.ts b/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
index f62bc75b7..663c79e9e 100644
--- a/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
+++ b/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
@@ -7,8 +7,8 @@
 import axios from 'axios';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
-import { CountryCode } from './model';
 import type {
+  CountryCode,
   ListPetsByAgeParams,
   ListPetsByCountryParams,
   Pets,
```

**`@orval/mock` test suite:**

```
 Test Files  13 passed (13)
      Tests  355 passed (355)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed response mock generation so nested schemas with constant enum values produce the required imports without altering shared import data.
  - Prevented mock-specific imports from leaking into other response type generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->