### PR TITLE
docs: fix allParamsOptional link missing the /docs route prefix

### DIFF
--- a/docs/content/docs/guides/react-query.mdx
+++ b/docs/content/docs/guides/react-query.mdx
@@ -208,7 +208,7 @@ This matters in two cases the `enabled` guard does not cover:
 - `enabled` does not gate `refetch()`, so a retry button sends the request with the unresolved param in the URL. With `skipToken` no request is sent — the query rejects with `Missing queryFn` instead, which is the tradeoff to know about before enabling the option.
 - `enabled` is a single option and `...queryOptions` is spread last, so `useShowPetById(petId, { query: { enabled: isTabVisible } })` replaces the generated param check. With `skipToken` the two gates are independent.
 
-Pair it with [`allParamsOptional`](/reference/configuration/output#allparamsoptional) so callers can pass an unresolved param without a cast.
+Pair it with [`allParamsOptional`](/docs/reference/configuration/output#allparamsoptional) so callers can pass an unresolved param without a cast.
 
 Suspense queries are unaffected: TanStack excludes `SkipToken` from their `queryFn`, which is also why they get no `enabled` guard.
 


### PR DESCRIPTION
## Problem

The docs deploy is failing on `master`: [run 34152762656](https://github.com/orval-labs/orval/actions/runs/34152762656/job/101838272385)

```
Error: Failed to fetch /reference/configuration/output#allparamsoptional: Not Found
    at @tanstack/start-plugin-core/dist/esm/prerender.js:137:19
```

The react-query guide linked `allParamsOptional` as `/reference/configuration/output#allparamsoptional`, without the `/docs` route prefix. Docs routes live under `docs/src/routes/docs`, so that path does not resolve.

TanStack Start's prerender crawls collected hrefs, so a bad internal link is not merely a dead link in the rendered page -- the 404 aborts `bun run build`, and with it `bun run deploy`.

## Fix

One character-level change, adding the missing prefix:

```diff
-Pair it with [`allParamsOptional`](/reference/configuration/output#allparamsoptional) ...
+Pair it with [`allParamsOptional`](/docs/reference/configuration/output#allparamsoptional) ...
```

## Notes

- Introduced in 43dd30370 (`feat(query): add useSkipToken option`), not by the recent docs commit that happened to touch `allParamsOptional`.
- This is the **only** internal link in the whole content tree that does not start with `/docs/` or `/zh/`. The other 32 internal hash links -- including the neighbouring `#queryobjectserialization`, same file, same heading level -- already carry the prefix.
- The anchor target itself was always fine: `### allParamsOptional` in `reference/configuration/output.mdx`.

## Verification

`cd docs && bun run build` (the exact step CI runs before `wrangler deploy`) exits 0. From the prerender log:

- `Crawling: /docs/guides/react-query` -- the page containing the link is crawled, so the link is genuinely exercised
- `Crawling: /docs/reference/configuration/output#allparamsoptional` -- the precise path that 404'd in CI now resolves and prerenders
- 160 pages crawled, no `Failed to fetch` / `Not Found` anywhere in the log

## Possible follow-up (not in this PR)

A prefix typo in any internal link takes down the whole docs deploy, and nothing catches it before CI. A small link checker alongside `scripts/check-i18n-coverage.ts` -- asserting every `](/...)` in `docs/content` starts with `/docs/` or `/zh/` and that its anchor exists -- would turn a failed deploy into a fast local failure. Happy to open that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Skip Token guide link to point to the correct reference documentation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->