### PR TITLE
fix(core): include schemas-dir imports when resolving per-operation schemas in tags-operations-split

### DIFF
--- a/packages/core/src/writers/tags-operations-split-mode.test.ts
+++ b/packages/core/src/writers/tags-operations-split-mode.test.ts
@@ -136,6 +136,70 @@ describe('writeTagsOperationsSplitMode', () => {
     expect(schemasContent).not.toContain('Unrelated');
   });
 
+  it('follows schema imports that already carry an importPath into the schemas directory', async () => {
+    const target = path.join(tmpDir, 'petstore.ts');
+    const baseProps = createSplitModeProps(target);
+
+    // With `output.schemas` set, the schemas writer runs first and rewrites
+    // each component-schema import with the path to its file in that
+    // directory. The per-operation schemas file must still include those
+    // schemas, otherwise `Pet` refers to `Dog` / `Cat` that are declared
+    // nowhere in the file.
+    const props = {
+      ...baseProps,
+      builder: {
+        ...baseProps.builder,
+        schemas: [
+          {
+            name: 'Pet',
+            model: 'export type Pet = Dog | Cat;',
+            imports: [
+              { name: 'Dog', importPath: './dog' },
+              { name: 'Cat', importPath: './cat' },
+            ],
+            schema: {},
+          },
+          {
+            name: 'Dog',
+            model: 'export type Dog = {};',
+            imports: [],
+            schema: {},
+          },
+          {
+            name: 'Cat',
+            model: 'export type Cat = {};',
+            imports: [],
+            schema: {},
+          },
+        ],
+        operations: {
+          getPet: createSplitModeOperation({
+            tags: ['pets'],
+            operationName: 'getPet',
+            imports: [{ name: 'Pet' }],
+            implementation:
+              'export const useGetPet = (): Pet => ({}) as Pet;\n',
+          }),
+        },
+      },
+      output: createSplitModeOutput(target, {
+        mode: OutputMode.TAGS_OPERATIONS_SPLIT,
+        client: OutputClient.REACT_QUERY,
+        schemas: path.join(tmpDir, 'model'),
+      }),
+    };
+
+    await writeTagsOperationsSplitMode({ ...props, needSchema: false });
+
+    const content = fs.readFileSync(
+      path.join(tmpDir, 'pets', 'get-pet.schemas.ts'),
+      'utf8',
+    );
+    expect(content).toContain('export type Pet = Dog | Cat;');
+    expect(content).toContain('export type Dog = {};');
+    expect(content).toContain('export type Cat = {};');
+  });
+
   it('writes the shared global schemas file when needSchema is true and output.schemas is unset', async () => {
     const target = path.join(tmpDir, 'petstore.ts');
     const baseProps = createSplitModeProps(target);

--- a/packages/core/src/writers/target-tags-operations.ts
+++ b/packages/core/src/writers/target-tags-operations.ts
@@ -1,6 +1,5 @@
 import {
   DefaultTag,
-  type GeneratorImport,
   type GeneratorOperation,
   type GeneratorOperationTarget,
   type GeneratorSchema,
@@ -13,10 +12,6 @@ import {
 import { getOperationTagKey, isOperationInTagBucket, pascal } from '../utils';
 import { flattenMockOutput } from './mock-outputs';
 import { hasTypeScriptAwaitedType } from './typescript-version';
-
-function isSchemaImport(imp: GeneratorImport): boolean {
-  return !imp.importPath;
-}
 
 /**
  * Resolves the transitive closure of component schemas an operation's
@@ -40,8 +35,12 @@ export function resolveTransitiveSchemas(
     const schema = schemaByName.get(name);
     if (!schema) continue;
     included.add(name);
+    // Match by name rather than by a missing `importPath`: when
+    // `output.schemas` is set, the schemas writer has already rewritten
+    // every component-schema import to point at its file in that
+    // directory, so an `importPath` no longer marks an external import.
     for (const imp of schema.imports) {
-      if (isSchemaImport(imp) && !included.has(imp.name)) {
+      if (schemaByName.has(imp.name) && !included.has(imp.name)) {
         queue.push(imp.name);
       }
     }


### PR DESCRIPTION
`tags-operations-split` writes a self-contained `<operation>.schemas.ts` per operation by walking the transitive closure of the component schemas the operation references (`resolveTransitiveSchemas`). That walk treated an import *without* `importPath` as a component-schema reference.

When `output.schemas` is set, the schemas-directory writer runs before the mode writer and rewrites every component-schema import with the path to its file in that directory. After that, no import lacks an `importPath`, so the walk stopped at the first level and the per-operation file declared `Pet` in terms of `Dog` / `Cat` / `PetCallingCode` / `PetCountry` that appear nowhere in the file:

```
create-pets.schemas.ts(8,6): error TS2304: Cannot find name 'Dog'.
```

Match imports by schema name instead of by a missing `importPath`. The one-line change is in `resolveTransitiveSchemas`; the rest of the diff removes the now-unused predicate.

Surfaced by the new snapshot configs in #4015 / #4017, whose typecheck step fails on `master` with exactly these errors. Includes a regression test that fails on `master`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Per-operation schema files now correctly include transitively referenced schemas when schema imports point to files in the configured schemas directory.
* **Tests**
  * Added coverage verifying that generated files include all required type definitions, including nested references such as `Pet`, `Dog`, and `Cat`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->