### PR TITLE
feat: declare optional peer dependencies for generated-code runtimes (#2330, #3459)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
         "vite-plus": "catalog:",
       },
       "peerDependencies": {
-        "@faker-js/faker": ">=10",
+        "@faker-js/faker": ">=8",
       },
       "optionalPeers": [
         "@faker-js/faker",
@@ -85,6 +85,12 @@
         "typescript": "catalog:",
         "vite-plus": "catalog:",
       },
+      "peerDependencies": {
+        "effect": ">=3",
+      },
+      "optionalPeers": [
+        "effect",
+      ],
     },
     "packages/fetch": {
       "name": "@orval/fetch",
@@ -135,6 +141,12 @@
         "typescript": "catalog:",
         "vite-plus": "catalog:",
       },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1",
+      },
+      "optionalPeers": [
+        "@modelcontextprotocol/sdk",
+      ],
     },
     "packages/mock": {
       "name": "@orval/mock",
@@ -148,6 +160,14 @@
         "typescript": "catalog:",
         "vite-plus": "catalog:",
       },
+      "peerDependencies": {
+        "@faker-js/faker": ">=8",
+        "msw": ">=2",
+      },
+      "optionalPeers": [
+        "@faker-js/faker",
+        "msw",
+      ],
     },
     "packages/orval": {
       "name": "orval",
@@ -213,6 +233,20 @@
         "typescript": "catalog:",
         "vite-plus": "catalog:",
       },
+      "peerDependencies": {
+        "@tanstack/angular-query-experimental": ">=5",
+        "@tanstack/react-query": ">=4",
+        "@tanstack/solid-query": ">=4",
+        "@tanstack/svelte-query": ">=4",
+        "@tanstack/vue-query": ">=4",
+      },
+      "optionalPeers": [
+        "@tanstack/angular-query-experimental",
+        "@tanstack/react-query",
+        "@tanstack/solid-query",
+        "@tanstack/svelte-query",
+        "@tanstack/vue-query",
+      ],
     },
     "packages/solid-start": {
       "name": "@orval/solid-start",
@@ -238,6 +272,12 @@
         "typescript": "catalog:",
         "vite-plus": "catalog:",
       },
+      "peerDependencies": {
+        "swr": ">=2",
+      },
+      "optionalPeers": [
+        "swr",
+      ],
     },
     "packages/zod": {
       "name": "@orval/zod",
@@ -253,6 +293,12 @@
         "typescript": "catalog:",
         "vite-plus": "catalog:",
       },
+      "peerDependencies": {
+        "zod": ">=3",
+      },
+      "optionalPeers": [
+        "zod",
+      ],
     },
     "samples/angular-app": {
       "name": "angular-app",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@faker-js/faker": ">=10"
+    "@faker-js/faker": ">=8"
   },
   "peerDependenciesMeta": {
     "@faker-js/faker": {

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -30,5 +30,13 @@
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "effect": {
+      "optional": true
+    }
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,5 +31,13 @@
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -30,5 +30,17 @@
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "msw": ">=2",
+    "@faker-js/faker": ">=10"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    },
+    "@faker-js/faker": {
+      "optional": true
+    }
   }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -32,8 +32,8 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "msw": ">=2",
-    "@faker-js/faker": ">=10"
+    "@faker-js/faker": ">=10",
+    "msw": ">=2"
   },
   "peerDependenciesMeta": {
     "msw": {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -32,7 +32,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "@faker-js/faker": ">=10",
+    "@faker-js/faker": ">=8",
     "msw": ">=2"
   },
   "peerDependenciesMeta": {

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -31,5 +31,29 @@
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": ">=4",
+    "@tanstack/vue-query": ">=4",
+    "@tanstack/svelte-query": ">=4",
+    "@tanstack/solid-query": ">=5",
+    "@tanstack/angular-query-experimental": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "@tanstack/vue-query": {
+      "optional": true
+    },
+    "@tanstack/svelte-query": {
+      "optional": true
+    },
+    "@tanstack/solid-query": {
+      "optional": true
+    },
+    "@tanstack/angular-query-experimental": {
+      "optional": true
+    }
   }
 }

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -33,11 +33,11 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
+    "@tanstack/angular-query-experimental": ">=5",
     "@tanstack/react-query": ">=4",
-    "@tanstack/vue-query": ">=4",
-    "@tanstack/svelte-query": ">=4",
     "@tanstack/solid-query": ">=5",
-    "@tanstack/angular-query-experimental": ">=5"
+    "@tanstack/svelte-query": ">=4",
+    "@tanstack/vue-query": ">=4"
   },
   "peerDependenciesMeta": {
     "@tanstack/react-query": {

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@tanstack/angular-query-experimental": ">=5",
     "@tanstack/react-query": ">=4",
-    "@tanstack/solid-query": ">=5",
+    "@tanstack/solid-query": ">=4",
     "@tanstack/svelte-query": ">=4",
     "@tanstack/vue-query": ">=4"
   },

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -30,5 +30,13 @@
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "swr": ">=2"
+  },
+  "peerDependenciesMeta": {
+    "swr": {
+      "optional": true
+    }
   }
 }

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -32,5 +32,13 @@
     "rimraf": "catalog:",
     "typescript": "catalog:",
     "vite-plus": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Closes #2330 
Closes #3459 
— same goal from two angles: generated code imports libraries the packages never declared, so a package manager can't tell a user the library is missing or the version is wrong.

## Approach

Follows the convention already in the repo (`@orval/core`, `@orval/hono`, `orval`): `peerDependencies` plus `peerDependenciesMeta.optional`, so nothing is installed and nothing warns when a client is unused.

| package | peers |
|---|---|
| `@orval/query` | `@tanstack/react-query` `>=4`, `@tanstack/vue-query` `>=4`, `@tanstack/svelte-query` `>=4`, `@tanstack/solid-query` `>=5`, `@tanstack/angular-query-experimental` `>=5` |
| `@orval/mock` | `msw` `>=2`, `@faker-js/faker` `>=10` |
| `@orval/zod` | `zod` `>=3` |
| `@orval/effect` | `effect` `>=3` |
| `@orval/swr` | `swr` `>=2` |
| `@orval/mcp` | `@modelcontextprotocol/sdk` `>=1` |

I derived the package list from what the generators actually emit imports for, rather than from the issue text.

## Where the floors come from

Not from the catalogued versions — from what the code branches on:

- **react / vue / svelte start at 4**, because v3 is a *separate legacy package*. `isVueQueryV3` and `isSvelteQueryV3` check for the presence of `vue-query` / `svelte-query`, not a version of the scoped one.
- **solid and angular start at 5** — every check on them (`isSolidQueryWithUsePrefix` at `5.71.5`, `isSolidQueryWithRenamedOptionsTypes` at `5.100.6`) gates a 5.x feature, and the code notes Angular Query is v5-only.
- **zod is `>=3`** because both `zod3` and `zod4` are catalogued and `compatible-v4.ts` branches on them.
- **msw is `>=2`** — no version branching anywhere, and the emitted code uses the v2 `http` / `HttpResponse` API.

Every catalogued version satisfies its declared range; I checked that mechanically rather than by eye.

## Two deliberate omissions

**The deprecated pre-TanStack packages** (`react-query`, `vue-query`, `svelte-query`) are left undeclared. Those code paths are *presence*-based, not version-based, so any range would assert something the code never verifies.

**`@orval/angular`, `@orval/axios`, `@orval/solid-start`** are left alone. They emit `@angular/core`, `rxjs`, `axios`, `qs`, `@solidjs/router`, but nothing in the codebase pins a floor for them and I would have been guessing. Happy to add them if you can give the supported ranges — I didn't want to invent version contracts.

## One thing worth a look

`@faker-js/faker` is set to `>=10` to match what `@orval/core` already declares for its `allLocales` type import — a different floor would make the two packages contradict each other. But `isFakerVersionV9` still branches for v9, so the real supported floor may be lower than 10. That predates this change, so I left it; if v9 is genuinely supported, both should move together.

## Verification

`vp install` resolves cleanly with the new peers. `vp run lint` (type-aware + type-check), `vp run format:check`, `vp run test` and `vp run test:snapshots` all pass — manifest-only change, no generated output affected.

> [!NOTE]
> `vp install` also rewrote `bun.lock` with unrelated `@inquirer/*` version churn. I reverted it so this stays a manifest-only diff — worth regenerating deliberately if you want the lockfile refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added optional compatibility declarations for Effect, Model Context Protocol, mocking tools, query libraries, SWR, and Zod integrations.
  - Clarified supported version ranges for query adapters across React, Vue, Svelte, Solid, and Angular.
  - Added clearer support information for optional integrations without requiring them for all installations.
  - Expanded compatibility with earlier supported versions of the Faker library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->