### PR TITLE
fix(core): avoid unused schema imports for reusable parameters

### DIFF
--- a/packages/core/src/getters/parameters.test.ts
+++ b/packages/core/src/getters/parameters.test.ts
@@ -82,6 +82,71 @@ describe('getParameters', () => {
     ]);
   });
 
+  it('keeps only the reusable parameter import when its schema is a component ref (issue #4057)', () => {
+    const whereItem = {
+      type: 'object',
+      properties: {
+        attribute: { type: 'string' },
+        value: { type: 'string' },
+      },
+    } as const;
+    const whereParameter: OpenApiParameterObject = {
+      name: 'where',
+      in: 'query',
+      description: 'Complex filtering criteria',
+      style: 'deepObject',
+      explode: true,
+      schema: { $ref: '#/components/schemas/WhereItem' },
+    };
+    const context = createTestContextSpec({
+      spec: {
+        components: {
+          parameters: { Where: whereParameter },
+          schemas: { WhereItem: whereItem },
+        },
+      },
+      override: {
+        components: {
+          schemas: {
+            prefix: '',
+            itemPrefix: '',
+            suffix: '',
+            itemSuffix: '',
+          },
+          responses: { prefix: '', suffix: '' },
+          parameters: { prefix: '', suffix: 'Parameter' },
+          requestBodies: { prefix: '', suffix: '' },
+        },
+      },
+    });
+
+    const result = getParameters({
+      parameters: [{ $ref: '#/components/parameters/Where' }],
+      context,
+    });
+
+    expect(result.query).toHaveLength(1);
+    expect(result.query[0].parameter.schema).toEqual(whereItem);
+    expect(result.query[0].imports).toEqual([
+      { name: 'WhereParameter', schemaName: 'Where' },
+    ]);
+  });
+
+  it('keeps imports empty for inline query parameters', () => {
+    const inlineParameter: OpenApiParameterObject = {
+      name: 'limit',
+      in: 'query',
+      schema: { type: 'integer' },
+    };
+
+    const result = getParameters({
+      parameters: [inlineParameter],
+      context: createTestContextSpec(),
+    });
+
+    expect(result.query).toEqual([{ parameter: inlineParameter, imports: [] }]);
+  });
+
   it('drops imports when a header parameter $ref targets a non-component slot (issue #1879)', () => {
     // Repro for #1879: JSON Pointer refs into another path's `parameters` array
     // (`#/paths/~1requestA/post/parameters/0`) resolve to a synthesized name

--- a/packages/core/src/getters/parameters.ts
+++ b/packages/core/src/getters/parameters.ts
@@ -6,7 +6,7 @@ import type {
   OpenApiReferenceObject,
 } from '../types';
 import { isReference } from '../utils';
-import { isComponentRef } from './ref';
+import { getRefInfo, isComponentRef } from './ref';
 
 interface GetParametersOptions {
   parameters: (OpenApiReferenceObject | OpenApiParameterObject)[];
@@ -20,7 +20,7 @@ export function getParameters({
   const result: GetterParameters = { path: [], query: [], header: [] };
   for (const p of parameters) {
     if (isReference(p)) {
-      const { schema, imports } = resolveRef(p, context);
+      const { schema } = resolveRef(p, context);
       const parameter = schema as OpenApiParameterObject;
 
       const location = parameter.in;
@@ -34,7 +34,21 @@ export function getParameters({
         // `generateParameterDefinition`, so emitting a named import would
         // dangle. Inline the resolved parameter's schema instead. Mirrors the
         // #398 fix in `resolvers/value.ts`. See issue #1879.
-        const safeImports = p.$ref && isComponentRef(p.$ref) ? imports : [];
+        // Operation params reference the reusable parameter alias itself. Any
+        // schema refs nested inside that parameter are imported by the generated
+        // `components.parameters` alias, so they must not be forwarded here.
+        const componentRefInfo =
+          p.$ref && isComponentRef(p.$ref)
+            ? getRefInfo(p.$ref, context)
+            : undefined;
+        const safeImports = componentRefInfo
+          ? [
+              {
+                name: componentRefInfo.name,
+                schemaName: componentRefInfo.originalName,
+              },
+            ]
+          : [];
         result[location].push({ parameter, imports: safeImports });
       }
     } else {

--- a/packages/core/src/getters/query-params.test.ts
+++ b/packages/core/src/getters/query-params.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import { createTestContextSpec } from '../test-utils/context';
 import { EnumGeneration, type OpenApiParameterObject } from '../types';
+import { getParameters } from './parameters';
 import { getQueryParams } from './query-params';
 
 // Fully-typed context via the shared factory — no unsafe cast, so missing
@@ -207,6 +208,69 @@ describe('getQueryParams getter', () => {
         ' * Parameter description.',
         ' */',
         'queryParamWithDescription?: string;',
+        '};',
+      ].join('\n'),
+    );
+  });
+
+  it('does not import schemas used only behind reusable parameter aliases (issue #4057)', () => {
+    const whereItem = {
+      type: 'object',
+      properties: {
+        attribute: { type: 'string' },
+        value: { type: 'string' },
+      },
+    } as const;
+    const whereParameter: OpenApiParameterObject = {
+      name: 'where',
+      in: 'query',
+      description: 'Complex filtering criteria',
+      style: 'deepObject',
+      explode: true,
+      schema: { $ref: '#/components/schemas/WhereItem' },
+    };
+    const reusableParameterContext = createTestContextSpec({
+      spec: {
+        components: {
+          parameters: { Where: whereParameter },
+          schemas: { WhereItem: whereItem },
+        },
+      },
+      override: {
+        components: {
+          schemas: {
+            prefix: '',
+            itemPrefix: '',
+            suffix: '',
+            itemSuffix: '',
+          },
+          responses: { prefix: '', suffix: '' },
+          parameters: { prefix: '', suffix: 'Parameter' },
+          requestBodies: { prefix: '', suffix: '' },
+        },
+      },
+    });
+    const parameters = getParameters({
+      parameters: [{ $ref: '#/components/parameters/Where' }],
+      context: reusableParameterContext,
+    });
+
+    const result = getQueryParams({
+      queryParams: parameters.query,
+      operationName: 'getItems',
+      context: reusableParameterContext,
+    });
+
+    expect(result?.schema.imports).toEqual([
+      { name: 'WhereParameter', schemaName: 'Where' },
+    ]);
+    expect(result?.schema.model.trim()).toBe(
+      [
+        'export type GetItemsParams = {',
+        '/**',
+        ' * Complex filtering criteria',
+        ' */',
+        'where?: WhereParameter;',
         '};',
       ].join('\n'),
     );


### PR DESCRIPTION
## Summary

Fixes unused schema imports generated for reusable parameter components
Fixes #4057

## Changes

* Use the reusable parameter reference as the generated import.
* Avoid propagating nested schema imports from `resolveRef()`.
* Add regression tests for reusable and inline parameters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated query parameter imports when parameters reference reusable components.
  - Prevented unnecessary or invalid imports for inline and bundled parameter schemas.
  - Preserved parameter aliases and their associated descriptions and optional types in generated output.

- **Tests**
  - Added coverage for reusable parameter references, aliases, component schemas, and inline query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->