### PR TITLE
chore(mock): format mocks.test.ts after #4009

### DIFF
--- a/packages/mock/src/msw/mocks.test.ts
+++ b/packages/mock/src/msw/mocks.test.ts
@@ -93,7 +93,10 @@ describe('getResponsesMockDefinition', () => {
 
     expect(result.definitions[0]).toContain('Object.values(CountryCode)');
     // The mock needs `CountryCode` at runtime, so the value import is reported...
-    expect(result.imports).toContainEqual({ name: 'CountryCode', values: true });
+    expect(result.imports).toContainEqual({
+      name: 'CountryCode',
+      values: true,
+    });
     // ...without being written back into the caller's array.
     expect(sharedImports).toEqual([{ name: 'Pets', schemaName: 'Pets' }]);
   });


### PR DESCRIPTION
Follow-up to #4009, which was merged with one line in the new test over the 80-column limit, so `Check formatting` fails for every PR that includes current `master` (see the failed run on #4009 itself). My mistake: I only tailed the last line of the local `vp fmt --check` output and missed the finding.

This is the output of `vp fmt --write` on that file, one `expect(...)` call wrapped. `vp fmt --check` on the whole repo passes with it; the test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted a mock response assertion for improved readability; no user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->