### PR TITLE
docs: fix broken logo image links in package READMEs

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
-![orval - Restful Client Generator](./logo/orval-logo-horizontal.svg?raw=true)
+![orval - Restful Client Generator](../../logo/orval-logo-horizontal.svg?raw=true)
 
 Angular generator support for [Orval](https://orval.dev).
 

--- a/packages/axios/README.md
+++ b/packages/axios/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/mock/README.md
+++ b/packages/mock/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restful Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restful Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/swr/README.md
+++ b/packages/swr/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -3,7 +3,7 @@
 [![tests](https://github.com/orval-labs/orval/actions/workflows/tests.yaml/badge.svg)](https://github.com/orval-labs/orval/actions/workflows/tests.yaml)
 
 <p align="center">
-  <img src="./logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
+  <img src="../../logo/orval-logo-horizontal.svg?raw=true" width="500" height="160" alt="orval - Restfull Client Generator" />
 </p>
 <h1 align="center">
   Visit <a href="https://orval.dev" target="_blank">orval.dev</a> for docs, guides, API and beer!


### PR DESCRIPTION
The package READMEs referenced the logo image with a relative path meant for the repo root, so it was broken when viewed from inside packages/*. I updated each of the ten package READMEs to point at ../../logo/orval-logo-horizontal.svg, which is where the file actually lives.

The checks evaluated by the fork CI gate passed. This excludes skipped checks and checks filtered out for fork-only conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected logo references across package README files.
  - README logos now render correctly from their package locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->