### PR TITLE
refactor(core): remove unused vite logger copy and dead logger helpers

### DIFF
--- a/packages/core/src/utils/log-warning.test.ts
+++ b/packages/core/src/utils/log-warning.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
-import {
-  createLogger,
-  getWarningCount,
-  logWarning,
-  resetWarnings,
-} from './logger';
+import { getWarningCount, logWarning, resetWarnings } from './logger';
 
 describe('logWarning', () => {
   afterEach(() => {
@@ -32,28 +27,5 @@ describe('logWarning', () => {
     expect(getWarningCount()).toBe(1);
     resetWarnings();
     expect(getWarningCount()).toBe(0);
-  });
-});
-
-describe('createLogger', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('deduplicates messages per logger instance', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const firstLogger = createLogger('info');
-    const secondLogger = createLogger('info');
-
-    firstLogger.info('same message');
-    secondLogger.info('same message');
-    firstLogger.info('same message');
-
-    expect(log).toHaveBeenCalledTimes(3);
-    expect(log.mock.calls[0]).toEqual(['same message']);
-    expect(log.mock.calls[1]).toEqual(['same message']);
-    expect(log.mock.calls[2][0]).toBe('same message');
-    expect(log.mock.calls[2][1]).toContain('(x2)');
   });
 });

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,4 +1,3 @@
-import readline from 'node:readline';
 import { styleText } from 'node:util';
 
 import { isString } from './assertion';
@@ -24,10 +23,6 @@ let _verbose = false;
 
 export function setVerbose(v: boolean) {
   _verbose = v;
-}
-
-export function isVerbose(): boolean {
-  return _verbose;
 }
 
 export const logVerbose: typeof console.log = (...args) => {
@@ -74,134 +69,10 @@ export function logError(err: unknown, tag?: string) {
   );
 }
 
-export function mismatchArgsMessage(mismatchArgs: string[]) {
-  logWarning(
-    `${mismatchArgs.join(', ')} ${
-      mismatchArgs.length === 1 ? 'is' : 'are'
-    } not defined in your configuration!`,
-  );
-}
-
 export function createSuccessMessage(backend?: string) {
   log(
     `🎉 ${
       backend ? `${styleText('green', backend)} - ` : ''
     }Your OpenAPI spec has been converted into ready to use orval!`,
   );
-}
-
-export type LogType = 'error' | 'warn' | 'info';
-export type LogLevel = LogType | 'silent';
-export interface Logger {
-  info(msg: string, options?: LogOptions): void;
-  warn(msg: string, options?: LogOptions): void;
-  warnOnce(msg: string, options?: LogOptions): void;
-  error(msg: string, options?: LogOptions): void;
-  clearScreen(type: LogType): void;
-  hasWarned: boolean;
-}
-
-export interface LogOptions {
-  clear?: boolean;
-  timestamp?: boolean;
-}
-
-export const LogLevels: Record<LogLevel, number> = {
-  silent: 0,
-  error: 1,
-  warn: 2,
-  info: 3,
-};
-
-function clearScreen() {
-  const repeatCount = process.stdout.rows - 2;
-  const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : '';
-  console.log(blank);
-  readline.cursorTo(process.stdout, 0, 0);
-  readline.clearScreenDown(process.stdout);
-}
-
-export interface LoggerOptions {
-  prefix?: string;
-  allowClearScreen?: boolean;
-}
-
-export function createLogger(
-  level: LogLevel = 'info',
-  options: LoggerOptions = {},
-): Logger {
-  const { prefix = '[vite]', allowClearScreen = true } = options;
-  let lastType: LogType | undefined;
-  let lastMsg: string | undefined;
-  let sameCount = 0;
-
-  const thresh = LogLevels[level];
-  const clear =
-    allowClearScreen && process.stdout.isTTY && !process.env.CI
-      ? clearScreen
-      : () => {
-          /* noop */
-        };
-
-  function output(type: LogType, msg: string, options: LogOptions = {}) {
-    if (thresh >= LogLevels[type]) {
-      const method = type === 'info' ? 'log' : type;
-      const format = () => {
-        if (options.timestamp) {
-          const tag =
-            type === 'info'
-              ? styleText(['cyan', 'bold'], prefix)
-              : type === 'warn'
-                ? styleText(['yellow', 'bold'], prefix)
-                : styleText(['red', 'bold'], prefix);
-          return `${styleText('dim', new Date().toLocaleTimeString())} ${tag} ${msg}`;
-        } else {
-          return msg;
-        }
-      };
-      if (type === lastType && msg === lastMsg) {
-        sameCount++;
-        clear();
-        console[method](format(), styleText('yellow', `(x${sameCount + 1})`));
-      } else {
-        sameCount = 0;
-        lastMsg = msg;
-        lastType = type;
-        if (options.clear) {
-          clear();
-        }
-        console[method](format());
-      }
-    }
-  }
-
-  const warnedMessages = new Set<string>();
-
-  const logger: Logger = {
-    hasWarned: false,
-    info(msg, opts) {
-      output('info', msg, opts);
-    },
-    warn(msg, opts) {
-      logger.hasWarned = true;
-      output('warn', msg, opts);
-    },
-    warnOnce(msg, opts) {
-      if (warnedMessages.has(msg)) return;
-      logger.hasWarned = true;
-      output('warn', msg, opts);
-      warnedMessages.add(msg);
-    },
-    error(msg, opts) {
-      logger.hasWarned = true;
-      output('error', msg, opts);
-    },
-    clearScreen(type) {
-      if (thresh >= LogLevels[type]) {
-        clear();
-      }
-    },
-  };
-
-  return logger;
 }


### PR DESCRIPTION
## Summary

Deletes dead code from `packages/core/src/utils/logger.ts`:

- `createLogger` and its supporting types/values (`Logger`, `LogLevels`, `LogLevel`, `LogType`, `LogOptions`, `LoggerOptions`, `clearScreen`) — a copy of vite's logger with zero callers
- `isVerbose` and `mismatchArgsMessage` — zero callers
- the `node:readline` import that only `clearScreen` used
- the `createLogger` unit test, since the function no longer exists

No behavior change. `log`, `logWarning`, `logVerbose`, `logError`, `startMessage`, `createSuccessMessage` and the warning counters are untouched.

## Verification

- `bun run lint` (type-aware) passes
- `bun run test` passes across all packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated verbose logging behavior to provide conditional diagnostic output when verbose mode is enabled.
  - Removed legacy configuration-mismatch warnings.
  - Simplified warning-related tests and removed coverage for per-instance message deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->