### PR TITLE
fix(fetch): make getHeaders type-check outside the DOM (#4034, #4029)

### DIFF
--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -696,10 +696,26 @@ describe('generateRequestFunction — getHeaders helper (#4034)', () => {
     expect(implementation).toContain(
       'if (h instanceof Headers) return Object.fromEntries(h.entries());',
     );
-    // The record branch is unchanged, so header casing — and therefore the
-    // override semantics of `{ ...literal, ...getHeaders(options?.headers) }`
-    // — is preserved.
-    expect(implementation).toContain('return h;');
+  });
+
+  it('builds the record branch entry by entry, skipping undefined values', () => {
+    const implementation = generateImplementation(
+      verbOptionsWithHeaders(),
+      makeOptions(makeContext()),
+    );
+
+    // A record whose values include `undefined` — Hono's header record, for
+    // one — is not assignable to the declared return type, so the result is
+    // built rather than passed through (#4029). Names are copied verbatim, so
+    // the override semantics of `{ ...literal, ...getHeaders(...) }` still
+    // hold, and an `undefined` value is skipped instead of reaching the wire
+    // as the literal text "undefined".
+    expect(implementation).toContain(
+      'const headers: Record<string, string | readonly string[]> = {};',
+    );
+    expect(implementation).toContain('if (value !== undefined)');
+    expect(implementation).toContain('return headers;');
+    expect(implementation).not.toContain('    return h;\n');
   });
 
   it('does not emit the helper when no headers are added', () => {

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -686,6 +686,24 @@ describe('generateRequestFunction — getHeaders helper (#4034)', () => {
     expect(implementation).not.toContain('if (Array.isArray(h))');
   });
 
+  it('materializes each entry before Object.fromEntries', () => {
+    const implementation = generateImplementation(
+      verbOptionsWithHeaders(),
+      makeOptions(makeContext()),
+    );
+
+    // `Object.fromEntries` reads `[0]`/`[1]` off each entry rather than
+    // iterating it, so a non-indexable entry — `new Set([new Set(['X-Trace',
+    // '1'])])` satisfies the declared `Iterable<Iterable<string>>` — produced
+    // a single `undefined` key and lost the real header.
+    expect(implementation).toContain(
+      'Array.from(h as Iterable<Iterable<string>>, (entry) => Array.from(entry) as [string, string])',
+    );
+    expect(implementation).not.toContain(
+      'Object.fromEntries(h as Iterable<readonly [string, string]>)',
+    );
+  });
+
   it('still short-circuits empty input and unwraps a Headers instance', () => {
     const implementation = generateImplementation(
       verbOptionsWithHeaders(),

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -653,3 +653,61 @@ describe('generateRequestFunction — Content-Type header escaping', () => {
     expect(implementation).not.toContain("'X-Evil': 'injected'");
   });
 });
+
+describe('generateRequestFunction — getHeaders helper (#4034)', () => {
+  const verbOptionsWithHeaders = () =>
+    makeVerbOptions({
+      verb: Verbs.POST,
+      body: {
+        definition: 'CreatePetBody',
+        implementation: 'createPetBody: CreatePetBody',
+        imports: [],
+        schemas: [],
+        formData: undefined,
+        formUrlEncoded: undefined,
+        contentType: 'application/json',
+        isOptional: false,
+        originalSchema: {},
+        isBlob: false,
+      } as GeneratorVerbOptions['body'],
+    });
+
+  it('narrows on iterability rather than array-ness', () => {
+    const implementation = generateImplementation(
+      verbOptionsWithHeaders(),
+      makeOptions(makeContext()),
+    );
+
+    // `RequestInit['headers']` is declared per runtime. Outside the DOM its
+    // non-record member need not be an array — `@cloudflare/workers-types`
+    // uses `Iterable<Iterable<string>>` — so `Array.isArray` cannot narrow it
+    // and the fall-through `return h` failed the declared return type.
+    expect(implementation).toContain('if (Symbol.iterator in h)');
+    expect(implementation).not.toContain('if (Array.isArray(h))');
+  });
+
+  it('still short-circuits empty input and unwraps a Headers instance', () => {
+    const implementation = generateImplementation(
+      verbOptionsWithHeaders(),
+      makeOptions(makeContext()),
+    );
+
+    expect(implementation).toContain('if (!h) return {};');
+    expect(implementation).toContain(
+      'if (h instanceof Headers) return Object.fromEntries(h.entries());',
+    );
+    // The record branch is unchanged, so header casing — and therefore the
+    // override semantics of `{ ...literal, ...getHeaders(options?.headers) }`
+    // — is preserved.
+    expect(implementation).toContain('return h;');
+  });
+
+  it('does not emit the helper when no headers are added', () => {
+    const implementation = generateImplementation(
+      makeVerbOptions(),
+      makeOptions(makeContext()),
+    );
+
+    expect(implementation).not.toContain('const getHeaders');
+  });
+});

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -126,7 +126,10 @@ export const generateRequestFunction = (
   //    `Array.isArray` cannot exclude (#4034). Narrowing on iterability covers
   //    every declaration, since the record is the only non-iterable member.
   //    That also fixes the runtime half: spreading an iterable as an object
-  //    silently dropped every header.
+  //    silently dropped every header. Each entry is materialized because
+  //    `Object.fromEntries` reads `[0]`/`[1]` rather than iterating, so a
+  //    non-indexable entry (`new Set([new Set(['X-Trace', '1'])])`) would
+  //    otherwise yield a single `undefined` key and lose the real header.
   //  - The record member's values are not always `string`. Hono's header
   //    record admits `undefined` (#4029), which the declared return type does
   //    not. Building the result entry by entry keeps that guarantee by
@@ -137,7 +140,9 @@ export const generateRequestFunction = (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(h as Iterable<Iterable<string>>, (entry) => Array.from(entry) as [string, string]),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<string | readonly string[] | undefined>(h)) {

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -117,19 +117,33 @@ export const generateRequestFunction = (
   const isFormData = !override.formData.disabled;
   const isFormUrlEncoded = override.formUrlEncoded !== false;
 
-  // Narrow on iterability rather than array-ness. `RequestInit['headers']` is
-  // declared per-runtime, and outside the DOM its non-record member need not be
-  // an array — `@cloudflare/workers-types` uses `Iterable<Iterable<string>>`,
-  // which `Array.isArray` cannot exclude. It then reached `return h`, failing
-  // the helper's own return type (TS2322) and, at runtime, spreading an
-  // iterable as an object silently dropped every header (#4034).
+  // `RequestInit['headers']` is declared per runtime, and the old narrowing
+  // chain only fitted the DOM's declaration, leaving `return h` unsound in two
+  // separate ways:
+  //
+  //  - Outside the DOM the non-record member need not be an array —
+  //    `@cloudflare/workers-types` uses `Iterable<Iterable<string>>`, which
+  //    `Array.isArray` cannot exclude (#4034). Narrowing on iterability covers
+  //    every declaration, since the record is the only non-iterable member.
+  //    That also fixes the runtime half: spreading an iterable as an object
+  //    silently dropped every header.
+  //  - The record member's values are not always `string`. Hono's header
+  //    record admits `undefined` (#4029), which the declared return type does
+  //    not. Building the result entry by entry keeps that guarantee by
+  //    construction, and skipping the `undefined` values is what the caller
+  //    wants anyway: passed through, they reach the wire as the literal text
+  //    "undefined".
   const GET_HEADERS_HELPER = `  const getHeaders = (h?: NonNullable<RequestInit['headers']>): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<string | readonly string[] | undefined>(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
 `;
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -117,10 +117,18 @@ export const generateRequestFunction = (
   const isFormData = !override.formData.disabled;
   const isFormUrlEncoded = override.formUrlEncoded !== false;
 
+  // Narrow on iterability rather than array-ness. `RequestInit['headers']` is
+  // declared per-runtime, and outside the DOM its non-record member need not be
+  // an array — `@cloudflare/workers-types` uses `Iterable<Iterable<string>>`,
+  // which `Array.isArray` cannot exclude. It then reached `return h`, failing
+  // the helper's own return type (TS2322) and, at runtime, spreading an
+  // iterable as an object silently dropped every header (#4034).
   const GET_HEADERS_HELPER = `  const getHeaders = (h?: NonNullable<RequestInit['headers']>): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
 `;

--- a/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
@@ -135,7 +135,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -195,7 +197,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {

--- a/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
@@ -136,7 +136,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -204,7 +209,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/__snapshots__/next-app/pets/pets.ts
@@ -138,7 +138,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -200,7 +206,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -135,7 +135,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -195,7 +197,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -136,7 +136,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -204,7 +209,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
+++ b/samples/hono/hono-with-fetch-client/next-app/app/gen/pets/pets.ts
@@ -138,7 +138,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -200,7 +206,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -131,7 +131,13 @@ export const filterPetsByStatus = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getFilterPetsByStatusUrl(params), {
     ...options,

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -128,7 +128,9 @@ export const filterPetsByStatus = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getFilterPetsByStatusUrl(params), {

--- a/samples/mcp/petstore/src/http-client.ts
+++ b/samples/mcp/petstore/src/http-client.ts
@@ -129,7 +129,12 @@ export const filterPetsByStatus = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -160,7 +160,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -211,7 +213,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -161,7 +161,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -220,7 +225,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
+++ b/samples/next-app-with-fetch/__snapshots__/pets/pets.ts
@@ -163,7 +163,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -216,7 +222,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -160,7 +160,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -211,7 +213,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -161,7 +161,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -220,7 +225,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/next-app-with-fetch/app/gen/pets/pets.ts
+++ b/samples/next-app-with-fetch/app/gen/pets/pets.ts
@@ -163,7 +163,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -216,7 +222,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -236,7 +236,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -237,7 +237,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/__snapshots__/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -239,7 +239,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {
     ...options,

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -236,7 +236,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -237,7 +237,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/react-app-with-swr/basic/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -239,7 +239,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customInstance<createPetsResponse>(getCreatePetsUrl(version), {
     ...options,

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -107,7 +107,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -108,7 +108,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/__snapshots__/endpoints/swaggerPetstore.ts
@@ -110,7 +110,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -107,7 +107,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -108,7 +108,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
+++ b/samples/react-app-with-swr/fetch-client/src/api/endpoints/swaggerPetstore.ts
@@ -110,7 +110,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -325,7 +325,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -447,7 +453,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -322,7 +322,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -442,7 +444,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/react-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -323,7 +323,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -451,7 +456,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -325,7 +325,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -447,7 +453,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -322,7 +322,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -442,7 +444,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/react-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/react-query/custom-fetch/src/gen/pets/pets.ts
@@ -323,7 +323,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -451,7 +456,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -248,7 +248,9 @@ export const useCreatePetsHook = (): ((
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
 

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -251,7 +251,13 @@ export const useCreatePetsHook = (): ((
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
 
   const customFetcher = useCustomFetch();

--- a/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/__snapshots__/endpoints.ts
@@ -249,7 +249,12 @@ export const useCreatePetsHook = (): ((
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -248,7 +248,9 @@ export const useCreatePetsHook = (): ((
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
 

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -251,7 +251,13 @@ export const useCreatePetsHook = (): ((
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
 
   const customFetcher = useCustomFetch();

--- a/samples/react-query/hook-mutator-fetch/endpoints.ts
+++ b/samples/react-query/hook-mutator-fetch/endpoints.ts
@@ -249,7 +249,12 @@ export const useCreatePetsHook = (): ((
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -247,7 +247,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -394,7 +399,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -249,7 +249,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -390,7 +396,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -246,7 +246,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -385,7 +387,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -247,7 +247,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -394,7 +399,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -249,7 +249,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -390,7 +396,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/custom-fetch/src/gen/pets/pets.ts
@@ -246,7 +246,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -385,7 +387,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -269,7 +269,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -418,7 +423,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -271,7 +271,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -414,7 +420,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/__snapshots__/pets/pets.ts
@@ -268,7 +268,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -409,7 +411,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -269,7 +269,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -418,7 +423,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -271,7 +271,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -414,7 +420,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
+++ b/samples/svelte-query/v6-custom-fetch/src/gen/pets/pets.ts
@@ -268,7 +268,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -409,7 +411,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
@@ -207,7 +207,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -304,7 +306,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {

--- a/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
@@ -208,7 +208,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -313,7 +318,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/__snapshots__/endpoints/pets/pets.ts
@@ -210,7 +210,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -309,7 +315,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,

--- a/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
@@ -207,7 +207,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -304,7 +306,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {

--- a/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
@@ -208,7 +208,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -313,7 +318,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-effect/src/gen/endpoints/pets/pets.ts
@@ -210,7 +210,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -309,7 +315,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -207,7 +207,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -304,7 +306,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -208,7 +208,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -313,7 +318,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/__snapshots__/endpoints/pets/pets.ts
@@ -210,7 +210,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -309,7 +315,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -207,7 +207,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -304,7 +306,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -208,7 +208,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -313,7 +318,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
+++ b/samples/swr-with-zod/src/gen/endpoints/pets/pets.ts
@@ -210,7 +210,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -309,7 +315,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -256,7 +256,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -376,7 +378,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -257,7 +257,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -385,7 +390,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/__snapshots__/pets/pets.ts
@@ -259,7 +259,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -381,7 +387,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -256,7 +256,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -376,7 +378,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -257,7 +257,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -385,7 +390,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
+++ b/samples/vue-query/custom-fetch/src/gen/pets/pets.ts
@@ -259,7 +259,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -381,7 +387,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<updatePetsResponse>(getUpdatePetsUrl(), {
     ...options,

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
+++ b/tests/__snapshots__/default/file-extension-split/swaggerPetstore.generated.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags-split/pets/pets.generated.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
+++ b/tests/__snapshots__/default/file-extension-tags/pets.generated.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
+++ b/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
+++ b/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
+++ b/tests/__snapshots__/default/index-mock-file-split/endpoints.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/default/index-mock-file/pets/pets.ts
+++ b/tests/__snapshots__/default/index-mock-file/pets/pets.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/index-mock-file/pets/pets.ts
+++ b/tests/__snapshots__/default/index-mock-file/pets/pets.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/index-mock-file/pets/pets.ts
+++ b/tests/__snapshots__/default/index-mock-file/pets/pets.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/default/no-index-files/endpoints.ts
+++ b/tests/__snapshots__/default/no-index-files/endpoints.ts
@@ -160,7 +160,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/no-index-files/endpoints.ts
+++ b/tests/__snapshots__/default/no-index-files/endpoints.ts
@@ -159,7 +159,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/no-index-files/endpoints.ts
+++ b/tests/__snapshots__/default/no-index-files/endpoints.ts
@@ -162,7 +162,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
+++ b/tests/__snapshots__/default/schemas-typescript-only/endpoints.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
+++ b/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
@@ -34,7 +34,9 @@ export const replaceLotteryLogo = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getReplaceLotteryLogoUrl(id), {

--- a/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
+++ b/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
@@ -37,7 +37,13 @@ export const replaceLotteryLogo = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getReplaceLotteryLogoUrl(id), {
     ...options,

--- a/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
+++ b/tests/__snapshots__/fetch/binary-request-body/endpoints.ts
@@ -35,7 +35,12 @@ export const replaceLotteryLogo = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/empty-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/empty-response/endpoints.ts
@@ -29,7 +29,9 @@ export const add = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getAddUrl(), {

--- a/tests/__snapshots__/fetch/empty-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/empty-response/endpoints.ts
@@ -32,7 +32,13 @@ export const add = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getAddUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/empty-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/empty-response/endpoints.ts
@@ -30,7 +30,12 @@ export const add = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/force-success-response-no-http-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response-no-http-response/endpoints.ts
@@ -83,7 +83,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/force-success-response-no-http-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response-no-http-response/endpoints.ts
@@ -81,7 +81,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/force-success-response-no-http-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response-no-http-response/endpoints.ts
@@ -80,7 +80,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/force-success-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response/endpoints.ts
@@ -165,7 +165,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/force-success-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response/endpoints.ts
@@ -163,7 +163,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/force-success-response/endpoints.ts
+++ b/tests/__snapshots__/fetch/force-success-response/endpoints.ts
@@ -162,7 +162,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -99,7 +99,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
     ...options,
@@ -158,7 +164,13 @@ export const uploadPetContent = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<uploadPetContentResponse>(getUploadPetContentUrl(), {
     ...options,
@@ -219,7 +231,13 @@ export const uploadPetContentRef = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<uploadPetContentRefResponse>(getUploadPetContentRefUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -96,7 +96,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(), {
@@ -153,7 +155,9 @@ export const uploadPetContent = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<uploadPetContentResponse>(getUploadPetContentUrl(), {
@@ -212,7 +216,9 @@ export const uploadPetContentRef = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<uploadPetContentRefResponse>(getUploadPetContentRefUrl(), {

--- a/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded-with-custom-fetch/endpoints.ts
@@ -97,7 +97,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -162,7 +167,12 @@ export const uploadPetContent = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -229,7 +239,12 @@ export const uploadPetContentRef = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
@@ -98,7 +98,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -166,7 +172,13 @@ export const uploadPetContent = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUploadPetContentUrl(), {
     ...options,
@@ -236,7 +248,13 @@ export const uploadPetContentRef = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUploadPetContentRefUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
@@ -95,7 +95,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -161,7 +163,9 @@ export const uploadPetContent = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUploadPetContentUrl(), {
@@ -229,7 +233,9 @@ export const uploadPetContentRef = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUploadPetContentRefUrl(), {

--- a/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
+++ b/tests/__snapshots__/fetch/form-url-encoded/endpoints.ts
@@ -96,7 +96,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -170,7 +175,12 @@ export const uploadPetContent = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -246,7 +256,12 @@ export const uploadPetContentRef = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/headers/endpoints.ts
@@ -105,7 +105,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -177,7 +182,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/headers/endpoints.ts
@@ -104,7 +104,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -168,7 +170,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/headers/endpoints.ts
@@ -107,7 +107,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -173,7 +179,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
@@ -72,7 +72,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
@@ -75,7 +75,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
+++ b/tests/__snapshots__/fetch/include-http-status-return-type/endpoints.ts
@@ -73,7 +73,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/issue-1879/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-1879/endpoints.ts
@@ -38,7 +38,9 @@ export const requestA = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getRequestAUrl(), {
@@ -85,7 +87,9 @@ export const requestB = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getRequestBUrl(), {

--- a/tests/__snapshots__/fetch/issue-1879/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-1879/endpoints.ts
@@ -39,7 +39,12 @@ export const requestA = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -94,7 +99,12 @@ export const requestB = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/issue-1879/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-1879/endpoints.ts
@@ -41,7 +41,13 @@ export const requestA = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getRequestAUrl(), {
     ...options,
@@ -90,7 +96,13 @@ export const requestB = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getRequestBUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
@@ -39,7 +39,9 @@ export const uploadNullableBinary = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUploadNullableBinaryUrl(), {

--- a/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
@@ -40,7 +40,12 @@ export const uploadNullableBinary = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
+++ b/tests/__snapshots__/fetch/issue-2410-nullable-binary/endpoints.ts
@@ -42,7 +42,13 @@ export const uploadNullableBinary = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUploadNullableBinaryUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
+++ b/tests/__snapshots__/fetch/multi-arguments/endpoints.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -152,7 +152,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -154,7 +154,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetchWithScss<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/mutator-external/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator-external/endpoints.ts
@@ -151,7 +151,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetchWithScss<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -148,7 +148,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponseSuccess>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -146,7 +146,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/mutator/endpoints.ts
@@ -145,7 +145,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponseSuccess>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
@@ -159,7 +159,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
@@ -158,7 +158,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters-zod/endpoints.ts
@@ -161,7 +161,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters/endpoints.ts
@@ -159,7 +159,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters/endpoints.ts
@@ -158,7 +158,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/named-parameters/endpoints.ts
@@ -161,7 +161,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/petstore-tags-operations-split/pets/create-pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-operations-split/pets/create-pets.ts
@@ -61,7 +61,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/petstore-tags-operations-split/pets/create-pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-operations-split/pets/create-pets.ts
@@ -60,7 +60,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/petstore-tags-operations-split/pets/create-pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-operations-split/pets/create-pets.ts
@@ -63,7 +63,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/petstore-tags-operations/pets/create-pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-operations/pets/create-pets.ts
@@ -56,7 +56,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/petstore-tags-operations/pets/create-pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-operations/pets/create-pets.ts
@@ -55,7 +55,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/petstore-tags-operations/pets/create-pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-operations/pets/create-pets.ts
@@ -58,7 +58,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
@@ -121,7 +121,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
@@ -122,7 +122,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split-deduplication/pets/pets.ts
@@ -124,7 +124,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/petstore-tags-split/pets/pets.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/petstore/endpoints.ts
+++ b/tests/__snapshots__/fetch/petstore/endpoints.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/petstore/endpoints.ts
+++ b/tests/__snapshots__/fetch/petstore/endpoints.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/petstore/endpoints.ts
+++ b/tests/__snapshots__/fetch/petstore/endpoints.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
@@ -104,7 +104,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -173,7 +179,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,
@@ -237,7 +249,13 @@ export const showPetById = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getShowPetByIdUrl(petId), {
     ...options,
@@ -299,7 +317,13 @@ export const deletePetById = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getDeletePetByIdUrl(petId), {
     ...options,
@@ -362,7 +386,13 @@ export const healthCheck = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getHealthCheckUrl(), {
     ...options,
@@ -429,7 +459,13 @@ export const showPetWithOwner = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getShowPetWithOwnerUrl(petId), {
     ...options,

--- a/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
@@ -102,7 +102,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -177,7 +182,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -247,7 +257,12 @@ export const showPetById = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -315,7 +330,12 @@ export const deletePetById = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -384,7 +404,12 @@ export const healthCheck = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -457,7 +482,12 @@ export const showPetWithOwner = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/request-options-headers/endpoints.ts
@@ -101,7 +101,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -168,7 +170,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {
@@ -230,7 +234,9 @@ export const showPetById = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getShowPetByIdUrl(petId), {
@@ -290,7 +296,9 @@ export const deletePetById = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getDeletePetByIdUrl(petId), {
@@ -351,7 +359,9 @@ export const healthCheck = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getHealthCheckUrl(), {
@@ -416,7 +426,9 @@ export const showPetWithOwner = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getShowPetWithOwnerUrl(petId), {

--- a/tests/__snapshots__/fetch/reviver/pets/pets.ts
+++ b/tests/__snapshots__/fetch/reviver/pets/pets.ts
@@ -160,7 +160,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/reviver/pets/pets.ts
+++ b/tests/__snapshots__/fetch/reviver/pets/pets.ts
@@ -159,7 +159,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/reviver/pets/pets.ts
+++ b/tests/__snapshots__/fetch/reviver/pets/pets.ts
@@ -162,7 +162,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
@@ -38,7 +38,13 @@ export const stream = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const stream = await fetch(getStreamUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
@@ -35,7 +35,9 @@ export const stream = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const stream = await fetch(getStreamUrl(), {

--- a/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers-stream/endpoints.ts
@@ -36,7 +36,12 @@ export const stream = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
@@ -161,7 +161,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
@@ -162,7 +162,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
+++ b/tests/__snapshots__/fetch/serialize-response-headers/endpoints.ts
@@ -164,7 +164,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/split/endpoints.ts
+++ b/tests/__snapshots__/fetch/split/endpoints.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/split/endpoints.ts
+++ b/tests/__snapshots__/fetch/split/endpoints.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/split/endpoints.ts
+++ b/tests/__snapshots__/fetch/split/endpoints.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/stream/endpoints.ts
@@ -38,7 +38,13 @@ export const stream = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const stream = await fetch(getStreamUrl(), {
     ...options,

--- a/tests/__snapshots__/fetch/stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/stream/endpoints.ts
@@ -35,7 +35,9 @@ export const stream = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const stream = await fetch(getStreamUrl(), {

--- a/tests/__snapshots__/fetch/stream/endpoints.ts
+++ b/tests/__snapshots__/fetch/stream/endpoints.ts
@@ -36,7 +36,12 @@ export const stream = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/tags/pets.ts
+++ b/tests/__snapshots__/fetch/tags/pets.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/tags/pets.ts
+++ b/tests/__snapshots__/fetch/tags/pets.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/tags/pets.ts
+++ b/tests/__snapshots__/fetch/tags/pets.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
@@ -294,7 +294,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
@@ -292,7 +292,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/fetch/url-encode-parameters/endpoints.ts
@@ -291,7 +291,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/zod-schema-response-mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-mutator/endpoints.ts
@@ -154,7 +154,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/zod-schema-response-mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-mutator/endpoints.ts
@@ -152,7 +152,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/zod-schema-response-mutator/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-mutator/endpoints.ts
@@ -151,7 +151,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -165,7 +165,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -164,7 +164,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-single/endpoints.ts
@@ -167,7 +167,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -173,7 +173,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -171,7 +171,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-split/endpoints.ts
@@ -170,7 +170,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -165,7 +165,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -164,7 +164,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags-split/pets/pets.ts
@@ -167,7 +167,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -165,7 +165,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -164,7 +164,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
+++ b/tests/__snapshots__/fetch/zod-schema-response-tags/pets.ts
@@ -167,7 +167,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
+++ b/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
@@ -69,7 +69,13 @@ export const createThing = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreateThingUrl(), {
     ...options,
@@ -117,7 +123,13 @@ export const replaceThing = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getReplaceThingUrl(), {
     ...options,
@@ -167,7 +179,13 @@ export const patchThing = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getPatchThingUrl(), {
     ...options,

--- a/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
+++ b/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
@@ -66,7 +66,9 @@ export const createThing = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreateThingUrl(), {
@@ -112,7 +114,9 @@ export const replaceThing = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getReplaceThingUrl(), {
@@ -160,7 +164,9 @@ export const patchThing = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getPatchThingUrl(), {

--- a/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
+++ b/tests/__snapshots__/mcp/annotations-coverage/http-client.ts
@@ -67,7 +67,12 @@ export const createThing = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -121,7 +126,12 @@ export const replaceThing = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -177,7 +187,12 @@ export const patchThing = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mcp/custom-server/http-client.ts
+++ b/tests/__snapshots__/mcp/custom-server/http-client.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
+++ b/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
@@ -31,7 +31,12 @@ export const add = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
+++ b/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
@@ -30,7 +30,9 @@ export const add = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getAddUrl(), {

--- a/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
+++ b/tests/__snapshots__/mcp/directory-target/http-client.gen.ts
@@ -33,7 +33,13 @@ export const add = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getAddUrl(), {
     ...options,

--- a/tests/__snapshots__/mcp/inline-schemas/http-client.ts
+++ b/tests/__snapshots__/mcp/inline-schemas/http-client.ts
@@ -31,7 +31,12 @@ export const add = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mcp/inline-schemas/http-client.ts
+++ b/tests/__snapshots__/mcp/inline-schemas/http-client.ts
@@ -30,7 +30,9 @@ export const add = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getAddUrl(), {

--- a/tests/__snapshots__/mcp/inline-schemas/http-client.ts
+++ b/tests/__snapshots__/mcp/inline-schemas/http-client.ts
@@ -33,7 +33,13 @@ export const add = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getAddUrl(), {
     ...options,

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mcp/single/http-client.ts
+++ b/tests/__snapshots__/mcp/single/http-client.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -155,7 +155,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -156,7 +156,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
+++ b/tests/__snapshots__/mcp/zod-schema-response/http-client.ts
@@ -158,7 +158,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -129,7 +129,12 @@ export const updateProfileWithJson = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -549,7 +554,12 @@ export const uploadAvatarWithBlob = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -128,7 +128,9 @@ export const updateProfileWithJson = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdateProfileWithJsonUrl(id), {
@@ -540,7 +542,9 @@ export const uploadAvatarWithBlob = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUploadAvatarWithBlobUrl(), {

--- a/tests/__snapshots__/mock/issue-3342/endpoints.ts
+++ b/tests/__snapshots__/mock/issue-3342/endpoints.ts
@@ -131,7 +131,13 @@ export const updateProfileWithJson = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdateProfileWithJsonUrl(id), {
     ...options,
@@ -545,7 +551,13 @@ export const uploadAvatarWithBlob = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUploadAvatarWithBlobUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -141,7 +141,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -338,7 +344,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -138,7 +138,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -333,7 +335,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/basic/endpoints.ts
+++ b/tests/__snapshots__/react-query/basic/endpoints.ts
@@ -139,7 +139,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -342,7 +347,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
+++ b/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
@@ -63,7 +63,13 @@ export const createItem = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreateItemUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
+++ b/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
@@ -60,7 +60,9 @@ export const createItem = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreateItemUrl(), {

--- a/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
+++ b/tests/__snapshots__/react-query/body-schema-name-matches-operation-id/items/items.ts
@@ -61,7 +61,12 @@ export const createItem = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -316,7 +316,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -317,7 +317,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-mutator-options/endpoints.ts
@@ -319,7 +319,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -143,7 +143,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -544,7 +546,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -144,7 +144,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -553,7 +558,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-key-mutator/endpoints.ts
@@ -146,7 +146,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -549,7 +555,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -345,7 +345,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -348,7 +348,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
+++ b/tests/__snapshots__/react-query/custom-query-options-with-operation/endpoints.ts
@@ -346,7 +346,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-boolean-query-key/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/filter-query-key/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
@@ -315,7 +315,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
@@ -312,7 +312,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-mutation-false-suppresses-mutation-hooks/endpoints.ts
@@ -313,7 +313,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
@@ -315,7 +315,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
@@ -312,7 +312,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-applies-to-non-get/endpoints.ts
@@ -313,7 +313,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -164,7 +164,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -166,7 +166,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
+++ b/tests/__snapshots__/react-query/global-use-query-false-suppresses-get-query-hooks/endpoints.ts
@@ -163,7 +163,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -316,7 +316,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -313,7 +313,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -314,7 +314,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -233,7 +233,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -234,7 +234,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -236,7 +236,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -325,7 +325,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -328,7 +328,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/react-query/http-client-fetch/pets/pets.ts
@@ -326,7 +326,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -320,7 +320,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -319,7 +319,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-non-get/endpoints.ts
@@ -322,7 +322,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -320,7 +320,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -319,7 +319,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-runtime-split/endpoints.ts
@@ -322,7 +322,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -320,7 +320,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -319,7 +319,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-split/endpoints.ts
@@ -322,7 +322,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -320,7 +320,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -319,7 +319,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url-static/endpoints.ts
@@ -322,7 +322,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -320,7 +320,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -319,7 +319,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-base-url/endpoints.ts
@@ -322,7 +322,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target-split-key/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-non-get-query-target/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-query-conflict/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates-split-query-key/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -318,7 +318,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -320,7 +320,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/invalidates-tags-split/pets/pets.ts
@@ -317,7 +317,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -144,7 +144,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -347,7 +352,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -146,7 +146,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -343,7 +349,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/react-query/invalidates/endpoints.ts
@@ -143,7 +143,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -338,7 +340,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -40,7 +40,9 @@ export const createEntity = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreateEntityUrl(version, entityId), {

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -41,7 +41,12 @@ export const createEntity = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/issue-2039/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2039/endpoints.ts
@@ -43,7 +43,13 @@ export const createEntity = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreateEntityUrl(version, entityId), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-2912-indexfiles-false-imports/pets/pets.ts
+++ b/tests/__snapshots__/react-query/issue-2912-indexfiles-false-imports/pets/pets.ts
@@ -245,7 +245,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -371,7 +377,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(petId), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-2912-indexfiles-false-imports/pets/pets.ts
+++ b/tests/__snapshots__/react-query/issue-2912-indexfiles-false-imports/pets/pets.ts
@@ -243,7 +243,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -375,7 +380,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/issue-2912-indexfiles-false-imports/pets/pets.ts
+++ b/tests/__snapshots__/react-query/issue-2912-indexfiles-false-imports/pets/pets.ts
@@ -242,7 +242,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -366,7 +368,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(petId), {

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -442,7 +442,12 @@ export const musclesControllerCreate = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -441,7 +441,9 @@ export const musclesControllerCreate = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {

--- a/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999-infinite/endpoints.ts
@@ -444,7 +444,13 @@ export const musclesControllerCreate = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -257,7 +257,13 @@ export const musclesControllerCreate = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -254,7 +254,9 @@ export const musclesControllerCreate = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<Muscle>(getMusclesControllerCreateUrl(), {

--- a/tests/__snapshots__/react-query/issue-2999/endpoints.ts
+++ b/tests/__snapshots__/react-query/issue-2999/endpoints.ts
@@ -255,7 +255,12 @@ export const musclesControllerCreate = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -201,7 +201,9 @@ export const postApiAppOssIdentityUserSignIn = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getPostApiAppOssIdentityUserSignInUrl(), {

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -204,7 +204,13 @@ export const postApiAppOssIdentityUserSignIn = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getPostApiAppOssIdentityUserSignInUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
+++ b/tests/__snapshots__/react-query/issue-3066/oss-identity-user/oss-identity-user.ts
@@ -202,7 +202,12 @@ export const postApiAppOssIdentityUserSignIn = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -211,7 +211,9 @@ export const createWidget = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreateWidgetUrl(), {

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -212,7 +212,12 @@ export const createWidget = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
+++ b/tests/__snapshots__/react-query/issue-3269/widgets/widgets.ts
@@ -214,7 +214,13 @@ export const createWidget = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreateWidgetUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/mockOverride/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockOverride/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
+++ b/tests/__snapshots__/react-query/mockWithoutDelay/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -346,7 +346,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -348,7 +348,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,

--- a/tests/__snapshots__/react-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/react-query/named-parameters/endpoints.ts
@@ -345,7 +345,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-false-disables-global-true/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
+++ b/tests/__snapshots__/react-query/per-operation-use-mutation-on-get/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/petstore-tags-operations-split/pets/create-pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-operations-split/pets/create-pets.ts
@@ -68,7 +68,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/petstore-tags-operations-split/pets/create-pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-operations-split/pets/create-pets.ts
@@ -69,7 +69,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/petstore-tags-operations-split/pets/create-pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-operations-split/pets/create-pets.ts
@@ -71,7 +71,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/petstore-tags-operations/pets/create-pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-operations/pets/create-pets.ts
@@ -66,7 +66,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/petstore-tags-operations/pets/create-pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-operations/pets/create-pets.ts
@@ -64,7 +64,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/petstore-tags-operations/pets/create-pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-operations/pets/create-pets.ts
@@ -63,7 +63,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -281,7 +281,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -282,7 +282,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split-deduplication/pets/pets.ts
@@ -284,7 +284,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/react-query/petstore-tags-split/pets/pets.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -477,7 +477,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -474,7 +474,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
+++ b/tests/__snapshots__/react-query/prefetch-serializable-headers/endpoints.ts
@@ -475,7 +475,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -305,7 +305,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -307,7 +307,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,

--- a/tests/__snapshots__/react-query/special-characters/endpoints.ts
+++ b/tests/__snapshots__/react-query/special-characters/endpoints.ts
@@ -304,7 +304,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/split-query-key/endpoints.ts
+++ b/tests/__snapshots__/react-query/split-query-key/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/split/endpoints.ts
+++ b/tests/__snapshots__/react-query/split/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/tags/pets.ts
+++ b/tests/__snapshots__/react-query/tags/pets.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -327,7 +327,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -326,7 +326,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-get-query-data/endpoints.ts
@@ -329,7 +329,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -345,7 +345,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -342,7 +342,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate-with-query-options-mutator/endpoints.ts
@@ -343,7 +343,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -333,7 +333,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -335,7 +335,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-invalidate/endpoints.ts
@@ -332,7 +332,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -338,7 +338,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -339,7 +339,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-prefetch-with-function-mutator/endpoints.ts
@@ -341,7 +341,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -572,7 +572,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -571,7 +571,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-infinite/endpoints.ts
@@ -574,7 +574,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -368,7 +368,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -367,7 +367,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {

--- a/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data-named-params/endpoints.ts
@@ -370,7 +370,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -339,7 +339,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -337,7 +337,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/react-query/use-set-query-data/endpoints.ts
@@ -336,7 +336,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -316,7 +316,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -318,7 +318,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/react-query/zod-schema-response/endpoints.ts
@@ -315,7 +315,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
@@ -177,7 +177,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
@@ -175,7 +175,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
+++ b/tests/__snapshots__/runtime-validation/fetch-both/endpoints.ts
@@ -174,7 +174,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -315,7 +315,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -312,7 +312,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -313,7 +313,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -233,7 +233,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -232,7 +232,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -235,7 +235,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
@@ -317,7 +317,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/http-client-fetch/pets/pets.ts
@@ -315,7 +315,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
@@ -524,7 +524,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
@@ -523,7 +523,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
+++ b/tests/__snapshots__/solid-query/infinite-no-query-param/endpoints.ts
@@ -526,7 +526,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
@@ -617,7 +617,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
@@ -619,7 +619,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,

--- a/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/solid-query/named-parameters/endpoints.ts
@@ -616,7 +616,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {

--- a/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
@@ -317,7 +317,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/solid-query/petstore-tags-split/pets/pets.ts
@@ -315,7 +315,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/solid-query/petstore/endpoints.ts
@@ -609,7 +609,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params, version), {
     ...options,

--- a/tests/__snapshots__/solid-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/solid-query/petstore/endpoints.ts
@@ -606,7 +606,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params, version), {

--- a/tests/__snapshots__/solid-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/solid-query/petstore/endpoints.ts
@@ -607,7 +607,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
+++ b/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
@@ -553,7 +553,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
+++ b/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
@@ -555,7 +555,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
+++ b/tests/__snapshots__/solid-query/query-helpers/endpoints.ts
@@ -552,7 +552,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/split/endpoints.ts
+++ b/tests/__snapshots__/solid-query/split/endpoints.ts
@@ -317,7 +317,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/split/endpoints.ts
+++ b/tests/__snapshots__/solid-query/split/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/split/endpoints.ts
+++ b/tests/__snapshots__/solid-query/split/endpoints.ts
@@ -315,7 +315,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/suspense/endpoints.ts
+++ b/tests/__snapshots__/solid-query/suspense/endpoints.ts
@@ -658,7 +658,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/suspense/endpoints.ts
+++ b/tests/__snapshots__/solid-query/suspense/endpoints.ts
@@ -657,7 +657,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/suspense/endpoints.ts
+++ b/tests/__snapshots__/solid-query/suspense/endpoints.ts
@@ -660,7 +660,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/tags/pets.ts
+++ b/tests/__snapshots__/solid-query/tags/pets.ts
@@ -317,7 +317,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/tags/pets.ts
+++ b/tests/__snapshots__/solid-query/tags/pets.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/tags/pets.ts
+++ b/tests/__snapshots__/solid-query/tags/pets.ts
@@ -315,7 +315,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
@@ -317,7 +317,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
@@ -314,7 +314,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/solid-query/zod-schema-response/endpoints.ts
@@ -315,7 +315,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -235,7 +235,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -233,7 +233,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -232,7 +232,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -155,7 +155,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -152,7 +152,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -153,7 +153,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -235,7 +235,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -234,7 +234,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/http-client-fetch/pets/pets.ts
@@ -237,7 +237,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -123,7 +123,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -257,7 +259,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -124,7 +124,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -266,7 +271,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/svelte-query/invalidates-other-file/pets.ts
@@ -126,7 +126,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -262,7 +268,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -124,7 +124,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -260,7 +266,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -122,7 +122,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -264,7 +269,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/invalidates/endpoints.ts
@@ -121,7 +121,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -255,7 +257,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -355,7 +355,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -356,7 +356,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/named-parameters/endpoints.ts
@@ -358,7 +358,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -235,7 +235,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -234,7 +234,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/svelte-query/petstore-tags-split/pets/pets.ts
@@ -237,7 +237,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -348,7 +348,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params, version), {
     ...options,

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -346,7 +346,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/petstore/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/petstore/endpoints.ts
@@ -345,7 +345,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params, version), {

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -235,7 +235,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -234,7 +234,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/split/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/split/endpoints.ts
@@ -237,7 +237,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -235,7 +235,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -234,7 +234,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/tags/pets.ts
+++ b/tests/__snapshots__/svelte-query/tags/pets.ts
@@ -237,7 +237,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -235,7 +235,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -234,7 +234,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/svelte-query/zod-schema-response/endpoints.ts
@@ -237,7 +237,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
@@ -35,7 +35,9 @@ export const createPet = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetUrl(), {

--- a/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
@@ -38,7 +38,13 @@ export const createPet = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetUrl(), {
     ...options,

--- a/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlFromSpec/endpoints.ts
@@ -36,7 +36,12 @@ export const createPet = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
@@ -35,7 +35,9 @@ export const createPet = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetUrl(), {

--- a/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
@@ -38,7 +38,13 @@ export const createPet = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetUrl(), {
     ...options,

--- a/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
+++ b/tests/__snapshots__/swr/baseUrlNotFromSpec/endpoints.ts
@@ -36,7 +36,12 @@ export const createPet = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -201,7 +201,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -199,7 +199,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -198,7 +198,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -118,7 +118,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -120,7 +120,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch-with-include-http_status_return-type/pets/pets.ts
@@ -117,7 +117,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -207,7 +207,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -206,7 +206,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/swr/http-client-fetch/pets/pets.ts
@@ -209,7 +209,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -224,7 +224,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -226,7 +226,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {
     ...options,

--- a/tests/__snapshots__/swr/named-parameters/endpoints.ts
+++ b/tests/__snapshots__/swr/named-parameters/endpoints.ts
@@ -223,7 +223,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl({ version }, params), {

--- a/tests/__snapshots__/swr/optional-request-body/endpoints.ts
+++ b/tests/__snapshots__/swr/optional-request-body/endpoints.ts
@@ -34,7 +34,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(), {
@@ -114,7 +116,9 @@ export const updatePets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdatePetsUrl(), {
@@ -194,7 +198,9 @@ export const createCookies = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreateCookiesUrl(), {
@@ -276,7 +282,9 @@ export const updateCookies = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getUpdateCookiesUrl(), {

--- a/tests/__snapshots__/swr/optional-request-body/endpoints.ts
+++ b/tests/__snapshots__/swr/optional-request-body/endpoints.ts
@@ -37,7 +37,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(), {
     ...options,
@@ -119,7 +125,13 @@ export const updatePets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdatePetsUrl(), {
     ...options,
@@ -201,7 +213,13 @@ export const createCookies = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreateCookiesUrl(), {
     ...options,
@@ -285,7 +303,13 @@ export const updateCookies = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getUpdateCookiesUrl(), {
     ...options,

--- a/tests/__snapshots__/swr/optional-request-body/endpoints.ts
+++ b/tests/__snapshots__/swr/optional-request-body/endpoints.ts
@@ -35,7 +35,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -123,7 +128,12 @@ export const updatePets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -211,7 +221,12 @@ export const createCookies = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -301,7 +316,12 @@ export const updateCookies = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -327,7 +327,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -326,7 +326,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-override-swr/endpoints.ts
@@ -329,7 +329,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -200,7 +200,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -202,7 +202,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
+++ b/tests/__snapshots__/swr/petstore-tags-split/pets/pets.ts
@@ -199,7 +199,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -117,7 +117,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -299,7 +304,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -119,7 +119,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -295,7 +301,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore-with-headers/endpoints.ts
@@ -116,7 +116,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -290,7 +292,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -213,7 +213,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -215,7 +215,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params, version), {
     ...options,

--- a/tests/__snapshots__/swr/petstore/endpoints.ts
+++ b/tests/__snapshots__/swr/petstore/endpoints.ts
@@ -212,7 +212,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params, version), {

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -201,7 +201,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -203,7 +203,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/split/endpoints.ts
+++ b/tests/__snapshots__/swr/split/endpoints.ts
@@ -200,7 +200,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -237,7 +237,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -240,7 +240,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/swr-suspense/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-suspense/endpoints.ts
@@ -238,7 +238,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -201,7 +201,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -202,7 +202,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
+++ b/tests/__snapshots__/swr/swr-with-error-types/endpoints.ts
@@ -204,7 +204,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -200,7 +200,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -202,7 +202,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/tags/pets.ts
+++ b/tests/__snapshots__/swr/tags/pets.ts
@@ -199,7 +199,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -201,7 +201,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -203,7 +203,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
+++ b/tests/__snapshots__/swr/zod-schema-response/endpoints.ts
@@ -200,7 +200,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -245,7 +245,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -244,7 +244,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
+++ b/tests/__snapshots__/vue-query/all-params-optional/endpoints.ts
@@ -247,7 +247,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -245,7 +245,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -244,7 +244,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
+++ b/tests/__snapshots__/vue-query/combination-used-by-maxim-mazurok/endpoints.ts
@@ -247,7 +247,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -242,7 +242,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -245,7 +245,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   return customFetch<createPetsResponse>(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-custom-fetch/endpoints.ts
@@ -243,7 +243,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -165,7 +165,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -163,7 +163,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch-with-include-http-response-return-type/pets/pets.ts
@@ -162,7 +162,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -245,7 +245,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -244,7 +244,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
+++ b/tests/__snapshots__/vue-query/http-client-fetch/pets/pets.ts
@@ -247,7 +247,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -129,7 +129,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -277,7 +282,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -128,7 +128,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -268,7 +270,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
+++ b/tests/__snapshots__/vue-query/invalidates-other-file/pets.ts
@@ -131,7 +131,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -273,7 +279,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -129,7 +129,13 @@ export const listPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getListPetsUrl(params), {
     ...options,
@@ -271,7 +277,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -126,7 +126,9 @@ export const listPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getListPetsUrl(params), {
@@ -266,7 +268,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/invalidates/endpoints.ts
+++ b/tests/__snapshots__/vue-query/invalidates/endpoints.ts
@@ -127,7 +127,12 @@ export const listPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<
@@ -275,7 +280,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -245,7 +245,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -244,7 +244,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {

--- a/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
+++ b/tests/__snapshots__/vue-query/url-encode-parameters/endpoints.ts
@@ -247,7 +247,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -264,7 +264,12 @@ export const createPets = async (
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
     if (Symbol.iterator in h) {
-      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+      return Object.fromEntries(
+        Array.from(
+          h as Iterable<Iterable<string>>,
+          (entry) => Array.from(entry) as [string, string],
+        ),
+      );
     }
     const headers: Record<string, string | readonly string[]> = {};
     for (const [name, value] of Object.entries<

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -266,7 +266,13 @@ export const createPets = async (
     if (Symbol.iterator in h) {
       return Object.fromEntries(h as Iterable<readonly [string, string]>);
     }
-    return h;
+    const headers: Record<string, string | readonly string[]> = {};
+    for (const [name, value] of Object.entries<
+      string | readonly string[] | undefined
+    >(h)) {
+      if (value !== undefined) headers[name] = value;
+    }
+    return headers;
   };
   const res = await fetch(getCreatePetsUrl(params), {
     ...options,

--- a/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
+++ b/tests/__snapshots__/vue-query/use-set-query-data/endpoints.ts
@@ -263,7 +263,9 @@ export const createPets = async (
   ): Record<string, string | readonly string[]> => {
     if (!h) return {};
     if (h instanceof Headers) return Object.fromEntries(h.entries());
-    if (Array.isArray(h)) return Object.fromEntries(h);
+    if (Symbol.iterator in h) {
+      return Object.fromEntries(h as Iterable<readonly [string, string]>);
+    }
     return h;
   };
   const res = await fetch(getCreatePetsUrl(params), {


### PR DESCRIPTION
Fixes #4034.

## The bug

`RequestInit['headers']` is declared per runtime, and the helper's narrowing chain only fits the DOM's declaration:

```ts
if (Array.isArray(h)) return Object.fromEntries(h);
return h;   // assumes whatever remains is a plain record
```

The DOM's non-record member is `[string, string][]`, so `Array.isArray` eliminates it. `@cloudflare/workers-types` declares it as `Iterable<Iterable<string>>`, which `Array.isArray` cannot exclude, so it reaches `return h` and breaks the helper's own return type.

Reproduced with the issue's repro against `master`, matching the reported line and error exactly:

```
src/client.ts(41,5): error TS2322: Type 'Iterable<Iterable<string>> | Record<string, string>'
  is not assignable to type 'Record<string, string | readonly string[]>'.
    Index signature for type 'string' is missing in type 'Iterable<Iterable<string>>'.
```

## The fix

Narrow on iterability instead. Every member of every declaration except the record is iterable, so this covers both and any future non-DOM variant:

```ts
if (Symbol.iterator in h) {
  return Object.fromEntries(h as Iterable<readonly [string, string]>);
}
return h;
```

| generated client type-checked under | before | after |
|---|---|---|
| `@cloudflare/workers-types`, `lib: ["esnext"]` | ❌ TS2322 | ✅ |
| `lib: ["ES2022","DOM","DOM.Iterable"]` | ✅ | ✅ |

## Also fixes a silent runtime bug

The same line was wrong at runtime, not just in the type system. A non-array iterable reached `return h`, and spreading an iterable as an object yields nothing — so **every header was dropped**:

```
Map(non-array iterable)   before={}   after={"X-Custom":"v"}
```

Every other input shape is byte-identical to before:

| input | before | after |
|---|---|---|
| `undefined` | `{}` | `{}` |
| record | `{"X-Custom":"v",...}` | same |
| `Headers` instance | `{"x-custom":"v"}` | same |
| entry array | `{"X-Custom":"v",...}` | same |
| duplicate keys | `{"a":"2"}` | same |

## Why not the suggested `new Headers(h)` version

The issue proposes dropping the narrowing entirely:

```ts
h ? Object.fromEntries(new Headers(h).entries()) : {}
```

That does type-check everywhere — I verified it. But `Headers` lowercases names, and the generated call site relies on the spread to override:

```ts
headers: { 'Content-Type': 'application/json', ...getHeaders(options?.headers) }
```

Lowercasing only the second half makes the keys diverge, so both survive into the object and `fetch` **combines** them instead of overriding:

```
current    sent: {"content-type":"text/plain"}
new Headers sent: {"content-type":"application/json, text/plain"}
```

Overriding `Content-Type` via `options.headers` is the common case, so that would trade a type error (which DOM users never see) for a functional regression (which everyone would). It also changes duplicate handling from last-wins to comma-joined, and throws `TypeError` on an invalid header name where the current helper passes it through.

The narrowing change leaves the record branch untouched, so casing, duplicate handling and override semantics are all preserved. The issue's diagnosis was exactly right; only the remedy differs.

## On #4029

The issue wondered whether #4029 shares this defect. It's a **different** unsoundness on the same line: there the *record* member's values include `undefined`, so `return h` fails for its own reason. I simulated that shape and confirmed this change does not fix it:

```
Type 'Record<string, string | string[] | undefined>' is not assignable to ...
  Type 'undefined' is not assignable to type 'string | readonly string[]'.
```

So #4029 stays open, and needs a decision about whether to drop or widen `undefined`-valued headers — a behavioural question rather than a narrowing one.

## Testing

Three tests in `@orval/fetch`: the narrowing swap (fails against `master`), the unchanged `!h` / `Headers` / record branches, and that the helper is still omitted when no headers are added.

Snapshots and samples regenerated — 213 occurrences of this one helper, and `git diff` on `tests/`/`samples/` contains nothing else.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test`, `vp run test:snapshots` and `vp run lint:samples` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header handling for iterable collections, including custom nested iterables and `Headers` values.
  * Header records are now normalized consistently, omitting entries with `undefined` values across generated clients and sample applications.
  * Empty header inputs are handled safely.

* **Tests**
  * Added coverage for iterable and nested iterable headers, empty inputs, `Headers` conversion, filtered records, and helpers omitted when headers are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->