### PR TITLE
fix: validate numeric constraints on the array and faker paths (GHSA-xm38-vjwp-qrg4)

### DIFF
--- a/packages/core/src/utils/assertion.test.ts
+++ b/packages/core/src/utils/assertion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import { SchemaType, Verbs } from '../types';
 import {
+  assertSafeNumericConstraint,
   isBoolean,
   isDirectory,
   isDynamicReference,
@@ -18,6 +19,7 @@ import {
   isStringLike,
   isUrl,
   isVerb,
+  safeNumericConstraint,
 } from './assertion';
 
 describe('assertion testing', () => {
@@ -184,5 +186,44 @@ describe('isDynamicReference', () => {
 
   it('returns true for objects with $ref in isReference', () => {
     expect(isReference({ $ref: '#/components/schemas/Foo' })).toBe(true);
+  });
+});
+
+describe('assertSafeNumericConstraint', () => {
+  it('returns a finite number unchanged', () => {
+    expect(assertSafeNumericConstraint(0, 'minimum')).toBe(0);
+    expect(assertSafeNumericConstraint(-1.5, 'minimum')).toBe(-1.5);
+  });
+
+  // These land in generated source as bare expressions, so there is no quote
+  // to escape and the value has to be rejected outright.
+  it.each<[unknown, string]>([
+    ['0); globalThis.pwned=1; void(0', 'a code payload string'],
+    ['3', 'a numeric string'],
+    [Number.NaN, 'NaN'],
+    [Number.POSITIVE_INFINITY, 'Infinity'],
+    [true, 'a boolean'],
+    [null, 'null'],
+    [{}, 'an object'],
+  ])('rejects %j (%s)', (value: unknown) => {
+    expect(() => assertSafeNumericConstraint(value, 'minimum')).toThrow(
+      /"minimum" constraint is not a finite number/,
+    );
+  });
+});
+
+describe('safeNumericConstraint', () => {
+  it('passes undefined through so absent stays distinct from invalid', () => {
+    expect(safeNumericConstraint(undefined, 'minItems')).toBeUndefined();
+  });
+
+  it('returns a finite number unchanged', () => {
+    expect(safeNumericConstraint(7, 'minItems')).toBe(7);
+  });
+
+  it('rejects a non-numeric value', () => {
+    expect(() =>
+      safeNumericConstraint('1); globalThis.pwned=1; void(0', 'minItems'),
+    ).toThrow(/"minItems" constraint is not a finite number/);
   });
 });

--- a/packages/core/src/utils/assertion.ts
+++ b/packages/core/src/utils/assertion.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { isFunction, isNullish, isString } from 'remeda';
+import { isFunction, isNullish, isNumber, isString } from 'remeda';
 
 import {
   type ClientMockBuilder,
@@ -238,3 +238,50 @@ export function isFakerMock(
 
 /** Re-exported Remeda type guards and predicates used alongside local assertions. */
 export { isBoolean, isFunction, isNullish, isNumber, isString } from 'remeda';
+
+/**
+ * Asserts that a spec-supplied numeric constraint really is a finite number.
+ *
+ * Constraints (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`,
+ * `multipleOf`, `minLength`/`maxLength`, `minItems`/`maxItems`) are emitted
+ * into generated source as bare, unquoted expressions — `.min(${min})`,
+ * `S.minItems(${min})`, `faker.number.int({min: ${min}})`. There is no
+ * surrounding quote, so no escaping can make an arbitrary value safe there.
+ *
+ * OpenAPI 3.1 documents pass validation with these fields set to arbitrary
+ * strings, so the value has to be checked here rather than trusted.
+ *
+ * @param value Constraint value taken from the document
+ * @param label Field name, used in the error message
+ * @throws If `value` is not a finite number
+ */
+export function assertSafeNumericConstraint(
+  value: unknown,
+  label: string,
+): number {
+  if (!isNumber(value) || !Number.isFinite(value)) {
+    throw new Error(
+      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${String(value)}). This value would otherwise be emitted verbatim into generated source.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * {@link assertSafeNumericConstraint} for an optional constraint.
+ *
+ * Passes `undefined` straight through so callers keep "absent" distinct from
+ * "present but not a number", which must still be rejected.
+ *
+ * @param value Constraint value taken from the document, possibly absent
+ * @param label Field name, used in the error message
+ */
+export function safeNumericConstraint(
+  value: unknown,
+  label: string,
+): number | undefined {
+  return value === undefined
+    ? undefined
+    : assertSafeNumericConstraint(value, label);
+}

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable unicorn/no-array-reduce */
 
 import {
+  assertSafeNumericConstraint,
   camel,
   type ClientBuilder,
   type ClientGeneratorsBuilder,
@@ -24,23 +25,10 @@ import {
   type OpenApiSchemaObject,
   pascal,
   resolveRef,
+  safeNumericConstraint,
   stringify,
 } from '@orval/core';
 import { unique } from 'remeda';
-
-// Numeric/length constraints are interpolated into generated source as a
-// bare, unquoted expression (e.g. `export const XMin = ${min};`), so no
-// syntactic escaping can make an untrusted value safe there. Reject anything
-// that isn't actually a finite number instead of emitting it as-is.
-const assertSafeNumericConstraint = (value: unknown, label: string): number => {
-  if (!isNumber(value) || !Number.isFinite(value)) {
-    throw new Error(
-      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${String(value)}). This value would otherwise be emitted verbatim into generated source.`,
-    );
-  }
-
-  return value;
-};
 
 const EFFECT_DEPENDENCIES: GeneratorDependency[] = [
   {
@@ -1260,14 +1248,19 @@ const parseBodyAndResponse = ({
   const resolvedJsonSchema = dereference(schema, context);
 
   if (resolvedJsonSchema.items) {
-    const min =
+    // Emitted as bare expressions (`S.minItems(${min})`), so they get the same
+    // finite-number assertion the scalar constraint block applies — nothing
+    // upstream validates them.
+    const rawMin =
       resolvedJsonSchema.minimum ??
       resolvedJsonSchema.minLength ??
       resolvedJsonSchema.minItems;
-    const max =
+    const rawMax =
       resolvedJsonSchema.maximum ??
       resolvedJsonSchema.maxLength ??
       resolvedJsonSchema.maxItems;
+    const min = safeNumericConstraint(rawMin, 'minimum/minLength/minItems');
+    const max = safeNumericConstraint(rawMax, 'maximum/maxLength/maxItems');
 
     return {
       input: generateEffectValidationSchemaDefinition(

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1367,3 +1367,65 @@ describe('getMockScalar (enum member type confusion)', () => {
     ).toBe('faker.helpers.arrayElement([true,false] as const)');
   });
 });
+
+describe('getMockScalar (numeric constraint safety)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  const payload = '0, x:(globalThis.pwned=1)' as unknown as number;
+
+  // These land inside faker call arguments as bare expressions
+  // (`faker.number.int({min: ${numMin}})`), so a non-numeric value would be
+  // spliced in as live code that runs when the mock factory is called.
+  it.each([
+    ['minimum', { type: 'integer', minimum: payload }],
+    ['maximum', { type: 'integer', maximum: payload }],
+    ['multipleOf', { type: 'integer', multipleOf: payload }],
+    ['minLength', { type: 'string', minLength: payload }],
+    ['maxLength', { type: 'string', maxLength: payload }],
+    [
+      'minItems',
+      { type: 'array', minItems: payload, items: { type: 'string' } },
+    ],
+    [
+      'maxItems',
+      { type: 'array', maxItems: payload, items: { type: 'string' } },
+    ],
+  ])('rejects a non-numeric %s', (label, schema) => {
+    expect(() =>
+      getMockScalar({
+        ...baseArg,
+        item: {
+          ...(schema as Record<string, unknown>),
+          name: 'field',
+        } as never,
+        // Faker v9: `multipleOf` is only emitted on that version, so the
+        // constraint is only reachable there.
+        context: scalarContext(
+          {},
+          { packageJson: { dependencies: { '@faker-js/faker': '^9.0.0' } } },
+        ),
+      }),
+    ).toThrow(new RegExp(`"${label}" constraint is not a finite number`));
+  });
+
+  it('still emits genuine numeric bounds', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'integer' as OpenApiSchemaObjectType,
+        minimum: 3,
+        maximum: 42,
+        name: 'count',
+      },
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe('faker.number.int({min: 3, max: 42})');
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1429,3 +1429,58 @@ describe('getMockScalar (numeric constraint safety)', () => {
     expect(result.value).toBe('faker.number.int({min: 3, max: 42})');
   });
 });
+
+describe('getMockScalar (non-finite numeric constraints)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    existingReferencedProperties: [],
+    splitMockImplementations: [],
+  };
+
+  // A YAML document can express `.nan` / `.inf`, which are numbers and so pass
+  // a `typeof` check, but would emit `min: NaN` / `max: Infinity` into the
+  // generated mock.
+  it.each<[string, Record<string, unknown>]>([
+    ['exclusiveMinimum NaN', { exclusiveMinimum: Number.NaN }],
+    ['exclusiveMaximum NaN', { exclusiveMaximum: Number.NaN }],
+    [
+      'exclusiveMinimum -Infinity',
+      { exclusiveMinimum: Number.NEGATIVE_INFINITY },
+    ],
+    [
+      'exclusiveMaximum Infinity',
+      { exclusiveMaximum: Number.POSITIVE_INFINITY },
+    ],
+    ['minimum Infinity', { minimum: Number.POSITIVE_INFINITY }],
+    ['maximum NaN', { maximum: Number.NaN }],
+  ])('rejects %s', (_label, constraint) => {
+    expect(() =>
+      getMockScalar({
+        ...baseArg,
+        item: {
+          type: 'number' as OpenApiSchemaObjectType,
+          ...constraint,
+          name: 'field',
+        } as never,
+        context: scalarContext(),
+      }),
+    ).toThrow(/constraint is not a finite number/);
+  });
+
+  it('still emits finite exclusive bounds', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'integer' as OpenApiSchemaObjectType,
+        exclusiveMinimum: 1,
+        exclusiveMaximum: 9,
+        name: 'field',
+      } as never,
+      context: scalarContext(),
+    });
+
+    expect(result.value).toBe('faker.number.int({min: 1, max: 9})');
+  });
+});

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -235,17 +235,18 @@ export function getMockScalar({
       // OpenAPI 3.0: booleans indicating whether minimum/maximum is exclusive — use minimum/maximum as the bound.
       // OpenAPI 3.1: numbers representing the exclusive boundary value — use directly.
       // Spec-supplied bounds land in `faker.number.int({min: ${numMin}})` as
-      // bare expressions, so assert them rather than casting. The
-      // `exclusive*` branches are already gated on `typeof === 'number'`.
+      // bare expressions, so assert them rather than casting. `typeof` is not
+      // enough for the exclusive branches: a YAML document can say `.nan` or
+      // `.inf`, which are numbers but would emit `min: NaN` / `max: Infinity`.
       const specMin = safeNumericConstraint(item.minimum, 'minimum');
       const specMax = safeNumericConstraint(item.maximum, 'maximum');
       const numMin =
         typeof item.exclusiveMinimum === 'number'
-          ? item.exclusiveMinimum
+          ? safeNumericConstraint(item.exclusiveMinimum, 'exclusiveMinimum')
           : (specMin ?? safeMockOptions.numberMin);
       const numMax =
         typeof item.exclusiveMaximum === 'number'
-          ? item.exclusiveMaximum
+          ? safeNumericConstraint(item.exclusiveMaximum, 'exclusiveMaximum')
           : (specMax ?? safeMockOptions.numberMax);
       const intParts: string[] = [];
       if (numMin !== undefined) intParts.push(`min: ${numMin}`);

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -16,6 +16,7 @@ import {
   isString,
   jsStringLiteralEscape,
   mergeDeep,
+  safeNumericConstraint,
   type MockOptions,
   type OpenApiSchemaObject,
 } from '@orval/core';
@@ -233,21 +234,26 @@ export function getMockScalar({
       // Handle exclusiveMinimum/exclusiveMaximum for both OpenAPI 3.0 (boolean) and 3.1 (number).
       // OpenAPI 3.0: booleans indicating whether minimum/maximum is exclusive — use minimum/maximum as the bound.
       // OpenAPI 3.1: numbers representing the exclusive boundary value — use directly.
-      const numMin = (
+      // Spec-supplied bounds land in `faker.number.int({min: ${numMin}})` as
+      // bare expressions, so assert them rather than casting. The
+      // `exclusive*` branches are already gated on `typeof === 'number'`.
+      const specMin = safeNumericConstraint(item.minimum, 'minimum');
+      const specMax = safeNumericConstraint(item.maximum, 'maximum');
+      const numMin =
         typeof item.exclusiveMinimum === 'number'
           ? item.exclusiveMinimum
-          : (item.minimum ?? safeMockOptions.numberMin)
-      ) as number | undefined;
-      const numMax = (
+          : (specMin ?? safeMockOptions.numberMin);
+      const numMax =
         typeof item.exclusiveMaximum === 'number'
           ? item.exclusiveMaximum
-          : (item.maximum ?? safeMockOptions.numberMax)
-      ) as number | undefined;
+          : (specMax ?? safeMockOptions.numberMax);
       const intParts: string[] = [];
       if (numMin !== undefined) intParts.push(`min: ${numMin}`);
       if (numMax !== undefined) intParts.push(`max: ${numMax}`);
       if (isFakerV9 && item.multipleOf !== undefined)
-        intParts.push(`multipleOf: ${item.multipleOf}`);
+        intParts.push(
+          `multipleOf: ${safeNumericConstraint(item.multipleOf, 'multipleOf')}`,
+        );
       let value = getNullable(
         `faker.number.${intFunction}(${intParts.length > 0 ? `{${intParts.join(', ')}}` : ''})`,
         isNullable,
@@ -258,7 +264,9 @@ export function getMockScalar({
         if (numMin !== undefined) floatParts.push(`min: ${numMin}`);
         if (numMax !== undefined) floatParts.push(`max: ${numMax}`);
         if (isFakerV9 && item.multipleOf !== undefined) {
-          floatParts.push(`multipleOf: ${item.multipleOf}`);
+          floatParts.push(
+            `multipleOf: ${safeNumericConstraint(item.multipleOf, 'multipleOf')}`,
+          );
         } else if (safeMockOptions.fractionDigits !== undefined) {
           floatParts.push(`fractionDigits: ${safeMockOptions.fractionDigits}`);
         }
@@ -438,8 +446,8 @@ export function getMockScalar({
       // min > max). This also avoids relying on faker's internal default
       // upper bound when only `minItems` is specified, which can otherwise
       // produce very large arrays.
-      const arrSchemaMin = item.minItems;
-      const arrSchemaMax = item.maxItems;
+      const arrSchemaMin = safeNumericConstraint(item.minItems, 'minItems');
+      const arrSchemaMax = safeNumericConstraint(item.maxItems, 'maxItems');
       const arrGlobalMin = safeMockOptions.arrayMin;
       const arrGlobalMax = safeMockOptions.arrayMax;
 
@@ -487,8 +495,8 @@ export function getMockScalar({
       // for the missing side only if it does not invert the range; otherwise
       // reuse the explicit bound so we never invent values the user did not
       // supply (and never produce min > max).
-      const schemaMin = item.minLength;
-      const schemaMax = item.maxLength;
+      const schemaMin = safeNumericConstraint(item.minLength, 'minLength');
+      const schemaMax = safeNumericConstraint(item.maxLength, 'maxLength');
       const globalMin = safeMockOptions.stringMin;
       const globalMax = safeMockOptions.stringMax;
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -3,6 +3,7 @@
 import {
   buildDynamicScope,
   buildInlineDynamicScope,
+  assertSafeNumericConstraint,
   camel,
   type ClientBuilder,
   type ClientDependenciesBuilder,
@@ -34,6 +35,7 @@ import {
   pascal,
   resolveDynamicRef,
   resolveRef,
+  safeNumericConstraint,
   stringify,
   type ZodCoerceType,
   type ZodVariantOption,
@@ -58,21 +60,6 @@ import {
   resolveIsZodV4,
 } from './compatible-v4';
 import { PURE_COMMENT, renderZodExport, zodMiniCall } from './export-emitter';
-
-// Numeric/length constraints (minimum, maximum, exclusiveMinimum,
-// exclusiveMaximum, multipleOf) are interpolated into generated source as a
-// bare, unquoted expression (e.g. `export const XMin = ${min};`), so there is
-// no syntactic escaping that can make an untrusted value safe there. Reject
-// anything that isn't actually a finite number instead of emitting it as-is.
-const assertSafeNumericConstraint = (value: unknown, label: string): number => {
-  if (!isNumber(value) || !Number.isFinite(value)) {
-    throw new Error(
-      `orval: refusing to generate code for an OpenAPI document whose "${label}" constraint is not a finite number (got ${String(value)}). This value would otherwise be emitted verbatim into generated source.`,
-    );
-  }
-
-  return value;
-};
 
 export const getZodDependencies: ClientDependenciesBuilder = (
   _hasGlobalMutator,
@@ -3027,14 +3014,19 @@ const parseBodyAndResponse = ({
 
   // keep the same behaviour for array
   if (resolvedJsonSchema.items) {
-    const min =
+    // These reach `renderArrayWithBounds` and are emitted as bare expressions
+    // (`.min(${min})`), so they get the same finite-number assertion the scalar
+    // constraint block applies — nothing upstream validates them.
+    const rawMin =
       resolvedJsonSchema.minimum ??
       resolvedJsonSchema.minLength ??
       resolvedJsonSchema.minItems;
-    const max =
+    const rawMax =
       resolvedJsonSchema.maximum ??
       resolvedJsonSchema.maxLength ??
       resolvedJsonSchema.maxItems;
+    const min = safeNumericConstraint(rawMin, 'minimum/minLength/minItems');
+    const max = safeNumericConstraint(rawMax, 'maximum/maxLength/maxItems');
 
     // When useReusableSchemas is on, shallow-resolve one level so that $ref
     // references inside the items schema are preserved for named-ref emission.


### PR DESCRIPTION
Fixes the numeric-constraint injection reported in GHSA-xm38-vjwp-qrg4.

## The gap

Commit d346d94a added `assertSafeNumericConstraint` to the **scalar** constraint block only. Three other paths emit the same spec-supplied constraints as bare, unquoted expressions and were never guarded:

| Generator | Sink | When it runs |
|---|---|---|
| zod | `.min(${rules.min})` via `renderArrayWithBounds` | **import** |
| effect | `.pipe(S.minItems(${rules.min}))` | **import** |
| faker | `faker.number.int({min: ${numMin}})`, `faker.string.alpha({length: {min: ${strMin}}})` | mock call |

There is no surrounding quote in any of them, so no escaping helps — the value has to be a number.

## Reachable by default

An OpenAPI **3.1** document passes validation with these fields set to arbitrary strings, so no `unsafeDisableValidation` is needed. Confirmed:

```yaml
type: array
minItems: "1); globalThis.__ZOD_PWNED=1; void(0"
items: { type: string }
```

Emitted zod (module scope):

```ts
export const ListPetsResponse = zod.array(ListPetsResponseItem).min(1); globalThis.__ZOD_PWNED=1; void(0)
```

Transpiled and run with the library stubbed:

```
parse: OK (compiles, so it ships)
injected executed at IMPORT time: __ZOD_PWNED
```

Effect behaves the same with a payload matched to its `.pipe(S.minItems(…))` shape (`__EFF_PWNED` fires at import). The faker sink is runtime rather than import-time, which the harness separates cleanly:

```
before mock call : __FAKER_PWNED=undefined  __STR_PWNED=undefined
mock output      : {"count":1,"name":"x"}
after mock call  : __FAKER_PWNED=1  __STR_PWNED=1
```

## Beyond the report

Auditing the faker path turned up three more sinks of the same class that the advisory doesn't list — `multipleOf` (both the int and float branches) and the array `minItems`/`maxItems` bounds. All fixed here.

## Consolidated rather than copied

The guard already existed twice, byte-identical, in zod and effect. Rather than add a fourth copy for mock, it moves to `@orval/core` and all three generators share it, alongside a `safeNumericConstraint` variant that passes `undefined` through so "absent" stays distinct from "present but not a number". The two local copies are gone.

After:

```
🛑 orval: refusing to generate code for an OpenAPI document whose
   "minimum/minLength/minItems" constraint is not a finite number (got 1); globalThis...).
```

No file is written for any of the three PoCs.

## No behaviour change for valid specs

Generated output is **byte-identical** before and after — verified with `diff -r` across zod, effect and faker output for a spec exercising `minimum`/`maximum`/`multipleOf`, exclusive bounds, `minLength`/`maxLength` and `minItems`/`maxItems`:

```
IDENTICAL — no behaviour change for valid specs
```

## Testing

17 new tests:

- **10** on the shared core guard, covering code-payload strings, numeric strings, `NaN`, `Infinity`, booleans, `null`, objects, and the `undefined` passthrough
- **7** on the faker sinks via `getMockScalar`, one per constraint field, all failing against the unfixed generator

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with zero drift in generated sample output.

> [!NOTE]
> Coverage is uneven by design: the faker sinks have direct unit tests because `getMockScalar` is exported, but the zod/effect array-rule sinks live inside the unexported `parseBodyAndResponse`, so they are covered by the shared-guard unit tests plus the end-to-end PoC verification above rather than by their own unit tests. I did not export another internal just to reach them — say the word if you would rather have that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric constraints are now validated before generating schemas, responses, and mock data.
  * Invalid values—including non-numeric, non-finite, boolean, null, and object inputs—now produce validation errors instead of invalid generated output.
  * Optional constraints remain supported when omitted.
  * Valid finite numeric constraints continue to work across minimum, maximum, length, item-count, and multiple-of settings.

* **Tests**
  * Added coverage for valid, omitted, and invalid numeric constraint values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->