### PR TITLE
fix(core): call handler factories in the tags-operations aggregate mock helper

### DIFF
--- a/packages/core/src/writers/tags-operations-mode.test.ts
+++ b/packages/core/src/writers/tags-operations-mode.test.ts
@@ -359,6 +359,63 @@ describe('writeTagsOperationsMode', () => {
     expect(paths).toContain(mockPath);
   });
 
+  it('calls each handler factory inside the per-operation aggregate mock helper', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const mockDir = path.join(tmpDir, 'mocks');
+    const baseProps = createSplitModeProps(target);
+
+    const props = {
+      ...baseProps,
+      builder: {
+        ...baseProps.builder,
+        header: () => ({
+          implementation: '',
+          implementationMock: 'export const getPetsMock = () => [\n',
+        }),
+        footer: () => ({ implementation: '', implementationMock: '\n]\n' }),
+        operations: {
+          listPets: createSplitModeOperation({
+            tags: ['pets'],
+            operationName: 'listPets',
+            mockOutputs: [
+              {
+                type: OutputMockType.MSW,
+                implementation: {
+                  function: '',
+                  handler: 'export const getListPetsMockHandler = () => {};\n',
+                  handlerName: 'getListPetsMockHandler',
+                },
+                imports: [],
+              },
+            ],
+          }),
+        },
+      },
+      output: createSplitModeOutput(target, {
+        mode: OutputMode.TAGS_OPERATIONS,
+        client: OutputClient.REACT_QUERY,
+        mock: {
+          indexMockFiles: false,
+          inline: false,
+          path: mockDir,
+          generators: [{ type: OutputMockType.MSW }],
+        },
+      }),
+    };
+
+    await writeTagsOperationsMode({ ...props, needSchema: false });
+
+    const content = fs.readFileSync(
+      path.join(mockDir, 'pets', 'list-pets.msw.ts'),
+      'utf8',
+    );
+    // The aggregate returns handler instances, not the factories themselves.
+    expect(content).toContain(
+      'export const getPetsMock = () => [\n  getListPetsMockHandler()\n]',
+    );
+    expect(content).not.toMatch(/getListPetsMockHandler\s*\n\]/);
+  });
+
   it('writes a single mock index aggregating operations across every tag', async () => {
     const target = path.join(tmpDir, 'petstore.ts');
     const mockDir = path.join(tmpDir, 'mocks');

--- a/packages/core/src/writers/target-tags-operations.ts
+++ b/packages/core/src/writers/target-tags-operations.ts
@@ -241,10 +241,16 @@ export function generateTargetForTagsOperations(
           type: m.type,
           implementation: {
             function: m.implementation.function,
+            // `handlerName` is the factory's identifier. The aggregate helper
+            // must call it, as `target.ts` / `target-tags.ts` do, so that
+            // `setupServer(...getPetsMock())` receives handlers, not
+            // factories.
             handler: m.implementation.handlerName
               ? m.implementation.handler +
                 header.implementationMock +
+                '  ' +
                 m.implementation.handlerName +
+                '()' +
                 footer.implementationMock
               : m.implementation.handler,
             handlerName: m.implementation.handlerName,


### PR DESCRIPTION
In `tags-operations` and `tags-operations-split`, the per-operation `get<Tag>Mock` helper is emitted as

```ts
export const getPetsMock = () => [getListPetsMockHandler];
```

i.e. the array holds the handler *factory*, so `setupServer(...getPetsMock())` receives a function instead of an MSW `RequestHandler`. Every other writer (`target.ts`, `target-tags.ts`) appends `()` when it joins handler names into the aggregate; `target-tags-operations.ts` forgot to. With this change the helper reads

```ts
export const getPetsMock = () => [
  getListPetsMockHandler()
]
```

Surfaced while adding snapshot coverage for these modes (#4014), where Copilot flagged the inconsistency. Includes a regression test that fails on `master`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Generated aggregate mock handlers now correctly invoke each handler factory, ensuring the expected handlers are included in per-operation mock files.

- **Tests**
  - Added coverage to verify generated mock files call handler factories rather than referencing them without invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->