### PR TITLE
feat(axios): export operation URL helpers

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -59,6 +59,25 @@ const customAxios = axios.create({ baseURL: 'https://api.example.com' });
 const api = getPetsApi(customAxios);
 ```
 
+The generated factory also exposes a `get<Operation>Url` helper for each
+operation that does not use a custom mutator:
+
+```typescript
+const url = api.getListPetsUrl({ limit: 10 });
+```
+
+The helper returns the generated OpenAPI route with its query parameters
+serialized by Axios. It uses the injected instance's Axios serialization
+configuration, while ignoring that instance's runtime `baseURL`, default
+request params, request options, and interceptors. The same helpers are emitted
+for `axios-functions` and Axios-backed query clients.
+
+Helpers are named `get<Operation>Url` (for example, `getListPetsUrl`) and
+return a `string`. They accept the operation's path and query parameters, but
+not Axios request options. Operations using a custom mutator do not emit a
+helper because the mutator owns the runtime URL and serialization behavior.
+Fetch output already has its own URL helper and is unchanged by this feature.
+
 ## httpClient
 
 **Type:** `'fetch' | 'axios' | 'angular'`

--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -63,6 +63,23 @@ const customAxios = axios.create({ baseURL: 'https://api.example.com' });
 const api = getPetsApi(customAxios);
 ```
 
+生成的 factory 还会为每个未使用自定义 mutator 的操作提供
+`get<Operation>Url` helper：
+
+```typescript
+const url = api.getListPetsUrl({ limit: 10 });
+```
+
+该 helper 返回生成的 OpenAPI 路由，以及由 Axios 序列化的查询参数。它会使用
+注入实例的 Axios 序列化配置，但不会包含该实例运行时的 `baseURL`、默认请求参数、
+请求选项或拦截器。同样的 helper 也会为 `axios-functions` 和基于 Axios 的 Query
+client 生成。
+
+Helper 的命名格式为 `get<Operation>Url`（例如 `getListPetsUrl`），返回值类型为
+`string`。它只接收操作的路径参数和查询参数，不接收 Axios 请求选项。使用自定义
+mutator 的操作不会生成 helper，因为 mutator 负责运行时 URL 和序列化行为。
+Fetch 输出已有自己的 URL helper，此功能不会改变 Fetch 的行为。
+
 ## httpClient
 
 **类型：** `'fetch' | 'axios' | 'angular'`

--- a/packages/axios/src/index.test.ts
+++ b/packages/axios/src/index.test.ts
@@ -1,11 +1,242 @@
+import type {
+  GeneratorOptions,
+  GeneratorVerbOptions,
+  GeneratorMutator,
+} from '@orval/core';
+import { OutputClient } from '@orval/core';
 import { describe, expect, it } from 'vite-plus/test';
 
 import {
+  generateAxios,
+  generateAxiosFactory,
   generateAxiosHeader,
+  generateAxiosFooter,
+  generateAxiosFunctions,
   generateAxiosTitle,
   getAxiosDependencies,
   getAxiosFactoryDependencies,
 } from './index';
+
+const response = {
+  imports: [],
+  definition: { success: 'Pet', errors: 'unknown' },
+  isBlob: false,
+  types: { success: [], errors: [] },
+  contentTypes: ['application/json'],
+  schemas: [],
+};
+
+const createVerbOptions = (
+  overrides: Partial<GeneratorVerbOptions> = {},
+): GeneratorVerbOptions =>
+  ({
+    operationId: 'getPet',
+    operationName: 'getPet',
+    typeName: 'getPet',
+    verb: 'get',
+    route: '/pets/${petId}',
+    pathRoute: '/pets/{petId}',
+    tags: [],
+    summary: '',
+    doc: '',
+    response,
+    body: {
+      implementation: '',
+      definition: '',
+      imports: [],
+      schemas: [],
+      originalSchema: {},
+      contentType: '',
+      formData: '',
+      formUrlEncoded: '',
+      isOptional: true,
+      isBlob: false,
+    },
+    headers: undefined,
+    queryParams: {
+      schema: { name: 'PetParams', model: 'PetParams', imports: [] },
+      deps: [],
+      isOptional: true,
+    },
+    params: [
+      {
+        name: 'petId',
+        definition: 'petId: string',
+        implementation: 'petId: string',
+        default: undefined,
+        required: true,
+        imports: [],
+      },
+    ],
+    props: [
+      {
+        name: 'petId',
+        definition: 'petId: string',
+        implementation: 'petId: string',
+        default: undefined,
+        required: true,
+        type: 'param',
+      },
+      {
+        name: 'params',
+        definition: 'params?: PetParams',
+        implementation: 'params?: PetParams',
+        default: undefined,
+        required: false,
+        type: 'queryParam',
+      },
+    ],
+    mutator: undefined,
+    formData: undefined,
+    formUrlEncoded: undefined,
+    paramsSerializer: undefined,
+    override: {
+      requestOptions: true,
+      formData: { disabled: true, arrayHandling: 'serialize' },
+      formUrlEncoded: true,
+      paramsSerializerOptions: undefined,
+    },
+    originalOperation: {},
+    ...overrides,
+  }) as GeneratorVerbOptions;
+
+const generatorOptions = {
+  route: '/pets/${petId}',
+  pathRoute: '/pets/{petId}',
+  context: {
+    output: {
+      tsconfig: { compilerOptions: { allowSyntheticDefaultImports: true } },
+    },
+  },
+} as unknown as GeneratorOptions;
+
+const mutator: GeneratorMutator = {
+  name: 'customInstance',
+  path: './custom-instance',
+  default: false,
+  hasErrorType: false,
+  errorTypeName: '',
+  hasSecondArg: true,
+  hasThirdArg: false,
+  isHook: false,
+};
+
+describe('Axios URL helpers', () => {
+  it('adds a public helper without changing the existing request call', async () => {
+    const { implementation } = await generateAxiosFunctions(
+      createVerbOptions(),
+      generatorOptions,
+      OutputClient.AXIOS_FUNCTIONS,
+    );
+
+    expect(implementation).toContain(
+      'export const getGetPetUrl = (petId: string,',
+    );
+    expect(implementation).toContain('params?: PetParams,');
+    expect(implementation).toContain(
+      "return axios.create({\n    baseURL: '',\n    params: null,\n  }).getUri({\n    url: `/pets/${petId}`",
+    );
+    expect(implementation).toContain(
+      'return axios.get(\n      `/pets/${petId}`',
+    );
+    expect(implementation).not.toContain('axios.get(getGetPetUrl(');
+  });
+
+  it('keeps the exact route expression received by Axios generation', () => {
+    const encodedRoute = '/pets/${encodeURIComponent(String(petId))}';
+    const implementation = generateAxios(
+      createVerbOptions({ route: encodedRoute }),
+      { ...generatorOptions, route: encodedRoute },
+    ).implementation;
+
+    expect(implementation).toContain(`url: \`${encodedRoute}\``);
+    expect(implementation).toContain(`axios.get(\n      \`${encodedRoute}\``);
+  });
+
+  it('does not add path encoding when urlEncodeParameters is enabled', () => {
+    const route = '/pets/${petId}';
+    const implementation = generateAxios(createVerbOptions({ route }), {
+      ...generatorOptions,
+      route,
+      context: {
+        ...generatorOptions.context,
+        output: {
+          ...generatorOptions.context.output,
+          urlEncodeParameters: true,
+        },
+      },
+    }).implementation;
+
+    expect(implementation).toContain(`url: \`${route}\``);
+    expect(implementation).toContain(`axios.get(\n      \`${route}\``);
+  });
+
+  it('returns the helper from factory-generated APIs', async () => {
+    const { implementation } = await generateAxiosFactory(
+      createVerbOptions(),
+      generatorOptions,
+      OutputClient.AXIOS,
+    );
+    const footer = generateAxiosFooter({
+      operationNames: ['getPet'],
+      operations: [{ operationName: 'getPet', mutator: undefined } as never],
+      noFunction: false,
+      hasMutator: false,
+      hasAwaitedType: true,
+    });
+
+    expect(implementation).toContain('const getGetPetUrl = (petId: string,');
+    expect(implementation).toContain('params?: PetParams,');
+    expect(implementation).toContain(
+      "axiosInstance.create({\n    baseURL: '',\n    params: null,\n  }).getUri",
+    );
+    expect(footer).toContain('return {getPet,getGetPetUrl}};');
+  });
+
+  it('does not emit a helper when a mutator owns the request', async () => {
+    const { implementation } = await generateAxiosFunctions(
+      createVerbOptions({ mutator }),
+      generatorOptions,
+      OutputClient.AXIOS_FUNCTIONS,
+    );
+
+    expect(implementation).not.toContain('getGetPetUrl');
+  });
+
+  it('omits mutator-owned helpers from mixed factory returns', () => {
+    const footer = generateAxiosFooter({
+      operationNames: ['getPet', 'getMutatedPet'],
+      operations: [
+        { operationName: 'getPet', mutator: undefined } as never,
+        { operationName: 'getMutatedPet', mutator } as never,
+      ],
+      noFunction: false,
+      hasMutator: true,
+      hasAwaitedType: true,
+    });
+
+    expect(footer).toContain('return {getPet,getMutatedPet,getGetPetUrl}};');
+    expect(footer).not.toContain('getMutatedPetUrl');
+  });
+  it('does not add request options to the URL helper when disabled', async () => {
+    const { implementation } = await generateAxiosFunctions(
+      createVerbOptions({
+        override: {
+          ...createVerbOptions().override,
+          requestOptions: false,
+        },
+      }),
+      generatorOptions,
+      OutputClient.AXIOS_FUNCTIONS,
+    );
+
+    expect(implementation).toContain(
+      'export const getGetPetUrl = (petId: string,',
+    );
+    expect(implementation).toContain('params?: PetParams,');
+    expect(implementation).not.toContain('options?: AxiosRequestConfig');
+  });
+});
 
 describe('getAxiosDependencies (axios-functions mode)', () => {
   it('should return axios runtime import when no global mutator', () => {

--- a/packages/axios/src/index.test.ts
+++ b/packages/axios/src/index.test.ts
@@ -3,7 +3,7 @@ import type {
   GeneratorVerbOptions,
   GeneratorMutator,
 } from '@orval/core';
-import { OutputClient } from '@orval/core';
+import { getOperationUrlHelperNames, OutputClient } from '@orval/core';
 import { describe, expect, it } from 'vite-plus/test';
 
 import {
@@ -122,6 +122,61 @@ const mutator: GeneratorMutator = {
 };
 
 describe('Axios URL helpers', () => {
+  it('uses collision-safe helper names in functions and factory output', async () => {
+    const [fooUrlName, getFooUrlName] = getOperationUrlHelperNames(
+      ['foo', 'getFooUrl'],
+      ['foo', 'getFooUrl'],
+    );
+    const foo = await generateAxiosFunctions(
+      createVerbOptions({ operationName: 'foo', urlHelperName: fooUrlName }),
+      generatorOptions,
+      OutputClient.AXIOS_FUNCTIONS,
+    );
+    const getFoo = await generateAxiosFunctions(
+      createVerbOptions({
+        operationName: 'getFooUrl',
+        urlHelperName: getFooUrlName,
+      }),
+      generatorOptions,
+      OutputClient.AXIOS_FUNCTIONS,
+    );
+
+    expect(`${foo.implementation}\n${getFoo.implementation}`).toContain(
+      'export const getFooUrl2',
+    );
+    expect(`${foo.implementation}\n${getFoo.implementation}`).toContain(
+      'export const getGetFooUrlUrl',
+    );
+    expect(
+      `${foo.implementation}\n${getFoo.implementation}`.match(
+        /export const getFooUrl\s*=/g,
+      ),
+    ).toHaveLength(1);
+
+    const footer = generateAxiosFooter({
+      operationNames: ['foo', 'getFooUrl'],
+      operations: [
+        {
+          operationName: 'foo',
+          urlHelperName: fooUrlName,
+          mutator: undefined,
+        } as never,
+        {
+          operationName: 'getFooUrl',
+          urlHelperName: getFooUrlName,
+          mutator: undefined,
+        } as never,
+      ],
+      noFunction: false,
+      hasMutator: false,
+      hasAwaitedType: true,
+    });
+
+    expect(footer).toContain(
+      'return {foo,getFooUrl,getFooUrl2,getGetFooUrlUrl}};',
+    );
+  });
+
   it('adds a public helper without changing the existing request call', async () => {
     const { implementation } = await generateAxiosFunctions(
       createVerbOptions(),

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -96,6 +96,7 @@ const generateAxiosImplementation = (
     headers,
     queryParams,
     operationName,
+    urlHelperName,
     typeName,
     response,
     mutator,
@@ -213,7 +214,7 @@ const generateAxiosImplementation = (
       prop.type === GetterPropType.QUERY_PARAM,
   );
   const urlImplementation = generateAxiosUrl({
-    functionName: camel(`get-${operationName}-url`),
+    functionName: urlHelperName ?? camel(`get-${operationName}-url`),
     propsImplementation: toObjectString(urlProps, 'implementation'),
     route,
     axiosRef,
@@ -285,7 +286,11 @@ export const generateAxiosFooter: ClientFooterBuilder = ({
   if (!noFunction) {
     const urlOperationNames = (operations ?? [])
       .filter((operation) => !operation.mutator)
-      .map((operation) => camel(`get-${operation.operationName}-url`));
+      .map(
+        (operation) =>
+          operation.urlHelperName ??
+          camel(`get-${operation.operationName}-url`),
+      );
     footer += `return {${[...operationNames, ...urlOperationNames].join(',')}}};\n`;
   }
 

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  camel,
   type ClientBuilder,
   type ClientDependenciesBuilder,
   type ClientFooterBuilder,
@@ -13,7 +14,9 @@ import {
   type GeneratorDependency,
   type GeneratorOptions,
   type GeneratorVerbOptions,
+  generateAxiosUrl,
   isSyntheticDefaultImportsAllow,
+  GetterPropType,
   pascal,
   sanitize,
   toObjectString,
@@ -203,6 +206,22 @@ const generateAxiosImplementation = (
     ? 'axiosInstance'
     : `axios${isSyntheticDefaultImportsAllowed ? '' : '.default'}`;
 
+  const urlProps = props.filter(
+    (prop) =>
+      prop.type === GetterPropType.PARAM ||
+      prop.type === GetterPropType.NAMED_PATH_PARAMS ||
+      prop.type === GetterPropType.QUERY_PARAM,
+  );
+  const urlImplementation = generateAxiosUrl({
+    functionName: camel(`get-${operationName}-url`),
+    propsImplementation: toObjectString(urlProps, 'implementation'),
+    route,
+    axiosRef,
+    hasQueryParams: !!queryParams,
+    paramsSerializer: paramsSerializer?.name,
+    paramsSerializerOptions: override.paramsSerializerOptions,
+  });
+
   return {
     implementation: `const ${operationName} = (\n    ${toObjectString(props, 'implementation')} ${
       isRequestOptions
@@ -211,7 +230,7 @@ const generateAxiosImplementation = (
     } ): Promise<AxiosResponse<${response.definition.success || 'unknown'}>> => {${bodyForm}
     return ${axiosRef}.${verb}(${options});
   }
-`,
+${isFactoryMode ? urlImplementation.replace(/^export /, '') : urlImplementation}`,
     returnType,
   };
 };
@@ -264,7 +283,10 @@ export const generateAxiosFooter: ClientFooterBuilder = ({
   let footer = '';
 
   if (!noFunction) {
-    footer += `return {${operationNames.join(',')}}};\n`;
+    const urlOperationNames = (operations ?? [])
+      .filter((operation) => !operation.mutator)
+      .map((operation) => camel(`get-${operation.operationName}-url`));
+    footer += `return {${[...operationNames, ...urlOperationNames].join(',')}}};\n`;
   }
 
   if (hasMutator && !hasAwaitedType) {

--- a/packages/core/src/generators/options.test.ts
+++ b/packages/core/src/generators/options.test.ts
@@ -1,3 +1,5 @@
+import { runInNewContext } from 'node:vm';
+
 import ts from 'typescript';
 import { describe, expect, it } from 'vite-plus/test';
 
@@ -12,6 +14,7 @@ import {
 import {
   buildAngularParamsFilterExpression,
   generateAxiosOptions,
+  generateAxiosUrl,
   generateBodyOptions,
   generateMutatorConfig,
   generateOptions,
@@ -20,6 +23,208 @@ import {
   getAngularFilteredParamsHelperBody,
   getAngularObjectParamStrategies,
 } from './options';
+
+const evaluateGeneratedUrl = (
+  source: string,
+  uriClient: { getUri: (config: Record<string, unknown>) => string },
+  functionName = 'getGetPetUrl',
+  globals: Record<string, unknown> = {},
+) => {
+  const client = {
+    create: (defaults: Record<string, unknown>) => {
+      expect(defaults).toEqual({ baseURL: '', params: null });
+      return {
+        getUri: (config: Record<string, unknown>) =>
+          uriClient.getUri({ ...defaults, ...config }),
+      };
+    },
+  };
+  const transpiled = ts.transpileModule(
+    `const axios = client;\n${source.replaceAll('export ', '')}`,
+    {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+    },
+  ).outputText;
+
+  return runInNewContext(`${transpiled}; ${functionName}`, {
+    client,
+    ...globals,
+  }) as (...args: unknown[]) => string;
+};
+
+describe('generateAxiosUrl', () => {
+  it('emits a static route helper without query parameters', () => {
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetsUrl',
+      propsImplementation: '',
+      route: '/pets',
+      axiosRef: 'axios',
+      hasQueryParams: false,
+    });
+    const getUrl = evaluateGeneratedUrl(
+      source,
+      { getUri: (config) => config.url as string },
+      'getGetPetsUrl',
+    );
+
+    expect(getUrl()).toBe('/pets');
+  });
+
+  it('preserves multiple path parameters in the generated route', () => {
+    const source = generateAxiosUrl({
+      functionName: 'getGetUserPostUrl',
+      propsImplementation: 'userId: string, postId: string',
+      route: '/users/${userId}/posts/${postId}',
+      axiosRef: 'axios',
+      hasQueryParams: false,
+    });
+    const getUrl = evaluateGeneratedUrl(
+      source,
+      { getUri: (config) => config.url as string },
+      'getGetUserPostUrl',
+    );
+
+    expect(getUrl('user-1', 'post-2')).toBe('/users/user-1/posts/post-2');
+  });
+
+  it('emits an Axios-compatible route helper without leaking the runtime baseURL', () => {
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'petId: string, params?: Record<string, unknown>',
+      route: '/pets/${petId}',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+    });
+
+    const getUrl = evaluateGeneratedUrl(source, {
+      getUri: (config) => {
+        expect(config.baseURL).toBe('');
+        const query = new URLSearchParams(
+          Object.entries((config.params as Record<string, unknown>) ?? {})
+            .filter(([, value]) => value !== undefined)
+            .flatMap(([key, value]): [string, string][] =>
+              Array.isArray(value)
+                ? value.map((item) => [key, String(item)])
+                : [[key, String(value)]],
+            ),
+        ).toString();
+        const url = config.url as string;
+        return `${url}${query ? `?${query}` : ''}`;
+      },
+    });
+
+    expect(
+      getUrl('a/b', { page: 2, tags: ['red', 'blue'], optional: undefined }),
+    ).toBe('/pets/a/b?page=2&tags=red&tags=blue');
+  });
+
+  it('keeps optional query values in the params object for Axios to serialize', () => {
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'params?: Record<string, unknown>',
+      route: '/pets',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+    });
+    const received: Record<string, unknown>[] = [];
+    const getUrl = evaluateGeneratedUrl(source, {
+      getUri: (config) => {
+        received.push(config.params as Record<string, unknown>);
+        return config.url as string;
+      },
+    });
+
+    expect(getUrl({ page: undefined, tag: null })).toBe('/pets');
+    expect(received).toEqual([{ page: undefined, tag: null }]);
+  });
+
+  it('uses the exact supplied route, including existing path escaping', () => {
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'petId: string',
+      route: '/pets/${encodeURIComponent(String(petId))}',
+      axiosRef: 'axios',
+      hasQueryParams: false,
+    });
+    const getUrl = evaluateGeneratedUrl(source, {
+      getUri: (config) => config.url as string,
+    });
+
+    expect(getUrl('a/b')).toBe('/pets/a%2Fb');
+  });
+
+  it('uses a custom serializer through Axios getUri', () => {
+    const customSerializer = (params: Record<string, unknown>) =>
+      `tag=${(params.tag as string[]).join('|')}`;
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'petId: string, params?: Record<string, unknown>',
+      route: '/pets/${petId}',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+      paramsSerializer: 'customSerializer',
+    });
+
+    const getUrl = evaluateGeneratedUrl(
+      source,
+      {
+        getUri: (config) => {
+          expect(config.baseURL).toBe('');
+          return `${config.url as string}?${(
+            config.paramsSerializer as (
+              params: Record<string, unknown>,
+            ) => string
+          )(config.params as Record<string, unknown>)}`;
+        },
+      },
+      'getGetPetUrl',
+      { customSerializer },
+    );
+
+    expect(getUrl('pet-1', { tag: ['red', 'blue'] })).toBe(
+      '/pets/pet-1?tag=red|blue',
+    );
+  });
+
+  it('uses qs options through Axios getUri', () => {
+    const qs = {
+      stringify: (params: Record<string, unknown>, options: unknown) => {
+        expect(options).toEqual({ arrayFormat: 'repeat' });
+        return (params.tag as string[]).map((tag) => `tag=${tag}`).join('&');
+      },
+    };
+
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'petId: string, params?: Record<string, unknown>',
+      route: '/pets/${petId}',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+      paramsSerializerOptions: { qs: { arrayFormat: 'repeat' } },
+    });
+
+    const getUrl = evaluateGeneratedUrl(
+      source,
+      {
+        getUri: (config) =>
+          `${config.url as string}?${(
+            config.paramsSerializer as (
+              params: Record<string, unknown>,
+            ) => string
+          )(config.params as Record<string, unknown>)}`,
+      },
+      'getGetPetUrl',
+      { qs },
+    );
+
+    expect(getUrl('pet-1', { tag: ['red', 'blue'] })).toBe(
+      '/pets/pet-1?tag=red&tag=blue',
+    );
+  });
+});
 
 const minimalSchema: GeneratorSchema = {
   name: 'TestSchema',

--- a/packages/core/src/generators/options.ts
+++ b/packages/core/src/generators/options.ts
@@ -607,6 +607,58 @@ interface GenerateAxiosOptions {
   paramsFilter?: GeneratorMutator;
 }
 
+interface GenerateAxiosUrlOptions {
+  functionName: string;
+  propsImplementation: string;
+  route: string;
+  axiosRef: string;
+  hasQueryParams: boolean;
+  beforeReturn?: string;
+  paramsSerializer?: string;
+  paramsSerializerOptions?: ParamsSerializerOptions;
+}
+
+/**
+ * Generates an Axios URL helper without applying runtime request options.
+ *
+ * Axios owns query-string serialization, so getUri is used to keep the helper
+ * aligned with the request's paramsSerializer and Axios defaults. A derived
+ * instance clears default params while retaining the configured serializer;
+ * an empty baseURL keeps the helper's result at the generated OpenAPI route
+ * instead of turning it into the final transport URL for a configured Axios
+ * instance.
+ */
+export function generateAxiosUrl({
+  functionName,
+  propsImplementation,
+  route,
+  axiosRef,
+  hasQueryParams,
+  beforeReturn,
+  paramsSerializer,
+  paramsSerializerOptions,
+}: GenerateAxiosUrlOptions) {
+  const serializer = paramsSerializer
+    ? `paramsSerializer: ${paramsSerializer},`
+    : paramsSerializerOptions?.qs
+      ? `paramsSerializer: (params) => qs.stringify(params, ${JSON.stringify(paramsSerializerOptions.qs)}),`
+      : '';
+
+  return `export const ${functionName} = (${propsImplementation}) => {
+    ${beforeReturn ?? ''}
+  return ${axiosRef}.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: \`${route}\`,
+    baseURL: '',
+    ${hasQueryParams ? 'params,' : ''}
+    ${serializer}
+  });
+}
+`;
+}
+
 export function generateAxiosOptions({
   response,
   isExactOptionalPropertyTypes,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1858,6 +1858,8 @@ export interface GeneratorOperation {
   paramsFilter?: GeneratorMutator;
   fetchReviver?: GeneratorMutator;
   operationName: string;
+  /** Resolved Axios URL-helper name when the output client emits one. */
+  urlHelperName?: string;
   types?: {
     result: (title?: string) => string;
   };
@@ -1923,6 +1925,8 @@ export interface GeneratorVerbOptions {
   tags: string[];
   operationId: string;
   operationName: string;
+  /** Resolved Axios URL-helper name when the output client emits one. */
+  urlHelperName?: string;
   typeName: string;
   response: GetterResponse;
   body: GetterBody;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './get-property-safe';
 export * from './is-body-verb';
 export * from './logger';
 export * from './merge-deep';
+export * from './name';
 export * from './occurrence';
 export * as upath from './path';
 export * from './required';

--- a/packages/core/src/utils/name.test.ts
+++ b/packages/core/src/utils/name.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { getOperationUrlHelperNames } from './name';
+
+describe('getOperationUrlHelperNames', () => {
+  it('reserves operation names and resolves collisions deterministically', () => {
+    expect(
+      getOperationUrlHelperNames(['foo', 'getFooUrl'], ['foo', 'getFooUrl']),
+    ).toEqual(['getFooUrl2', 'getGetFooUrlUrl']);
+  });
+
+  it('keeps non-conflicting helper names unchanged', () => {
+    expect(
+      getOperationUrlHelperNames(
+        ['listPets', 'createPet'],
+        ['listPets', 'createPet'],
+      ),
+    ).toEqual(['getListPetsUrl', 'getCreatePetUrl']);
+  });
+
+  it('does not let a fallback collide with another operation or helper', () => {
+    expect(
+      getOperationUrlHelperNames(
+        ['foo', 'getFooUrl', 'getFooUrl2'],
+        ['foo', 'getFooUrl', 'getFooUrl2'],
+      ),
+    ).toEqual(['getFooUrl3', 'getGetFooUrlUrl', 'getGetFooUrl2Url']);
+  });
+});

--- a/packages/core/src/utils/name.ts
+++ b/packages/core/src/utils/name.ts
@@ -1,0 +1,40 @@
+import { camel } from './case';
+
+/**
+ * Returns `name` or the first deterministic numeric suffix not in
+ * `reservedNames`.
+ */
+export function getUniqueName(
+  name: string,
+  reservedNames: ReadonlySet<string>,
+): string {
+  let candidate = name;
+  let index = 2;
+
+  while (reservedNames.has(candidate)) {
+    candidate = `${name}${index}`;
+    index += 1;
+  }
+
+  return candidate;
+}
+
+/**
+ * Resolves URL helper names while reserving every generated operation name.
+ * The returned names correspond to `helperOperationNames` in order.
+ */
+export function getOperationUrlHelperNames(
+  operationNames: readonly string[],
+  helperOperationNames: readonly string[],
+): string[] {
+  const reservedNames = new Set(operationNames);
+
+  return helperOperationNames.map((operationName) => {
+    const helperName = getUniqueName(
+      camel(`get-${operationName}-url`),
+      reservedNames,
+    );
+    reservedNames.add(helperName);
+    return helperName;
+  });
+}

--- a/packages/orval/src/api.ts
+++ b/packages/orval/src/api.ts
@@ -4,6 +4,7 @@ import {
   createSchemaOutputPlanForOutput,
   type ContextSpec,
   generateVerbsOptions,
+  getOperationUrlHelperNames,
   type GeneratorApiBuilder,
   type GeneratorApiOperations,
   type GeneratorSchema,
@@ -15,6 +16,7 @@ import {
   type NormalizedInputOptions,
   type NormalizedOutputOptions,
   type OpenApiPathItemObject,
+  type GeneratorVerbsOptions,
   resolveRef,
 } from '@orval/core';
 import {
@@ -46,42 +48,68 @@ export async function getApiBuilder({
    */
   componentSchemas: GeneratorSchema[];
 }): Promise<GeneratorApiBuilder> {
-  const api = await asyncReduce(
-    Object.entries(context.spec.paths ?? {}),
-    async (acc, [pathRoute, verbs]) => {
-      if (!verbs) {
-        return acc;
-      }
+  const pathEntries: Array<{
+    pathRoute: string;
+    route: string;
+    resolvedVerbs: OpenApiPathItemObject;
+    verbsOptions: GeneratorVerbsOptions;
+  }> = [];
 
-      const route = getRoute(pathRoute);
+  for (const [pathRoute, verbs] of Object.entries(context.spec.paths ?? {})) {
+    if (!verbs) {
+      continue;
+    }
 
-      let resolvedVerbs: OpenApiPathItemObject = verbs;
+    const route = getRoute(pathRoute);
+    let resolvedVerbs: OpenApiPathItemObject = verbs;
 
-      if (isReference(verbs)) {
-        const { schema }: { schema: OpenApiPathItemObject } = resolveRef(
-          verbs,
-          context,
-        );
-
-        resolvedVerbs = schema;
-      }
-
-      let verbsOptions = await generateVerbsOptions({
-        verbs: resolvedVerbs,
-        input,
-        output,
-        route,
-        pathRoute,
+    if (isReference(verbs)) {
+      const { schema }: { schema: OpenApiPathItemObject } = resolveRef(
+        verbs,
         context,
+      );
+
+      resolvedVerbs = schema;
+    }
+
+    let verbsOptions = await generateVerbsOptions({
+      verbs: resolvedVerbs,
+      input,
+      output,
+      route,
+      pathRoute,
+      context,
+    });
+
+    // GitHub #564 check if we want to exclude deprecated operations
+    if (output.override.useDeprecatedOperations === false) {
+      verbsOptions = verbsOptions.filter((verb) => !verb.deprecated);
+    }
+
+    pathEntries.push({ pathRoute, route, resolvedVerbs, verbsOptions });
+  }
+
+  const allOperationNames = pathEntries.flatMap(({ verbsOptions }) =>
+    verbsOptions.map(({ operationName }) => operationName),
+  );
+  const helperOptions = pathEntries.flatMap(({ verbsOptions }) =>
+    verbsOptions.filter(({ mutator }) => !mutator),
+  );
+  const helperNames = getOperationUrlHelperNames(
+    allOperationNames,
+    helperOptions.map(({ operationName }) => operationName),
+  );
+  const helperNamesByOption = new Map(
+    helperOptions.map((verbOption, index) => [verbOption, helperNames[index]]),
+  );
+
+  const api = await asyncReduce(
+    pathEntries,
+    async (acc, { pathRoute, route, resolvedVerbs, verbsOptions }) => {
+      const resolvedVerbOptions = verbsOptions.map((verbOption) => {
+        const urlHelperName = helperNamesByOption.get(verbOption);
+        return urlHelperName ? { ...verbOption, urlHelperName } : verbOption;
       });
-
-      // GitHub #564 check if we want to exclude deprecated operations
-      if (output.override.useDeprecatedOperations === false) {
-        verbsOptions = verbsOptions.filter((verb) => {
-          return !verb.deprecated;
-        });
-      }
-
       const schemas: GeneratorSchema[] = [];
       for (const {
         queryParams,
@@ -89,7 +117,7 @@ export async function getApiBuilder({
         body,
         response,
         props,
-      } of verbsOptions) {
+      } of resolvedVerbOptions) {
         schemas.push(
           ...props.flatMap((param) =>
             param.type === GetterPropType.NAMED_PATH_PARAMS ? param.schema : [],
@@ -115,7 +143,7 @@ export async function getApiBuilder({
       }
       const pathOperations = await generateOperations(
         output.client,
-        verbsOptions,
+        resolvedVerbOptions,
         {
           route: fullRoute,
           pathRoute,
@@ -126,7 +154,7 @@ export async function getApiBuilder({
         output,
       );
 
-      for (const verbOption of verbsOptions) {
+      for (const verbOption of resolvedVerbOptions) {
         acc.verbOptions[verbOption.operationId] = verbOption;
       }
       acc.schemas.push(...schemas);

--- a/packages/orval/src/client.ts
+++ b/packages/orval/src/client.ts
@@ -348,6 +348,7 @@ export const generateOperations = (
         paramsSerializer: verbOption.paramsSerializer,
         paramsFilter: verbOption.paramsFilter,
         operationName: verbOption.operationName,
+        urlHelperName: verbOption.urlHelperName,
         fetchReviver: verbOption.fetchReviver,
         ...(client.returnType
           ? { types: { result: client.returnType } }

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -50,6 +50,25 @@ const PETSTORE_SPEC: OpenApiDocument = {
   },
 };
 
+const URL_HELPER_COLLISION_SPEC: OpenApiDocument = {
+  openapi: '3.1.0',
+  info: { title: 'URL helper collision', version: '1.0.0' },
+  paths: {
+    '/foo': {
+      get: {
+        operationId: 'foo',
+        responses: { '200': { description: 'OK' } },
+      },
+    },
+    '/get-foo-url': {
+      get: {
+        operationId: 'getFooUrl',
+        responses: { '200': { description: 'OK' } },
+      },
+    },
+  },
+};
+
 const ROUTED_SCHEMA_SPEC: OpenApiDocument = {
   ...PETSTORE_SPEC,
   components: {
@@ -359,6 +378,40 @@ describe('generateSpec - unchanged formatted output', () => {
       await rm(workspace, { recursive: true, force: true });
     }
   });
+});
+
+describe('generateSpec - collision-safe Axios URL helpers', () => {
+  for (const client of ['axios-functions', 'axios', 'react-query'] as const) {
+    it(`keeps ${client} output free of duplicate declarations`, async () => {
+      const workspace = await createTempWorkspace();
+      const targetFile = path.join(workspace, 'endpoints.ts');
+
+      try {
+        const options = await normalizeOptions(
+          {
+            input: { target: URL_HELPER_COLLISION_SPEC },
+            output: {
+              target: './endpoints.ts',
+              client,
+              ...(client === 'react-query' ? { httpClient: 'axios' } : {}),
+            },
+          },
+          workspace,
+        );
+
+        await generateSpec(workspace, options);
+
+        const content = await fs.readFile(targetFile, 'utf8');
+        expect(content).toContain('getFooUrl2');
+        expect(content).toContain('getGetFooUrlUrl');
+        expect(content.match(/(?:export )?const getFooUrl\s*=/g)).toHaveLength(
+          1,
+        );
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+  }
 });
 
 describe('generateSpec - HTTP QUERY method', () => {

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -1789,6 +1789,18 @@ export const handleResource = (
         params: {...params, ...options?.params},}
     );
   }
+export const getHandleResourceUrl = (workspaceId: string,
+    id: string,
+    params?: HandleResourceParams,) => {
+    \n  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: \`/\${workspaceId}/resource/\${id}\`,
+    baseURL: '',
+    params,
+    \n  });
+}
 `;
 
     expect(implementation).toBe(expectedImplementation);
@@ -1859,6 +1871,18 @@ export const handleResource = (
         params: {...params, ...options?.params},}
     );
   }
+export const getHandleResourceUrl = (workspaceId: string,
+    id: string,
+    params: HandleResourceParams,) => {
+    \n  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: \`/\${workspaceId}/resource/\${id}\`,
+    baseURL: '',
+    params,
+    \n  });
+}
 `;
 
     expect(implementation).toBe(expectedImplementation);

--- a/packages/query/src/client.test.ts
+++ b/packages/query/src/client.test.ts
@@ -4,6 +4,7 @@ import type {
   GeneratorOptions,
   GeneratorVerbOptions,
   OpenApiSchemaObject,
+  PackageJson,
   ResReqTypesValue,
 } from '@orval/core';
 import { OutputHttpClient } from '@orval/core';
@@ -784,6 +785,144 @@ describe('generateAxiosRequestFunction with useDatesTransform', () => {
     expect(result.indexOf('const getPet')).toBeLessThan(
       result.indexOf('const deserializeGetPetResponse'),
     );
+  });
+
+  it('exports the Axios URL helper without replacing the request call', () => {
+    const result = generateAxiosRequestFunction(
+      { ...verbOptions, mutator: undefined },
+      options,
+      adapter,
+    );
+
+    expect(result).toContain('export const getGetPetUrl');
+    expect(result).toContain('axios.default.create({');
+    expect(result).toContain("baseURL: '',");
+    expect(result).toContain('params: null,');
+    expect(result).toContain('}).getUri({');
+    expect(result).toContain('axios.default.get(');
+    expect(result).not.toContain('axios.default.get(getGetPetUrl(');
+  });
+
+  it('unwraps Vue MaybeRef path values inside the URL helper', () => {
+    const vueAdapter = createFrameworkAdapter({ outputClient: 'vue-query' });
+    const result = generateAxiosRequestFunction(
+      {
+        ...verbOptions,
+        route: '/pets/${petId}',
+        pathRoute: '/pets/{petId}',
+        params: [
+          {
+            name: 'petId',
+            definition: 'petId: string',
+            implementation: 'petId: string',
+            default: undefined,
+            required: true,
+            imports: [],
+          },
+        ],
+        props: [
+          {
+            name: 'petId',
+            definition: 'petId: string',
+            implementation: 'petId: string',
+            default: undefined,
+            required: true,
+            type: 'param',
+          },
+        ],
+        mutator: undefined,
+      },
+      createOptions({ route: '/pets/${petId}' }),
+      vueAdapter,
+    );
+
+    expect(result).toContain('export const getGetPetUrl');
+    expect(result).toContain('petId: MaybeRef<string>');
+    expect(result).toContain('petId = unref(petId);');
+  });
+
+  it('uses Vue toValue for MaybeRefOrGetter URL parameters in Query v5', () => {
+    const vueAdapter = createFrameworkAdapter({
+      outputClient: 'vue-query',
+      packageJson: {
+        dependencies: { '@tanstack/vue-query': '5.92.7' },
+      } as PackageJson,
+    });
+    const result = generateAxiosRequestFunction(
+      {
+        ...verbOptions,
+        route: '/pets/${petId}',
+        pathRoute: '/pets/{petId}',
+        params: [
+          {
+            name: 'petId',
+            definition: 'petId: string',
+            implementation: 'petId: string',
+            default: undefined,
+            required: true,
+            imports: [],
+          },
+        ],
+        props: [
+          {
+            name: 'petId',
+            definition: 'petId: string',
+            implementation: 'petId: string',
+            default: undefined,
+            required: true,
+            type: 'param',
+          },
+        ],
+        mutator: undefined,
+      },
+      createOptions({ route: '/pets/${petId}' }),
+      vueAdapter,
+    );
+
+    expect(result).toContain('petId: MaybeRefOrGetter<string>');
+    expect(result).toContain('petId = toValue(petId);');
+  });
+
+  it('does not unwrap body-only parameters inside the URL helper', () => {
+    const vueAdapter = createFrameworkAdapter({ outputClient: 'vue-query' });
+    const result = generateAxiosRequestFunction(
+      {
+        ...verbOptions,
+        route: '/pets',
+        pathRoute: '/pets',
+        props: [
+          {
+            name: 'createPetsBody',
+            definition: 'createPetsBody: CreatePetsBody',
+            implementation: 'createPetsBody: CreatePetsBody',
+            default: undefined,
+            required: true,
+            type: 'body',
+          },
+          {
+            name: 'params',
+            definition: 'params: CreatePetsParams',
+            implementation: 'params: CreatePetsParams',
+            default: undefined,
+            required: true,
+            type: 'queryParam',
+          },
+        ],
+        mutator: undefined,
+      },
+      createOptions({ route: '/pets' }),
+      vueAdapter,
+    );
+
+    const helper = result.slice(result.indexOf('export const getGetPetUrl'));
+    expect(helper).not.toContain('createPetsBody = toValue(createPetsBody);');
+    expect(helper).toContain('params = unref(params);');
+  });
+
+  it('does not export a URL helper for Axios mutators', () => {
+    const result = generateAxiosRequestFunction(verbOptions, options, adapter);
+
+    expect(result).not.toContain('getGetPetUrl');
   });
 
   it('emits identical output to today when the flag is off or no dates exist', () => {

--- a/packages/query/src/client.test.ts
+++ b/packages/query/src/client.test.ts
@@ -7,7 +7,7 @@ import type {
   PackageJson,
   ResReqTypesValue,
 } from '@orval/core';
-import { OutputHttpClient } from '@orval/core';
+import { getOperationUrlHelperNames, OutputHttpClient } from '@orval/core';
 import { describe, expect, it } from 'vite-plus/test';
 
 import { createFrameworkAdapter } from './frameworks';
@@ -801,6 +801,37 @@ describe('generateAxiosRequestFunction with useDatesTransform', () => {
     expect(result).toContain('}).getUri({');
     expect(result).toContain('axios.default.get(');
     expect(result).not.toContain('axios.default.get(getGetPetUrl(');
+  });
+
+  it('uses the resolved helper name for colliding Axios operations', () => {
+    const [fooUrlName, getFooUrlName] = getOperationUrlHelperNames(
+      ['foo', 'getFooUrl'],
+      ['foo', 'getFooUrl'],
+    );
+    const foo = generateAxiosRequestFunction(
+      {
+        ...verbOptions,
+        operationName: 'foo',
+        urlHelperName: fooUrlName,
+        mutator: undefined,
+      },
+      options,
+      adapter,
+    );
+    const getFoo = generateAxiosRequestFunction(
+      {
+        ...verbOptions,
+        operationName: 'getFooUrl',
+        urlHelperName: getFooUrlName,
+        mutator: undefined,
+      },
+      options,
+      adapter,
+    );
+
+    expect(`${foo}\n${getFoo}`).toContain('export const getFooUrl2');
+    expect(`${foo}\n${getFoo}`).toContain('export const getGetFooUrlUrl');
+    expect(`${foo}\n${getFoo}`).not.toMatch(/export const getFooUrl\s*=/);
   });
 
   it('unwraps Vue MaybeRef path values inside the URL helper', () => {

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -292,6 +292,7 @@ export const generateAxiosRequestFunction = (
     headers,
     queryParams,
     operationName,
+    urlHelperName,
     response,
     mutator,
     body,
@@ -461,7 +462,7 @@ export const generateAxiosRequestFunction = (
   );
   const axiosRef = `axios${isSyntheticDefaultImportsAllowed ? '' : '.default'}`;
   const urlImplementation = generateAxiosUrl({
-    functionName: camel(`get-${operationName}-url`),
+    functionName: urlHelperName ?? camel(`get-${operationName}-url`),
     propsImplementation: toObjectString(urlProps, 'implementation'),
     route,
     axiosRef,

--- a/packages/query/src/client.ts
+++ b/packages/query/src/client.ts
@@ -1,9 +1,11 @@
 import {
+  camel,
   type ClientHeaderBuilder,
   emitResponseValidation,
   generateFormDataAndUrlEncodedFunction,
   generateMutatorConfig,
   generateMutatorRequestOptions,
+  generateAxiosUrl,
   generateOptions,
   generateResponseDateDeserializer,
   type GeneratorDependency,
@@ -18,6 +20,7 @@ import {
   hasSchemaImport,
   isPrimitiveResponseType,
   type GetterResponse,
+  GetterPropType,
   isObject,
   isOperationInTagBucket,
   isSyntheticDefaultImportsAllow,
@@ -450,6 +453,24 @@ export const generateAxiosRequestFunction = (
 
   const queryProps = toObjectString(props, 'implementation');
 
+  const urlProps = props.filter(
+    (prop) =>
+      prop.type === GetterPropType.PARAM ||
+      prop.type === GetterPropType.NAMED_PATH_PARAMS ||
+      prop.type === GetterPropType.QUERY_PARAM,
+  );
+  const axiosRef = `axios${isSyntheticDefaultImportsAllowed ? '' : '.default'}`;
+  const urlImplementation = generateAxiosUrl({
+    functionName: camel(`get-${operationName}-url`),
+    propsImplementation: toObjectString(urlProps, 'implementation'),
+    route,
+    axiosRef,
+    hasQueryParams: !!queryParams,
+    beforeReturn: adapter.getRequestUnrefStatements(urlProps),
+    paramsSerializer: paramsSerializer?.name,
+    paramsSerializerOptions: override.paramsSerializerOptions,
+  });
+
   const httpRequestFunctionImplementation = `${override.query.shouldExportHttpClient ? 'export ' : ''}const ${operationName} = (\n    ${queryProps} ${optionsArgs} ): Promise<AxiosResponse<${
     response.definition.success || 'unknown'
   }>> => {
@@ -463,7 +484,8 @@ export const generateAxiosRequestFunction = (
         : ''
     };
   }
-${dateDeserializerImplementation}`;
+${dateDeserializerImplementation}
+${urlImplementation}`;
 
   return httpRequestFunctionImplementation;
 };

--- a/samples/basic/__snapshots__/endpoints/petstoreFromFileSpecWithConfig.ts
+++ b/samples/basic/__snapshots__/endpoints/petstoreFromFileSpecWithConfig.ts
@@ -91,6 +91,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params?: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -100,6 +112,17 @@ export const createPets = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
+};
+export const getCreatePetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -114,6 +137,20 @@ export const listPetsNestedArray = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsNestedArrayUrl = (
+  params?: ListPetsNestedArrayParams,
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets-nested-array`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -123,6 +160,17 @@ export const showPetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
+};
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<PetsArray>;

--- a/samples/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -38,6 +38,17 @@ export const createPets = (
 ): Promise<AxiosResponse<void>> => {
   return axios.post(`/v${version}/pets`, createPetsBody, options);
 };
+export const getCreatePetsUrl = (version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary List all pets as nested array
@@ -52,6 +63,21 @@ export const listPetsNestedArray = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsNestedArrayUrl = (
+  params?: ListPetsNestedArrayParams,
+  version: number = 1,
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets-nested-array`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -62,6 +88,17 @@ export const showPetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/v${version}/pets/${petId}`, options);
+};
+export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 type AwaitedInput<T> = PromiseLike<T> | T;

--- a/samples/dynamic-ref/__snapshots__/api/petstore.ts
+++ b/samples/dynamic-ref/__snapshots__/api/petstore.ts
@@ -67,6 +67,17 @@ export const getPetstoreWithDynamicReferences = (
   ): Promise<AxiosResponse<Pet[]>> => {
     return axiosInstance.get(`/pets`, options);
   };
+  const getListPetsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Get a pet by ID
@@ -77,8 +88,19 @@ export const getPetstoreWithDynamicReferences = (
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: number) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
-  return { listPets, showPetById };
+  return { listPets, showPetById, getListPetsUrl, getShowPetByIdUrl };
 };
 export type ListPetsResult = AxiosResponse<Pet[]>;
 export type ShowPetByIdResult = AxiosResponse<Pet>;

--- a/samples/paginated-response-tags-split/__snapshots__/api/owners/owners.ts
+++ b/samples/paginated-response-tags-split/__snapshots__/api/owners/owners.ts
@@ -28,7 +28,19 @@ export const getOwners = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
-  return { listOwners };
+  const getListOwnersUrl = (params?: ListOwnersParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/owners`,
+        baseURL: '',
+        params,
+      });
+  };
+  return { listOwners, getListOwnersUrl };
 };
 export type ListOwnersResult = AxiosResponse<
   ApiEnvelopeTemplate<PaginatedOwnerItems>

--- a/samples/paginated-response-tags-split/__snapshots__/api/pets/pets.ts
+++ b/samples/paginated-response-tags-split/__snapshots__/api/pets/pets.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params?: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -38,6 +50,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<ApiEnvelopeTemplate<Pet>>> => {
     return axiosInstance.post(`/pets`, petFields, options);
+  };
+  const getCreatePetUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Get a pet by ID
@@ -48,7 +71,25 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<ApiEnvelopeTemplate<Pet>>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
-  return { listPets, createPet, getPet };
+  const getGetPetUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPet,
+    getPet,
+    getListPetsUrl,
+    getCreatePetUrl,
+    getGetPetUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<
   ApiEnvelopeTemplate<PaginatedPetItems>

--- a/samples/paginated-response-tags-split/__snapshots__/api/shelters/shelters.ts
+++ b/samples/paginated-response-tags-split/__snapshots__/api/shelters/shelters.ts
@@ -21,6 +21,17 @@ export const getShelters = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<ShelterResource>> => {
     return axiosInstance.get(`/shelters/${shelterId}/resources`, options);
   };
-  return { getShelterResources };
+  const getGetShelterResourcesUrl = (shelterId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/shelters/${shelterId}/resources`,
+        baseURL: '',
+      });
+  };
+  return { getShelterResources, getGetShelterResourcesUrl };
 };
 export type GetShelterResourcesResult = AxiosResponse<ShelterResource>;

--- a/samples/paginated-response-tags-split/__snapshots__/api/species/species.ts
+++ b/samples/paginated-response-tags-split/__snapshots__/api/species/species.ts
@@ -20,6 +20,17 @@ export const getSpecies = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<LocalizedSpeciesCategory>> => {
     return axiosInstance.get(`/species/tree`, options);
   };
-  return { getSpeciesTree };
+  const getGetSpeciesTreeUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/species/tree`,
+        baseURL: '',
+      });
+  };
+  return { getSpeciesTree, getGetSpeciesTreeUrl };
 };
 export type GetSpeciesTreeResult = AxiosResponse<LocalizedSpeciesCategory>;

--- a/samples/paginated-response/__snapshots__/api/petstore.ts
+++ b/samples/paginated-response/__snapshots__/api/petstore.ts
@@ -150,6 +150,18 @@ export const getDynamicRefPetstoreShowcaseAPI = (
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params?: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -160,6 +172,17 @@ export const getDynamicRefPetstoreShowcaseAPI = (
   ): Promise<AxiosResponse<ApiEnvelopeTemplate<Pet>>> => {
     return axiosInstance.post(`/pets`, petFields, options);
   };
+  const getCreatePetUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Get a pet by ID
@@ -169,6 +192,17 @@ export const getDynamicRefPetstoreShowcaseAPI = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<ApiEnvelopeTemplate<Pet>>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getGetPetUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -183,6 +217,18 @@ export const getDynamicRefPetstoreShowcaseAPI = (
       params: { ...params, ...options?.params },
     });
   };
+  const getListOwnersUrl = (params?: ListOwnersParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/owners`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Get species category tree
@@ -191,6 +237,17 @@ export const getDynamicRefPetstoreShowcaseAPI = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<LocalizedSpeciesCategory>> => {
     return axiosInstance.get(`/species/tree`, options);
+  };
+  const getGetSpeciesTreeUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/species/tree`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -202,6 +259,17 @@ export const getDynamicRefPetstoreShowcaseAPI = (
   ): Promise<AxiosResponse<ShelterResource>> => {
     return axiosInstance.get(`/shelters/${shelterId}/resources`, options);
   };
+  const getGetShelterResourcesUrl = (shelterId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/shelters/${shelterId}/resources`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -210,6 +278,12 @@ export const getDynamicRefPetstoreShowcaseAPI = (
     listOwners,
     getSpeciesTree,
     getShelterResources,
+    getListPetsUrl,
+    getCreatePetUrl,
+    getGetPetUrl,
+    getListOwnersUrl,
+    getGetSpeciesTreeUrl,
+    getGetShelterResourcesUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<

--- a/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithDocsHtml.ts
+++ b/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithDocsHtml.ts
@@ -44,6 +44,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params?: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -54,6 +66,17 @@ export const createPets = (
 ): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
+export const getCreatePetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -63,6 +86,17 @@ export const showPetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
+};
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithDocsHtmlPlugin.ts
+++ b/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithDocsHtmlPlugin.ts
@@ -44,6 +44,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params?: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -54,6 +66,17 @@ export const createPets = (
 ): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
+export const getCreatePetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -63,6 +86,17 @@ export const showPetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
+};
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithDocsMarkdown.ts
+++ b/samples/react-app/__snapshots__/endpoints/petstoreFromFileSpecWithDocsMarkdown.ts
@@ -44,6 +44,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params?: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -54,6 +66,17 @@ export const createPets = (
 ): Promise<AxiosResponse<void>> => {
   return axios.post(`/pets`, createPetsBody, options);
 };
+export const getCreatePetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -63,6 +86,17 @@ export const showPetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
+};
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/axios/gateway-tuple-tags-split/catalog/catalog.ts
+++ b/tests/__snapshots__/axios/gateway-tuple-tags-split/catalog/catalog.ts
@@ -19,13 +19,36 @@ export const getCatalog = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getGetProductsUrl = (params?: GetCatalogProductsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/api/catalog/products`,
+        baseURL: '',
+        params,
+      });
+  };
   const postProducts = (
     product: Product,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Product>> => {
     return axiosInstance.post(`/api/catalog/products`, product, options);
   };
-  return { getProducts, postProducts };
+  const getPostProductsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/api/catalog/products`,
+        baseURL: '',
+      });
+  };
+  return { getProducts, postProducts, getGetProductsUrl, getPostProductsUrl };
 };
 export type GetCatalogProductsResult = AxiosResponse<Product>;
 export type PostCatalogProductsResult = AxiosResponse<Product>;

--- a/tests/__snapshots__/axios/gateway-tuple-tags-split/inventory/inventory.ts
+++ b/tests/__snapshots__/axios/gateway-tuple-tags-split/inventory/inventory.ts
@@ -19,13 +19,36 @@ export const getInventory = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getGetStockUrl = (params?: GetInventoryStockParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/api/inventory/stock`,
+        baseURL: '',
+        params,
+      });
+  };
   const postStock = (
     product: Product,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Product>> => {
     return axiosInstance.post(`/api/inventory/stock`, product, options);
   };
-  return { getStock, postStock };
+  const getPostStockUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/api/inventory/stock`,
+        baseURL: '',
+      });
+  };
+  return { getStock, postStock, getGetStockUrl, getPostStockUrl };
 };
 export type GetInventoryStockResult = AxiosResponse<Product>;
 export type PostInventoryStockResult = AxiosResponse<Product>;

--- a/tests/__snapshots__/axios/issue-3330/endpoints.ts
+++ b/tests/__snapshots__/axios/issue-3330/endpoints.ts
@@ -19,6 +19,17 @@ export const getIssue3330 = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getDownloadInlineUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/download-inline`,
+        baseURL: '',
+      });
+  };
 
   const downloadRef = (
     options?: AxiosRequestConfig,
@@ -28,8 +39,24 @@ export const getIssue3330 = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getDownloadRefUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/download-ref`,
+        baseURL: '',
+      });
+  };
 
-  return { downloadInline, downloadRef };
+  return {
+    downloadInline,
+    downloadRef,
+    getDownloadInlineUrl,
+    getDownloadRefUrl,
+  };
 };
 export type DownloadInlineResult = AxiosResponse<Blob>;
 export type DownloadRefResult = AxiosResponse<TestPdfFile>;

--- a/tests/__snapshots__/axios/issue-3675-index-target/index.ts
+++ b/tests/__snapshots__/axios/issue-3675-index-target/index.ts
@@ -16,7 +16,18 @@ export const getIssue3675Petstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet[]>> => {
     return axiosInstance.get(`/pets`, options);
   };
+  const getListPetsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
+  };
 
-  return { listPets };
+  return { listPets, getListPetsUrl };
 };
 export type ListPetsResult = AxiosResponse<Pet[]>;

--- a/tests/__snapshots__/axios/issue-3675-non-index-target/endpoints.ts
+++ b/tests/__snapshots__/axios/issue-3675-non-index-target/endpoints.ts
@@ -16,7 +16,18 @@ export const getIssue3675Petstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet[]>> => {
     return axiosInstance.get(`/pets`, options);
   };
+  const getListPetsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
+  };
 
-  return { listPets };
+  return { listPets, getListPetsUrl };
 };
 export type ListPetsResult = AxiosResponse<Pet[]>;

--- a/tests/__snapshots__/axios/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/axios/named-parameters/endpoints.ts
@@ -35,6 +35,21 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (
+  { version = 1 }: ListPetsPathParameters = {},
+  params: ListPetsParams,
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -50,6 +65,21 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (
+  { version = 1 }: CreatePetsPathParameters = {},
+  params: CreatePetsParams,
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -60,6 +90,20 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/v${version}/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = ({
+  version = 1,
+  petId,
+}: ShowPetByIdPathParameters) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -69,6 +113,20 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/v${version}/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = ({
+  version = 1,
+  petId,
+}: DeletePetByIdPathParameters) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -83,6 +141,19 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = ({
+  version = 1,
+}: HealthCheckPathParameters = {}) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -92,6 +163,20 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/v${version}/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = ({
+  version = 1,
+  petId,
+}: ShowPetWithOwnerPathParameters) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/axios/petstore-tags-split-nodenext-workspace/health/health.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-nodenext-workspace/health/health.ts
@@ -20,6 +20,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios.default) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/axios/petstore-tags-split-nodenext-workspace/pets/pets.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-nodenext-workspace/pets/pets.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -44,6 +56,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -53,6 +77,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -64,6 +99,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -74,7 +120,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/petstore-tags-split-nodenext/health/health.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-nodenext/health/health.ts
@@ -20,6 +20,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios.default) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/axios/petstore-tags-split-nodenext/pets/pets.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-nodenext/pets/pets.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -44,6 +56,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -53,6 +77,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -64,6 +99,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -74,7 +120,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios.default) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/petstore-tags-split-workspace-generated-ext/health/health.generated.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-workspace-generated-ext/health/health.generated.ts
@@ -20,6 +20,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/axios/petstore-tags-split-workspace-generated-ext/pets/pets.generated.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-workspace-generated-ext/pets/pets.generated.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -44,6 +56,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -53,6 +77,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -64,6 +99,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -74,7 +120,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/health/health.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/health/health.ts
@@ -20,6 +20,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/pets/pets.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split-zod-schemas/pets/pets.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -44,6 +56,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -53,6 +77,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -64,6 +99,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -74,7 +120,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split/health/health.ts
@@ -20,6 +20,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/axios/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/axios/petstore-tags-split/pets/pets.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -44,6 +56,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -53,6 +77,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -64,6 +99,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -74,7 +120,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/petstore/endpoints.ts
+++ b/tests/__snapshots__/axios/petstore/endpoints.ts
@@ -30,6 +30,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -45,6 +57,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -56,6 +80,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -66,6 +101,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -80,6 +126,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -91,6 +148,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -99,6 +167,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/axios/split-by-tags-faker-schemas-no-index/pets/pets.ts
+++ b/tests/__snapshots__/axios/split-by-tags-faker-schemas-no-index/pets/pets.ts
@@ -25,11 +25,34 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params?: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   const createPet = (
     createPetBody?: CreatePetBody,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.post(`/pets`, createPetBody, options);
+  };
+  const getCreatePetUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
   };
   const getPetById = (
     petId: string,
@@ -37,7 +60,25 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
-  return { listPets, createPet, getPetById };
+  const getGetPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPet,
+    getPetById,
+    getListPetsUrl,
+    getCreatePetUrl,
+    getGetPetByIdUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<PetList>;
 export type CreatePetResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/split-by-tags-faker-schemas-no-index/stores/stores.ts
+++ b/tests/__snapshots__/axios/split-by-tags-faker-schemas-no-index/stores/stores.ts
@@ -25,11 +25,34 @@ export const getStores = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListStoresUrl = (params?: ListStoresParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores`,
+        baseURL: '',
+        params,
+      });
+  };
   const createStore = (
     createStoreBody?: CreateStoreBody,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Store>> => {
     return axiosInstance.post(`/stores`, createStoreBody, options);
+  };
+  const getCreateStoreUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores`,
+        baseURL: '',
+      });
   };
   const getStoreById = (
     storeId: string,
@@ -37,7 +60,25 @@ export const getStores = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Store>> => {
     return axiosInstance.get(`/stores/${storeId}`, options);
   };
-  return { listStores, createStore, getStoreById };
+  const getGetStoreByIdUrl = (storeId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores/${storeId}`,
+        baseURL: '',
+      });
+  };
+  return {
+    listStores,
+    createStore,
+    getStoreById,
+    getListStoresUrl,
+    getCreateStoreUrl,
+    getGetStoreByIdUrl,
+  };
 };
 export type ListStoresResult = AxiosResponse<StoreList>;
 export type CreateStoreResult = AxiosResponse<Store>;

--- a/tests/__snapshots__/axios/split-mode-split-schemas/endpoints.ts
+++ b/tests/__snapshots__/axios/split-mode-split-schemas/endpoints.ts
@@ -30,6 +30,18 @@ export const getTagsSplitSharedModels = (
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params?: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   const createPet = (
     createPetBody?: CreatePetBody,
@@ -37,12 +49,34 @@ export const getTagsSplitSharedModels = (
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.post(`/pets`, createPetBody, options);
   };
+  const getCreatePetUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
+  };
 
   const getPetById = (
     petId: string,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getGetPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   const listStores = (
@@ -54,6 +88,18 @@ export const getTagsSplitSharedModels = (
       params: { ...params, ...options?.params },
     });
   };
+  const getListStoresUrl = (params?: ListStoresParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores`,
+        baseURL: '',
+        params,
+      });
+  };
 
   const createStore = (
     createStoreBody?: CreateStoreBody,
@@ -61,12 +107,34 @@ export const getTagsSplitSharedModels = (
   ): Promise<AxiosResponse<Store>> => {
     return axiosInstance.post(`/stores`, createStoreBody, options);
   };
+  const getCreateStoreUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores`,
+        baseURL: '',
+      });
+  };
 
   const getStoreById = (
     storeId: string,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Store>> => {
     return axiosInstance.get(`/stores/${storeId}`, options);
+  };
+  const getGetStoreByIdUrl = (storeId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores/${storeId}`,
+        baseURL: '',
+      });
   };
 
   return {
@@ -76,6 +144,12 @@ export const getTagsSplitSharedModels = (
     listStores,
     createStore,
     getStoreById,
+    getListPetsUrl,
+    getCreatePetUrl,
+    getGetPetByIdUrl,
+    getListStoresUrl,
+    getCreateStoreUrl,
+    getGetStoreByIdUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<PetList>;

--- a/tests/__snapshots__/axios/split/endpoints.ts
+++ b/tests/__snapshots__/axios/split/endpoints.ts
@@ -30,6 +30,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -45,6 +57,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -56,6 +80,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -66,6 +101,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -80,6 +126,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -91,6 +148,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -99,6 +167,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/axios/tags-split-shared-models/pets/pets.ts
+++ b/tests/__snapshots__/axios/tags-split-shared-models/pets/pets.ts
@@ -19,11 +19,34 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params?: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   const createPet = (
     createPetBody?: CreatePetBody,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.post(`/pets`, createPetBody, options);
+  };
+  const getCreatePetUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
   };
   const getPetById = (
     petId: string,
@@ -31,7 +54,25 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
-  return { listPets, createPet, getPetById };
+  const getGetPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPet,
+    getPetById,
+    getListPetsUrl,
+    getCreatePetUrl,
+    getGetPetByIdUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<PetList>;
 export type CreatePetResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/tags-split-shared-models/stores/stores.ts
+++ b/tests/__snapshots__/axios/tags-split-shared-models/stores/stores.ts
@@ -24,11 +24,34 @@ export const getStores = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListStoresUrl = (params?: ListStoresParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores`,
+        baseURL: '',
+        params,
+      });
+  };
   const createStore = (
     createStoreBody?: CreateStoreBody,
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Store>> => {
     return axiosInstance.post(`/stores`, createStoreBody, options);
+  };
+  const getCreateStoreUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores`,
+        baseURL: '',
+      });
   };
   const getStoreById = (
     storeId: string,
@@ -36,7 +59,25 @@ export const getStores = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Store>> => {
     return axiosInstance.get(`/stores/${storeId}`, options);
   };
-  return { listStores, createStore, getStoreById };
+  const getGetStoreByIdUrl = (storeId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/stores/${storeId}`,
+        baseURL: '',
+      });
+  };
+  return {
+    listStores,
+    createStore,
+    getStoreById,
+    getListStoresUrl,
+    getCreateStoreUrl,
+    getGetStoreByIdUrl,
+  };
 };
 export type ListStoresResult = AxiosResponse<StoreList>;
 export type CreateStoreResult = AxiosResponse<Store>;

--- a/tests/__snapshots__/axios/tags/health.ts
+++ b/tests/__snapshots__/axios/tags/health.ts
@@ -20,6 +20,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = (version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/axios/tags/pets.ts
+++ b/tests/__snapshots__/axios/tags/pets.ts
@@ -30,6 +30,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -44,6 +56,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -53,6 +77,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -64,6 +99,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/v${version}/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -74,7 +120,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/v${version}/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/v${version}/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/axios/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/axios/zod-schema-response/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/cli/petstore/endpoints.ts
+++ b/tests/__snapshots__/cli/petstore/endpoints.ts
@@ -168,6 +168,18 @@ export const listPets = (
         params: {...params, ...options?.params},}
     );
   }
+export const getListPetsUrl = (params: ListPetsParams,) => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/pets`,
+    baseURL: '',
+    params,
+
+  });
+}
 
 /**
  * @summary Create a pet
@@ -183,6 +195,18 @@ export const createPets = (
         params: {...params, ...options?.params},}
     );
   }
+export const getCreatePetsUrl = (params: CreatePetsParams,) => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/pets`,
+    baseURL: '',
+    params,
+
+  });
+}
 
 /**
  * @summary Info for a specific pet
@@ -194,6 +218,18 @@ export const showPetById = (
       `/pets/${petId}`,options
     );
   }
+export const getShowPetByIdUrl = (petId: string,) => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/pets/${petId}`,
+    baseURL: '',
+
+
+  });
+}
 
 /**
  * @summary Deletes a specific pet
@@ -205,6 +241,18 @@ export const deletePetById = (
       `/pets/${petId}`,options
     );
   }
+export const getDeletePetByIdUrl = (petId: string,) => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/pets/${petId}`,
+    baseURL: '',
+
+
+  });
+}
 
 /**
  * @summary health check
@@ -218,6 +266,18 @@ export const healthCheck = (
     ...options,}
     );
   }
+export const getHealthCheckUrl = () => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/health`,
+    baseURL: '',
+
+
+  });
+}
 
 /**
  * @summary combinate nullable and $ref
@@ -229,6 +289,18 @@ export const showPetWithOwner = (
       `/pets/${petId}/owner`,options
     );
   }
+export const getShowPetWithOwnerUrl = (petId: string,) => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/pets/${petId}/owner`,
+    baseURL: '',
+
+
+  });
+}
 
 export type ListPetsResult = AxiosResponse<Pets>
 export type CreatePetsResult = AxiosResponse<Pet>

--- a/tests/__snapshots__/default/all-of-all-of/endpoints.ts
+++ b/tests/__snapshots__/default/all-of-all-of/endpoints.ts
@@ -14,6 +14,17 @@ export const createSharedNote = (
 ): Promise<AxiosResponse<SharedNote>> => {
   return axios.post(`/shared-notes`, undefined, options);
 };
+export const getCreateSharedNoteUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/shared-notes`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Create a private note for the beneficiary.
@@ -22,6 +33,17 @@ export const createPrivateNote = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PrivateNote>> => {
   return axios.post(`/private-notes`, undefined, options);
+};
+export const getCreatePrivateNoteUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/private-notes`,
+      baseURL: '',
+    });
 };
 
 export type CreateSharedNoteResult = AxiosResponse<SharedNote>;

--- a/tests/__snapshots__/default/all-of-one-of/endpoints.ts
+++ b/tests/__snapshots__/default/all-of-one-of/endpoints.ts
@@ -14,5 +14,16 @@ export const postSomething = (
 ): Promise<AxiosResponse<PostSomething200>> => {
   return axios.post(`/something`, undefined, options);
 };
+export const getPostSomethingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/something`,
+      baseURL: '',
+    });
+};
 
 export type PostSomethingResult = AxiosResponse<PostSomething200>;

--- a/tests/__snapshots__/default/all-of-primitive/endpoints.ts
+++ b/tests/__snapshots__/default/all-of-primitive/endpoints.ts
@@ -14,5 +14,16 @@ export const getPets = (
 ): Promise<AxiosResponse<Pets[]>> => {
   return axios.get(`/pets`, options);
 };
+export const getGetPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export type GetPetsResult = AxiosResponse<Pets[]>;

--- a/tests/__snapshots__/default/all-of-ref/endpoints.ts
+++ b/tests/__snapshots__/default/all-of-ref/endpoints.ts
@@ -14,5 +14,16 @@ export const getPet = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pet`, options);
 };
+export const getGetPetUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pet`,
+      baseURL: '',
+    });
+};
 
 export type GetPetResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/default/all-of-required-in-parent/endpoints.ts
+++ b/tests/__snapshots__/default/all-of-required-in-parent/endpoints.ts
@@ -14,5 +14,16 @@ export const get = (
 ): Promise<AxiosResponse<Get200>> => {
   return axios.get(`/`, options);
 };
+export const getGetUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/`,
+      baseURL: '',
+    });
+};
 
 export type GetResult = AxiosResponse<Get200>;

--- a/tests/__snapshots__/default/all-of-without-type/endpoints.ts
+++ b/tests/__snapshots__/default/all-of-without-type/endpoints.ts
@@ -14,5 +14,16 @@ export const get = (
 ): Promise<AxiosResponse<Get200>> => {
   return axios.get(`/`, options);
 };
+export const getGetUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/`,
+      baseURL: '',
+    });
+};
 
 export type GetResult = AxiosResponse<Get200>;

--- a/tests/__snapshots__/default/all-of/endpoints.ts
+++ b/tests/__snapshots__/default/all-of/endpoints.ts
@@ -27,6 +27,17 @@ export const createPets = (
 
   return axios.post(`/pets`, formData, options);
 };
+export const getCreatePetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 /**
  * Not has properties with allOf pets.
@@ -35,6 +46,17 @@ export const getNotHasPropertiesWithAllOfPets = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<GetNotHasPropertiesWithAllOfPets200>> => {
   return axios.get(`/not-has-properties-with-all-of-pets`, options);
+};
+export const getGetNotHasPropertiesWithAllOfPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/not-has-properties-with-all-of-pets`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -45,6 +67,17 @@ export const getNestedRefInAllOfPets = (
 ): Promise<AxiosResponse<Pet & PetDetail>> => {
   return axios.get(`/rested-ref-in-all-of-pets`, options);
 };
+export const getGetNestedRefInAllOfPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/rested-ref-in-all-of-pets`,
+      baseURL: '',
+    });
+};
 
 /**
  * Test allOf with nullable and required fields.
@@ -53,6 +86,17 @@ export const getItemsWithNullableRequired = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<ItemWithNullableRequired[]>> => {
   return axios.get(`/items-with-nullable-required`, options);
+};
+export const getGetItemsWithNullableRequiredUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/items-with-nullable-required`,
+      baseURL: '',
+    });
 };
 
 export type CreatePetsResult = AxiosResponse<void>;

--- a/tests/__snapshots__/default/any-of-primitive/endpoints.ts
+++ b/tests/__snapshots__/default/any-of-primitive/endpoints.ts
@@ -14,5 +14,16 @@ export const getPets = (
 ): Promise<AxiosResponse<Pets[]>> => {
   return axios.get(`/pets`, options);
 };
+export const getGetPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export type GetPetsResult = AxiosResponse<Pets[]>;

--- a/tests/__snapshots__/default/any-of/endpoints.ts
+++ b/tests/__snapshots__/default/any-of/endpoints.ts
@@ -21,6 +21,18 @@ export const getItems = (
     params: { ...params, ...options?.params },
   });
 };
+export const getGetItemsUrl = (params?: GetItemsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/test`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Gets anyOf included allOf pets
@@ -30,6 +42,17 @@ export const getAnyOfIncludedAllOfPets = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/any-of-included-all-of-pet`, options);
 };
+export const getGetAnyOfIncludedAllOfPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/any-of-included-all-of-pet`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Gets anyOf included allOf and shared schema pets
@@ -38,6 +61,17 @@ export const getAnyOfIncludedAllOfAndSharedSchemaPets = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<CatDetail>> => {
   return axios.get(`/any-of-included-all-of-and-shared-schema-pet`, options);
+};
+export const getGetAnyOfIncludedAllOfAndSharedSchemaPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/any-of-included-all-of-and-shared-schema-pet`,
+      baseURL: '',
+    });
 };
 
 export type GetItemsResult = AxiosResponse<void>;

--- a/tests/__snapshots__/default/boolean-discriminator/endpoints.ts
+++ b/tests/__snapshots__/default/boolean-discriminator/endpoints.ts
@@ -14,11 +14,33 @@ export const getResult = (
 ): Promise<AxiosResponse<ApiResult>> => {
   return axios.get(`/api/result`, options);
 };
+export const getGetResultUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/result`,
+      baseURL: '',
+    });
+};
 
 export const getStatus = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<StatusResult>> => {
   return axios.get(`/api/status`, options);
+};
+export const getGetStatusUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/status`,
+      baseURL: '',
+    });
 };
 
 export type GetResultResult = AxiosResponse<ApiResult>;

--- a/tests/__snapshots__/default/circular-v2/endpoints.ts
+++ b/tests/__snapshots__/default/circular-v2/endpoints.ts
@@ -18,5 +18,16 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 export type ShowPetByIdResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/default/combine-enum/combinedEnums.ts
+++ b/tests/__snapshots__/default/combine-enum/combinedEnums.ts
@@ -17,5 +17,16 @@ export const getApiColors = (
 ): Promise<AxiosResponse<ColorObject>> => {
   return axios.get(`/api/colors`, options);
 };
+export const getGetApiColorsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/colors`,
+      baseURL: '',
+    });
+};
 
 export type GetApiColorsResult = AxiosResponse<ColorObject>;

--- a/tests/__snapshots__/default/deeply-nested-refs/endpoints.ts
+++ b/tests/__snapshots__/default/deeply-nested-refs/endpoints.ts
@@ -17,5 +17,16 @@ export const getDeeplyNested = (
 ): Promise<AxiosResponse<DeeplyNestedRefSchema1>> => {
   return axios.get(`/deeply-nested`, options);
 };
+export const getGetDeeplyNestedUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/deeply-nested`,
+      baseURL: '',
+    });
+};
 
 export type GetDeeplyNestedResult = AxiosResponse<DeeplyNestedRefSchema1>;

--- a/tests/__snapshots__/default/default-status/endpoints.ts
+++ b/tests/__snapshots__/default/default-status/endpoints.ts
@@ -14,11 +14,33 @@ export const defaultOnly = (
 ): Promise<AxiosResponse<Sample>> => {
   return axios.get(`/default-only`, options);
 };
+export const getDefaultOnlyUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/default-only`,
+      baseURL: '',
+    });
+};
 
 export const with200 = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Sample>> => {
   return axios.get(`/w-200`, options);
+};
+export const getWith200Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/w-200`,
+      baseURL: '',
+    });
 };
 
 export const with400 = (
@@ -26,11 +48,33 @@ export const with400 = (
 ): Promise<AxiosResponse<Sample>> => {
   return axios.get(`/w-400`, options);
 };
+export const getWith400Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/w-400`,
+      baseURL: '',
+    });
+};
 
 export const with200and400 = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Sample>> => {
   return axios.get(`/w-200-400`, options);
+};
+export const getWith200and400Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/w-200-400`,
+      baseURL: '',
+    });
 };
 
 export type DefaultOnlyResult = AxiosResponse<Sample>;

--- a/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
+++ b/tests/__snapshots__/default/endpoint-parameters/endpoints.ts
@@ -27,6 +27,21 @@ export const listPetsByCountry = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsByCountryUrl = (
+  params?: ListPetsByCountryParams,
+  country: CountryCode = 'UY',
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets-by-country/${country}`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary List all pets by age
@@ -40,6 +55,21 @@ export const listPetsByAge = (
     ...options,
     params: { ...params, ...options?.params },
   });
+};
+export const getListPetsByAgeUrl = (
+  params?: ListPetsByAgeParams,
+  age: number = 5,
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets-by-age/${age}`,
+      baseURL: '',
+      params,
+    });
 };
 
 export type ListPetsByCountryResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/enums/const/endpoints.ts
+++ b/tests/__snapshots__/default/enums/const/endpoints.ts
@@ -26,6 +26,17 @@ export const getApiCat = (
 ): Promise<AxiosResponse<DogGroup[]>> => {
   return axios.get(`/api/cat`, options);
 };
+export const getGetApiCatUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/cat`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample required cat
@@ -34,6 +45,17 @@ export const getApiRequiredCat = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RequiredCat>> => {
   return axios.get(`/api/required-cat`, options);
+};
+export const getGetApiRequiredCatUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/required-cat`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -44,6 +66,17 @@ export const getApiDog = (
 ): Promise<AxiosResponse<Dog>> => {
   return axios.get(`/api/dog`, options);
 };
+export const getGetApiDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/dog`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample required dog
@@ -52,6 +85,17 @@ export const getApiRequiredDog = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RequiredDog>> => {
   return axios.get(`/api/required-dog`, options);
+};
+export const getGetApiRequiredDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/required-dog`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -62,6 +106,17 @@ export const getApiDuck = (
 ): Promise<AxiosResponse<Duck>> => {
   return axios.get(`/api/duck`, options);
 };
+export const getGetApiDuckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/duck`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample cat dog
@@ -70,6 +125,17 @@ export const getApiCatDog = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<CatDog>> => {
   return axios.get(`/api/cat-dog`, options);
+};
+export const getGetApiCatDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/cat-dog`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -80,6 +146,17 @@ export const getApiPetTraining = (
 ): Promise<AxiosResponse<PetTrainingLevel>> => {
   return axios.get(`/api/pet-training`, options);
 };
+export const getGetApiPetTrainingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/pet-training`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample pet needs training
@@ -88,6 +165,17 @@ export const getApiPetNeedsTraining = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetNeedsTraining>> => {
   return axios.get(`/api/pet-needs-training`, options);
+};
+export const getGetApiPetNeedsTrainingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/pet-needs-training`,
+      baseURL: '',
+    });
 };
 
 export type GetApiCatResult = AxiosResponse<DogGroup[]>;

--- a/tests/__snapshots__/default/enums/native/endpoints.ts
+++ b/tests/__snapshots__/default/enums/native/endpoints.ts
@@ -26,6 +26,17 @@ export const getApiCat = (
 ): Promise<AxiosResponse<DogGroup[]>> => {
   return axios.get(`/api/cat`, options);
 };
+export const getGetApiCatUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/cat`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample required cat
@@ -34,6 +45,17 @@ export const getApiRequiredCat = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RequiredCat>> => {
   return axios.get(`/api/required-cat`, options);
+};
+export const getGetApiRequiredCatUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/required-cat`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -44,6 +66,17 @@ export const getApiDog = (
 ): Promise<AxiosResponse<Dog>> => {
   return axios.get(`/api/dog`, options);
 };
+export const getGetApiDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/dog`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample required dog
@@ -52,6 +85,17 @@ export const getApiRequiredDog = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RequiredDog>> => {
   return axios.get(`/api/required-dog`, options);
+};
+export const getGetApiRequiredDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/required-dog`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -62,6 +106,17 @@ export const getApiDuck = (
 ): Promise<AxiosResponse<Duck>> => {
   return axios.get(`/api/duck`, options);
 };
+export const getGetApiDuckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/duck`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample cat dog
@@ -70,6 +125,17 @@ export const getApiCatDog = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<CatDog>> => {
   return axios.get(`/api/cat-dog`, options);
+};
+export const getGetApiCatDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/cat-dog`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -80,6 +146,17 @@ export const getApiPetTraining = (
 ): Promise<AxiosResponse<PetTrainingLevel>> => {
   return axios.get(`/api/pet-training`, options);
 };
+export const getGetApiPetTrainingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/pet-training`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample pet needs training
@@ -88,6 +165,17 @@ export const getApiPetNeedsTraining = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetNeedsTraining>> => {
   return axios.get(`/api/pet-needs-training`, options);
+};
+export const getGetApiPetNeedsTrainingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/pet-needs-training`,
+      baseURL: '',
+    });
 };
 
 export type GetApiCatResult = AxiosResponse<DogGroup[]>;

--- a/tests/__snapshots__/default/enums/union/endpoints.ts
+++ b/tests/__snapshots__/default/enums/union/endpoints.ts
@@ -26,6 +26,17 @@ export const getApiCat = (
 ): Promise<AxiosResponse<DogGroup[]>> => {
   return axios.get(`/api/cat`, options);
 };
+export const getGetApiCatUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/cat`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample required cat
@@ -34,6 +45,17 @@ export const getApiRequiredCat = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RequiredCat>> => {
   return axios.get(`/api/required-cat`, options);
+};
+export const getGetApiRequiredCatUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/required-cat`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -44,6 +66,17 @@ export const getApiDog = (
 ): Promise<AxiosResponse<Dog>> => {
   return axios.get(`/api/dog`, options);
 };
+export const getGetApiDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/dog`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample required dog
@@ -52,6 +85,17 @@ export const getApiRequiredDog = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RequiredDog>> => {
   return axios.get(`/api/required-dog`, options);
+};
+export const getGetApiRequiredDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/required-dog`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -62,6 +106,17 @@ export const getApiDuck = (
 ): Promise<AxiosResponse<Duck>> => {
   return axios.get(`/api/duck`, options);
 };
+export const getGetApiDuckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/duck`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample cat dog
@@ -70,6 +125,17 @@ export const getApiCatDog = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<CatDog>> => {
   return axios.get(`/api/cat-dog`, options);
+};
+export const getGetApiCatDogUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/cat-dog`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -80,6 +146,17 @@ export const getApiPetTraining = (
 ): Promise<AxiosResponse<PetTrainingLevel>> => {
   return axios.get(`/api/pet-training`, options);
 };
+export const getGetApiPetTrainingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/pet-training`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary sample pet needs training
@@ -88,6 +165,17 @@ export const getApiPetNeedsTraining = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetNeedsTraining>> => {
   return axios.get(`/api/pet-needs-training`, options);
+};
+export const getGetApiPetNeedsTrainingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/pet-needs-training`,
+      baseURL: '',
+    });
 };
 
 export type GetApiCatResult = AxiosResponse<DogGroup[]>;

--- a/tests/__snapshots__/default/external-ref/endpoints.ts
+++ b/tests/__snapshots__/default/external-ref/endpoints.ts
@@ -27,5 +27,16 @@ export const getPoints = (
 ): Promise<AxiosResponse<GetPoints200Item[]>> => {
   return axios.get(`/points`, options);
 };
+export const getGetPointsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/points`,
+      baseURL: '',
+    });
+};
 
 export type GetPointsResult = AxiosResponse<GetPoints200Item[]>;

--- a/tests/__snapshots__/default/form-data-explode/endpoints.ts
+++ b/tests/__snapshots__/default/form-data-explode/endpoints.ts
@@ -38,5 +38,16 @@ export const createPets = (
 
   return axios.post(`/pets`, formData, options);
 };
+export const getCreatePetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/default/http-status-mocks/endpoints.ts
+++ b/tests/__snapshots__/default/http-status-mocks/endpoints.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/issue-1107-cross-file-ref/endpoints.ts
+++ b/tests/__snapshots__/default/issue-1107-cross-file-ref/endpoints.ts
@@ -14,5 +14,16 @@ export const listPets = (
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets`, options);
 };
+export const getListPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/issue-1775/endpoints.ts
+++ b/tests/__snapshots__/default/issue-1775/endpoints.ts
@@ -14,5 +14,16 @@ export const putApiOrderLimit = (
 ): Promise<AxiosResponse<PutApiOrderLimit200Item[]>> => {
   return axios.put(`/api/order/limit`, undefined, options);
 };
+export const getPutApiOrderLimitUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/order/limit`,
+      baseURL: '',
+    });
+};
 
 export type PutApiOrderLimitResult = AxiosResponse<PutApiOrderLimit200Item[]>;

--- a/tests/__snapshots__/default/issue-1935-double-linked-ref/endpoints.ts
+++ b/tests/__snapshots__/default/issue-1935-double-linked-ref/endpoints.ts
@@ -18,5 +18,16 @@ export const getUserProjects = (
 ): Promise<AxiosResponse<UserProject[]>> => {
   return axios.get(`/users/${userId}/projects`, options);
 };
+export const getGetUserProjectsUrl = (userId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/users/${userId}/projects`,
+      baseURL: '',
+    });
+};
 
 export type GetUserProjectsResult = AxiosResponse<UserProject[]>;

--- a/tests/__snapshots__/default/issue-2642-prefix/endpoints.ts
+++ b/tests/__snapshots__/default/issue-2642-prefix/endpoints.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<IPet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<IPetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<IPets>;

--- a/tests/__snapshots__/default/issue-3380-external-path-ref/endpoints.ts
+++ b/tests/__snapshots__/default/issue-3380-external-path-ref/endpoints.ts
@@ -12,6 +12,17 @@ export const listPets = (
 ): Promise<AxiosResponse<string[]>> => {
   return axios.get(`/pets`, options);
 };
+export const getListPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export const getPet = (
   petId: string,
@@ -20,6 +31,17 @@ export const getPet = (
   return axios.get(`/pets/${petId}`, {
     ...options,
   });
+};
+export const getGetPetUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<string[]>;

--- a/tests/__snapshots__/default/issue-3505/endpoints.ts
+++ b/tests/__snapshots__/default/issue-3505/endpoints.ts
@@ -14,5 +14,16 @@ export const ping = (
 ): Promise<AxiosResponse<Ping200>> => {
   return axios.get(`/ping`, options);
 };
+export const getPingUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/ping`,
+      baseURL: '',
+    });
+};
 
 export type PingResult = AxiosResponse<Ping200>;

--- a/tests/__snapshots__/default/issue-3583/endpoints.ts
+++ b/tests/__snapshots__/default/issue-3583/endpoints.ts
@@ -17,5 +17,20 @@ export const listFiles = (
     ...options,
   });
 };
+export const getListFilesUrl = (
+  prefix: string = 'C:\\logs\\',
+  namespace: string = 'App\\Models\\Document',
+  tz: string = 'Asia/Tokyo',
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/files/${prefix}/${namespace}/${tz}`,
+      baseURL: '',
+    });
+};
 
 export type ListFilesResult = AxiosResponse<string>;

--- a/tests/__snapshots__/default/issue-3722/endpoints.ts
+++ b/tests/__snapshots__/default/issue-3722/endpoints.ts
@@ -20,5 +20,16 @@ export const getPetTagInfo = (
 ): Promise<AxiosResponse<PetTagInfo>> => {
   return axios.get(`/pets/${petId}/tag-info`, options);
 };
+export const getGetPetTagInfoUrl = (petId: number) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/tag-info`,
+      baseURL: '',
+    });
+};
 
 export type GetPetTagInfoResult = AxiosResponse<PetTagInfo>;

--- a/tests/__snapshots__/default/issue-3748/endpoints.ts
+++ b/tests/__snapshots__/default/issue-3748/endpoints.ts
@@ -17,5 +17,16 @@ export const getItem = (
 ): Promise<AxiosResponse<ItemDetail>> => {
   return axios.get(`/item`, options);
 };
+export const getGetItemUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/item`,
+      baseURL: '',
+    });
+};
 
 export type GetItemResult = AxiosResponse<ItemDetail>;

--- a/tests/__snapshots__/default/issue-3750/endpoints.ts
+++ b/tests/__snapshots__/default/issue-3750/endpoints.ts
@@ -21,11 +21,33 @@ export const getItem = (
 ): Promise<AxiosResponse<ItemDetail>> => {
   return axios.get(`/item`, options);
 };
+export const getGetItemUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/item`,
+      baseURL: '',
+    });
+};
 
 export const getNullableItem = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableItemDetail | null>> => {
   return axios.get(`/nullable-item`, options);
+};
+export const getGetNullableItemUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-item`,
+      baseURL: '',
+    });
 };
 
 export const getNestedNullableItem = (
@@ -33,11 +55,33 @@ export const getNestedNullableItem = (
 ): Promise<AxiosResponse<NestedNullableItemDetail | null>> => {
   return axios.get(`/nested-nullable-item`, options);
 };
+export const getGetNestedNullableItemUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nested-nullable-item`,
+      baseURL: '',
+    });
+};
 
 export const getRefNullableItem = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<RefNullableItemDetail | null>> => {
   return axios.get(`/ref-nullable-item`, options);
+};
+export const getGetRefNullableItemUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/ref-nullable-item`,
+      baseURL: '',
+    });
 };
 
 export type GetItemResult = AxiosResponse<ItemDetail>;

--- a/tests/__snapshots__/default/issue-398-encoded-path-ref/endpoints.ts
+++ b/tests/__snapshots__/default/issue-398-encoded-path-ref/endpoints.ts
@@ -15,5 +15,16 @@ export const getById = (
     ...options,
   });
 };
+export const getGetByIdUrl = (id: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/${id}`,
+      baseURL: '',
+    });
+};
 
 export type GetByIdResult = AxiosResponse<string>;

--- a/tests/__snapshots__/default/lowercase-discriminator/endpoints.ts
+++ b/tests/__snapshots__/default/lowercase-discriminator/endpoints.ts
@@ -47,5 +47,16 @@ export const getTest = (
 ): Promise<AxiosResponse<Resp>> => {
   return axios.get(`/test`, options);
 };
+export const getGetTestUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/test`,
+      baseURL: '',
+    });
+};
 
 export type GetTestResult = AxiosResponse<Resp>;

--- a/tests/__snapshots__/default/multi-files-with-same-import-names/endpoints.ts
+++ b/tests/__snapshots__/default/multi-files-with-same-import-names/endpoints.ts
@@ -14,5 +14,16 @@ export const getTest = (
 ): Promise<AxiosResponse<Response>> => {
   return axios.get(`/test`, options);
 };
+export const getGetTestUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/test`,
+      baseURL: '',
+    });
+};
 
 export type GetTestResult = AxiosResponse<Response>;

--- a/tests/__snapshots__/default/multiple-tags-split/cats/cats.ts
+++ b/tests/__snapshots__/default/multiple-tags-split/cats/cats.ts
@@ -17,6 +17,17 @@ export const listPets = (
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets`, options);
 };
+export const getListPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 /**
  * @summary List all pets
  */
@@ -24,6 +35,17 @@ export const listPets2 = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets2`, options);
+};
+export const getListPets2Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets2`,
+      baseURL: '',
+    });
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type ListPets2Result = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/multiple-tags-split/dogs/dogs.ts
+++ b/tests/__snapshots__/default/multiple-tags-split/dogs/dogs.ts
@@ -17,4 +17,15 @@ export const listPets3 = (
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets3`, options);
 };
+export const getListPets3Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets3`,
+      baseURL: '',
+    });
+};
 export type ListPets3Result = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/multiple-tags/cats.ts
+++ b/tests/__snapshots__/default/multiple-tags/cats.ts
@@ -17,6 +17,17 @@ export const listPets = (
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets`, options);
 };
+export const getListPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 /**
  * @summary List all pets
  */
@@ -24,6 +35,17 @@ export const listPets2 = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets2`, options);
+};
+export const getListPets2Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets2`,
+      baseURL: '',
+    });
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type ListPets2Result = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/multiple-tags/dogs.ts
+++ b/tests/__snapshots__/default/multiple-tags/dogs.ts
@@ -17,4 +17,15 @@ export const listPets3 = (
 ): Promise<AxiosResponse<Pets>> => {
   return axios.get(`/pets3`, options);
 };
+export const getListPets3Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets3`,
+      baseURL: '',
+    });
+};
 export type ListPets3Result = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/null-type-v3-0/endpoints.ts
+++ b/tests/__snapshots__/default/null-type-v3-0/endpoints.ts
@@ -22,6 +22,17 @@ export const fetchNullable = (
 ): Promise<AxiosResponse<string | null>> => {
   return axios.get(`/nullable`, options);
 };
+export const getFetchNullableUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Nullable object with nullable properties response
@@ -30,6 +41,17 @@ export const fetchNullableObject = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableObject | null>> => {
   return axios.get(`/nullable-object`, options);
+};
+export const getFetchNullableObjectUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-object`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -40,6 +62,17 @@ export const fetchNullableAnyObject = (
 ): Promise<AxiosResponse<NullableAnyObject | null>> => {
   return axios.get(`/nullable-any-object-key`, options);
 };
+export const getFetchNullableAnyObjectUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-any-object-key`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Nullable string enums
@@ -48,6 +81,17 @@ export const fetchNullableEnums = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableStringEnum | null>> => {
   return axios.get(`/nullable-string-enum`, options);
+};
+export const getFetchNullableEnumsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-string-enum`,
+      baseURL: '',
+    });
 };
 
 export type FetchNullableResult = AxiosResponse<string | null>;

--- a/tests/__snapshots__/default/null-type/endpoints.ts
+++ b/tests/__snapshots__/default/null-type/endpoints.ts
@@ -18,6 +18,17 @@ export const fetchNullable = (
 ): Promise<AxiosResponse<string | null>> => {
   return axios.get(`/nullable`, options);
 };
+export const getFetchNullableUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Nullable object response
@@ -26,6 +37,17 @@ export const fetchNullableObject = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableObject>> => {
   return axios.get(`/nullable-object`, options);
+};
+export const getFetchNullableObjectUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-object`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -57,6 +79,17 @@ export const nullableWithMultipartFormRequest = (
 
   return axios.post(`/nullable-with-multipart-form-data`, formData, options);
 };
+export const getNullableWithMultipartFormRequestUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-with-multipart-form-data`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Nullable $ref (type null + allOf) response
@@ -65,6 +98,17 @@ export const fetchNullableRef = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableRefContainer>> => {
   return axios.get(`/nullable-ref`, options);
+};
+export const getFetchNullableRefUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-ref`,
+      baseURL: '',
+    });
 };
 
 export type FetchNullableResult = AxiosResponse<string | null>;

--- a/tests/__snapshots__/default/nullable-any-of-refs/endpoints.ts
+++ b/tests/__snapshots__/default/nullable-any-of-refs/endpoints.ts
@@ -20,11 +20,33 @@ export const getPets = (
 ): Promise<AxiosResponse<Pets[]>> => {
   return axios.get(`/pets`, options);
 };
+export const getGetPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export const getAnimals = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Animals[]>> => {
   return axios.get(`/animals`, options);
+};
+export const getGetAnimalsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/animals`,
+      baseURL: '',
+    });
 };
 
 export const getNestedAnimals = (
@@ -32,17 +54,50 @@ export const getNestedAnimals = (
 ): Promise<AxiosResponse<NestedAnimals[]>> => {
   return axios.get(`/nested-animals`, options);
 };
+export const getGetNestedAnimalsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nested-animals`,
+      baseURL: '',
+    });
+};
 
 export const getMixedNullable = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<MixedNullable[]>> => {
   return axios.get(`/mixed-nullable`, options);
 };
+export const getGetMixedNullableUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/mixed-nullable`,
+      baseURL: '',
+    });
+};
 
 export const getMixedTypes = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<MixedTypes[]>> => {
   return axios.get(`/mixed-types`, options);
+};
+export const getGetMixedTypesUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/mixed-types`,
+      baseURL: '',
+    });
 };
 
 export type GetPetsResult = AxiosResponse<Pets[]>;

--- a/tests/__snapshots__/default/nullable-oneof-enums/endpoints.ts
+++ b/tests/__snapshots__/default/nullable-oneof-enums/endpoints.ts
@@ -21,11 +21,33 @@ export const getItems = (
 ): Promise<AxiosResponse<Item1[]>> => {
   return axios.get(`/items`, options);
 };
+export const getGetItemsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/items`,
+      baseURL: '',
+    });
+};
 
 export const getItemsWithMultipleProps = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Item3[]>> => {
   return axios.get(`/items-with-multiple-props`, options);
+};
+export const getGetItemsWithMultiplePropsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/items-with-multiple-props`,
+      baseURL: '',
+    });
 };
 
 export const getNestedItems = (
@@ -33,17 +55,50 @@ export const getNestedItems = (
 ): Promise<AxiosResponse<NestedItem[]>> => {
   return axios.get(`/nested-items`, options);
 };
+export const getGetNestedItemsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nested-items`,
+      baseURL: '',
+    });
+};
 
 export const getMixedEnumItems = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<MixedEnumItem[]>> => {
   return axios.get(`/mixed-enum-items`, options);
 };
+export const getGetMixedEnumItemsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/mixed-enum-items`,
+      baseURL: '',
+    });
+};
 
 export const getMixedTypeEnums = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<MixedTypeEnums[]>> => {
   return axios.get(`/mixed-type-enums`, options);
+};
+export const getGetMixedTypeEnumsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/mixed-type-enums`,
+      baseURL: '',
+    });
 };
 
 export type GetItemsResult = AxiosResponse<Item1[]>;

--- a/tests/__snapshots__/default/one-of-nested/endpoints.ts
+++ b/tests/__snapshots__/default/one-of-nested/endpoints.ts
@@ -15,5 +15,16 @@ export const example = (
 ): Promise<AxiosResponse<Example>> => {
   return axios.get(`/example`, options);
 };
+export const getExampleUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/example`,
+      baseURL: '',
+    });
+};
 
 export type ExampleResult = AxiosResponse<Example>;

--- a/tests/__snapshots__/default/one-of-primitive/endpoints.ts
+++ b/tests/__snapshots__/default/one-of-primitive/endpoints.ts
@@ -14,5 +14,16 @@ export const getPets = (
 ): Promise<AxiosResponse<Pets[]>> => {
   return axios.get(`/pets`, options);
 };
+export const getGetPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
 
 export type GetPetsResult = AxiosResponse<Pets[]>;

--- a/tests/__snapshots__/default/one-of-required/endpoints.ts
+++ b/tests/__snapshots__/default/one-of-required/endpoints.ts
@@ -15,5 +15,16 @@ export const createUser = (
 ): Promise<AxiosResponse<void>> => {
   return axios.post(`/users`, requestUser, options);
 };
+export const getCreateUserUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/users`,
+      baseURL: '',
+    });
+};
 
 export type CreateUserResult = AxiosResponse<void>;

--- a/tests/__snapshots__/default/one-of/endpoints.ts
+++ b/tests/__snapshots__/default/one-of/endpoints.ts
@@ -17,5 +17,16 @@ export const getOneOfWithNullableObject = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/one-of-with-nullable-object`, options);
 };
+export const getGetOneOfWithNullableObjectUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/one-of-with-nullable-object`,
+      baseURL: '',
+    });
+};
 
 export type GetOneOfWithNullableObjectResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/default/override-js-doc/endpoints.ts
+++ b/tests/__snapshots__/default/override-js-doc/endpoints.ts
@@ -276,6 +276,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -290,6 +302,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -300,6 +324,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -309,6 +344,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -322,6 +368,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -331,6 +388,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/override-mock/endpoints.ts
+++ b/tests/__snapshots__/default/override-mock/endpoints.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore-filter-exclude-mode/endpoints.ts
+++ b/tests/__snapshots__/default/petstore-filter-exclude-mode/endpoints.ts
@@ -165,6 +165,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -179,6 +191,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -189,6 +213,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -198,6 +233,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -211,6 +257,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -220,6 +277,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore-filter/endpoints.ts
+++ b/tests/__snapshots__/default/petstore-filter/endpoints.ts
@@ -34,5 +34,16 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/default/petstore-naming-convention-camel-case/endpoints/swaggerPetstore.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-camel-case/endpoints/swaggerPetstore.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore-naming-convention-kebab-case/endpoints/swagger-petstore.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-kebab-case/endpoints/swagger-petstore.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore-naming-convention-pascal-case/endpoints/SwaggerPetstore.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-pascal-case/endpoints/SwaggerPetstore.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore-naming-convention-snake-case/endpoints/swagger_petstore.ts
+++ b/tests/__snapshots__/default/petstore-naming-convention-snake-case/endpoints/swagger_petstore.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore-transformer/endpoints.ts
+++ b/tests/__snapshots__/default/petstore-transformer/endpoints.ts
@@ -29,6 +29,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams, version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -44,6 +56,21 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (
+  params: CreatePetsParams,
+  version: number = 1,
+) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -55,6 +82,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/v${version}/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string, version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -65,6 +103,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/v${version}/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string, version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -79,6 +128,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = (version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -89,6 +149,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/v${version}/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string, version: number = 1) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/petstore/endpoints.ts
+++ b/tests/__snapshots__/default/petstore/endpoints.ts
@@ -165,6 +165,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -179,6 +191,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -189,6 +213,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -198,6 +233,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -211,6 +257,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -220,6 +277,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/readonly/endpoints.ts
+++ b/tests/__snapshots__/default/readonly/endpoints.ts
@@ -52,6 +52,17 @@ export const createReadonlyFreeObject = (
 ): Promise<AxiosResponse<ReadonlyObject>> => {
   return axios.post(`/without-readonly`, createReadonlyFreeObjectBody, options);
 };
+export const getCreateReadonlyFreeObjectUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/without-readonly`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Create readonly object
@@ -61,6 +72,17 @@ export const createReadonly = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<ReadonlyObject>> => {
   return axios.post(`/readonly-ref`, readonlyObject, options);
+};
+export const getCreateReadonlyUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/readonly-ref`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -72,6 +94,17 @@ export const updateReadonly = (
 ): Promise<AxiosResponse<ReadonlyObject>> => {
   return axios.put(`/readonly-direct`, updateReadonlyBody, options);
 };
+export const getUpdateReadonlyUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/readonly-direct`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Create object with a nested readonly object
@@ -81,6 +114,17 @@ export const createNestedReadonly = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NestedReadonlyObject>> => {
   return axios.post(`/readonly-nested`, nestedReadonlyObject, options);
+};
+export const getCreateNestedReadonlyUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/readonly-nested`,
+      baseURL: '',
+    });
 };
 
 export type CreateReadonlyFreeObjectResult = AxiosResponse<ReadonlyObject>;

--- a/tests/__snapshots__/default/regressions/dup-tag/dup-tag.ts
+++ b/tests/__snapshots__/default/regressions/dup-tag/dup-tag.ts
@@ -12,25 +12,80 @@ export const getEndpointA = (
 ): Promise<AxiosResponse<void>> => {
   return axios.get(`/endpointA`, options);
 };
+export const getGetEndpointAUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/endpointA`,
+      baseURL: '',
+    });
+};
 export const getEndpointB = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.get(`/endpointB`, options);
+};
+export const getGetEndpointBUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/endpointB`,
+      baseURL: '',
+    });
 };
 export const getEndpointC = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.get(`/endpointC`, options);
 };
+export const getGetEndpointCUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/endpointC`,
+      baseURL: '',
+    });
+};
 export const getEndpointD = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.get(`/endpointD`, options);
 };
+export const getGetEndpointDUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/endpointD`,
+      baseURL: '',
+    });
+};
 export const getEndpointE = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.get(`/endpointE`, options);
+};
+export const getGetEndpointEUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/endpointE`,
+      baseURL: '',
+    });
 };
 export type GetEndpointAResult = AxiosResponse<void>;
 export type GetEndpointBResult = AxiosResponse<void>;

--- a/tests/__snapshots__/default/runtime-mock-delay/endpoints.ts
+++ b/tests/__snapshots__/default/runtime-mock-delay/endpoints.ts
@@ -28,6 +28,18 @@ export const listPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getListPetsUrl = (params: ListPetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Create a pet
@@ -42,6 +54,18 @@ export const createPets = (
     params: { ...params, ...options?.params },
   });
 };
+export const getCreatePetsUrl = (params: CreatePetsParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
 
 /**
  * @summary Info for a specific pet
@@ -52,6 +76,17 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Deletes a specific pet
@@ -61,6 +96,17 @@ export const deletePetById = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<void>> => {
   return axios.delete(`/pets/${petId}`, options);
+};
+export const getDeletePetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -74,6 +120,17 @@ export const healthCheck = (
     ...options,
   });
 };
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary combinate nullable and $ref
@@ -83,6 +140,17 @@ export const showPetWithOwner = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<PetWithTag>> => {
   return axios.get(`/pets/${petId}/owner`, options);
+};
+export const getShowPetWithOwnerUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/default/split-by-content-type/endpoints.ts
+++ b/tests/__snapshots__/default/split-by-content-type/endpoints.ts
@@ -19,6 +19,17 @@ export const updateProfileWithJson = (
 ): Promise<AxiosResponse<Profile>> => {
   return axios.put(`/profiles/${id}`, updateProfileBody, options);
 };
+export const getUpdateProfileWithJsonUrl = (id: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/profiles/${id}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Update a profile
@@ -36,6 +47,17 @@ export const updateProfileWithFormData = (
 
   return axios.put(`/profiles/${id}`, formData, options);
 };
+export const getUpdateProfileWithFormDataUrl = (id: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/profiles/${id}`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Upload an avatar
@@ -52,6 +74,17 @@ export const uploadAvatarWithFormData = (
 
   return axios.post(`/avatars`, formData, options);
 };
+export const getUploadAvatarWithFormDataUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/avatars`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Upload an avatar
@@ -62,6 +95,17 @@ export const uploadAvatarWithBlob = (
 ): Promise<AxiosResponse<Avatar>> => {
   return axios.post(`/avatars`, uploadAvatarBody, options);
 };
+export const getUploadAvatarWithBlobUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/avatars`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary List profiles
@@ -70,6 +114,17 @@ export const listProfiles = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Profile[]>> => {
   return axios.get(`/profiles`, options);
+};
+export const getListProfilesUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/profiles`,
+      baseURL: '',
+    });
 };
 
 export type UpdateProfileWithJsonResult = AxiosResponse<Profile>;

--- a/tests/__snapshots__/default/translation/endpoints.ts
+++ b/tests/__snapshots__/default/translation/endpoints.ts
@@ -19,5 +19,16 @@ export const retrieveTranslations = (
 ): Promise<AxiosResponse<RetrieveTranslations200>> => {
   return axios.get(`/${locale}.js`, options);
 };
+export const getRetrieveTranslationsUrl = (locale: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/${locale}.js`,
+      baseURL: '',
+    });
+};
 
 export type RetrieveTranslationsResult = AxiosResponse<RetrieveTranslations200>;

--- a/tests/__snapshots__/factory-methods/combined/endpoints.ts
+++ b/tests/__snapshots__/factory-methods/combined/endpoints.ts
@@ -21,5 +21,17 @@ export const getTest = (
       `/test`,options
     );
   }
+export const getGetTestUrl = () => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/test`,
+    baseURL: '',
+
+
+  });
+}
 
 export type GetTestResult = AxiosResponse<User>

--- a/tests/__snapshots__/factory-methods/inline/endpoints.ts
+++ b/tests/__snapshots__/factory-methods/inline/endpoints.ts
@@ -21,5 +21,17 @@ export const getTest = (
       `/test`,options
     );
   }
+export const getGetTestUrl = () => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/test`,
+    baseURL: '',
+
+
+  });
+}
 
 export type GetTestResult = AxiosResponse<User>

--- a/tests/__snapshots__/factory-methods/separate/endpoints.ts
+++ b/tests/__snapshots__/factory-methods/separate/endpoints.ts
@@ -21,5 +21,17 @@ export const getTest = (
       `/test`,options
     );
   }
+export const getGetTestUrl = () => {
+
+  return axios.create({
+    baseURL: '',
+    params: null,
+  }).getUri({
+    url: `/test`,
+    baseURL: '',
+
+
+  });
+}
 
 export type GetTestResult = AxiosResponse<User>

--- a/tests/__snapshots__/mock/allof-shared-base/endpoints.ts
+++ b/tests/__snapshots__/mock/allof-shared-base/endpoints.ts
@@ -17,5 +17,16 @@ export const getAllOfSharedBase = (
 ): Promise<AxiosResponse<Response>> => {
   return axios.get(`/allof-shared-base`, options);
 };
+export const getGetAllOfSharedBaseUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/allof-shared-base`,
+      baseURL: '',
+    });
+};
 
 export type GetAllOfSharedBaseResult = AxiosResponse<Response>;

--- a/tests/__snapshots__/mock/circular/endpoints.ts
+++ b/tests/__snapshots__/mock/circular/endpoints.ts
@@ -22,6 +22,17 @@ export const getExample = (
 ): Promise<AxiosResponse<Node>> => {
   return axios.get(`/example`, options);
 };
+export const getGetExampleUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/example`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Node with required child
@@ -30,6 +41,17 @@ export const getNodeWithRequiredChild = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NodeWithRequiredChild>> => {
   return axios.get(`/node-with-required-child`, options);
+};
+export const getGetNodeWithRequiredChildUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/node-with-required-child`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -44,6 +66,18 @@ export const addList = (
     ...options,
     params: { ...params, ...options?.params },
   });
+};
+export const getAddListUrl = (params?: AddListParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/list`,
+      baseURL: '',
+      params,
+    });
 };
 
 export type GetExampleResult = AxiosResponse<Node>;

--- a/tests/__snapshots__/mock/discriminator-oneof-allof-inherited/endpoints.ts
+++ b/tests/__snapshots__/mock/discriminator-oneof-allof-inherited/endpoints.ts
@@ -14,5 +14,16 @@ export const getAnimal = (
 ): Promise<AxiosResponse<Animal>> => {
   return axios.get(`/animal`, options);
 };
+export const getGetAnimalUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/animal`,
+      baseURL: '',
+    });
+};
 
 export type GetAnimalResult = AxiosResponse<Animal>;

--- a/tests/__snapshots__/mock/discriminator-oneof-allof/endpoints.ts
+++ b/tests/__snapshots__/mock/discriminator-oneof-allof/endpoints.ts
@@ -14,5 +14,16 @@ export const getTest = (
 ): Promise<AxiosResponse<DiscriminatorTest>> => {
   return axios.get(`/test`, options);
 };
+export const getGetTestUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/test`,
+      baseURL: '',
+    });
+};
 
 export type GetTestResult = AxiosResponse<DiscriminatorTest>;

--- a/tests/__snapshots__/mock/discriminator-oneof-union/endpoints.ts
+++ b/tests/__snapshots__/mock/discriminator-oneof-union/endpoints.ts
@@ -14,5 +14,16 @@ export const getTest = (
 ): Promise<AxiosResponse<DiscriminatorTest>> => {
   return axios.get(`/test`, options);
 };
+export const getGetTestUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/test`,
+      baseURL: '',
+    });
+};
 
 export type GetTestResult = AxiosResponse<DiscriminatorTest>;

--- a/tests/__snapshots__/mock/endpoints-named-delay/endpoints.ts
+++ b/tests/__snapshots__/mock/endpoints-named-delay/endpoints.ts
@@ -22,5 +22,17 @@ export const delayInName = (
     params: { ...params, ...options?.params },
   });
 };
+export const getDelayInNameUrl = (params?: DelayInNameParams) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/delay-in-name`,
+      baseURL: '',
+      params,
+    });
+};
 
 export type DelayInNameResult = AxiosResponse<void>;

--- a/tests/__snapshots__/mock/enumRefs/sample.ts
+++ b/tests/__snapshots__/mock/enumRefs/sample.ts
@@ -16,6 +16,17 @@ export const getSample = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<SampleStepsResponse>> => {
     return axiosInstance.get(`/sampleApi`, options);
   };
-  return { getSampleApi };
+  const getGetSampleApiUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/sampleApi`,
+        baseURL: '',
+      });
+  };
+  return { getSampleApi, getGetSampleApiUrl };
 };
 export type GetSampleApiResult = AxiosResponse<SampleStepsResponse>;

--- a/tests/__snapshots__/mock/enums-inline-tags-split-native/template/template.ts
+++ b/tests/__snapshots__/mock/enums-inline-tags-split-native/template/template.ts
@@ -18,4 +18,15 @@ export const getTemplate = (
 ): Promise<AxiosResponse<Template>> => {
   return axios.get(`/api/template`, options);
 };
+export const getGetTemplateUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/template`,
+      baseURL: '',
+    });
+};
 export type GetTemplateResult = AxiosResponse<Template>;

--- a/tests/__snapshots__/mock/enums-inline-tags-split-native/user/user.ts
+++ b/tests/__snapshots__/mock/enums-inline-tags-split-native/user/user.ts
@@ -18,4 +18,15 @@ export const getUser = (
 ): Promise<AxiosResponse<User>> => {
   return axios.get(`/api/user`, options);
 };
+export const getGetUserUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/user`,
+      baseURL: '',
+    });
+};
 export type GetUserResult = AxiosResponse<User>;

--- a/tests/__snapshots__/mock/faker-array-items-tags-split/alpha/alpha.ts
+++ b/tests/__snapshots__/mock/faker-array-items-tags-split/alpha/alpha.ts
@@ -15,6 +15,17 @@ export const getAlpha = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<TenantListResponse>> => {
     return axiosInstance.get(`/a`, options);
   };
-  return { getA };
+  const getGetAUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/a`,
+        baseURL: '',
+      });
+  };
+  return { getA, getGetAUrl };
 };
 export type GetAResult = AxiosResponse<TenantListResponse>;

--- a/tests/__snapshots__/mock/faker-array-items-tags-split/beta/beta.ts
+++ b/tests/__snapshots__/mock/faker-array-items-tags-split/beta/beta.ts
@@ -15,6 +15,17 @@ export const getBeta = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<TenantListResponse>> => {
     return axiosInstance.get(`/b`, options);
   };
-  return { getB };
+  const getGetBUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/b`,
+        baseURL: '',
+      });
+  };
+  return { getB, getGetBUrl };
 };
 export type GetBResult = AxiosResponse<TenantListResponse>;

--- a/tests/__snapshots__/mock/faker-array-items/endpoints.ts
+++ b/tests/__snapshots__/mock/faker-array-items/endpoints.ts
@@ -24,11 +24,33 @@ export const getFakerArrayItemFactories = (
   ): Promise<AxiosResponse<GetTenants200>> => {
     return axiosInstance.get(`/tenants`, options);
   };
+  const getGetTenantsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/tenants`,
+        baseURL: '',
+      });
+  };
 
   const getTenantsByRef = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<TenantListResponse>> => {
     return axiosInstance.get(`/tenants-by-ref`, options);
+  };
+  const getGetTenantsByRefUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/tenants-by-ref`,
+        baseURL: '',
+      });
   };
 
   const getTenantsA = (
@@ -36,11 +58,33 @@ export const getFakerArrayItemFactories = (
   ): Promise<AxiosResponse<TenantListResponse>> => {
     return axiosInstance.get(`/tenants-a`, options);
   };
+  const getGetTenantsAUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/tenants-a`,
+        baseURL: '',
+      });
+  };
 
   const getTenantsB = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<TenantListResponse>> => {
     return axiosInstance.get(`/tenants-b`, options);
+  };
+  const getGetTenantsBUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/tenants-b`,
+        baseURL: '',
+      });
   };
 
   const getNames = (
@@ -48,11 +92,33 @@ export const getFakerArrayItemFactories = (
   ): Promise<AxiosResponse<GetNames200>> => {
     return axiosInstance.get(`/names`, options);
   };
+  const getGetNamesUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/names`,
+        baseURL: '',
+      });
+  };
 
   const getThings = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<GetThings200>> => {
     return axiosInstance.get(`/things`, options);
+  };
+  const getGetThingsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/things`,
+        baseURL: '',
+      });
   };
 
   const getNullable = (
@@ -60,11 +126,33 @@ export const getFakerArrayItemFactories = (
   ): Promise<AxiosResponse<GetNullable200>> => {
     return axiosInstance.get(`/nullable-rows`, options);
   };
+  const getGetNullableUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/nullable-rows`,
+        baseURL: '',
+      });
+  };
 
   const getCollide = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<GetCollide200>> => {
     return axiosInstance.get(`/collide`, options);
+  };
+  const getGetCollideUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/collide`,
+        baseURL: '',
+      });
   };
 
   return {
@@ -76,6 +164,14 @@ export const getFakerArrayItemFactories = (
     getThings,
     getNullable,
     getCollide,
+    getGetTenantsUrl,
+    getGetTenantsByRefUrl,
+    getGetTenantsAUrl,
+    getGetTenantsBUrl,
+    getGetNamesUrl,
+    getGetThingsUrl,
+    getGetNullableUrl,
+    getGetCollideUrl,
   };
 };
 export type GetTenantsResult = AxiosResponse<GetTenants200>;

--- a/tests/__snapshots__/mock/formats/endpoints.ts
+++ b/tests/__snapshots__/mock/formats/endpoints.ts
@@ -18,5 +18,16 @@ export const showPetById = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${petId}`, options);
 };
+export const getShowPetByIdUrl = (petId: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
 
 export type ShowPetByIdResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/issue-2327/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-2327/endpoints.ts
@@ -17,7 +17,18 @@ export const getIssue2327BaseMockHandlerContentTypeWithMixedStatusCodes = (
   ): Promise<AxiosResponse<Pets>> => {
     return axiosInstance.get(`/pets`, options);
   };
+  const getListPetsUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+      });
+  };
 
-  return { listPets };
+  return { listPets, getListPetsUrl };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/issue-3200/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3200/endpoints.ts
@@ -23,14 +23,41 @@ export const getIssue3200 = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<StringToIntegerMap>> => {
     return axiosInstance.get(`/integer-map`, options);
   };
+  const getGetIntegerMapUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/integer-map`,
+        baseURL: '',
+      });
+  };
 
   const getNumberMap = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<StringToNumberMap>> => {
     return axiosInstance.get(`/number-map`, options);
   };
+  const getGetNumberMapUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/number-map`,
+        baseURL: '',
+      });
+  };
 
-  return { getIntegerMap, getNumberMap };
+  return {
+    getIntegerMap,
+    getNumberMap,
+    getGetIntegerMapUrl,
+    getGetNumberMapUrl,
+  };
 };
 export type GetIntegerMapResult = AxiosResponse<StringToIntegerMap>;
 export type GetNumberMapResult = AxiosResponse<StringToNumberMap>;

--- a/tests/__snapshots__/mock/issue-3505/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3505/endpoints.ts
@@ -17,7 +17,18 @@ export const getOrvalEnumValueEscapingRepro = (
   ): Promise<AxiosResponse<Ping200>> => {
     return axiosInstance.get(`/ping`, options);
   };
+  const getPingUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/ping`,
+        baseURL: '',
+      });
+  };
 
-  return { ping };
+  return { ping, getPingUrl };
 };
 export type PingResult = AxiosResponse<Ping200>;

--- a/tests/__snapshots__/mock/issue-3691/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3691/endpoints.ts
@@ -17,7 +17,18 @@ export const getIssue3691TuplePrefixItemsMock = (
   ): Promise<AxiosResponse<Example>> => {
     return axiosInstance.get(`/example`, options);
   };
+  const getGetExampleUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/example`,
+        baseURL: '',
+      });
+  };
 
-  return { getExample };
+  return { getExample, getGetExampleUrl };
 };
 export type GetExampleResult = AxiosResponse<Example>;

--- a/tests/__snapshots__/mock/mixed-success-status/endpoints.ts
+++ b/tests/__snapshots__/mock/mixed-success-status/endpoints.ts
@@ -21,6 +21,17 @@ export const getMixedSuccessStatusAPI = (
   ): Promise<AxiosResponse<Resource[]>> => {
     return axiosInstance.get(`/resources`, options);
   };
+  const getListResourcesUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/resources`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Get a resource
@@ -30,6 +41,17 @@ export const getMixedSuccessStatusAPI = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Resource | void>> => {
     return axiosInstance.get(`/resources/${resourceId}`, options);
+  };
+  const getGetResourceUrl = (resourceId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/resources/${resourceId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -41,8 +63,26 @@ export const getMixedSuccessStatusAPI = (
   ): Promise<AxiosResponse<Resource | void>> => {
     return axiosInstance.delete(`/resources/${resourceId}`, options);
   };
+  const getDeleteResourceUrl = (resourceId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/resources/${resourceId}`,
+        baseURL: '',
+      });
+  };
 
-  return { listResources, getResource, deleteResource };
+  return {
+    listResources,
+    getResource,
+    deleteResource,
+    getListResourcesUrl,
+    getGetResourceUrl,
+    getDeleteResourceUrl,
+  };
 };
 export type ListResourcesResult = AxiosResponse<Resource[]>;
 export type GetResourceResult = AxiosResponse<Resource | void>;

--- a/tests/__snapshots__/mock/mock-constraints/endpoints.ts
+++ b/tests/__snapshots__/mock/mock-constraints/endpoints.ts
@@ -18,5 +18,16 @@ export const getItems = (
 ): Promise<AxiosResponse<ConstrainedItem>> => {
   return axios.get(`/items`, options);
 };
+export const getGetItemsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/items`,
+      baseURL: '',
+    });
+};
 
 export type GetItemsResult = AxiosResponse<ConstrainedItem>;

--- a/tests/__snapshots__/mock/msw-array-items/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-array-items/endpoints.ts
@@ -17,7 +17,18 @@ export const getMSWArrayItemFactories = (
   ): Promise<AxiosResponse<TenantListResponse>> => {
     return axiosInstance.get(`/tenants-by-ref`, options);
   };
+  const getGetTenantsByRefUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/tenants-by-ref`,
+        baseURL: '',
+      });
+  };
 
-  return { getTenantsByRef };
+  return { getTenantsByRef, getGetTenantsByRefUrl };
 };
 export type GetTenantsByRefResult = AxiosResponse<TenantListResponse>;

--- a/tests/__snapshots__/mock/msw-binary-multi-content/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-binary-multi-content/endpoints.ts
@@ -18,7 +18,18 @@ export const getBinaryMultiContent = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getGetProfilePictureUrl = (id: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/api/account/profile-picture-file/${id}`,
+        baseURL: '',
+      });
+  };
 
-  return { getProfilePicture };
+  return { getProfilePicture, getGetProfilePictureUrl };
 };
 export type GetProfilePictureResult = AxiosResponse<Blob>;

--- a/tests/__snapshots__/mock/msw-mixed-content-union-each-status/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-mixed-content-union-each-status/endpoints.ts
@@ -20,7 +20,18 @@ export const getMSWMixedContentEachStatusRegression = (
   ): Promise<AxiosResponse<string | Pet>> => {
     return axiosInstance.get(`/mixed-content-each-status`, options);
   };
+  const getGetMixedContentEachStatusUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/mixed-content-each-status`,
+        baseURL: '',
+      });
+  };
 
-  return { getMixedContentEachStatus };
+  return { getMixedContentEachStatus, getGetMixedContentEachStatusUrl };
 };
 export type GetMixedContentEachStatusResult = AxiosResponse<string | Pet>;

--- a/tests/__snapshots__/mock/msw-mixed-content-union-preferred-json/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-mixed-content-union-preferred-json/endpoints.ts
@@ -20,7 +20,18 @@ export const getMSWMixedContentUnionRegression = (
   ): Promise<AxiosResponse<string | Pet>> => {
     return axiosInstance.get(`/mixed-content`, options);
   };
+  const getGetMixedContentUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/mixed-content`,
+        baseURL: '',
+      });
+  };
 
-  return { getMixedContent };
+  return { getMixedContent, getGetMixedContentUrl };
 };
 export type GetMixedContentResult = AxiosResponse<string | Pet>;

--- a/tests/__snapshots__/mock/msw-mixed-content-union-vendor/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-mixed-content-union-vendor/endpoints.ts
@@ -20,7 +20,18 @@ export const getMSWMixedVendorMediaRegression = (
   ): Promise<AxiosResponse<string | Pet>> => {
     return axiosInstance.get(`/mixed-content-vendor`, options);
   };
+  const getGetMixedContentVendorUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/mixed-content-vendor`,
+        baseURL: '',
+      });
+  };
 
-  return { getMixedContentVendor };
+  return { getMixedContentVendor, getGetMixedContentVendorUrl };
 };
 export type GetMixedContentVendorResult = AxiosResponse<string | Pet>;

--- a/tests/__snapshots__/mock/msw-mixed-content-union/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-mixed-content-union/endpoints.ts
@@ -20,7 +20,18 @@ export const getMSWMixedContentUnionRegression = (
   ): Promise<AxiosResponse<string | Pet>> => {
     return axiosInstance.get(`/mixed-content`, options);
   };
+  const getGetMixedContentUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/mixed-content`,
+        baseURL: '',
+      });
+  };
 
-  return { getMixedContent };
+  return { getMixedContent, getGetMixedContentUrl };
 };
 export type GetMixedContentResult = AxiosResponse<string | Pet>;

--- a/tests/__snapshots__/mock/msw-problem-details-content-type/endpoints.ts
+++ b/tests/__snapshots__/mock/msw-problem-details-content-type/endpoints.ts
@@ -21,7 +21,18 @@ export const getMSWProblemDetailsContentType = (
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getGetPetUrl = (petId: number) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
-  return { getPet };
+  return { getPet, getGetPetUrl };
 };
 export type GetPetResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/null-type/endpoints.ts
+++ b/tests/__snapshots__/mock/null-type/endpoints.ts
@@ -18,6 +18,17 @@ export const fetchNullable = (
 ): Promise<AxiosResponse<string | null>> => {
   return axios.get(`/nullable`, options);
 };
+export const getFetchNullableUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Nullable object response
@@ -26,6 +37,17 @@ export const fetchNullableObject = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableObject>> => {
   return axios.get(`/nullable-object`, options);
+};
+export const getFetchNullableObjectUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-object`,
+      baseURL: '',
+    });
 };
 
 /**
@@ -57,6 +79,17 @@ export const nullableWithMultipartFormRequest = (
 
   return axios.post(`/nullable-with-multipart-form-data`, formData, options);
 };
+export const getNullableWithMultipartFormRequestUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-with-multipart-form-data`,
+      baseURL: '',
+    });
+};
 
 /**
  * @summary Nullable $ref (type null + allOf) response
@@ -65,6 +98,17 @@ export const fetchNullableRef = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<NullableRefContainer>> => {
   return axios.get(`/nullable-ref`, options);
+};
+export const getFetchNullableRefUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/nullable-ref`,
+      baseURL: '',
+    });
 };
 
 export type FetchNullableResult = AxiosResponse<string | null>;

--- a/tests/__snapshots__/mock/petstore-custom-mock-builder-split/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore-custom-mock-builder-split/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/petstore-custom-mock-builder-tags-split/health/health.ts
+++ b/tests/__snapshots__/mock/petstore-custom-mock-builder-tags-split/health/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/petstore-custom-mock-builder-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/mock/petstore-custom-mock-builder-tags-split/pets/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/petstore-custom-mock-builder/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore-custom-mock-builder/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/petstore-each-http-status/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore-each-http-status/endpoints.ts
@@ -17,11 +17,33 @@ export const getOrvalDefaultStatusTest = (
   ): Promise<AxiosResponse<Sample>> => {
     return axiosInstance.get(`/default-only`, options);
   };
+  const getDefaultOnlyUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/default-only`,
+        baseURL: '',
+      });
+  };
 
   const with200 = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Sample>> => {
     return axiosInstance.get(`/w-200`, options);
+  };
+  const getWith200Url = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/w-200`,
+        baseURL: '',
+      });
   };
 
   const with400 = (
@@ -29,14 +51,45 @@ export const getOrvalDefaultStatusTest = (
   ): Promise<AxiosResponse<Sample>> => {
     return axiosInstance.get(`/w-400`, options);
   };
+  const getWith400Url = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/w-400`,
+        baseURL: '',
+      });
+  };
 
   const with200and400 = (
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Sample>> => {
     return axiosInstance.get(`/w-200-400`, options);
   };
+  const getWith200and400Url = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/w-200-400`,
+        baseURL: '',
+      });
+  };
 
-  return { defaultOnly, with200, with400, with200and400 };
+  return {
+    defaultOnly,
+    with200,
+    with400,
+    with200and400,
+    getDefaultOnlyUrl,
+    getWith200Url,
+    getWith400Url,
+    getWith200and400Url,
+  };
 };
 export type DefaultOnlyResult = AxiosResponse<Sample>;
 export type With200Result = AxiosResponse<Sample>;

--- a/tests/__snapshots__/mock/petstore-faker-schemas-and-ops/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore-faker-schemas-and-ops/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/petstore-faker-schemas/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore-faker-schemas/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/mock/petstore-tags-split/health/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/mock/petstore-tags-split/pets/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/petstore/endpoints.ts
+++ b/tests/__snapshots__/mock/petstore/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/recursive-discriminator-allof/endpoints.ts
+++ b/tests/__snapshots__/mock/recursive-discriminator-allof/endpoints.ts
@@ -14,11 +14,33 @@ export const getDerived1 = (
 ): Promise<AxiosResponse<Derived1>> => {
   return axios.get(`/derived1`, options);
 };
+export const getGetDerived1Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/derived1`,
+      baseURL: '',
+    });
+};
 
 export const getDerived2 = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Derived2>> => {
   return axios.get(`/derived2`, options);
+};
+export const getGetDerived2Url = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/derived2`,
+      baseURL: '',
+    });
 };
 
 export type GetDerived1Result = AxiosResponse<Derived1>;

--- a/tests/__snapshots__/mock/single-mock-path/endpoints.ts
+++ b/tests/__snapshots__/mock/single-mock-path/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/split-mock-path/endpoints.ts
+++ b/tests/__snapshots__/mock/split-mock-path/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/split-msw-handlers-only/endpoints.ts
+++ b/tests/__snapshots__/mock/split-msw-handlers-only/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/split/endpoints.ts
+++ b/tests/__snapshots__/mock/split/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/mock/tags-mock-path/health.ts
+++ b/tests/__snapshots__/mock/tags-mock-path/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/tags-mock-path/pets.ts
+++ b/tests/__snapshots__/mock/tags-mock-path/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/tags-split-mock-path/health/health.ts
+++ b/tests/__snapshots__/mock/tags-split-mock-path/health/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/tags-split-mock-path/pets/pets.ts
+++ b/tests/__snapshots__/mock/tags-split-mock-path/pets/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/tags-split-msw-handlers-only/health/health.ts
+++ b/tests/__snapshots__/mock/tags-split-msw-handlers-only/health/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/tags-split-msw-handlers-only/pets/pets.ts
+++ b/tests/__snapshots__/mock/tags-split-msw-handlers-only/pets/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/tags-split-per-generator-path/health/health.ts
+++ b/tests/__snapshots__/mock/tags-split-per-generator-path/health/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/tags-split-per-generator-path/pets/pets.ts
+++ b/tests/__snapshots__/mock/tags-split-per-generator-path/pets/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/tags/health.ts
+++ b/tests/__snapshots__/mock/tags/health.ts
@@ -19,6 +19,17 @@ export const getHealth = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
-  return { healthCheck };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
+  return { healthCheck, getHealthCheckUrl };
 };
 export type HealthCheckResult = AxiosResponse<string>;

--- a/tests/__snapshots__/mock/tags/pets.ts
+++ b/tests/__snapshots__/mock/tags/pets.ts
@@ -29,6 +29,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Create a pet
    */
@@ -42,6 +54,18 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
   /**
    * @summary Info for a specific pet
    */
@@ -50,6 +74,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
+  };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
   /**
    * @summary Deletes a specific pet
@@ -60,6 +95,17 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
   };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
   /**
    * @summary combinate nullable and $ref
    */
@@ -69,7 +115,29 @@ export const getPets = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
-  return { listPets, createPets, showPetById, deletePetById, showPetWithOwner };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
+  return {
+    listPets,
+    createPets,
+    showPetById,
+    deletePetById,
+    showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getShowPetWithOwnerUrl,
+  };
 };
 export type ListPetsResult = AxiosResponse<Pets>;
 export type CreatePetsResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/mock/typelessEnum/typelessEnums.ts
+++ b/tests/__snapshots__/mock/typelessEnum/typelessEnums.ts
@@ -17,5 +17,16 @@ export const getApiColors = (
 ): Promise<AxiosResponse<ColorObject>> => {
   return axios.get(`/api/colors`, options);
 };
+export const getGetApiColorsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/colors`,
+      baseURL: '',
+    });
+};
 
 export type GetApiColorsResult = AxiosResponse<ColorObject>;

--- a/tests/__snapshots__/mock/union-enum-ref-msw/endpoints.ts
+++ b/tests/__snapshots__/mock/union-enum-ref-msw/endpoints.ts
@@ -21,7 +21,18 @@ export const getUnionEnumRefMock = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<DisplayValueDto>> => {
     return axiosInstance.get(`/display`, options);
   };
+  const getGetDisplayUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/display`,
+        baseURL: '',
+      });
+  };
 
-  return { getDisplay };
+  return { getDisplay, getGetDisplayUrl };
 };
 export type GetDisplayResult = AxiosResponse<DisplayValueDto>;

--- a/tests/__snapshots__/mock/use-dates-examples/endpoints.ts
+++ b/tests/__snapshots__/mock/use-dates-examples/endpoints.ts
@@ -46,6 +46,18 @@ export const listPets = (
   return axios.get(`/pets`, options);
 };
 
+export const getListPetsUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+    });
+};
+
 export const getListPetsQueryKey = () => {
   return [`/pets`] as const;
 };
@@ -167,6 +179,18 @@ export const getPet = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<Pet>> => {
   return axios.get(`/pets/${id}`, options);
+};
+
+export const getGetPetUrl = (id: string) => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${id}`,
+      baseURL: '',
+    });
 };
 
 export const getGetPetQueryKey = (id: string) => {

--- a/tests/__snapshots__/mock/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/mock/zod-schema-response/endpoints.ts
@@ -29,6 +29,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getListPetsUrl = (params: ListPetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Create a pet
@@ -43,6 +55,18 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       params: { ...params, ...options?.params },
     });
   };
+  const getCreatePetsUrl = (params: CreatePetsParams) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets`,
+        baseURL: '',
+        params,
+      });
+  };
 
   /**
    * @summary Info for a specific pet
@@ -53,6 +77,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<Pet>> => {
     return axiosInstance.get(`/pets/${petId}`, options);
   };
+  const getShowPetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary Deletes a specific pet
@@ -62,6 +97,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     options?: AxiosRequestConfig,
   ): Promise<AxiosResponse<void>> => {
     return axiosInstance.delete(`/pets/${petId}`, options);
+  };
+  const getDeletePetByIdUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}`,
+        baseURL: '',
+      });
   };
 
   /**
@@ -75,6 +121,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
       ...options,
     });
   };
+  const getHealthCheckUrl = () => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/health`,
+        baseURL: '',
+      });
+  };
 
   /**
    * @summary combinate nullable and $ref
@@ -85,6 +142,17 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
   ): Promise<AxiosResponse<PetWithTag>> => {
     return axiosInstance.get(`/pets/${petId}/owner`, options);
   };
+  const getShowPetWithOwnerUrl = (petId: string) => {
+    return axiosInstance
+      .create({
+        baseURL: '',
+        params: null,
+      })
+      .getUri({
+        url: `/pets/${petId}/owner`,
+        baseURL: '',
+      });
+  };
 
   return {
     listPets,
@@ -93,6 +161,12 @@ export const getSwaggerPetstore = (axiosInstance: AxiosInstance = axios) => {
     deletePetById,
     healthCheck,
     showPetWithOwner,
+    getListPetsUrl,
+    getCreatePetsUrl,
+    getShowPetByIdUrl,
+    getDeletePetByIdUrl,
+    getHealthCheckUrl,
+    getShowPetWithOwnerUrl,
   };
 };
 export type ListPetsResult = AxiosResponse<Pets>;

--- a/tests/__snapshots__/multi-files/api/endpoints.ts
+++ b/tests/__snapshots__/multi-files/api/endpoints.ts
@@ -24,5 +24,16 @@ export const putPet = (
 ): Promise<AxiosResponse<Pet>> => {
   return axios.put(`/my-path`, pet, options);
 };
+export const getPutPetUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/my-path`,
+      baseURL: '',
+    });
+};
 
 export type PutPetResult = AxiosResponse<Pet>;

--- a/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
+++ b/tests/__snapshots__/react-query/tag-hook-mutator-axios/endpoints.ts
@@ -567,6 +567,18 @@ export const healthCheck = (
   });
 };
 
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
+
 export const getHealthCheckQueryKey = () => {
   return [`/health`] as const;
 };

--- a/tests/__snapshots__/vue-query/issue-1026/endpoints.ts
+++ b/tests/__snapshots__/vue-query/issue-1026/endpoints.ts
@@ -37,6 +37,18 @@ export const getSomeEndpoint = (
   });
 };
 
+export const getGetSomeEndpointUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/api/v1/someEndPoint`,
+      baseURL: '',
+    });
+};
+
 export const getGetSomeEndpointQueryKey = () => {
   return ['api', 'v1', 'someEndPoint'] as const;
 };

--- a/tests/__snapshots__/vue-query/petstore-tags-split/health/health.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/health/health.ts
@@ -33,6 +33,18 @@ export const healthCheck = (
   });
 };
 
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
+
 export const getHealthCheckQueryKey = () => {
   return ['health'] as const;
 };

--- a/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/petstore-tags-split/pets/pets.ts
@@ -48,6 +48,20 @@ export const listPets = (
   });
 };
 
+export const getListPetsUrl = (params: MaybeRefOrGetter<ListPetsParams>) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getListPetsQueryKey = (
   params?: MaybeRefOrGetter<ListPetsParams>,
 ) => {
@@ -138,6 +152,22 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsUrl = (
+  params: MaybeRefOrGetter<CreatePetsParams>,
+) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getCreatePetsMutationKey = () => ['createPets'] as const;
 
 export const getCreatePetsMutationOptions = <
@@ -220,6 +250,19 @@ export const showPetById = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}`, options);
+};
+
+export const getShowPetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetByIdQueryKey = (petId: MaybeRefOrGetter<string>) => {
@@ -308,6 +351,19 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
+
 export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
 
 export const getDeletePetByIdMutationOptions = <
@@ -390,6 +446,19 @@ export const showPetWithOwner = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}/owner`, options);
+};
+
+export const getShowPetWithOwnerUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetWithOwnerQueryKey = (

--- a/tests/__snapshots__/vue-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/vue-query/petstore/endpoints.ts
@@ -50,6 +50,24 @@ export const listPets = (
   });
 };
 
+export const getListPetsUrl = (
+  params: MaybeRefOrGetter<ListPetsParams>,
+  version: MaybeRefOrGetter<number> = 1,
+) => {
+  params = toValue(params);
+  version = toValue(version);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getListPetsInfiniteQueryKey = (
   params?: MaybeRefOrGetter<ListPetsParams>,
   version: MaybeRefOrGetter<number> = 1,
@@ -270,6 +288,24 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsUrl = (
+  params: MaybeRefOrGetter<CreatePetsParams>,
+  version: MaybeRefOrGetter<number> = 1,
+) => {
+  params = toValue(params);
+  version = toValue(version);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getCreatePetsQueryKey = (
   createPetsBody?: MaybeRefOrGetter<CreatePetsBody>,
   params?: MaybeRefOrGetter<CreatePetsParams>,
@@ -379,6 +415,23 @@ export const showPetById = (
   return axios.get(`/v${version}/pets/${petId}`, options);
 };
 
+export const getShowPetByIdUrl = (
+  petId: MaybeRefOrGetter<string>,
+  version: MaybeRefOrGetter<number> = 1,
+) => {
+  petId = toValue(petId);
+  version = toValue(version);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
+};
+
 export const getShowPetByIdQueryKey = (
   petId: MaybeRefOrGetter<string>,
   version: MaybeRefOrGetter<number> = 1,
@@ -474,6 +527,23 @@ export const deletePetById = (
   version = toValue(version);
 
   return axios.delete(`/v${version}/pets/${petId}`, options);
+};
+
+export const getDeletePetByIdUrl = (
+  petId: MaybeRefOrGetter<string>,
+  version: MaybeRefOrGetter<number> = 1,
+) => {
+  petId = toValue(petId);
+  version = toValue(version);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export const getDeletePetByIdQueryKey = (
@@ -578,6 +648,19 @@ export const healthCheck = (
   });
 };
 
+export const getHealthCheckUrl = (version: MaybeRefOrGetter<number> = 1) => {
+  version = toValue(version);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/health`,
+      baseURL: '',
+    });
+};
+
 export const getHealthCheckQueryKey = (
   version: MaybeRefOrGetter<number> = 1,
 ) => {
@@ -666,6 +749,23 @@ export const showPetWithOwner = (
   version = toValue(version);
 
   return axios.get(`/v${version}/pets/${petId}/owner`, options);
+};
+
+export const getShowPetWithOwnerUrl = (
+  petId: MaybeRefOrGetter<string>,
+  version: MaybeRefOrGetter<number> = 1,
+) => {
+  petId = toValue(petId);
+  version = toValue(version);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/v${version}/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetWithOwnerQueryKey = (

--- a/tests/__snapshots__/vue-query/split/endpoints.ts
+++ b/tests/__snapshots__/vue-query/split/endpoints.ts
@@ -48,6 +48,20 @@ export const listPets = (
   });
 };
 
+export const getListPetsUrl = (params: MaybeRefOrGetter<ListPetsParams>) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getListPetsQueryKey = (
   params?: MaybeRefOrGetter<ListPetsParams>,
 ) => {
@@ -138,6 +152,22 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsUrl = (
+  params: MaybeRefOrGetter<CreatePetsParams>,
+) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getCreatePetsMutationKey = () => ['createPets'] as const;
 
 export const getCreatePetsMutationOptions = <
@@ -221,6 +251,19 @@ export const showPetById = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}`, options);
+};
+
+export const getShowPetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetByIdQueryKey = (petId: MaybeRefOrGetter<string>) => {
@@ -309,6 +352,19 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
+
 export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
 
 export const getDeletePetByIdMutationOptions = <
@@ -394,6 +450,18 @@ export const healthCheck = (
   });
 };
 
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
+
 export const getHealthCheckQueryKey = () => {
   return ['health'] as const;
 };
@@ -471,6 +539,19 @@ export const showPetWithOwner = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}/owner`, options);
+};
+
+export const getShowPetWithOwnerUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetWithOwnerQueryKey = (

--- a/tests/__snapshots__/vue-query/tags/health.ts
+++ b/tests/__snapshots__/vue-query/tags/health.ts
@@ -33,6 +33,18 @@ export const healthCheck = (
   });
 };
 
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
+
 export const getHealthCheckQueryKey = () => {
   return ['health'] as const;
 };

--- a/tests/__snapshots__/vue-query/tags/pets.ts
+++ b/tests/__snapshots__/vue-query/tags/pets.ts
@@ -48,6 +48,20 @@ export const listPets = (
   });
 };
 
+export const getListPetsUrl = (params: MaybeRefOrGetter<ListPetsParams>) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getListPetsQueryKey = (
   params?: MaybeRefOrGetter<ListPetsParams>,
 ) => {
@@ -138,6 +152,22 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsUrl = (
+  params: MaybeRefOrGetter<CreatePetsParams>,
+) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getCreatePetsMutationKey = () => ['createPets'] as const;
 
 export const getCreatePetsMutationOptions = <
@@ -220,6 +250,19 @@ export const showPetById = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}`, options);
+};
+
+export const getShowPetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetByIdQueryKey = (petId: MaybeRefOrGetter<string>) => {
@@ -308,6 +351,19 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
+
 export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
 
 export const getDeletePetByIdMutationOptions = <
@@ -390,6 +446,19 @@ export const showPetWithOwner = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}/owner`, options);
+};
+
+export const getShowPetWithOwnerUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetWithOwnerQueryKey = (

--- a/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/vue-query/zod-schema-response/endpoints.ts
@@ -48,6 +48,20 @@ export const listPets = (
   });
 };
 
+export const getListPetsUrl = (params: MaybeRefOrGetter<ListPetsParams>) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getListPetsQueryKey = (
   params?: MaybeRefOrGetter<ListPetsParams>,
 ) => {
@@ -138,6 +152,22 @@ export const createPets = (
   });
 };
 
+export const getCreatePetsUrl = (
+  params: MaybeRefOrGetter<CreatePetsParams>,
+) => {
+  params = toValue(params);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets`,
+      baseURL: '',
+      params,
+    });
+};
+
 export const getCreatePetsMutationKey = () => ['createPets'] as const;
 
 export const getCreatePetsMutationOptions = <
@@ -221,6 +251,19 @@ export const showPetById = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}`, options);
+};
+
+export const getShowPetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetByIdQueryKey = (petId: MaybeRefOrGetter<string>) => {
@@ -309,6 +352,19 @@ export const deletePetById = (
   return axios.delete(`/pets/${petId}`, options);
 };
 
+export const getDeletePetByIdUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}`,
+      baseURL: '',
+    });
+};
+
 export const getDeletePetByIdMutationKey = () => ['deletePetById'] as const;
 
 export const getDeletePetByIdMutationOptions = <
@@ -394,6 +450,18 @@ export const healthCheck = (
   });
 };
 
+export const getHealthCheckUrl = () => {
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/health`,
+      baseURL: '',
+    });
+};
+
 export const getHealthCheckQueryKey = () => {
   return ['health'] as const;
 };
@@ -471,6 +539,19 @@ export const showPetWithOwner = (
   petId = toValue(petId);
 
   return axios.get(`/pets/${petId}/owner`, options);
+};
+
+export const getShowPetWithOwnerUrl = (petId: MaybeRefOrGetter<string>) => {
+  petId = toValue(petId);
+  return axios
+    .create({
+      baseURL: '',
+      params: null,
+    })
+    .getUri({
+      url: `/pets/${petId}/owner`,
+      baseURL: '',
+    });
 };
 
 export const getShowPetWithOwnerQueryKey = (

--- a/tests/axios-url-runtime.spec.ts
+++ b/tests/axios-url-runtime.spec.ts
@@ -1,0 +1,352 @@
+import { runInNewContext } from 'node:vm';
+
+import { generateAxiosUrl } from '@orval/core';
+import axios from 'axios';
+import { describe, expect, it } from 'vite-plus/test';
+import { computed, ref } from 'vue';
+
+import { getListPetsUrl as getListPetsUrlFromFunctions } from './generated/axios/named-parameters/endpoints';
+import { getSwaggerPetstore } from './generated/axios/petstore/endpoints';
+import { getHealthCheckUrl as getHealthCheckUrlFromReactQuery } from './generated/react-query/tag-hook-mutator-axios/endpoints';
+import { getListPetsUrl as getListPetsUrlFromVueQuery } from './generated/vue-query/petstore/endpoints';
+
+const evaluateGeneratedUrl = (
+  source: string,
+  axiosClient: ReturnType<typeof axios.create>,
+  functionName: string,
+  globals: Record<string, unknown> = {},
+) =>
+  runInNewContext(`${source.replace('export ', '')}; ${functionName}`, {
+    axios: axiosClient,
+    ...globals,
+  }) as (...args: unknown[]) => string;
+
+describe('generated Axios URL helpers', () => {
+  it('uses factory instance serialization while excluding the instance baseURL', () => {
+    const axiosInstance = axios.create({
+      baseURL: 'https://api.example.test',
+      paramsSerializer: { indexes: null },
+    });
+    const api = getSwaggerPetstore(axiosInstance);
+    const params = {
+      tags: ['red', 'blue'],
+      sort: 'name' as const,
+      optional: undefined,
+      empty: null,
+    };
+
+    const expected = axiosInstance.getUri({
+      url: '/v2/pets',
+      baseURL: '',
+      params,
+    });
+
+    expect(api.getListPetsUrl(params, 2)).toBe(expected);
+    expect(api.getListPetsUrl(params, 2)).toBe(
+      '/v2/pets?tags=red&tags=blue&sort=name',
+    );
+    expect(api.getListPetsUrl(params, 2)).not.toContain('api.example.test');
+  });
+
+  it('uses the configured Axios serializer in factory mode', () => {
+    const axiosInstance = axios.create({
+      baseURL: 'https://api.example.test',
+      paramsSerializer: {
+        serialize: (params) =>
+          `filter=${encodeURIComponent(String(params.filter))}`,
+      },
+    });
+    const api = getSwaggerPetstore(axiosInstance);
+    const params = { filter: 'red/blue', sort: 'name' as const };
+    const expected = axiosInstance.getUri({
+      url: '/v3/pets',
+      baseURL: '',
+      params,
+    });
+
+    expect(api.getListPetsUrl(params, 3)).toBe(expected);
+    expect(api.getListPetsUrl(params, 3)).toBe('/v3/pets?filter=red%2Fblue');
+  });
+
+  it('uses serializers declared by the generated Axios configuration', () => {
+    const customSerializer = (params: Record<string, unknown>) =>
+      `filter=${encodeURIComponent(String(params.filter))}`;
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'params',
+      route: '/pets',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+      paramsSerializer: 'customSerializer',
+    });
+    const getUrl = evaluateGeneratedUrl(
+      source,
+      axios.create(),
+      'getGetPetUrl',
+      { customSerializer },
+    );
+
+    expect(getUrl({ filter: 'red/blue' })).toBe('/pets?filter=red%2Fblue');
+  });
+
+  it('passes paramsSerializerOptions.qs through Axios getUri', () => {
+    const qs = {
+      stringify: (params: Record<string, unknown>, options: unknown) => {
+        expect(options).toEqual({ arrayFormat: 'repeat' });
+        return (params.tags as string[])
+          .map((tag) => `tag=${encodeURIComponent(tag)}`)
+          .join('&');
+      },
+    };
+    const source = generateAxiosUrl({
+      functionName: 'getGetPetUrl',
+      propsImplementation: 'params',
+      route: '/pets',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+      paramsSerializerOptions: { qs: { arrayFormat: 'repeat' } },
+    });
+    const getUrl = evaluateGeneratedUrl(
+      source,
+      axios.create(),
+      'getGetPetUrl',
+      { qs },
+    );
+
+    expect(getUrl({ tags: ['a', 'b'] })).toBe('/pets?tag=a&tag=b');
+  });
+
+  it('preserves root and trailing-slash OpenAPI routes', () => {
+    const rootUrl = evaluateGeneratedUrl(
+      generateAxiosUrl({
+        functionName: 'getRootUrl',
+        propsImplementation: 'params = {}',
+        route: '/',
+        axiosRef: 'axios',
+        hasQueryParams: true,
+      }),
+      axios.create(),
+      'getRootUrl',
+    );
+    const trailingSlashUrl = evaluateGeneratedUrl(
+      generateAxiosUrl({
+        functionName: 'getUsersUrl',
+        propsImplementation: 'params = {}',
+        route: '/users/',
+        axiosRef: 'axios',
+        hasQueryParams: true,
+      }),
+      axios.create(),
+      'getUsersUrl',
+    );
+
+    expect(rootUrl({ foo: 'bar' })).toBe('/?foo=bar');
+    expect(rootUrl()).toBe('/');
+    expect(trailingSlashUrl({ foo: 'bar' })).toBe('/users/?foo=bar');
+  });
+  it('does not leak instance default params into the OpenAPI URL', () => {
+    const axiosInstance = axios.create({
+      baseURL: 'https://api.example.test',
+      params: { tenant: 'runtime-default', page: 99 },
+    });
+    const api = getSwaggerPetstore(axiosInstance);
+
+    expect(api.getListPetsUrl({ sort: 'name' }, 2)).toBe('/v2/pets?sort=name');
+  });
+
+  it('matches Axios exactly for null, undefined, and empty query values', () => {
+    const axiosInstance = axios.create();
+    const api = getSwaggerPetstore(axiosInstance);
+    const cases = [
+      { foo: null },
+      { foo: undefined },
+      { foo: '' },
+      { foo: null, bar: 'x' },
+    ];
+    const expected = ['/users', '/users', '/users?foo=', '/users?bar=x'];
+
+    expect(
+      cases.map((params) => axiosInstance.getUri({ url: '/users', params })),
+    ).toEqual(expected);
+    expect(
+      cases.map((params) => api.getListPetsUrl(params as never, 1)),
+    ).toEqual(['/v1/pets', '/v1/pets', '/v1/pets?foo=', '/v1/pets?bar=x']);
+  });
+
+  it('uses global Axios serialization in axios-functions mode', () => {
+    const params = { tags: ['red', 'blue'], sort: 'name' as const };
+
+    expect(getListPetsUrlFromFunctions({ version: 3 }, params)).toBe(
+      axios.getUri({
+        url: '/v3/pets',
+        baseURL: '',
+        params,
+      }),
+    );
+  });
+
+  it('excludes global Axios runtime defaults in functions mode', () => {
+    const previousBaseURL = axios.defaults.baseURL;
+    const previousParams = axios.defaults.params;
+    axios.defaults.baseURL = 'https://api.example.test';
+    axios.defaults.params = { tenant: 'runtime-default' };
+
+    try {
+      expect(
+        getListPetsUrlFromFunctions({ version: 3 }, { sort: 'name' }),
+      ).toBe('/v3/pets?sort=name');
+    } finally {
+      axios.defaults.baseURL = previousBaseURL;
+      axios.defaults.params = previousParams;
+    }
+  });
+
+  it('matches Axios for scalar edge cases, arrays, and repeated calls', () => {
+    const axiosInstance = axios.create();
+    const api = getSwaggerPetstore(axiosInstance);
+    const params = {
+      sort: 'name' as const,
+      limit: '20',
+      search: 'hello world',
+      foo: undefined,
+      nullable: null,
+      enabled: true,
+      disabled: false,
+      zero: 0,
+      negative: -1,
+      decimal: 1.5,
+      empty: '',
+      special: 'foo&bar=a? #+/%',
+      unicode: '你好 漢字 José ñ 日本語',
+      tags: ['a&b', '你好'],
+      emptyTags: [],
+    };
+    const before = structuredClone(params);
+    const expected = axiosInstance.getUri({
+      url: '/v2/pets',
+      baseURL: '',
+      params,
+    });
+
+    expect(api.getListPetsUrl(params, 2)).toBe(expected);
+    expect(api.getListPetsUrl(params, 2)).toContain('search=hello+world');
+    expect(api.getListPetsUrl(params, 2)).toContain('enabled=true');
+    expect(api.getListPetsUrl(params, 2)).toContain('disabled=false');
+    expect(api.getListPetsUrl(params, 2)).toContain('zero=0');
+    expect(api.getListPetsUrl(params, 2)).toContain('negative=-1');
+    expect(api.getListPetsUrl(params, 2)).toContain('decimal=1.5');
+    expect(api.getListPetsUrl(params, 2)).toContain('empty=');
+    expect(api.getListPetsUrl(params, 2)).not.toContain('foo=undefined');
+    expect(api.getListPetsUrl(params, 2)).not.toContain('nullable');
+    expect(params).toEqual(before);
+
+    expect(api.getListPetsUrl({ sort: 'name' }, 2)).toBe('/v2/pets?sort=name');
+    expect(api.getListPetsUrl({ sort: 'email' }, 2)).toBe(
+      '/v2/pets?sort=email',
+    );
+    expect(api.getListPetsUrl({ sort: 'name' }, 2)).not.toContain('email');
+  });
+
+  it('preserves existing generated path interpolation without double encoding', () => {
+    const axiosInstance = axios.create({
+      baseURL: 'https://api.example.test/v1',
+    });
+    const api = getSwaggerPetstore(axiosInstance);
+
+    for (const petId of [
+      'hello world',
+      'a/b',
+      'foo?bar',
+      '100%',
+      '你好',
+      'hello%20world',
+      'a%2Fb',
+    ]) {
+      expect(api.getShowPetByIdUrl(petId, 2)).toBe(
+        axiosInstance.getUri({
+          url: `/v2/pets/${petId}`,
+          baseURL: '',
+        }),
+      );
+    }
+
+    expect(api.getHealthCheckUrl(2)).toBe('/v2/health');
+  });
+
+  it('preserves custom serializer output, including empty output and errors', () => {
+    const params = { sort: 'name' as const };
+    const customInstance = axios.create({
+      paramsSerializer: { serialize: () => 'foo=a;b=c' },
+    });
+    const emptyInstance = axios.create({
+      paramsSerializer: { serialize: () => '' },
+    });
+    const throwingInstance = axios.create({
+      paramsSerializer: {
+        serialize: () => {
+          throw new Error('serializer failed');
+        },
+      },
+    });
+
+    expect(getSwaggerPetstore(customInstance).getListPetsUrl(params)).toBe(
+      '/v1/pets?foo=a;b=c',
+    );
+    expect(getSwaggerPetstore(emptyInstance).getListPetsUrl(params)).toBe(
+      '/v1/pets',
+    );
+    expect(() =>
+      getSwaggerPetstore(throwingInstance).getListPetsUrl(params),
+    ).toThrow('serializer failed');
+  });
+
+  it('uses the same generated helper behavior for a path plus query', () => {
+    const source = generateAxiosUrl({
+      functionName: 'getUserMessagesUrl',
+      propsImplementation: 'userId, params',
+      route: '/users/${userId}/messages',
+      axiosRef: 'axios',
+      hasQueryParams: true,
+    });
+    const axiosInstance = axios.create();
+    const getUserMessagesUrl = evaluateGeneratedUrl(
+      source,
+      axiosInstance,
+      'getUserMessagesUrl',
+    );
+    const params = { search: 'hello world', tags: ['a', 'b'] };
+
+    expect(getUserMessagesUrl('john/doe', params)).toBe(
+      axiosInstance.getUri({
+        url: '/users/john/doe/messages',
+        baseURL: '',
+        params,
+      }),
+    );
+    expect(getUserMessagesUrl('john/doe', params)).toBe(
+      '/users/john/doe/messages?search=hello+world&tags%5B%5D=a&tags%5B%5D=b',
+    );
+  });
+
+  it('unwraps Vue MaybeRefOrGetter values before Axios serialization', () => {
+    const params = ref({ sort: 'name' as const, limit: '10' });
+    const version = computed(() => 3);
+
+    expect(getListPetsUrlFromVueQuery(params, version)).toBe(
+      axios.getUri({
+        url: '/v3/pets',
+        baseURL: '',
+        params: params.value,
+      }),
+    );
+  });
+
+  it('exports helpers for Axios-backed React Query output', () => {
+    expect(getHealthCheckUrlFromReactQuery()).toBe(
+      axios.getUri({
+        url: '/health',
+        baseURL: '',
+      }),
+    );
+  });
+});

--- a/tests/vitest.snapshots.ts
+++ b/tests/vitest.snapshots.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'handler-preservation.spec.ts',
       'query-key-mutator.spec.ts',
       'serialize-response-headers.spec.ts',
+      'axios-url-runtime.spec.ts',
     ],
     silent: 'passed-only',
   },


### PR DESCRIPTION
## Summary
Adds reusable Axios URL helpers for generated operations using the existing Fetch naming convention:

```ts
get<Operation>Url(...)
```

Example:

```ts
const url = api.getListPetsUrl({ limit: 10 });
```

The helper returns the generated OpenAPI route with query parameters serialized using Axios semantics.
Closes #892

## Changes

* Added URL helpers to Axios functions and Axios factory clients.
* Added support to Axios-backed Query clients, including Vue ref unwrapping.
* Preserved custom Axios query serializers through `getUri()`.
* Excluded runtime `baseURL`, instance default params, request options, interceptors, and mutator-specific behavior.
* Mutator-controlled operations do not emit URL helpers.
* Existing Axios request calls and Fetch generation remain unchanged.
* Added English and Chinese documentation.
* Added runtime, generator, Query, and serialization regression tests.

## Design notes

The helper represents:

```text
generated OpenAPI route + Axios-serialized query parameters
```

It does not represent the final runtime transport URL

Factory helpers use the injected Axios instance and derive a clean instance for URL generation so configured serializers are preserved without leaking runtime `baseURL` or default request params

## Snapshots

156 generated snapshot files were updated because the new helpers are emitted across Axios-backed outputs.

The changes are limited to the new URL helpers, `getUri()` usage, derived Axios instances, and factory return objects. Existing request bodies, headers, request options, query keys, mutation keys, response types, and Fetch output were not changed.

## Validation

* Focused Core/Axios/Query tests: **147/147 passed**
* Axios runtime URL tests: **15/15 passed**
* Affected package typechecks: **passed**
* Type-aware lint: **passed**
* Formatting checks: **passed**
* `git diff --check`: **passed**

The broader repository still has unrelated pre-existing failures in version-resolution tests and one orphaned external-reference snapshot.

## Related

* #2851 - existing Axios factory pattern extended by this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generated Axios clients now provide `get<Operation>Url` helpers with Axios-compatible query serialization.
  - Supported in Axios factories, Axios functions, and Axios-backed query clients.
  - Helpers support custom serializers, query-string options, path parameters, and reactive values.
  - Names avoid collisions; helpers are excluded for operations using custom mutators.

- **Documentation**
  - Added English and Chinese documentation for URL helpers, limitations, and `allParamsOptional` behavior.

- **Tests**
  - Added coverage for URL generation, serialization, escaping, factories, query clients, and custom mutators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->