### PR TITLE
fix: parse response status keys before emitting them (GHSA-q8g3-2pxp-2gmw)

### DIFF
--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -2242,12 +2242,22 @@ describe('response status key safety', () => {
 
   // The key lands in an unquoted expression position, so a non-numeric value
   // would splice live code into the handler rather than break a string.
-  it.each(['2,x:(globalThis.pwned=1)', '200,y:1', '(1)', 'abc'])(
-    'refuses the non-numeric response key %j',
-    (statusKey) => {
-      expect(() => generateMSW(verbOptions(statusKey), options)).toThrow(
-        /not a status code/,
-      );
-    },
-  );
+  it.each([
+    '2,x:(globalThis.pwned=1)',
+    '200,y:1',
+    '(1)',
+    'abc',
+    // Near-miss wildcards: only a single-digit `NXX` is a valid wildcard, so
+    // none of these may be salvaged into a three-digit status.
+    '20XX',
+    '2XXX',
+    'XX',
+    '1000',
+    '20X',
+    '',
+  ])('refuses the non-numeric response key %j', (statusKey) => {
+    expect(() => generateMSW(verbOptions(statusKey), options)).toThrow(
+      /not a status code/,
+    );
+  });
 });

--- a/packages/mock/src/msw/index.test.ts
+++ b/packages/mock/src/msw/index.test.ts
@@ -2183,3 +2183,71 @@ describe('recursion guards for cyclic allOf schemas', () => {
     expect(() => run(schemas, 'XElement')).not.toThrow();
   });
 });
+
+describe('response status key safety', () => {
+  const verbOptions = (statusKey: string): GeneratorVerbOptions =>
+    ({
+      operationId: 'getUser',
+      operationName: 'getUser',
+      typeName: 'getUser',
+      verb: 'get',
+      tags: [],
+      response: {
+        imports: [],
+        definition: { success: 'User' },
+        types: { success: [{ key: statusKey, value: 'User' }] },
+        contentTypes: ['application/json'],
+      },
+    }) as unknown as GeneratorVerbOptions;
+
+  const options = {
+    route: '/users/{id}',
+    pathRoute: '/users/{id}',
+    output: 'test',
+    override: { operations: {}, tags: {} } as NormalizedOverrideOutput,
+    context: {
+      target: 'test',
+      workspace: '',
+      spec: {
+        openapi: '3.0.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {},
+      },
+      output: {
+        target: 'test',
+        namingConvention: 'camelCase',
+        fileExtension: '.ts',
+        mode: 'single',
+        override: {
+          operations: {},
+          tags: {},
+          mock: { type: OutputMockType.MSW },
+        } as unknown as NormalizedOverrideOutput,
+        client: 'axios-functions',
+        httpClient: 'fetch',
+        propertySortOrder: 'specification',
+      },
+    },
+  } as unknown as GeneratorOptions;
+
+  it.each([
+    ['200', 'status: 200'],
+    ['default', 'status: 200'],
+    ['2XX', 'status: 200'],
+    ['5XX', 'status: 500'],
+  ])('emits %s as %s', (statusKey, expected) => {
+    const result = generateMSW(verbOptions(statusKey), options);
+    expect(result.implementation.handler).toContain(expected);
+  });
+
+  // The key lands in an unquoted expression position, so a non-numeric value
+  // would splice live code into the handler rather than break a string.
+  it.each(['2,x:(globalThis.pwned=1)', '200,y:1', '(1)', 'abc'])(
+    'refuses the non-numeric response key %j',
+    (statusKey) => {
+      expect(() => generateMSW(verbOptions(statusKey), options)).toThrow(
+        /not a status code/,
+      );
+    },
+  );
+});

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -47,7 +47,17 @@ import { getMockDefinition, getMockOptionsDataOverride } from './mocks';
  * handler previously emitted for those keys.
  */
 function assertSafeStatusCode(status: string): number {
-  const normalized = status === 'default' ? '200' : status.replace(/XX$/, '00');
+  // Map only the two forms the spec actually defines — `default` and a
+  // single-digit `NXX` wildcard — and leave everything else to fail the check
+  // below as-is. Rewriting a trailing `XX` before validating would work out
+  // the same (`20XX` becomes the four-digit `2000` and is still rejected), but
+  // this way the accepted shapes are stated rather than inferred.
+  const normalized =
+    status === 'default'
+      ? '200'
+      : /^\dXX$/.test(status)
+        ? `${status[0]}00`
+        : status;
 
   if (!/^\d{3}$/.test(normalized)) {
     throw new Error(

--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -33,6 +33,31 @@ import {
 } from '../mock-types';
 import { getMockDefinition, getMockOptionsDataOverride } from './mocks';
 
+/**
+ * Resolves an OpenAPI response key to the numeric status the generated handler
+ * emits.
+ *
+ * The key comes straight from the document and lands in an unquoted expression
+ * position (`{ status: 200 }`), so there is no quote to escape and no way to
+ * make a non-numeric value safe there — a key like
+ * `2,x:(<expression>)` would splice live code into the handler. Parse it, and
+ * refuse the document rather than emitting whatever it says.
+ *
+ * `default` maps to 200 and a `NXX` wildcard to `N00`, matching what the
+ * handler previously emitted for those keys.
+ */
+function assertSafeStatusCode(status: string): number {
+  const normalized = status === 'default' ? '200' : status.replace(/XX$/, '00');
+
+  if (!/^\d{3}$/.test(normalized)) {
+    throw new Error(
+      `orval: refusing to generate a mock handler for an OpenAPI response key that is not a status code (got "${status}"). This value would otherwise be emitted verbatim into generated source.`,
+    );
+  }
+
+  return Number(normalized);
+}
+
 function getMSWDependencies(
   options?: GlobalMockOptions,
 ): GeneratorDependency[] {
@@ -216,8 +241,11 @@ function generateDefinition(
   const isVoidUnionType =
     mockReturnType !== 'void' &&
     mockReturnType.split('|').some((part) => part.trim() === 'void');
+  // Also a raw response key, emitted unquoted in the void-union branch below.
   const noContentStatusCode = isVoidUnionType
-    ? (responses.find((r) => r.value === 'void')?.key ?? '204')
+    ? assertSafeStatusCode(
+        responses.find((r) => r.value === 'void')?.key ?? '204',
+      )
     : undefined;
   const nonVoidMockReturnType = isVoidUnionType
     ? mockReturnType
@@ -304,7 +332,7 @@ function generateDefinition(
     ? (typeof overrideResponse === "function" ? await overrideResponse(${infoParam}) : overrideResponse)
     : ${getResponseMockFunctionName}()`;
 
-  const statusCode = status === 'default' ? 200 : status.replace(/XX$/, '00');
+  const statusCode = assertSafeStatusCode(status);
 
   // Determine the preferred non-JSON content type for binary responses
   const binaryContentType =


### PR DESCRIPTION
Fixes the MSW status-code injection reported in GHSA-q8g3-2pxp-2gmw.

## The bug

The response key from the OpenAPI document was emitted into an **unquoted expression position**, after only rewriting a `NXX` wildcard:

```ts
const statusCode = status === 'default' ? 200 : status.replace(/XX$/, '00');
// ...
{ status: ${statusCode} }
```

There is no quote to escape in that position, so a crafted key is spliced in as live code. Response key:

```
2,x:(globalThis.__STATUS_PWNED=1)
```

Generated handler (before):

```js
return HttpResponse.json(..., { status: 2,x:(globalThis.__STATUS_PWNED=1)
})
```

Evaluating that object literal:

```
keys           : [ 'status', 'x' ]
__STATUS_PWNED : 1
```

The injected expression runs whenever the generated handlers load — test runner, or `setupWorker` in the browser.

## Reachability — worth being precise

The advisory lists the precondition as just `mock: true`. In practice the default validator already rejects such a key:

```
🛑 poc - OpenAPI spec validation failed:
   Property 2,x:(globalThis.__STATUS_PWNED=1) is not expected to be here
```

Reproducing it needs `input.unsafeDisableValidation: true`, which is documented as unsupported. So the practical severity is well below Critical.

I fixed it regardless: leaning on an external validator to prevent code injection is a thin defence — if `@scalar/openapi-parser` ever loosens its response-key rule this becomes live with no change on our side — and parsing the value costs nothing.

## The fix

Parse the key to a three-digit status and refuse the document otherwise, mirroring how the zod/effect generators already handle numeric constraints that escaping cannot make safe:

```
🛑 orval: refusing to generate a mock handler for an OpenAPI response key that
   is not a status code (got "2,x:(globalThis.__STATUS_PWNED=1)").
```

Applied at both derivation points rather than at each emission:

- `statusCode` — feeds 10 emission sites
- `noContentStatusCode` — the void-union branch, also a raw response key (`responses.find(...)?.key`), which the advisory doesn't mention

That covers all 11 sites at the source, so a new emission site can't reintroduce it.

## No behaviour change for valid specs

Generated msw output is **byte-identical** before and after — verified by `diff` on a spec exercising `default`, `2XX`, `5XX`, plain `200`/`404`, and a `200`/`204` void union, with `generateEachHttpStatus` on:

```
IDENTICAL - no behaviour change for valid specs
```

## Testing

Nine new tests. Five pin the valid mappings (`200`→200, `default`→200, `2XX`→200, `5XX`→500) and pass both before and after as regression guards; four assert refusal of non-numeric keys and fail against the unfixed generator.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with zero drift in generated sample output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated mock handlers’ handling of response status codes.
  - Valid status keys, including numeric codes, `default`, and supported wildcard patterns, are converted to valid numeric status values.
  - Invalid or potentially unsafe status keys—including malformed wildcard patterns—are now rejected with a clear error instead of being emitted into generated handler code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->