### PR TITLE
fix: escape date defaults in generated factories (GHSA-wx66-36r6-v5g7)

### DIFF
--- a/packages/core/src/generators/factory.test.ts
+++ b/packages/core/src/generators/factory.test.ts
@@ -334,6 +334,58 @@ describe('generateFactory', () => {
     expect(result?.model).toContain("dateField: new Date('2026-01-01')");
   });
 
+  it('escapes a quote in a date default so it cannot close the literal', () => {
+    // The default is document text spliced into a hand-built single-quoted
+    // literal. An unescaped quote appended expressions to the `new Date(...)`
+    // argument, which the factory then evaluated on every call.
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['dateField'],
+      properties: {
+        dateField: {
+          type: 'string',
+          format: 'date-time',
+          default: "2024-01-01' + (globalThis.pwned = 1, '') + '",
+        },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'InjectedDateObj',
+      createMockContext({ override: { useDates: true } }),
+    );
+
+    expect(result?.model).toContain(
+      String.raw`dateField: new Date('2024-01-01\' + (globalThis.pwned = 1, \'\') + \'')`,
+    );
+    // The tell-tale of a break-out: the expression sitting outside the literal.
+    expect(result?.model).not.toContain("' + (globalThis.pwned = 1, '') + '')");
+  });
+
+  it('escapes a backslash in a date default', () => {
+    const schema: OpenApiSchemaObject = {
+      type: 'object',
+      required: ['dateField'],
+      properties: {
+        dateField: {
+          type: 'string',
+          format: 'date',
+          default: '2024-01-01\\',
+        },
+      },
+    };
+
+    const result = generateFactory(
+      schema,
+      'BackslashDateObj',
+      createMockContext({ override: { useDates: true } }),
+    );
+
+    // A trailing backslash would otherwise escape the closing quote.
+    expect(result?.model).toContain(String.raw`new Date('2024-01-01\\')`);
+  });
+
   it('handles enums with strings and numbers', () => {
     const schema: OpenApiSchemaObject = {
       type: 'object',

--- a/packages/core/src/generators/factory.ts
+++ b/packages/core/src/generators/factory.ts
@@ -11,6 +11,7 @@ import {
   getFileInfo,
   getSchemasImportPath,
   isString,
+  jsStringLiteralEscape,
   logWarning,
   pascal,
   upath,
@@ -490,7 +491,10 @@ function buildDefaultPayload(
     typeof schema.default === 'string' &&
     (schema.format === 'date' || schema.format === 'date-time')
   ) {
-    return `new Date('${schema.default}')`;
+    // The default is document text, and this builds a single-quoted literal by
+    // hand: an unescaped `'` closed it and appended expressions to the
+    // `new Date(...)` argument, which the factory then evaluated on every call.
+    return `new Date('${jsStringLiteralEscape(schema.default)}')`;
   }
   return formatValue(schema.default);
 }


### PR DESCRIPTION
Fixes the factory date-default injection reported in GHSA-wx66-36r6-v5g7.

## The bug

`buildDefaultPayload` built a single-quoted literal by hand for string date defaults under `useDates`:

```ts
return `new Date('${schema.default}')`;
```

The default is document text, so an unescaped `'` closes the literal and appends expressions to the `new Date(...)` argument:

```yaml
createdAt:
  type: string
  format: date-time
  default: '2024-01-01'' + (console.log("ORVAL_DATE_POC"), '''') + '''
```

```ts
createdAt: new Date('2024-01-01' + (console.log("ORVAL_DATE_POC"), '') + '')
```

The `typeof schema.default === 'string'` guard above it confirms the value is a string — it does nothing about a quote inside that string.

Transpiled and executed, this fires exactly where the reporter said, on the factory call rather than at import:

```
after import      : nothing fired
after factory call: [ 'ORVAL_DATE_POC' ]
```

## The fix

Escape with `jsStringLiteralEscape`, the helper already used for this context throughout the codebase:

```ts
return `new Date('${jsStringLiteralEscape(schema.default)}')`;
```

After:

```ts
createdAt: new Date('2024-01-01\' + (console.log("ORVAL_DATE_POC"), \'\') + \'')
```

```
after factory call: nothing fired
factory result    : {"createdAt":null}
```

Contained, and the garbage date correctly yields an Invalid Date.

## Why escaping rather than re-quoting

My first attempt used `formatValue` (i.e. `JSON.stringify`), which is safe and matches the sibling enum path. But it switched valid output from single to double quotes:

```diff
-    dt: new Date('2024-01-01T00:00:00Z'),
+    dt: new Date("2024-01-01T00:00:00Z"),
```

Semantically identical, but it would churn every generated factory and every affected snapshot for no benefit. Escaping keeps the output byte-identical, so I went with that.

## Scope

This is the **only** spec-controlled interpolation in `factory.ts` — I checked the neighbours rather than assuming:

- `new Date(0).toISOString()` — internally generated constant, safe
- `formatValue` — already uses `JSON.stringify` for strings and objects, safe

## No behaviour change for valid specs

`diff -r` on generated models for `date-time`, `date`, string (containing an apostrophe), integer, boolean, object and array defaults:

```
IDENTICAL — no behaviour or formatting change
```

## Testing

Two new tests, both failing against the unfixed generator: a quote break-out (asserting the escaped form *and* that the tell-tale unescaped expression is absent), and a trailing backslash, which would otherwise escape the closing quote.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with zero drift in generated sample output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated date and date-time defaults containing apostrophes or trailing backslashes.
  - Generated values now preserve these characters safely without breaking the resulting date expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->