### PR TITLE
fix: reject a schemas path that names a file (#4042)

### DIFF
--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -1085,6 +1085,90 @@ describe('normalizeOptions', () => {
     }
   });
 
+  it.each([
+    ['./model/schemas.ts', 'schemas.path'],
+    ['./model/schemas.tsx', 'schemas.path'],
+    ['./model/schemas.mjs', 'schemas.path'],
+  ])('rejects %s as schemas.path, which names a file', async (path) => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      // The path is a directory: a filename silently became a directory with
+      // that name, holding the split schema files (#4042).
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './generated.ts',
+              schemas: { path, type: 'zod' },
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow(/names a file/);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a filename given in the string form of schemas', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+              },
+            },
+            output: { target: './generated.ts', schemas: './model/schemas.ts' },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow(/`schemas` is a directory/);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a directory whose name merely contains a dot', async () => {
+    const workspace = await createTempWorkspace();
+
+    try {
+      const normalized = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
+              paths: {},
+            },
+          },
+          output: {
+            target: './generated.ts',
+            schemas: { path: './model/v1.0', type: 'zod' },
+          },
+        },
+        workspace,
+      );
+
+      expect(normalized.output.schemas).toBeDefined();
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it('preserves schemas.importPath through normalization', async () => {
     const workspace = await createTempWorkspace();
 

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -116,6 +116,40 @@ function createFormData(
   };
 }
 
+/** Extensions that mean a value names a source file rather than a directory. */
+const SOURCE_FILE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+]);
+
+/**
+ * Reject a schemas path that names a source file.
+ *
+ * The path is always a directory — orval writes one file per schema into it,
+ * plus a barrel. A filename was accepted silently and produced a *directory*
+ * with that name, so `./model/example.zod.ts` became a folder called
+ * `example.zod.ts` holding the split files: the shape a user asking for
+ * single-file output would least expect (#4042).
+ */
+function assertSchemasPathIsDirectory(path: string, option: string): void {
+  if (!SOURCE_FILE_EXTENSIONS.has(nodePath.extname(path).toLowerCase())) {
+    return;
+  }
+
+  throw new Error(
+    styleText(
+      'red',
+      `\`${option}\` is a directory, but "${path}" names a file. Orval writes one file per schema into that directory, so a filename would become a directory with that name.\nPass the directory instead (e.g. \`${option}: './model'\`), or omit \`schemas\` to generate them alongside the target.`,
+    ),
+  );
+}
+
 function normalizeSchemasOption(
   schemas: string | SchemaOptions | false | undefined,
   workspace: string,
@@ -125,6 +159,7 @@ function normalizeSchemasOption(
   }
 
   if (isString(schemas)) {
+    assertSchemasPathIsDirectory(schemas, 'schemas');
     return normalizePath(schemas, workspace);
   }
 
@@ -137,6 +172,7 @@ function normalizeSchemasOption(
     );
   }
 
+  assertSchemasPathIsDirectory(schemas.path, 'schemas.path');
   validatePackageSpecifier(schemas.importPath, 'schemas.importPath');
 
   const routes = schemas.routes


### PR DESCRIPTION
Fixes the papercut found while triaging #4042. **Not** the feature request itself — single-file schema output is still open there.

## The bug

`schemas.path` is a directory: orval writes one file per schema into it, plus a barrel. A filename was accepted silently and became a directory with that name:

```ts
schemas: { path: './src/example.schema.zod.ts', type: 'zod' }
```

```
src/example.schema.zod.ts/example.zod.ts
src/example.schema.zod.ts/exampleItem.zod.ts
src/example.schema.zod.ts/index.ts
```

A directory that looks like a file, containing exactly the split output the user was trying to avoid. That's how #4042's author found it, and it's worth failing loudly regardless of whether the feature lands.

## After

```
Error: `schemas.path` is a directory, but "./src/example.schema.zod.ts" names a file.
Orval writes one file per schema into that directory, so a filename would become
a directory with that name.
Pass the directory instead (e.g. `schemas.path: './model'`), or omit `schemas` to
generate them alongside the target.
```

Applied to the string form too, which had the same behaviour:

```
Error: `schemas` is a directory, but "./model/schemas.ts" names a file. ...
```

## Scope

Only extensions that clearly name a source file are rejected — `.ts .tsx .mts .cts .js .jsx .mjs .cjs`. A directory whose name merely contains a dot, like `./model/v1.0`, still works, and there's a test pinning that.

I checked every sample and test config: none passes a file-like schemas path, so nothing existing breaks.

## Testing

Five tests — three extensions rejected via the object form, one via the string form, and the dot-directory guard. The four rejection tests fail against `master`; the guard passes both ways.

`vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass, with no change to generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid schema paths that point to source files now produce a clear validation error.
  - Schema directories containing dots in their names are accepted correctly.
  - Validation now applies consistently to both supported schema configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->