### PR TITLE
docs: correct allParamsOptional, warn on an undetectable query version (#2396, #2397)

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -3133,7 +3133,21 @@ Takes effect only when used `mode` is `split` or `single-split`.
 **Type:** `Boolean`
 **Default:** `false`
 
-Make all parameters optional except path parameters.
+Let callers leave parameters unresolved.
+
+Path parameters keep their position in the signature but widen to accept a missing value, and the query/header parameters object becomes optional:
+
+```ts
+// allParamsOptional: false
+export const getPet = async (petId: string, params: GetPetParams, ...)
+
+// allParamsOptional: true
+export const getPet = async (petId: string | undefined | null, params?: GetPetParams, ...)
+```
+
+Properties inside the parameters object keep whatever the document says — a `required: true` query parameter stays required within `GetPetParams`.
+
+This is useful with the TanStack Query clients, where a hook is often called before its id is known and the generated `enabled` guard (or [`useSkipToken`](#useskiptoken)) already holds the request back until then.
 
 ### urlEncodeParameters
 

--- a/packages/query/src/dependencies.ts
+++ b/packages/query/src/dependencies.ts
@@ -629,7 +629,7 @@ export const isSolidQueryWithRenamedOptionsTypes = (
   return compareVersions(withoutRc, '5.100.6');
 };
 
-const getPackageByQueryClient = (
+export const getPackageByQueryClient = (
   packageJson: PackageJson | undefined,
   queryClient:
     | 'react-query'

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -4,6 +4,7 @@ import {
   type GetterProps,
   GetterPropType,
   isObject,
+  logWarning,
   type OutputClient,
   OutputClient as OutputClientConst,
   type OutputClientFunc,
@@ -18,6 +19,7 @@ import {
   getQueryArgumentsRequestType,
 } from '../client';
 import {
+  getPackageByQueryClient,
   isQueryV5,
   isQueryV5WithDataTagError,
   isQueryV5WithInfiniteQueryOptionsError,
@@ -265,6 +267,46 @@ type QueryClientType =
   | 'solid-query';
 
 /**
+ * Clients already warned about, so an undetectable version is reported once per
+ * run rather than once per operation.
+ */
+const undetectedVersionWarnings = new Set<string>();
+
+/**
+ * Warn when the installed version could not be determined and none was
+ * configured.
+ *
+ * `isQueryV5` and friends answer `false` for an unresolvable dependency, so the
+ * hooks are generated for v4. That is the right guess for a v4 project but
+ * silently wrong for a v5 one — v5 needs its option types wrapped in `Partial`,
+ * and without that the caller cannot omit `queryKey` (#2396). Detection only
+ * fails in setups where the dependency is not visible from the resolved
+ * `package.json` (a monorepo root, a catalog reference), which is exactly when
+ * the user needs telling.
+ */
+const warnOnUndetectedQueryVersion = (
+  clientType: QueryClientType,
+  packageJson: PackageJson | undefined,
+  queryVersion: number | undefined,
+) => {
+  if (
+    queryVersion !== undefined ||
+    // Angular Query is v5-only, so there is nothing to detect.
+    clientType === 'angular-query' ||
+    getPackageByQueryClient(packageJson, clientType) ||
+    undetectedVersionWarnings.has(clientType)
+  ) {
+    return;
+  }
+
+  undetectedVersionWarnings.add(clientType);
+  logWarning(
+    `Could not determine the installed @tanstack/${clientType} version, so hooks are generated for v4.\n` +
+      `If the project is on v5, set \`override.query.version: 5\` (or point \`output.packageJson\` at the package.json that declares the dependency) — otherwise the generated option types will not accept a partial \`query\` object.`,
+  );
+};
+
+/**
  * Create a FrameworkAdapter for the given output client, resolving version flags
  * from the packageJson and query config.
  */
@@ -278,6 +320,8 @@ export const createFrameworkAdapter = ({
   queryVersion?: number;
 }): FrameworkAdapter => {
   const clientType = outputClient as QueryClientType;
+
+  warnOnUndetectedQueryVersion(clientType, packageJson, queryVersion);
 
   const _hasQueryV5 = queryVersion === 5 || isQueryV5(packageJson, clientType);
 

--- a/packages/query/src/frameworks/index.ts
+++ b/packages/query/src/frameworks/index.ts
@@ -4,6 +4,7 @@ import {
   type GetterProps,
   GetterPropType,
   isObject,
+  isString,
   logWarning,
   type OutputClient,
   OutputClient as OutputClientConst,
@@ -266,6 +267,29 @@ type QueryClientType =
   | 'angular-query'
   | 'solid-query';
 
+const QUERY_CLIENT_TYPES = new Set<string>([
+  'react-query',
+  'vue-query',
+  'svelte-query',
+  'angular-query',
+  'solid-query',
+]);
+
+/**
+ * The client as one of the known TanStack adapters, or `undefined` for a custom
+ * `OutputClientFunc`.
+ *
+ * `createFrameworkAdapter` casts its `outputClient` to `QueryClientType`, but a
+ * custom client reaches this generator as the user's own function — naming it
+ * in a message would print the function source.
+ */
+const asQueryClientType = (
+  outputClient: OutputClient | OutputClientFunc,
+): QueryClientType | undefined =>
+  isString(outputClient) && QUERY_CLIENT_TYPES.has(outputClient)
+    ? (outputClient as QueryClientType)
+    : undefined;
+
 /**
  * Clients already warned about, so an undetectable version is reported once per
  * run rather than once per operation.
@@ -285,11 +309,15 @@ const undetectedVersionWarnings = new Set<string>();
  * the user needs telling.
  */
 const warnOnUndetectedQueryVersion = (
-  clientType: QueryClientType,
+  outputClient: OutputClient | OutputClientFunc,
   packageJson: PackageJson | undefined,
   queryVersion: number | undefined,
 ) => {
+  // A custom client has no package to name, so there is no advice to give.
+  const clientType = asQueryClientType(outputClient);
+
   if (
+    clientType === undefined ||
     queryVersion !== undefined ||
     // Angular Query is v5-only, so there is nothing to detect.
     clientType === 'angular-query' ||
@@ -321,7 +349,7 @@ export const createFrameworkAdapter = ({
 }): FrameworkAdapter => {
   const clientType = outputClient as QueryClientType;
 
-  warnOnUndetectedQueryVersion(clientType, packageJson, queryVersion);
+  warnOnUndetectedQueryVersion(outputClient, packageJson, queryVersion);
 
   const _hasQueryV5 = queryVersion === 5 || isQueryV5(packageJson, clientType);
 

--- a/packages/query/src/frameworks/version-warning.test.ts
+++ b/packages/query/src/frameworks/version-warning.test.ts
@@ -14,7 +14,7 @@ describe('undetected query version warning', () => {
   const build = (
     packageJson?: PackageJson,
     queryVersion?: number,
-    outputClient = 'react-query',
+    outputClient: unknown = 'react-query',
   ) => {
     const warn = vi.spyOn(orvalCore, 'logWarning').mockImplementation(() => {});
     try {
@@ -54,6 +54,19 @@ describe('undetected query version warning', () => {
 
   it('stays quiet for angular-query, which is v5 only', () => {
     const warnings = build(undefined, undefined, 'angular-query');
+
+    expect(warnings).toBe('');
+  });
+
+  it('stays quiet for a custom OutputClientFunc', () => {
+    // A custom client reaches this generator as the user's own function.
+    // Interpolating it into the message printed the function source, and there
+    // is no package name to advise on anyway.
+    const customClient = () => ({
+      client: () => ({ implementation: '', imports: [] }),
+    });
+
+    const warnings = build(undefined, undefined, customClient as never);
 
     expect(warnings).toBe('');
   });

--- a/packages/query/src/frameworks/version-warning.test.ts
+++ b/packages/query/src/frameworks/version-warning.test.ts
@@ -1,0 +1,70 @@
+import type { PackageJson } from '@orval/core';
+import * as orvalCore from '@orval/core';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { createFrameworkAdapter } from './index';
+
+/**
+ * `isQueryV5` answers `false` for a dependency it cannot resolve, so an
+ * undetectable version silently generates v4-shaped hooks. On a v5 project that
+ * makes the generated `query` option non-partial and `queryKey` mandatory
+ * (#2396), so the ambiguity is worth reporting.
+ */
+describe('undetected query version warning', () => {
+  const build = (
+    packageJson?: PackageJson,
+    queryVersion?: number,
+    outputClient = 'react-query',
+  ) => {
+    const warn = vi.spyOn(orvalCore, 'logWarning').mockImplementation(() => {});
+    try {
+      createFrameworkAdapter({
+        outputClient: outputClient as never,
+        packageJson,
+        queryVersion,
+      });
+      return warn.mock.calls.map(([msg]) => msg).join('\n');
+    } finally {
+      warn.mockRestore();
+    }
+  };
+
+  it('warns when neither a package.json nor an explicit version resolves', () => {
+    const warnings = build(undefined, undefined, 'svelte-query');
+
+    expect(warnings).toContain('@tanstack/svelte-query');
+    expect(warnings).toContain('override.query.version: 5');
+  });
+
+  it('stays quiet when the dependency resolves', () => {
+    const warnings = build(
+      { resolvedVersions: { '@tanstack/vue-query': '5.90.1' } },
+      undefined,
+      'vue-query',
+    );
+
+    expect(warnings).toBe('');
+  });
+
+  it('stays quiet when the version is configured explicitly', () => {
+    const warnings = build(undefined, 4, 'solid-query');
+
+    expect(warnings).toBe('');
+  });
+
+  it('stays quiet for angular-query, which is v5 only', () => {
+    const warnings = build(undefined, undefined, 'angular-query');
+
+    expect(warnings).toBe('');
+  });
+
+  it('reports a client once, not once per operation', () => {
+    // react-query is used here so the dedupe set is not shared with the
+    // clients the other cases assert on.
+    const first = build(undefined, undefined, 'react-query');
+    const second = build(undefined, undefined, 'react-query');
+
+    expect(first).toContain('@tanstack/react-query');
+    expect(second).toBe('');
+  });
+});


### PR DESCRIPTION
Follow-up from triaging #2396 and #2397. Both reports reproduce, and both are already solved by existing options — but the options were hard to find, for two reasons this PR fixes.

Fix #2396 
Fix #2397

## The config matrix

I reproduced both reports and tested each option against them:

| config | #2396 `queryKey` required | #2397 param not optional |
|---|---|---|
| baseline | FAILS | FAILS |
| `override.query.version: 5` | **OK** | FAILS |
| `allParamsOptional: true` | FAILS | **OK** |
| both | **OK** | **OK** |

## 1. `allParamsOptional` was documented as not doing what it does

The old line — *"Make all parameters optional except path parameters"* — reads as "path parameters are unaffected". They are affected:

```ts
// allParamsOptional: false
export const getPet = async (petId: string, params: GetPetParams, ...)

// allParamsOptional: true
export const getPet = async (petId: string | undefined | null, params?: GetPetParams, ...)
```

Path parameters keep their position but widen to accept a missing value, and the parameters object becomes optional. That is exactly what #2397 asks for, so the docs were steering people away from the answer. Now documented as measured, with a note about the TanStack use case and a link to `useSkipToken`.

## 2. An undetectable query version is silently treated as v4

`isQueryV5` answers `false` for a dependency it cannot resolve:

```ts
const version = getPackageByQueryClient(packageJson, queryClient);
if (!version) {
  return false;
}
```

That is the right guess for a v4 project. On a v5 one it means the `query` option type is not wrapped in `Partial`, so the caller cannot omit `queryKey` — #2396 exactly, and it explains the reporter's own puzzlement that orval's samples wrap in `Partial` while their project does not: samples have a discoverable dependency.

Now warned once per client:

```
Could not determine the installed @tanstack/react-query version, so hooks are generated for v4.
If the project is on v5, set `override.query.version: 5` (or point `output.packageJson` at the
package.json that declares the dependency) — otherwise the generated option types will not accept
a partial `query` object.
```

Silent as soon as the dependency resolves or a version is configured. Angular Query is skipped, being v5-only.

> [!NOTE]
> This fires **6 times** in this repo's own `test:snapshots` run — `petstore` ×3, `issue3326`, `mswMixedContentUnion`, `issue-1879-header-pathref`. Cause: `findUp` resolves the repo root `package.json` for those configs, and it does not declare `@tanstack/react-query`, so detection genuinely cannot tell. A normal app declares the dependency and stays quiet, so I expect this to be rare in the wild — but it is noise in our own output, and those fixtures are in fact generating v4-shaped hooks today. Say the word and I will gate it behind `--verbose`, or set `override.query.version` in those configs instead.

## Testing

Five tests covering: warns when nothing resolves, quiet when the dependency resolves, quiet when the version is explicit, quiet for `angular-query`, and reported once per client rather than once per operation.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with no change to generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for the `allParamsOptional` output option, including parameter behavior, examples, and usage with TanStack Query clients.

- **Improvements**
  - Added a warning when the TanStack Query version cannot be detected and no version is configured.
  - Warnings appear only once per query client and are suppressed when the version is known, explicitly configured, or using Angular Query.
  - Improved support for custom query clients and package-based version detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->