### PR TITLE
fix: keep zod object defaults with tuples or ref arrays inline

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1038,12 +1038,41 @@ export const generateZodValidationSchemaDefinition = (
       // readonly, which zod v4's `.default()` rejects (#3399).
       const formatDefaultEntryValue = (
         entryValue: unknown,
+        entrySchema?: unknown,
       ): string | undefined => {
         if (isString(entryValue)) {
           return `${JSON.stringify(entryValue)} as const`;
         }
 
         if (Array.isArray(entryValue)) {
+          const entrySchemaObj =
+            entrySchema && typeof entrySchema === 'object'
+              ? (entrySchema as Record<string, unknown>)
+              : undefined;
+          const prefixItems =
+            entrySchemaObj && Array.isArray(entrySchemaObj.prefixItems)
+              ? entrySchemaObj.prefixItems
+              : undefined;
+          if (prefixItems) {
+            // Nested tuple (prefixItems): items must NOT get `as const`
+            // on the whole array (that widens to readonly, which zod v4
+            // `.default()` rejects — #3399). Emit plain literals so
+            // TypeScript contextually types them as the tuple (#4023).
+            const tupleItems = entryValue.map((item) => {
+              if (isString(item)) {
+                return `${JSON.stringify(item)} as const`;
+              }
+              if (isNumber(item) || isBoolean(item)) {
+                return `${item}`;
+              }
+              if (item === null || item === undefined) {
+                return `${item}`;
+              }
+              const formatted = formatDefaultEntryValue(item);
+              return formatted ?? 'null';
+            });
+            return `[${tupleItems.join(', ')}]`;
+          }
           const arrayItems = entryValue.map((item) => {
             if (isString(item)) {
               return `${JSON.stringify(item)} as const`;
@@ -1073,7 +1102,23 @@ export const generateZodValidationSchemaDefinition = (
         if (isObject(entryValue)) {
           const nestedEntries = Object.entries(entryValue)
             .map(([nestedKey, nestedValue]) => {
-              const formatted = formatDefaultEntryValue(nestedValue);
+              const nestedSchema =
+                entrySchema &&
+                typeof entrySchema === 'object' &&
+                entrySchema !== null &&
+                'properties' in entrySchema &&
+                typeof (entrySchema as Record<string, unknown>).properties ===
+                  'object' &&
+                (entrySchema as Record<string, unknown>).properties !== null
+                  ? (
+                      (entrySchema as Record<string, unknown>)
+                        .properties as Record<string, unknown>
+                    )[nestedKey]
+                  : undefined;
+              const formatted = formatDefaultEntryValue(
+                nestedValue,
+                nestedSchema,
+              );
               return formatted === undefined
                 ? undefined
                 : `${JSON.stringify(nestedKey)}: ${formatted}`;
@@ -1097,9 +1142,13 @@ export const generateZodValidationSchemaDefinition = (
         return undefined;
       };
 
+      const properties =
+        schema.properties && isObject(schema.properties)
+          ? (schema.properties as Record<string, unknown>)
+          : undefined;
       const entries = Object.entries(schema.default)
         .map(([key, value]) => {
-          const formatted = formatDefaultEntryValue(value);
+          const formatted = formatDefaultEntryValue(value, properties?.[key]);
           return formatted === undefined
             ? undefined
             : `${JSON.stringify(key)}: ${formatted}`;
@@ -1107,19 +1156,64 @@ export const generateZodValidationSchemaDefinition = (
         .filter((entry) => entry !== undefined)
         .join(', ');
       defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;
+
+      // If the object default contains a nested tuple (prefixItems), an
+      // array of objects (which may have enum-literal props), or any array
+      // with enum items, keep the whole object inline rather than hoisting
+      // it into a named const.  Named const loses TypeScript's contextual
+      // type information, widening tuple arrays to `T[]` and enum-literal
+      // properties to their base type (#4023, #4024).
+      const hasNestedTupleOrEnumArray =
+        properties !== undefined &&
+        Object.entries(properties).some(([key, p]) => {
+          if (!p || typeof p !== 'object') return false;
+          const propSchema = p as Record<string, unknown>;
+          // Direct tuple property.
+          if ('prefixItems' in propSchema) return true;
+          // Array whose items are $ref (we can't narrow inline objects
+          // without resolving the ref, and hoisting loses the type).
+          if (
+            propSchema.type === 'array' &&
+            propSchema.items &&
+            typeof propSchema.items === 'object' &&
+            propSchema.items !== null &&
+            '$ref' in propSchema.items
+          ) {
+            return true;
+          }
+          return false;
+        });
+      if (hasNestedTupleOrEnumArray) {
+        defaultVarName = defaultValue;
+        defaultValue = undefined;
+      }
     } else {
       // OpenApiSchemaObject defines default as 'any'
       defaultValue = formatDefaultValue(schema.default);
 
-      // If the schema is an array with enum items, inject inplace to avoid issues with default values
+      // If the schema is an array with enum items, inject inplace to avoid issues with default values.
+      // Also keep inline when array items are objects (or $ref to objects)
+      // that may contain enum-literal properties — hoisting to a const
+      // widens literal values to their base type (#4024).
+      const hasEnumOrObjectItems =
+        schema.items &&
+        typeof schema.items === 'object' &&
+        ('enum' in schema.items ||
+          schema.items.type === 'object' ||
+          '$ref' in schema.items);
       const isArrayWithEnumItems =
         Array.isArray(schema.default) &&
         type === 'array' &&
         schema.items &&
         'enum' in schema.items &&
         schema.default.length > 0;
+      const isArrayWithObjectItems =
+        Array.isArray(schema.default) &&
+        type === 'array' &&
+        hasEnumOrObjectItems &&
+        schema.default.length > 0;
 
-      if (isArrayWithEnumItems) {
+      if (isArrayWithEnumItems || isArrayWithObjectItems) {
         defaultVarName = defaultValue;
         defaultValue = undefined;
       }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1165,7 +1165,7 @@ export const generateZodValidationSchemaDefinition = (
       // properties to their base type (#4023, #4024).
       const hasNestedTupleOrEnumArray =
         properties !== undefined &&
-        Object.entries(properties).some(([key, p]) => {
+        Object.values(properties).some((p) => {
           if (!p || typeof p !== 'object') return false;
           const propSchema = p as Record<string, unknown>;
           // Direct tuple property.

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -224,6 +224,63 @@ export interface ZodValidationSchemaDefinition {
 
 const minAndMaxTypes = new Set(['number', 'integer', 'string', 'array']);
 
+/**
+ * Whether a schema's default has to be emitted inline rather than hoisted into
+ * a named const.
+ *
+ * Hoisting throws away the contextual type, which matters for two shapes: a
+ * tuple widens to `T[]`, and an array of `$ref` items widens its literal
+ * properties to their base types (#4023, #4024). Neither can be repaired after
+ * the fact — unlike an array of `enum` items, where the hoisted const narrows
+ * each element with `as const` and so must keep hoisting.
+ *
+ * The walk covers `properties` and `items`, so a tuple nested at any depth is
+ * still found.
+ *
+ * @param schema Schema node to inspect, from anywhere in the document
+ * @param seen Nodes already visited, guarding against a self-referential schema
+ */
+function needsInlineDefault(
+  schema: unknown,
+  seen = new Set<object>(),
+): boolean {
+  if (!schema || typeof schema !== 'object') {
+    return false;
+  }
+  if (seen.has(schema)) {
+    return false;
+  }
+  seen.add(schema);
+
+  const node = schema as Record<string, unknown>;
+
+  // A tuple anywhere below the default is enough on its own.
+  if ('prefixItems' in node) {
+    return true;
+  }
+
+  const items = node.items;
+  if (items && typeof items === 'object') {
+    // An array of `$ref` items cannot be narrowed here without resolving the
+    // ref, so its literal types only survive inline.
+    if ('$ref' in (items as Record<string, unknown>)) {
+      return true;
+    }
+    if (needsInlineDefault(items, seen)) {
+      return true;
+    }
+  }
+
+  const properties = node.properties;
+  if (properties && typeof properties === 'object') {
+    return Object.values(properties as Record<string, unknown>).some((child) =>
+      needsInlineDefault(child, seen),
+    );
+  }
+
+  return false;
+}
+
 const removeReadOnlyProperties = (
   schema: OpenApiSchemaObject,
 ): OpenApiSchemaObject => {
@@ -1073,6 +1130,11 @@ export const generateZodValidationSchemaDefinition = (
             });
             return `[${tupleItems.join(', ')}]`;
           }
+          // The items schema describes every element, so pass it down: without
+          // it an array of tuples formats its elements through the generic
+          // path and picks up per-item `as const`, instead of the plain
+          // literals the tuple branch emits.
+          const itemsSchema = entrySchemaObj?.items;
           const arrayItems = entryValue.map((item) => {
             if (isString(item)) {
               return `${JSON.stringify(item)} as const`;
@@ -1081,14 +1143,14 @@ export const generateZodValidationSchemaDefinition = (
               return `${item} as const`;
             }
             if (Array.isArray(item)) {
-              const formatted = formatDefaultEntryValue(item);
+              const formatted = formatDefaultEntryValue(item, itemsSchema);
               return formatted ?? '[]';
             }
             // Object items recurse so nested string values get `as const`
             // (e.g. `{ value: 'active' as const }`), which JSON.stringify
             // alone would drop (#3982 CodeRabbit).
             if (isObject(item)) {
-              const formatted = formatDefaultEntryValue(item);
+              const formatted = formatDefaultEntryValue(item, itemsSchema);
               return formatted ?? 'null';
             }
             return `${JSON.stringify(item)}`;
@@ -1157,33 +1219,16 @@ export const generateZodValidationSchemaDefinition = (
         .join(', ');
       defaultValue = entries.length === 0 ? `{}` : `{ ${entries} }`;
 
-      // If the object default contains a nested tuple (prefixItems), an
-      // array of objects (which may have enum-literal props), or any array
-      // with enum items, keep the whole object inline rather than hoisting
-      // it into a named const.  Named const loses TypeScript's contextual
-      // type information, widening tuple arrays to `T[]` and enum-literal
-      // properties to their base type (#4023, #4024).
-      const hasNestedTupleOrEnumArray =
+      // If the object default contains a tuple (prefixItems), an array of
+      // objects (which may have enum-literal props), or any array with enum
+      // items — at any depth — keep the whole object inline rather than
+      // hoisting it into a named const. A named const loses TypeScript's
+      // contextual type information, widening tuple arrays to `T[]` and
+      // enum-literal properties to their base type (#4023, #4024).
+      if (
         properties !== undefined &&
-        Object.values(properties).some((p) => {
-          if (!p || typeof p !== 'object') return false;
-          const propSchema = p as Record<string, unknown>;
-          // Direct tuple property.
-          if ('prefixItems' in propSchema) return true;
-          // Array whose items are $ref (we can't narrow inline objects
-          // without resolving the ref, and hoisting loses the type).
-          if (
-            propSchema.type === 'array' &&
-            propSchema.items &&
-            typeof propSchema.items === 'object' &&
-            propSchema.items !== null &&
-            '$ref' in propSchema.items
-          ) {
-            return true;
-          }
-          return false;
-        });
-      if (hasNestedTupleOrEnumArray) {
+        Object.values(properties).some((p) => needsInlineDefault(p))
+      ) {
         defaultVarName = defaultValue;
         defaultValue = undefined;
       }
@@ -1195,12 +1240,16 @@ export const generateZodValidationSchemaDefinition = (
       // Also keep inline when array items are objects (or $ref to objects)
       // that may contain enum-literal properties — hoisting to a const
       // widens literal values to their base type (#4024).
+      // `needsInlineDefault` also catches items that are themselves tuples, or
+      // that hide a tuple further down, which an `items`-only check misses
+      // (e.g. an array of `[number, number]` pairs).
       const hasEnumOrObjectItems =
         schema.items &&
         typeof schema.items === 'object' &&
         ('enum' in schema.items ||
           schema.items.type === 'object' ||
-          '$ref' in schema.items);
+          '$ref' in schema.items ||
+          needsInlineDefault(schema.items));
       const isArrayWithEnumItems =
         Array.isArray(schema.default) &&
         type === 'array' &&

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2900,6 +2900,90 @@ describe('generateZodValidationSchemaDefinition`', () => {
       );
       expect(parsed.consts).not.toContain('exampleWithRefItemsDefault =');
     });
+
+    const intTuple = {
+      type: 'array',
+      prefixItems: [{ type: 'integer' }, { type: 'integer' }],
+    };
+
+    const parseDefault = (schema: unknown, name: string) => {
+      const result = generateZodValidationSchemaDefinition(
+        schema as never,
+        context,
+        name,
+        false,
+        false,
+        { required: false },
+      );
+      return parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+    };
+
+    it('keeps a default inline when a tuple sits under a nested object', () => {
+      // Only the top-level properties were inspected, so this hoisted and
+      // TypeScript widened `position` to `number[]`, which is not assignable
+      // to the `[number, number]` tuple `zod.tuple()` expects.
+      const parsed = parseDefault(
+        {
+          type: 'object',
+          properties: {
+            settings: { type: 'object', properties: { position: intTuple } },
+          },
+          default: { settings: { position: [0, 0] } },
+        },
+        'nestedObjectTuple',
+      );
+
+      expect(parsed.zod).toContain(
+        '.default({ "settings": { "position": [0, 0] } })',
+      );
+      expect(parsed.consts).not.toContain('nestedObjectTupleDefault =');
+    });
+
+    it('keeps a default inline for an array-of-tuples property', () => {
+      const parsed = parseDefault(
+        {
+          type: 'object',
+          properties: { points: { type: 'array', items: intTuple } },
+          default: { points: [[0, 0]] },
+        },
+        'arrayOfTuplesProp',
+      );
+
+      expect(parsed.zod).toContain('.default({ "points": [[0, 0]] })');
+      expect(parsed.consts).not.toContain('arrayOfTuplesPropDefault =');
+    });
+
+    it('keeps a top-level array-of-tuples default inline', () => {
+      const parsed = parseDefault(
+        { type: 'array', items: intTuple, default: [[0, 0]] },
+        'topLevelArrayOfTuples',
+      );
+
+      expect(parsed.zod).toContain('.default([[0, 0]])');
+      expect(parsed.consts).not.toContain('topLevelArrayOfTuplesDefault =');
+    });
+
+    it('still hoists a default with no tuple or ref array in it', () => {
+      // The inline path is only for shapes that lose type information, so an
+      // ordinary object default must keep being hoisted.
+      const parsed = parseDefault(
+        {
+          type: 'object',
+          properties: { a: { type: 'string' }, b: { type: 'integer' } },
+          default: { a: 'x', b: 1 },
+        },
+        'plainObject',
+      );
+
+      expect(parsed.consts).toContain('plainObjectDefault =');
+      expect(parsed.zod).toContain('.default(plainObjectDefault)');
+    });
   });
 
   describe('default value template-literal injection', () => {

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -2831,6 +2831,75 @@ describe('generateZodValidationSchemaDefinition`', () => {
         'export const exampleRange1ItemMax = 100;',
       );
     });
+
+    it('keeps nested tuple (prefixItems) object defaults inline (#4023)', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            position: {
+              type: 'array',
+              prefixItems: [{ type: 'integer' }, { type: 'integer' }],
+            },
+          },
+          default: { name: 'example', position: [0, 0] },
+        },
+        context,
+        'exampleWithTuple',
+        false,
+        false,
+        { required: false },
+      );
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      // The whole object default must be inline so TS contextually types
+      // `position` as the tuple, not `number[]`.
+      expect(parsed.zod).toContain(
+        '.default({ "name": "example" as const, "position": [0, 0] })',
+      );
+      expect(parsed.consts).not.toContain('exampleWithTupleDefault =');
+    });
+
+    it('keeps $ref object-array defaults inline so literal types survive (#4024)', () => {
+      const result = generateZodValidationSchemaDefinition(
+        {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/ExampleItem' },
+            },
+          },
+          default: { items: [{ value: 1 }, { value: 2 }] },
+        },
+        context,
+        'exampleWithRefItems',
+        false,
+        false,
+        { required: false },
+      );
+
+      const parsed = parseZodValidationSchemaDefinition(
+        result,
+        context,
+        false,
+        false,
+        false,
+      );
+      // Hoisting to a const widens `value` to `number`, incompatible with
+      // the `zod.literal(1) | zod.literal(2)` union.
+      expect(parsed.zod).toContain(
+        '.default({ "items": [{ "value": 1 as const }, { "value": 2 as const }] })',
+      );
+      expect(parsed.consts).not.toContain('exampleWithRefItemsDefault =');
+    });
   });
 
   describe('default value template-literal injection', () => {


### PR DESCRIPTION
Fixes #4023 and #4024. Object defaults containing nested tuples or ref object arrays stay inline so TypeScript keeps tuple and literal types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated default values for tuple-shaped arrays, preserving correct TypeScript tuple and literal typing.
  * Improved nested object defaults by applying schema information recursively.
  * Preserved literal types for arrays containing enums, objects, or referenced values.
  * Kept complex defaults inline when needed to maintain accurate contextual typing.

* **Tests**
  * Added regression coverage for nested tuple defaults, arrays of tuples, top-level tuple arrays, and ordinary object defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->