### PR TITLE
fix: quote mock enum members by their own type (GHSA-j7p3-24q8-rm47)

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1230,3 +1230,119 @@ describe('getMockScalar (referenced string enum by enumGenerationType #3690)', (
     );
   });
 });
+
+describe('getMockScalar (enum member type confusion)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  // The declared `type` and the members both come from the document and need
+  // not agree. Quoting keyed off the declared type let a string member under a
+  // numeric/boolean type through as a live expression.
+  it('quotes a string member declared under type: integer', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'integer' as OpenApiSchemaObjectType,
+        enum: ['(globalThis.pwned=1)'],
+        name: 'numEnum',
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe(
+      "faker.helpers.arrayElement(['(globalThis.pwned=1)'] as const)",
+    );
+  });
+
+  it('quotes a string member declared under type: boolean', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'boolean' as OpenApiSchemaObjectType,
+        enum: ['(globalThis.pwned=1)'],
+        name: 'boolEnum',
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe(
+      "faker.helpers.arrayElement(['(globalThis.pwned=1)'] as const)",
+    );
+  });
+
+  it('escapes a quote in a string member declared under type: integer', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'integer' as OpenApiSchemaObjectType,
+        enum: ["a',(globalThis.pwned=1),'b"],
+        name: 'numEnum',
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe(
+      String.raw`faker.helpers.arrayElement(['a\',(globalThis.pwned=1),\'b'] as const)`,
+    );
+  });
+
+  it('emits a numeric member declared under type: string without crashing', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: [1, 2] as unknown as string[],
+        name: 'strEnum',
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe('faker.helpers.arrayElement([1,2] as const)');
+  });
+
+  it('serializes an object member instead of emitting [object Object]', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'integer' as OpenApiSchemaObjectType,
+        enum: [{ a: 1 }] as unknown as string[],
+        name: 'objEnum',
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe('faker.helpers.arrayElement([{"a":1}] as const)');
+    expect(result.value).not.toContain('[object Object]');
+  });
+
+  it('leaves genuine numeric and boolean members unquoted', () => {
+    expect(
+      getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'integer' as OpenApiSchemaObjectType,
+          enum: [1, 2] as unknown as string[],
+          name: 'numEnum',
+        },
+        context: scalarContext(),
+      }).value,
+    ).toBe('faker.helpers.arrayElement([1,2] as const)');
+
+    expect(
+      getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'boolean' as OpenApiSchemaObjectType,
+          enum: [true, false] as unknown as string[],
+          name: 'boolEnum',
+        },
+        context: scalarContext(),
+      }).value,
+    ).toBe('faker.helpers.arrayElement([true,false] as const)');
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1229,6 +1229,27 @@ describe('getMockScalar (referenced string enum by enumGenerationType #3690)', (
       expect.objectContaining({ name: 'MyEnum', values: true }),
     );
   });
+
+  it('inlines a referenced enum whose members are not actually strings', () => {
+    // Numeric members emit a numeric TS enum, and those compile to a two-way
+    // map (`{1: 'NUMBER_1', NUMBER_1: 1}`). `Object.values` would then also
+    // yield 'NUMBER_1'/'NUMBER_2', letting the mock return a value the schema
+    // never declared, so these have to stay inlined.
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        ...enumRefItem,
+        enum: [1, 2] as unknown as string[],
+      },
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).not.toContain('Object.values');
+    expect(result.value).toBe('faker.helpers.arrayElement([1,2] as MyEnum[])');
+    expect(result.imports).not.toContainEqual(
+      expect.objectContaining({ name: 'MyEnum', values: true }),
+    );
+  });
 });
 
 describe('getMockScalar (enum member type confusion)', () => {

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -706,9 +706,15 @@ function getEnum(
   // the imports and `Object.values`. A `union` reference is a pure type with
   // no runtime value, so `Object.values` would fail (TS2693) — keep the
   // inlined values in that case (#3690).
+  //
+  // Members must all actually be strings, not merely declared `type: 'string'`.
+  // A numeric member emits a numeric TS enum, which compiles to a two-way map
+  // (`{1: 'NUMBER_1', NUMBER_1: 1}`), so `Object.values` would also yield the
+  // member *names* and the mock could return a value the schema never declared.
   if (
     item.isRef &&
     type === 'string' &&
+    item.enum.every((e) => isString(e)) &&
     context.output.override.enumGenerationType !== EnumGeneration.UNION
   ) {
     enumValue = `Object.values(${item.name})`;

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -10,6 +10,8 @@ import {
   EnumGeneration,
   type GeneratorImport,
   getRefInfo,
+  isBoolean,
+  isNumber,
   isReference,
   isString,
   jsStringLiteralEscape,
@@ -636,21 +638,40 @@ function getItemType(item: MockSchemaObject) {
   return ['string', 'number'].includes(type) ? type : undefined;
 }
 
+/**
+ * Renders one enum member as a literal for the generated faker array.
+ *
+ * The branch is on the member's own type, never on the schema's declared
+ * `type`: both come from the document and nothing makes them agree. Keying off
+ * the declared type meant a string member under `type: 'integer'` was spliced
+ * in as a live expression, a numeric member under `type: 'string'` crashed the
+ * generator, and an object member emitted `[object Object]`.
+ */
+function formatEnumMember(value: unknown): string {
+  if (isString(value)) {
+    return `'${jsStringLiteralEscape(value)}'`;
+  }
+
+  if (isNumber(value) || isBoolean(value)) {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
 function getEnum(
   item: MockSchemaObject,
   imports: GeneratorImport[],
   context: ContextSpec,
   existingReferencedProperties: string[],
+  // Only gates the `Object.values(...)` reference shortcut below. It must not
+  // decide how a member is quoted — see `formatEnumMember`.
   type?: 'string' | 'number' | 'boolean',
 ) {
   if (!item.enum) return '';
   const joinedEnumValues = item.enum
     .filter((e) => e !== null) // TODO fix type, e can absolutely be null
-    .map((e) =>
-      type === 'string' || (type === undefined && isString(e))
-        ? `'${jsStringLiteralEscape(e)}'`
-        : e,
-    )
+    .map((e) => formatEnumMember(e))
     .join(',');
 
   let enumValue = `[${joinedEnumValues}]`;

--- a/packages/mock/src/msw/mocks.test.ts
+++ b/packages/mock/src/msw/mocks.test.ts
@@ -93,7 +93,10 @@ describe('getResponsesMockDefinition', () => {
 
     expect(result.definitions[0]).toContain('Object.values(CountryCode)');
     // The mock needs `CountryCode` at runtime, so the value import is reported...
-    expect(result.imports).toContainEqual({ name: 'CountryCode', values: true });
+    expect(result.imports).toContainEqual({
+      name: 'CountryCode',
+      values: true,
+    });
     // ...without being written back into the caller's array.
     expect(sharedImports).toEqual([{ name: 'Pets', schemaName: 'Pets' }]);
   });


### PR DESCRIPTION
Fixes the enum type-confusion code injection reported in GHSA-j7p3-24q8-rm47.

## The bug

`getEnum` decided how to quote an enum member from the schema's **declared** `type`:

```ts
type === 'string' || (type === undefined && isString(e))
  ? `'${jsStringLiteralEscape(e)}'`
  : e,
```

But the declared type and the members both come from the OpenAPI document, and nothing makes them agree. A schema declaring a numeric or boolean type with *string* members routes around the escape branch and has them spliced into the faker array as live expressions.

Spec:

```json
{ "type": "integer", "enum": ["(globalThis.pwned=1)"] }
```

Generated mock (before):

```js
faker.helpers.arrayElement([(globalThis.pwned=1)] as const)
```

Transpiled and executed with `faker` stubbed, this runs whenever `getXResponseMock()` is called — test setup, or per request:

```
mock output      : {"numEnum":1,"boolEnum":1}
injected executed: __NUM_PWNED, __BOOL_PWNED
```

The mock returning `1` — the assignment's value — rather than the string confirms it evaluated as an expression rather than being emitted as data.

## The fix

Branch on the member's own type instead of the declared one, in a small `formatEnumMember` helper. After:

```js
faker.helpers.arrayElement(['(globalThis.pwned=1)'] as const)
```

```
injected executed: none
```

`type` stays a parameter because it still gates the `Object.values(...)` reference shortcut further down — it just no longer decides quoting.

## Two more bugs from the same root cause

Probing adjacent cases turned up the mirror images of the same confusion, both fixed here:

| Case | Before | After |
|---|---|---|
| `type: 'string'`, members `[1, 2]` | 🛑 `input.replaceAll is not a function` — generation aborts | `[1,2]` |
| `type: 'integer'`, member `{"a":1}` | `[object Object]` — not valid syntax | `{"a":1}` |

## No behaviour change for valid schemas

Verified byte-identical output for every legitimate shape:

| Schema | Output |
|---|---|
| `type: integer, enum: [1,2]` | `[1,2]` |
| `type: boolean, enum: [true,false]` | `[true,false]` |
| `type: string, enum: ['a',"b'c"]` | `['a','b\'c']` |
| untyped `enum: ['x',3,true]` | `['x',3,true]` |

## Review follow-up: referenced enums

CodeRabbit caught a real consequence of the fix above, confirmed empirically. The `Object.values(<Enum>)` shortcut fired for any referenced enum declaring `type: 'string'`, without checking the members really are strings. Numeric members emit a *numeric* TS enum, and those compile to a two-way map:

```
NumStatus object : {"1":"NUMBER_1","2":"NUMBER_2","NUMBER_1":1,"NUMBER_2":2}
Object.values    : ["NUMBER_1","NUMBER_2",1,2]    <- member names leak in
StrStatus values : ["A","B"]                       <- string enum is fine
```

So the mock could return `"NUMBER_1"`, a value the schema never declared. Notably this only became reachable *because* of the parent commit — the same input previously crashed generation outright.

Now gated on `item.enum.every(isString)`:

| Schema | Before | After |
|---|---|---|
| ref, `type: string`, members `[1,2]` | `Object.values(NumStatus)` | `[1,2] as NumStatus[]` |
| ref, `type: string`, members `['A','B']` | `Object.values(StrStatus)` | unchanged |

Verified the emitted `[1,2] as NumStatus[]` type-checks under `strict`.

## Testing

Seven new tests. Six fail against the unfixed generator; the seventh is the regression guard that must pass both ways. The crash case surfaces as `TypeError: input.replaceAll is not a function`, pinning that fix too.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with zero drift in generated sample output.

> [!NOTE]
> This branch also carries a 4-line pure line-wrap in `packages/mock/src/msw/mocks.test.ts`. That file was left unformatted on `master` by #4009 and fails `format:check`; `vp run format` picked it up here. No semantic change, included so CI is green rather than red on an unrelated pre-existing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mock data generation for enum values with mixed or unexpected types.
  - String values are now correctly quoted and escaped.
  - Numeric and boolean values are emitted as valid literals.
  - Object values are serialized as JSON instead of displaying as `[object Object]`.
  - Prevented generation failures when enum values differ from the declared schema type.
  - Referenced enums containing numeric values now remain correctly inlined during mock generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->