### PR TITLE
fix: check every redirect hop against externalRefs.allow (GHSA-jmpc-3jgr-j7jv)

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -1,4 +1,6 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -1466,6 +1468,163 @@ describe('externalRefs', () => {
         'Can not generate unique compressed values',
       );
     } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('externalRefs allow-list and redirects', () => {
+  const EXTERNAL_DOC = JSON.stringify({
+    openapi: '3.0.2',
+    info: { title: 'ext', version: '1.0' },
+    paths: {},
+    components: { schemas: { Foo: { type: 'string' } } },
+  });
+
+  /**
+   * Two loopback servers: `redirectUrl` answers 302 pointing at `targetUrl`,
+   * and `targetUrl` serves the external document while counting requests.
+   */
+  async function startRedirectingServers() {
+    const target = http.createServer((_req, res) => {
+      target.hits += 1;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(EXTERNAL_DOC);
+    }) as http.Server & { hits: number };
+    target.hits = 0;
+
+    await new Promise<void>((resolve) =>
+      target.listen(0, '127.0.0.1', resolve),
+    );
+    const targetPort = (target.address() as AddressInfo).port;
+    const targetUrl = `http://127.0.0.1:${targetPort}/external.json`;
+
+    const redirector = http.createServer((_req, res) => {
+      res.writeHead(302, { Location: targetUrl });
+      res.end();
+    });
+    await new Promise<void>((resolve) =>
+      redirector.listen(0, '127.0.0.1', resolve),
+    );
+    const redirectUrl = `http://127.0.0.1:${(redirector.address() as AddressInfo).port}/external.json`;
+
+    return {
+      redirectUrl,
+      targetUrl,
+      get targetHits() {
+        return target.hits;
+      },
+      async close() {
+        await Promise.all([
+          new Promise<void>((resolve) => target.close(() => resolve())),
+          new Promise<void>((resolve) => redirector.close(() => resolve())),
+        ]);
+      },
+    };
+  }
+
+  async function createWorkspaceFor(ref: string) {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), 'orval-redirect-'));
+    const specPath = path.join(workspace, 'spec.yaml');
+    await writeFile(
+      specPath,
+      JSON.stringify({
+        openapi: '3.0.2',
+        info: { title: 'main', version: '1.0' },
+        paths: {
+          '/x': {
+            get: {
+              operationId: 'getX',
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: `${ref}#/components/schemas/Foo` },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+      'utf8',
+    );
+    return { workspace, specPath };
+  }
+
+  it('does not follow a redirect to a URL outside the allow-list', async () => {
+    const servers = await startRedirectingServers();
+    const { workspace, specPath } = await createWorkspaceFor(
+      servers.redirectUrl,
+    );
+    const warnSpy = vi
+      .spyOn(orvalCore, 'logWarning')
+      .mockImplementation(() => {});
+
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            // Only the redirecting URL is allowed, not where it points.
+            parserOptions: {
+              externalRefs: { allow: [servers.redirectUrl] },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      await expect(
+        importSpecs(workspace, normalizedOptions),
+      ).rejects.toBeDefined();
+
+      // The blocked destination must never be contacted.
+      expect(servers.targetHits).toBe(0);
+
+      const warnings = warnSpy.mock.calls.map(([msg]) => msg).join('\n');
+      expect(warnings).toContain('Refused to follow a redirect');
+      expect(warnings).toContain(servers.targetUrl);
+    } finally {
+      warnSpy.mockRestore();
+      await servers.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('follows a redirect when the destination is also allowed', async () => {
+    const servers = await startRedirectingServers();
+    const { workspace, specPath } = await createWorkspaceFor(
+      servers.redirectUrl,
+    );
+
+    try {
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              externalRefs: {
+                allow: [servers.redirectUrl, servers.targetUrl],
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      const spec = await importSpecs(workspace, normalizedOptions);
+
+      expect(spec.verbOptions).toHaveProperty('getX');
+      expect(servers.targetHits).toBe(1);
+    } finally {
+      await servers.close();
       await rm(workspace, { recursive: true, force: true });
     }
   });

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -1486,12 +1486,17 @@ describe('externalRefs allow-list and redirects', () => {
    * and `targetUrl` serves the external document while counting requests.
    */
   async function startRedirectingServers() {
-    const target = http.createServer((_req, res) => {
+    const target = http.createServer((req, res) => {
       target.hits += 1;
+      target.lastHeaders = { ...req.headers };
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(EXTERNAL_DOC);
-    }) as http.Server & { hits: number };
+    }) as http.Server & {
+      hits: number;
+      lastHeaders: Record<string, string | string[] | undefined>;
+    };
     target.hits = 0;
+    target.lastHeaders = {};
 
     await new Promise<void>((resolve) =>
       target.listen(0, '127.0.0.1', resolve),
@@ -1513,6 +1518,9 @@ describe('externalRefs allow-list and redirects', () => {
       targetUrl,
       get targetHits() {
         return target.hits;
+      },
+      get targetHeaders() {
+        return target.lastHeaders;
       },
       async close() {
         await Promise.all([
@@ -1623,6 +1631,91 @@ describe('externalRefs allow-list and redirects', () => {
 
       expect(spec.verbOptions).toHaveProperty('getX');
       expect(servers.targetHits).toBe(1);
+    } finally {
+      await servers.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('does not carry headers configured for the source host to the redirect target', async () => {
+    const servers = await startRedirectingServers();
+    const { workspace, specPath } = await createWorkspaceFor(
+      servers.redirectUrl,
+    );
+
+    try {
+      const sourceHost = new URL(servers.redirectUrl).host;
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              // The credential is scoped to the redirecting host only.
+              headers: [
+                {
+                  domains: [sourceHost],
+                  headers: { authorization: 'Bearer SOURCE-ONLY' },
+                },
+              ],
+              externalRefs: {
+                allow: [servers.redirectUrl, servers.targetUrl],
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      const spec = await importSpecs(workspace, normalizedOptions);
+
+      expect(spec.verbOptions).toHaveProperty('getX');
+      expect(servers.targetHits).toBe(1);
+      // `fetchUrls` matches headers against the first URL's host, so carrying
+      // `init` across hops would hand this credential to the other host.
+      expect(servers.targetHeaders.authorization).toBeUndefined();
+    } finally {
+      await servers.close();
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('sends headers configured for the redirect target host', async () => {
+    const servers = await startRedirectingServers();
+    const { workspace, specPath } = await createWorkspaceFor(
+      servers.redirectUrl,
+    );
+
+    try {
+      const targetHost = new URL(servers.targetUrl).host;
+      const normalizedOptions = await normalizeOptions(
+        {
+          output: { target: '' },
+          input: {
+            target: specPath,
+            parserOptions: {
+              headers: [
+                {
+                  domains: [targetHost],
+                  headers: { authorization: 'Bearer TARGET' },
+                },
+              ],
+              externalRefs: {
+                allow: [servers.redirectUrl, servers.targetUrl],
+              },
+            },
+          },
+        },
+        workspace,
+        {},
+      );
+
+      await importSpecs(workspace, normalizedOptions);
+
+      // Recomputing per hop must still deliver what the user configured for
+      // the host actually being contacted.
+      expect(servers.targetHeaders.authorization).toBe('Bearer TARGET');
     } finally {
       await servers.close();
       await rm(workspace, { recursive: true, force: true });

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -722,6 +722,86 @@ function createSafeFileLoader(
   };
 }
 
+/** Redirect hops to follow before giving up, matching common HTTP clients. */
+const MAX_EXTERNAL_REF_REDIRECTS = 5;
+
+/**
+ * Whether a URL may be fetched: the top-level spec URL is always allowed, and
+ * anything else has to match an explicit allow-list entry. Mirrors the check in
+ * `createSafeUrlLoader.exec` so a redirect cannot reach somewhere the initial
+ * `$ref` could not.
+ */
+function isFetchableUrl(
+  url: string,
+  origin: string | undefined,
+  allowedExternalRefs: string[],
+): boolean {
+  if (origin && resolveRefTarget(url, origin) === resolveRefTarget(origin)) {
+    return true;
+  }
+  return isAllowedRef(url, allowedExternalRefs, origin);
+}
+
+/**
+ * A `fetch` that follows redirects itself so every hop is allow-list checked.
+ *
+ * The global `fetch` follows redirects transparently, so an allowed URL could
+ * answer `302` and send the request to a host the user never allowed — the
+ * allow-list only ever saw the first URL (GHSA-jmpc-3jgr-j7jv). Resolving each
+ * `Location` and re-checking it closes that.
+ */
+function createAllowListCheckedFetch(
+  origin: string | undefined,
+  allowedExternalRefs: string[],
+) {
+  return async (
+    input: string | URL | globalThis.Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    let url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+
+    for (let hop = 0; ; hop++) {
+      const response = await fetch(url, { ...init, redirect: 'manual' });
+
+      const location = response.headers.get('location');
+      const isRedirect =
+        response.status >= 300 && response.status < 400 && location;
+      if (!isRedirect) {
+        return response;
+      }
+
+      if (hop >= MAX_EXTERNAL_REF_REDIRECTS) {
+        throw new Error(
+          `Refused to follow more than ${MAX_EXTERNAL_REF_REDIRECTS} redirects while fetching an external $ref (stopped at ${url}).`,
+        );
+      }
+
+      const next = new URL(location, url).href;
+      if (!isFetchableUrl(next, origin, allowedExternalRefs)) {
+        // The loader swallows whatever this throws and reports only a generic
+        // "reference may be invalid, inaccessible" error, so say plainly what
+        // happened first — otherwise a blocked redirect is indistinguishable
+        // from an unreachable server.
+        logWarning(
+          `Refused to follow a redirect to a URL that is not allowed: ${next}\n` +
+            `Reached by redirect from ${url}.\n` +
+            `Add it to externalRefs.allow or use ['*'] to allow all.`,
+        );
+        throw new Error(
+          `Refused to follow a redirect to a URL that is not allowed: ${next}`,
+        );
+      }
+
+      url = next;
+    }
+  };
+}
+
 /**
  * Wrap `fetchUrls()` so every URL fetch is checked against the allow-list.
  * The top-level spec URL (matching `origin`) is always allowed; subsequent
@@ -733,7 +813,14 @@ function createSafeUrlLoader(
   allowedExternalRefs: string[],
   headers?: { domains: string[]; headers: Record<string, string> }[],
 ) {
-  const base = fetchUrls({ headers });
+  const base = fetchUrls({
+    headers,
+    // With the wildcard every destination is permitted anyway, so leave the
+    // default redirect handling in place.
+    ...(isWildcard
+      ? {}
+      : { fetch: createAllowListCheckedFetch(origin, allowedExternalRefs) }),
+  });
   return {
     type: 'loader' as const,
     validate: base.validate,

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -743,16 +743,46 @@ function isFetchableUrl(
 }
 
 /**
+ * The configured headers that apply to a URL's host.
+ *
+ * Mirrors the domain matching `fetchUrls` performs, so a hop is sent only the
+ * headers the user configured for the host actually being contacted.
+ */
+function headersForUrl(
+  url: string,
+  headers?: { domains: string[]; headers: Record<string, string> }[],
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  let host: string;
+  try {
+    host = new URL(url).host;
+  } catch {
+    return undefined;
+  }
+
+  return headers.find((entry) => entry.domains.includes(host))?.headers;
+}
+
+/**
  * A `fetch` that follows redirects itself so every hop is allow-list checked.
  *
  * The global `fetch` follows redirects transparently, so an allowed URL could
  * answer `302` and send the request to a host the user never allowed — the
  * allow-list only ever saw the first URL (GHSA-jmpc-3jgr-j7jv). Resolving each
  * `Location` and re-checking it closes that.
+ *
+ * Headers are recomputed per hop rather than carried over. `fetchUrls` picks
+ * them by domain for the *first* URL only, so reusing them would hand headers
+ * configured for one host to whatever the redirect points at — and the global
+ * `fetch` this replaces drops `Authorization` across origins by itself.
  */
 function createAllowListCheckedFetch(
   origin: string | undefined,
   allowedExternalRefs: string[],
+  headers?: { domains: string[]; headers: Record<string, string> }[],
 ) {
   return async (
     input: string | URL | globalThis.Request,
@@ -766,7 +796,11 @@ function createAllowListCheckedFetch(
           : input.url;
 
     for (let hop = 0; ; hop++) {
-      const response = await fetch(url, { ...init, redirect: 'manual' });
+      const response = await fetch(url, {
+        ...init,
+        headers: headersForUrl(url, headers),
+        redirect: 'manual',
+      });
 
       const location = response.headers.get('location');
       const isRedirect =
@@ -819,7 +853,13 @@ function createSafeUrlLoader(
     // default redirect handling in place.
     ...(isWildcard
       ? {}
-      : { fetch: createAllowListCheckedFetch(origin, allowedExternalRefs) }),
+      : {
+          fetch: createAllowListCheckedFetch(
+            origin,
+            allowedExternalRefs,
+            headers,
+          ),
+        }),
   });
   return {
     type: 'loader' as const,


### PR DESCRIPTION
Fixes the `externalRefs.allow` redirect bypass reported in GHSA-jmpc-3jgr-j7jv.

## The bug

`createSafeUrlLoader` checked the `$ref` URL against the allow-list and then handed it to the global `fetch`:

```ts
const isAllowed = isAllowedRef(value, allowedExternalRefs, origin);
if (!isAllowed) { throw ... }
return base.exec(value);   // fetch() follows redirects on its own
```

`fetch` follows redirects transparently, so an allowed URL can answer `302` and send the request somewhere the user never allowed. The allow-list only ever saw the first URL.

Reproduced with two loopback servers — A allow-listed and redirecting, B not allow-listed:

```
A /ext.json -> 302     ← allowed server issues the redirect
B /ext.json            ← BLOCKED server contacted
🎉 poc - generation succeeded
```

Generation completed *using B's content*, which is the part that makes this more than a probe: an internal endpoint's response ends up in the resolved document.

## The fix

`fetchUrls` accepts a `fetch` option, documented as "use this to intercept requests". So redirects are now followed manually, re-checking each resolved `Location` with the same predicate the initial ref uses — an allow-list entry, or the spec's own origin:

```
A /ext.json -> 302     ← allowed server still contacted
                       ← B never contacted
```

Capped at 5 hops. Under the wildcard the default handling is kept, since every destination is permitted there anyway.

## The refusal is now legible

The loader swallows errors thrown from a loader and reports only a generic message, so my first pass produced this — technically secure, but impossible to diagnose:

```
[WARN] Failed to parse JSON/YAML from URL: http://127.0.0.1:57973/ext.json
Failed to resolve external reference ... The reference may be invalid, inaccessible ...
```

A blocked redirect was indistinguishable from an unreachable server. The refusal is now logged before throwing:

```
Refused to follow a redirect to a URL that is not allowed: http://127.0.0.1:57972/ext.json
Reached by redirect from http://127.0.0.1:57973/ext.json.
Add it to externalRefs.allow or use ['*'] to allow all.
```

## Behaviour matrix

Verified end-to-end against live loopback servers:

| case | result |
|---|---|
| direct allowed URL, no redirect | succeeds |
| redirect, **both** hops allowed | succeeds |
| redirect, destination **not** allowed | **blocked** (the fix) |
| wildcard `['*']` with redirect | succeeds |
| URL not allowed at all | blocked (unchanged) |

Legitimate redirects keep working as long as the destination is allow-listed, which is the behaviour a user configuring an allow-list would expect.

## Testing

Two integration tests using real loopback servers, in the style of the existing `externalRefs` tests:

- **blocked redirect** — asserts the destination server received **zero** requests and that the refusal warning names the blocked URL. Fails against the unfixed loader.
- **allowed redirect** — asserts the destination received exactly one request and `getX` resolved. Passes both before and after, so it guards against over-blocking.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with zero drift in generated sample output.

## One thing deliberately left alone

The manual follower forwards the request `init` (including any `parserOptions.headers` matched for the original host) across hops, which is what `fetch` already did implicitly. Dropping credentials on a cross-origin hop would be a further hardening, but it is a behaviour change beyond this advisory and could break a user who intends the same headers for both allow-listed hosts. Happy to do it separately if you want it — worth noting every hop must now be explicitly allow-listed, so the destination is one the user affirmatively permitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - External OpenAPI references now re-check every redirect destination against the configured allow-list.
  - Redirects to unapproved URLs are blocked before the destination is contacted.
  - Approved redirects continue to work, with redirect chains limited to five hops.
  - Request headers are recalculated for each redirect destination, preventing credentials from being sent to the wrong host.
- **Tests**
  - Added coverage for blocked redirects, approved redirects, request handling, header scoping, and warning messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->