### PR TITLE
chore: update js-yaml to 4.3.2 (GHSA-2883-xcg3-v3hh)

### DIFF
--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -77,7 +77,7 @@
     "fs-extra": "^11.3.2",
     "get-tsconfig": "^4.14.0",
     "jiti": "^2.6.1",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "remeda": "^2.33.6",
     "string-argv": "^0.3.2",
     "typedoc": "^0.28.19",


### PR DESCRIPTION
* bump up the js-yaml version from 4.3.1 to 4.3.2 addressing a high severity vulnerability
  * [GHSA-2883-xcg3-v3hh](https://github.com/nodeca/js-yaml/security/advisories/GHSA-2883-xcg3-v3hh)
  * CVE-2026-84375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the YAML parsing dependency to version 4.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->