### PR TITLE
feat(cli): add --quiet flag to suppress banner and success messages

### DIFF
--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -25,6 +25,16 @@ export function setVerbose(v: boolean) {
   _verbose = v;
 }
 
+let _quiet = false;
+
+export function setQuiet(v: boolean) {
+  _quiet = v;
+}
+
+export function isQuiet(): boolean {
+  return _quiet;
+}
+
 export const logVerbose: typeof console.log = (...args) => {
   if (_verbose) log(...args);
 };
@@ -70,6 +80,9 @@ export function logError(err: unknown, tag?: string) {
 }
 
 export function createSuccessMessage(backend?: string) {
+  if (isQuiet()) {
+    return;
+  }
   log(
     `🎉 ${
       backend ? `${styleText('green', backend)} - ` : ''

--- a/packages/orval/src/bin/orval.ts
+++ b/packages/orval/src/bin/orval.ts
@@ -5,12 +5,14 @@ import { Option, program } from '@commander-js/extra-typings';
 import {
   ErrorWithTag,
   getWarningCount,
+  isQuiet,
   isString,
   log,
   logError,
   OutputClient,
   OutputMode,
   resetWarnings,
+  setQuiet,
   setVerbose,
   startMessage,
   SupportedFormatter,
@@ -83,6 +85,7 @@ cli
   )
   .option('--tsconfig <path>', 'path to your tsconfig file')
   .option('--verbose', 'Enable verbose logging')
+  .option('--quiet', 'Suppress the startup banner and success messages')
   .option(
     '--fail-on-warnings',
     'Exit with error code 1 when warnings are emitted',
@@ -91,9 +94,14 @@ cli
     if (options.verbose) {
       setVerbose(true);
     }
+    if (options.quiet) {
+      setQuiet(true);
+    }
 
     resetWarnings();
-    log(orvalMessage);
+    if (!isQuiet()) {
+      log(orvalMessage);
+    }
 
     if (isString(options.input) && isString(options.output)) {
       const normalizedOptions = await normalizeOptions({


### PR DESCRIPTION
Fixes #3632. Adds `--quiet` CLI flag that suppresses the startup banner and the success message. Warnings and errors still print, so the flag is safe for CI pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--quiet` command-line option for reduced terminal output.
  - Quiet mode suppresses the startup banner and success messages while commands run.
  - Quiet mode can be enabled or disabled through the logger, allowing applications to control whether success messages are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->