### PR TITLE
refactor(core): share the per-file assembly steps between the mode writers

### DIFF
--- a/packages/core/src/writers/implementation-parts.ts
+++ b/packages/core/src/writers/implementation-parts.ts
@@ -1,0 +1,133 @@
+import { generateMutatorImports } from '../generators';
+import type {
+  GeneratorDependency,
+  GeneratorImport,
+  GeneratorMutator,
+  NormalizedOutputOptions,
+  WriteSpecBuilder,
+} from '../types';
+import { escapeRegExp } from '../utils/string';
+import { getOrvalGeneratedTypes, getTypedResponse } from './types';
+
+/**
+ * Keeps only the imports whose name or alias appears in `implementation`, so
+ * an import pulled in by another tag or operation does not leak into a file
+ * that never references it.
+ */
+export function filterImportsUsedInImplementation(
+  imports: GeneratorImport[],
+  implementation: string,
+): GeneratorImport[] {
+  return imports.filter((imp) => {
+    const searchWords = [imp.alias, imp.name]
+      .filter((part): part is string => Boolean(part?.length))
+      .map((part) => escapeRegExp(part))
+      .join('|');
+    if (!searchWords) {
+      return false;
+    }
+
+    return new RegExp(String.raw`\b(${searchWords})\b`, 'g').test(
+      implementation,
+    );
+  });
+}
+
+/** The client's import header for one implementation file. */
+export function generateClientImports({
+  builder,
+  output,
+  implementation,
+  imports,
+  projectName,
+  isAllowSyntheticDefaultImports,
+}: {
+  builder: Pick<WriteSpecBuilder, 'imports'>;
+  output: NormalizedOutputOptions;
+  implementation: string;
+  imports: readonly GeneratorDependency[];
+  projectName?: string;
+  isAllowSyntheticDefaultImports: boolean;
+}): string {
+  return builder.imports({
+    client: output.client,
+    implementation,
+    imports,
+    projectName,
+    hasSchemaDir: !!output.schemas,
+    isAllowSyntheticDefaultImports,
+    hasGlobalMutator: !!output.override.mutator,
+    hasTagsMutator: Object.values(output.override.tags).some(
+      (tag) => !!tag?.mutator,
+    ),
+    hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
+    packageJson: output.packageJson,
+    output,
+  });
+}
+
+export interface TargetMutators {
+  mutators?: GeneratorMutator[];
+  clientMutators?: GeneratorMutator[];
+  formData?: GeneratorMutator[];
+  formUrlEncoded?: GeneratorMutator[];
+  paramsSerializer?: GeneratorMutator[];
+  paramsFilter?: GeneratorMutator[];
+  fetchReviver?: GeneratorMutator[];
+}
+
+/**
+ * Import statements for every mutator kind a target carries, in the order
+ * the generated file declares them. Only the plain `mutators` are matched
+ * against `implementation`; the other kinds are always imported.
+ */
+export function generateTargetMutatorImports(
+  target: TargetMutators,
+  implementation: string,
+  oneMore?: boolean,
+): string {
+  let data = '';
+
+  if (target.mutators) {
+    data += generateMutatorImports({
+      mutators: target.mutators,
+      implementation,
+      oneMore,
+    });
+  }
+
+  for (const mutators of [
+    target.clientMutators,
+    target.formData,
+    target.formUrlEncoded,
+    target.paramsSerializer,
+    target.paramsFilter,
+    target.fetchReviver,
+  ]) {
+    if (mutators) {
+      data += generateMutatorImports({ mutators, oneMore });
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Local type declarations an implementation relies on (`NonReadonly<>`,
+ * `TypedResponse<>`), emitted only when the implementation uses them.
+ */
+export function generateOrvalHelperTypes(implementation: string): string {
+  let data = '';
+
+  if (implementation.includes('NonReadonly<')) {
+    data += getOrvalGeneratedTypes();
+    data += '\n';
+  }
+
+  if (implementation.includes('TypedResponse<')) {
+    data += getTypedResponse();
+    data += '\n';
+  }
+
+  return data;
+}

--- a/packages/core/src/writers/single-mode.ts
+++ b/packages/core/src/writers/single-mode.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateModelsInline, generateMutatorImports } from '../generators';
+import { generateModelsInline } from '../generators';
 import { OutputMockType, type WriteModeProps } from '../types';
 import {
   conventionName,
@@ -13,7 +13,6 @@ import {
   upath,
 } from '../utils';
 import { getMockFileExtensionByTypeName } from '../utils/file-extensions';
-import { escapeRegExp } from '../utils/string';
 import { writeGeneratedFile } from './file';
 import {
   getFinalizeMockImplementationOptions,
@@ -21,13 +20,18 @@ import {
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import {
+  filterImportsUsedInImplementation,
+  generateClientImports,
+  generateOrvalHelperTypes,
+  generateTargetMutatorImports,
+} from './implementation-parts';
+import {
   collectRecoveredSchemaFactoryImports,
   mergeGeneratorImports,
 } from './mock-imports';
 import { collapseInlineMockOutputs } from './mock-outputs';
 import { getMockDir, resolveMockSchemasPath } from './mock-utils';
 import { generateTarget } from './target';
-import { getOrvalGeneratedTypes, getTypedResponse } from './types';
 
 export async function writeSingleMode({
   builder,
@@ -53,18 +57,9 @@ export async function writeSingleMode({
       extension: output.fileExtension,
     });
 
-    const {
-      imports,
-      mockOutputs: rawMockOutputs,
-      implementation,
-      mutators,
-      clientMutators,
-      formData,
-      formUrlEncoded,
-      paramsSerializer,
-      paramsFilter,
-      fetchReviver,
-    } = generateTarget(builder, output);
+    const target = generateTarget(builder, output);
+
+    const { imports, mockOutputs: rawMockOutputs, implementation } = target;
 
     const isAllowSyntheticDefaultImports = isSyntheticDefaultImportsAllow(
       output.tsconfig,
@@ -98,19 +93,10 @@ export async function writeSingleMode({
         ).dirname
       : targetPath;
 
-    const implementationImports = imports.filter((imp) => {
-      const searchWords = [imp.alias, imp.name]
-        .filter((part): part is string => Boolean(part?.length))
-        .map((part) => escapeRegExp(part))
-        .join('|');
-      if (!searchWords) {
-        return false;
-      }
-
-      return new RegExp(String.raw`\b(${searchWords})\b`, 'g').test(
-        implementation,
-      );
-    });
+    const implementationImports = filterImportsUsedInImplementation(
+      imports,
+      implementation,
+    );
 
     const normalizedImports = implementationImports.map((imp) => ({ ...imp }));
 
@@ -157,20 +143,13 @@ export async function writeSingleMode({
           '.',
         );
 
-    data += builder.imports({
-      client: output.client,
+    data += generateClientImports({
+      builder,
+      output,
       implementation,
       imports: importsForBuilder,
       projectName,
-      hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
-      hasGlobalMutator: !!output.override.mutator,
-      hasTagsMutator: Object.values(output.override.tags).some(
-        (tag) => !!tag?.mutator,
-      ),
-      hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
-      packageJson: output.packageJson,
-      output,
     });
 
     if (!shouldDeinlineMocks) {
@@ -238,43 +217,9 @@ export async function writeSingleMode({
       }
     }
 
-    if (mutators) {
-      data += generateMutatorImports({ mutators, implementation });
-    }
+    data += generateTargetMutatorImports(target, implementation);
 
-    if (clientMutators) {
-      data += generateMutatorImports({ mutators: clientMutators });
-    }
-
-    if (formData) {
-      data += generateMutatorImports({ mutators: formData });
-    }
-
-    if (formUrlEncoded) {
-      data += generateMutatorImports({ mutators: formUrlEncoded });
-    }
-
-    if (paramsSerializer) {
-      data += generateMutatorImports({ mutators: paramsSerializer });
-    }
-
-    if (paramsFilter) {
-      data += generateMutatorImports({ mutators: paramsFilter });
-    }
-
-    if (fetchReviver) {
-      data += generateMutatorImports({ mutators: fetchReviver });
-    }
-
-    if (implementation.includes('NonReadonly<')) {
-      data += getOrvalGeneratedTypes();
-      data += '\n';
-    }
-
-    if (implementation.includes('TypedResponse<')) {
-      data += getTypedResponse();
-      data += '\n';
-    }
+    data += generateOrvalHelperTypes(implementation);
 
     if (!output.schemas && needSchema) {
       data += generateSchemasInline

--- a/packages/core/src/writers/split-mode.ts
+++ b/packages/core/src/writers/split-mode.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateModelsInline, generateMutatorImports } from '../generators';
+import { generateModelsInline } from '../generators';
 import {
   type MswMockOptions,
   OutputClient,
@@ -25,6 +25,11 @@ import {
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import {
+  generateClientImports,
+  generateOrvalHelperTypes,
+  generateTargetMutatorImports,
+} from './implementation-parts';
+import {
   collectRecoveredSchemaFactoryImports,
   mergeGeneratorImports,
 } from './mock-imports';
@@ -36,7 +41,6 @@ import {
 } from './mock-outputs';
 import { getMockDir, resolveMockSchemasPath } from './mock-utils';
 import { generateTarget } from './target';
-import { getOrvalGeneratedTypes, getTypedResponse } from './types';
 
 export async function writeSplitMode({
   builder,
@@ -62,18 +66,9 @@ export async function writeSplitMode({
       extension: output.fileExtension,
     });
 
-    const {
-      imports,
-      implementation,
-      mockOutputsFull,
-      mutators,
-      clientMutators,
-      formData,
-      formUrlEncoded,
-      paramsSerializer,
-      paramsFilter,
-      fetchReviver,
-    } = generateTarget(builder, output);
+    const target = generateTarget(builder, output);
+
+    const { imports, implementation, mockOutputsFull } = target;
 
     const mswGeneratorEntry = output.mock.generators.find(
       (g): g is MswMockOptions =>
@@ -134,20 +129,13 @@ export async function writeSplitMode({
       schemaOutputPlan,
     );
 
-    implementationData += builder.imports({
-      client: output.client,
+    implementationData += generateClientImports({
+      builder,
+      output,
       implementation,
       imports: importsForBuilder,
       projectName,
-      hasSchemaDir: !!output.schemas,
       isAllowSyntheticDefaultImports,
-      hasGlobalMutator: !!output.override.mutator,
-      hasTagsMutator: Object.values(output.override.tags).some(
-        (tag) => !!tag?.mutator,
-      ),
-      hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
-      packageJson: output.packageJson,
-      output,
     });
 
     const schemasPath =
@@ -163,56 +151,9 @@ export async function writeSplitMode({
       await writeGeneratedFile(schemasPath, schemasData);
     }
 
-    if (mutators) {
-      implementationData += generateMutatorImports({
-        mutators,
-        implementation,
-      });
-    }
+    implementationData += generateTargetMutatorImports(target, implementation);
 
-    if (clientMutators) {
-      implementationData += generateMutatorImports({
-        mutators: clientMutators,
-      });
-    }
-
-    if (formData) {
-      implementationData += generateMutatorImports({ mutators: formData });
-    }
-
-    if (formUrlEncoded) {
-      implementationData += generateMutatorImports({
-        mutators: formUrlEncoded,
-      });
-    }
-
-    if (paramsSerializer) {
-      implementationData += generateMutatorImports({
-        mutators: paramsSerializer,
-      });
-    }
-
-    if (paramsFilter) {
-      implementationData += generateMutatorImports({
-        mutators: paramsFilter,
-      });
-    }
-
-    if (fetchReviver) {
-      implementationData += generateMutatorImports({
-        mutators: fetchReviver,
-      });
-    }
-
-    if (implementation.includes('NonReadonly<')) {
-      implementationData += getOrvalGeneratedTypes();
-      implementationData += '\n';
-    }
-
-    if (implementation.includes('TypedResponse<')) {
-      implementationData += getTypedResponse();
-      implementationData += '\n';
-    }
+    implementationData += generateOrvalHelperTypes(implementation);
 
     implementationData += `\n${implementation}`;
 

--- a/packages/core/src/writers/split-tags-mode.ts
+++ b/packages/core/src/writers/split-tags-mode.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateModelsInline, generateMutatorImports } from '../generators';
+import { generateModelsInline } from '../generators';
 import {
   type MswMockOptions,
   OutputClient,
@@ -28,6 +28,11 @@ import {
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import {
+  generateClientImports,
+  generateOrvalHelperTypes,
+  generateTargetMutatorImports,
+} from './implementation-parts';
+import {
   collectRecoveredSchemaFactoryImports,
   mergeGeneratorImports,
 } from './mock-imports';
@@ -39,7 +44,6 @@ import {
 } from './mock-outputs';
 import { getMockDir, resolveMockSchemasPath } from './mock-utils';
 import { generateTargetForTags } from './target-tags';
-import { getOrvalGeneratedTypes, getTypedResponse } from './types';
 
 export async function writeSplitTagsMode({
   builder,
@@ -129,18 +133,7 @@ export async function writeSplitTagsMode({
   const generatedFilePathsArray = await Promise.all(
     tagEntries.map(async ([tag, target]) => {
       try {
-        const {
-          imports,
-          implementation,
-          mockOutputsFull,
-          mutators,
-          clientMutators,
-          formData,
-          fetchReviver,
-          formUrlEncoded,
-          paramsSerializer,
-          paramsFilter,
-        } = target;
+        const { imports, implementation, mockOutputsFull } = target;
 
         const mswGeneratorEntry = output.mock.generators.find(
           (g): g is MswMockOptions =>
@@ -218,20 +211,13 @@ export async function writeSplitTagsMode({
           schemaOutputPlan,
         );
 
-        implementationData += builder.imports({
-          client: output.client,
+        implementationData += generateClientImports({
+          builder,
+          output,
           implementation,
           imports: importsForBuilder,
           projectName,
-          hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
-          hasGlobalMutator: !!output.override.mutator,
-          hasTagsMutator: Object.values(output.override.tags).some(
-            (tag) => !!tag?.mutator,
-          ),
-          hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
-          packageJson: output.packageJson,
-          output,
         });
 
         const schemasPath =
@@ -247,62 +233,13 @@ export async function writeSplitTagsMode({
           await writeGeneratedFile(schemasPath, schemasData);
         }
 
-        if (mutators) {
-          implementationData += generateMutatorImports({
-            mutators,
-            implementation,
-            oneMore: true,
-          });
-        }
+        implementationData += generateTargetMutatorImports(
+          target,
+          implementation,
+          true,
+        );
 
-        if (clientMutators) {
-          implementationData += generateMutatorImports({
-            mutators: clientMutators,
-            oneMore: true,
-          });
-        }
-
-        if (formData) {
-          implementationData += generateMutatorImports({
-            mutators: formData,
-            oneMore: true,
-          });
-        }
-        if (formUrlEncoded) {
-          implementationData += generateMutatorImports({
-            mutators: formUrlEncoded,
-            oneMore: true,
-          });
-        }
-        if (paramsSerializer) {
-          implementationData += generateMutatorImports({
-            mutators: paramsSerializer,
-            oneMore: true,
-          });
-        }
-        if (paramsFilter) {
-          implementationData += generateMutatorImports({
-            mutators: paramsFilter,
-            oneMore: true,
-          });
-        }
-
-        if (fetchReviver) {
-          implementationData += generateMutatorImports({
-            mutators: fetchReviver,
-            oneMore: true,
-          });
-        }
-
-        if (implementation.includes('NonReadonly<')) {
-          implementationData += getOrvalGeneratedTypes();
-          implementationData += '\n';
-        }
-
-        if (implementation.includes('TypedResponse<')) {
-          implementationData += getTypedResponse();
-          implementationData += '\n';
-        }
+        implementationData += generateOrvalHelperTypes(implementation);
 
         implementationData += `\n${implementation}`;
 

--- a/packages/core/src/writers/tags-mode.ts
+++ b/packages/core/src/writers/tags-mode.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateModelsInline, generateMutatorImports } from '../generators';
+import { generateModelsInline } from '../generators';
 import { OutputMockType, type WriteModeProps } from '../types';
 import {
   conventionName,
@@ -15,7 +15,6 @@ import {
   upath,
 } from '../utils';
 import { getMockFileExtensionByTypeName } from '../utils/file-extensions';
-import { escapeRegExp } from '../utils/string';
 import { writeGeneratedFile } from './file';
 import {
   getFinalizeMockImplementationOptions,
@@ -23,13 +22,18 @@ import {
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import {
+  filterImportsUsedInImplementation,
+  generateClientImports,
+  generateOrvalHelperTypes,
+  generateTargetMutatorImports,
+} from './implementation-parts';
+import {
   collectRecoveredSchemaFactoryImports,
   mergeGeneratorImports,
 } from './mock-imports';
 import { collapseInlineMockOutputs } from './mock-outputs';
 import { getMockDir, resolveMockSchemasPath } from './mock-utils';
 import { generateTargetForTags } from './target-tags';
-import { getOrvalGeneratedTypes, getTypedResponse } from './types';
 
 export async function writeTagsMode({
   builder,
@@ -105,32 +109,12 @@ export async function writeTagsMode({
   const generatedFilePathsArray = await Promise.all(
     tagEntries.map(async ([tag, target]) => {
       try {
-        const {
+        const { imports, implementation, mockOutputs: rawMockOutputs } = target;
+
+        const implementationImports = filterImportsUsedInImplementation(
           imports,
           implementation,
-          mockOutputs: rawMockOutputs,
-          mutators,
-          clientMutators,
-          formData,
-          formUrlEncoded,
-          fetchReviver,
-          paramsSerializer,
-          paramsFilter,
-        } = target;
-
-        const implementationImports = imports.filter((imp) => {
-          const searchWords = [imp.alias, imp.name]
-            .filter((part): part is string => Boolean(part?.length))
-            .map((part) => escapeRegExp(part))
-            .join('|');
-          if (!searchWords) {
-            return false;
-          }
-
-          return new RegExp(String.raw`\b(${searchWords})\b`, 'g').test(
-            implementation,
-          );
-        });
+        );
 
         const normalizedImports = implementationImports.map((imp) => ({
           ...imp,
@@ -173,20 +157,13 @@ export async function writeTagsMode({
           schemaOutputPlan,
         );
 
-        data += builder.imports({
-          client: output.client,
+        data += generateClientImports({
+          builder,
+          output,
           implementation,
           imports: importsForBuilder,
           projectName,
-          hasSchemaDir: !!output.schemas,
           isAllowSyntheticDefaultImports,
-          hasGlobalMutator: !!output.override.mutator,
-          hasTagsMutator: Object.values(output.override.tags).some(
-            (tag) => !!tag?.mutator,
-          ),
-          hasParamsSerializerOptions: !!output.override.paramsSerializerOptions,
-          packageJson: output.packageJson,
-          output,
         });
 
         if (!shouldDeinlineMocks) {
@@ -233,47 +210,11 @@ export async function writeTagsMode({
           await writeGeneratedFile(schemasPath, schemasData);
         }
 
-        if (mutators) {
-          data += generateMutatorImports({ mutators, implementation });
-        }
-
-        if (clientMutators) {
-          data += generateMutatorImports({
-            mutators: clientMutators,
-          });
-        }
-
-        if (formData) {
-          data += generateMutatorImports({ mutators: formData });
-        }
-
-        if (formUrlEncoded) {
-          data += generateMutatorImports({ mutators: formUrlEncoded });
-        }
-
-        if (paramsSerializer) {
-          data += generateMutatorImports({ mutators: paramsSerializer });
-        }
-
-        if (paramsFilter) {
-          data += generateMutatorImports({ mutators: paramsFilter });
-        }
-
-        if (fetchReviver) {
-          data += generateMutatorImports({ mutators: fetchReviver });
-        }
+        data += generateTargetMutatorImports(target, implementation);
 
         data += '\n\n';
 
-        if (implementation.includes('NonReadonly<')) {
-          data += getOrvalGeneratedTypes();
-          data += '\n';
-        }
-
-        if (implementation.includes('TypedResponse<')) {
-          data += getTypedResponse();
-          data += '\n';
-        }
+        data += generateOrvalHelperTypes(implementation);
 
         data += implementation;
 

--- a/packages/core/src/writers/tags-operations-mode.ts
+++ b/packages/core/src/writers/tags-operations-mode.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateModelsInline, generateMutatorImports } from '../generators';
+import { generateModelsInline } from '../generators';
 import {
   OutputClient,
   type OutputClientFunc,
@@ -27,6 +27,12 @@ import {
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import {
+  filterImportsUsedInImplementation,
+  generateClientImports,
+  generateOrvalHelperTypes,
+  generateTargetMutatorImports,
+} from './implementation-parts';
+import {
   collectRecoveredSchemaFactoryImports,
   mergeGeneratorImports,
 } from './mock-imports';
@@ -35,7 +41,6 @@ import {
   buildTagHelpersImport,
   generateTargetForTagsOperations,
 } from './target-tags-operations';
-import { getOrvalGeneratedTypes, getTypedResponse } from './types';
 
 const SUPPORTED_CLIENTS = new Set<string>([
   OutputClient.REACT_QUERY,
@@ -181,15 +186,10 @@ export async function writeTagsOperationsMode({
               `${operationFilename}${extension}`,
             );
 
-            const implementationImports = operation.imports.filter((imp) => {
-              const searchWords = [imp.alias, imp.name]
-                .filter((part): part is string => Boolean(part?.length))
-                .join('|');
-              if (!searchWords) return false;
-              return new RegExp(String.raw`\b(${searchWords})\b`, 'g').test(
-                operation.implementation,
-              );
-            });
+            const implementationImports = filterImportsUsedInImplementation(
+              operation.imports,
+              operation.implementation,
+            );
 
             const importsForBuilder = generateImportsForBuilder(
               output,
@@ -209,84 +209,24 @@ export async function writeTagsOperationsMode({
               );
             }
 
-            data += builder.imports({
-              client: output.client,
+            data += generateClientImports({
+              builder,
+              output,
               implementation: operation.implementation,
               imports: importsForBuilder,
               projectName,
-              hasSchemaDir: !!output.schemas,
               isAllowSyntheticDefaultImports,
-              hasGlobalMutator: !!output.override.mutator,
-              hasTagsMutator: Object.values(output.override.tags).some(
-                (tagOverride) => !!tagOverride?.mutator,
-              ),
-              hasParamsSerializerOptions:
-                !!output.override.paramsSerializerOptions,
-              packageJson: output.packageJson,
-              output,
             });
 
-            if (operation.mutators) {
-              data += generateMutatorImports({
-                mutators: operation.mutators,
-                implementation: operation.implementation,
-                oneMore: true,
-              });
-            }
-
-            if (operation.clientMutators) {
-              data += generateMutatorImports({
-                mutators: operation.clientMutators,
-                oneMore: true,
-              });
-            }
-
-            if (operation.formData) {
-              data += generateMutatorImports({
-                mutators: operation.formData,
-                oneMore: true,
-              });
-            }
-
-            if (operation.formUrlEncoded) {
-              data += generateMutatorImports({
-                mutators: operation.formUrlEncoded,
-                oneMore: true,
-              });
-            }
-
-            if (operation.paramsSerializer) {
-              data += generateMutatorImports({
-                mutators: operation.paramsSerializer,
-                oneMore: true,
-              });
-            }
-
-            if (operation.paramsFilter) {
-              data += generateMutatorImports({
-                mutators: operation.paramsFilter,
-                oneMore: true,
-              });
-            }
-
-            if (operation.fetchReviver) {
-              data += generateMutatorImports({
-                mutators: operation.fetchReviver,
-                oneMore: true,
-              });
-            }
+            data += generateTargetMutatorImports(
+              operation,
+              operation.implementation,
+              true,
+            );
 
             data += '\n\n';
 
-            if (operation.implementation.includes('NonReadonly<')) {
-              data += getOrvalGeneratedTypes();
-              data += '\n';
-            }
-
-            if (operation.implementation.includes('TypedResponse<')) {
-              data += getTypedResponse();
-              data += '\n';
-            }
+            data += generateOrvalHelperTypes(operation.implementation);
 
             data += operation.implementation;
 

--- a/packages/core/src/writers/tags-operations-split-mode.ts
+++ b/packages/core/src/writers/tags-operations-split-mode.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { generateModelsInline, generateMutatorImports } from '../generators';
+import { generateModelsInline } from '../generators';
 import { OutputMockType, type WriteModeProps } from '../types';
 import {
   conventionName,
@@ -23,6 +23,12 @@ import {
 } from './finalize-mock-implementation';
 import { generateImportsForBuilder } from './generate-imports-for-builder';
 import {
+  filterImportsUsedInImplementation,
+  generateClientImports,
+  generateOrvalHelperTypes,
+  generateTargetMutatorImports,
+} from './implementation-parts';
+import {
   collectRecoveredSchemaFactoryImports,
   mergeGeneratorImports,
 } from './mock-imports';
@@ -32,7 +38,6 @@ import {
   generateTargetForTagsOperations,
   resolveTransitiveSchemas,
 } from './target-tags-operations';
-import { getOrvalGeneratedTypes, getTypedResponse } from './types';
 
 /**
  * `tags-operations-split` mode: two files per operation, nested under a
@@ -163,15 +168,10 @@ export async function writeTagsOperationsSplitMode({
             const operationSchemasImportPath =
               './' + operationFilename + '.schemas' + helperImportExtension;
 
-            const implementationImports = operation.imports.filter((imp) => {
-              const searchWords = [imp.alias, imp.name]
-                .filter((part): part is string => Boolean(part?.length))
-                .join('|');
-              if (!searchWords) return false;
-              return new RegExp(String.raw`\b(${searchWords})\b`, 'g').test(
-                operation.implementation,
-              );
-            });
+            const implementationImports = filterImportsUsedInImplementation(
+              operation.imports,
+              operation.implementation,
+            );
 
             // Component schemas this operation's implementation actually
             // references, scoped down from the full builder schema list —
@@ -223,84 +223,24 @@ export async function writeTagsOperationsSplitMode({
               );
             }
 
-            data += builder.imports({
-              client: output.client,
+            data += generateClientImports({
+              builder,
+              output,
               implementation: operation.implementation,
               imports: importsForBuilder,
               projectName,
-              hasSchemaDir: !!output.schemas,
               isAllowSyntheticDefaultImports,
-              hasGlobalMutator: !!output.override.mutator,
-              hasTagsMutator: Object.values(output.override.tags).some(
-                (tagOverride) => !!tagOverride?.mutator,
-              ),
-              hasParamsSerializerOptions:
-                !!output.override.paramsSerializerOptions,
-              packageJson: output.packageJson,
-              output,
             });
 
-            if (operation.mutators) {
-              data += generateMutatorImports({
-                mutators: operation.mutators,
-                implementation: operation.implementation,
-                oneMore: true,
-              });
-            }
-
-            if (operation.clientMutators) {
-              data += generateMutatorImports({
-                mutators: operation.clientMutators,
-                oneMore: true,
-              });
-            }
-
-            if (operation.formData) {
-              data += generateMutatorImports({
-                mutators: operation.formData,
-                oneMore: true,
-              });
-            }
-
-            if (operation.formUrlEncoded) {
-              data += generateMutatorImports({
-                mutators: operation.formUrlEncoded,
-                oneMore: true,
-              });
-            }
-
-            if (operation.paramsSerializer) {
-              data += generateMutatorImports({
-                mutators: operation.paramsSerializer,
-                oneMore: true,
-              });
-            }
-
-            if (operation.paramsFilter) {
-              data += generateMutatorImports({
-                mutators: operation.paramsFilter,
-                oneMore: true,
-              });
-            }
-
-            if (operation.fetchReviver) {
-              data += generateMutatorImports({
-                mutators: operation.fetchReviver,
-                oneMore: true,
-              });
-            }
+            data += generateTargetMutatorImports(
+              operation,
+              operation.implementation,
+              true,
+            );
 
             data += '\n\n';
 
-            if (operation.implementation.includes('NonReadonly<')) {
-              data += getOrvalGeneratedTypes();
-              data += '\n';
-            }
-
-            if (operation.implementation.includes('TypedResponse<')) {
-              data += getTypedResponse();
-              data += '\n';
-            }
+            data += generateOrvalHelperTypes(operation.implementation);
 
             data += operation.implementation;
 


### PR DESCRIPTION
The six output-mode writers in `packages/core/src/writers` (`single`, `split`, `tags`, `tags-split`, `tags-operations`, `tags-operations-split`) each carried their own copy of the same four steps for every implementation file they emit:

1. filter the imports down to the ones the implementation actually references,
2. build the client import header via `builder.imports({...})`,
3. append the mutator imports (seven consecutive `if` blocks), and
4. append the `NonReadonly<>` / `TypedResponse<>` helper types.

This PR moves those four steps into `writers/implementation-parts.ts` and calls them from each writer. The layout-specific logic (where files go, how mocks are split, barrels) stays in each mode file untouched.

Generated output is byte-for-byte unchanged across every snapshot config, and the writer unit tests pass as before.

One incidental alignment: `tags-operations` and `tags-operations-split` now escape regex metacharacters when matching import names, as the other four writers already did. The shared helper carries the `escapeRegExp` call, so the two copies that had drifted are now in step. No snapshot changed as a result.

### Net effect

| | lines |
|---|---|
| removed from the six writers | 461 |
| added to the six writers | 105 |
| new `implementation-parts.ts` | 133 |

Snapshot coverage for `tags-operations` / `tags-operations-split`, which these modes were missing, is added in separate small PRs so this one stays reviewable on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized generated client imports, mutator imports, and helper type generation across all supported output modes.
  * Improved filtering so generated files include only imports referenced by their implementations.
  * Consolidated handling of supported mutator configurations.
  * Helper types are now emitted only when required by generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->