### PR TITLE
feat(zod): support date-time-local format

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -101,6 +101,7 @@ export const predefinedZodFormats = new Set([
   'date',
   'time',
   'date-time',
+  'date-time-local',
   'email',
   'uri',
   'hostname',
@@ -1483,8 +1484,14 @@ export const generateZodValidationSchemaDefinition = (
           break;
         }
 
-        if (schema.format === 'date-time') {
-          const options = context.output.override.zod.dateTimeOptions;
+        if (
+          schema.format === 'date-time' ||
+          schema.format === 'date-time-local'
+        ) {
+          const options =
+            schema.format === 'date-time-local'
+              ? { local: true }
+              : context.output.override.zod.dateTimeOptions;
           const formatAPI = getZodDateTimeFormat(isZodV4);
 
           functions.push([formatAPI, JSON.stringify(options)]);

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -130,13 +130,15 @@ describe.each([
       'generates local datetime validation with required=%s',
       (required) => {
         const validator =
-          version === 4
-            ? 'zod.iso.datetime({"local":true})'
-            : 'zod.string().datetime({"local":true})';
+          variant === 'mini'
+            ? '/*#__PURE__*/ zod.iso.datetime({"local":true})'
+            : version === 4
+              ? 'zod.iso.datetime({"local":true})'
+              : 'zod.string().datetime({"local":true})';
         const expected = required
           ? validator
           : variant === 'mini'
-            ? `zod.optional(${validator})`
+            ? `/*#__PURE__*/ zod.optional(${validator})`
             : `${validator}.optional()`;
 
         expect(render('date-time-local', required)).toBe(expected);
@@ -145,9 +147,11 @@ describe.each([
 
     it('preserves timezone offset validation for date-time', () => {
       expect(render('date-time', true)).toBe(
-        version === 4
-          ? 'zod.iso.datetime({"offset":true})'
-          : 'zod.string().datetime({"offset":true})',
+        variant === 'mini'
+          ? '/*#__PURE__*/ zod.iso.datetime({"offset":true})'
+          : version === 4
+            ? 'zod.iso.datetime({"offset":true})'
+            : 'zod.string().datetime({"offset":true})',
       );
     });
   },

--- a/packages/zod/src/zod.test.ts
+++ b/packages/zod/src/zod.test.ts
@@ -96,6 +96,63 @@ function makeContextSpec({
   };
 }
 
+describe.each([
+  { version: 3, variant: 'classic' },
+  { version: 4, variant: 'classic' },
+  { version: 4, variant: 'mini' },
+] as const)(
+  'date-time-local (Zod $version, $variant)',
+  ({ version, variant }) => {
+    const render = (format: string, required: boolean) => {
+      const context = makeContextSpec();
+      context.output.override.zod.dateTimeOptions = { offset: true };
+      const definition = generateZodValidationSchemaDefinition(
+        { type: 'string', format },
+        context,
+        'localDateTime',
+        false,
+        version === 4,
+        { required },
+      );
+      return parseZodValidationSchemaDefinition(
+        definition,
+        context,
+        false,
+        false,
+        version === 4,
+        undefined,
+        undefined,
+        variant,
+      ).zod;
+    };
+
+    it.each([true, false])(
+      'generates local datetime validation with required=%s',
+      (required) => {
+        const validator =
+          version === 4
+            ? 'zod.iso.datetime({"local":true})'
+            : 'zod.string().datetime({"local":true})';
+        const expected = required
+          ? validator
+          : variant === 'mini'
+            ? `zod.optional(${validator})`
+            : `${validator}.optional()`;
+
+        expect(render('date-time-local', required)).toBe(expected);
+      },
+    );
+
+    it('preserves timezone offset validation for date-time', () => {
+      expect(render('date-time', true)).toBe(
+        version === 4
+          ? 'zod.iso.datetime({"offset":true})'
+          : 'zod.string().datetime({"offset":true})',
+      );
+    });
+  },
+);
+
 const record: ZodValidationSchemaDefinition = {
   functions: [
     [
@@ -1957,6 +2014,7 @@ describe('generateZodValidationSchemaDefinition`', () => {
       ['date', getZodDateFormat(true)],
       ['time', getZodTimeFormat(true)],
       ['date-time', getZodDateTimeFormat(true)],
+      ['date-time-local', getZodDateTimeFormat(true)],
       ['email', 'email'],
       ['uri', 'url'],
       ['hostname', 'hostname'],


### PR DESCRIPTION
OpenAPI `format: date-time-local` currently generates a plain string schema, so invalid datetime strings pass validation. Generate datetime validation with `{ local: true }` using the existing Zod 3/4 adapters, including Zod mini, optional fields and pattern constraints.

Keep `date-time` and its `dateTimeOptions` behavior unchanged. The new format uses `{ local: true }` as proposed in the issue; it does not inherit `dateTimeOptions`. Zod still accepts UTC timestamps ending in `Z` with this option.

Closes #4063.

## Validation

- Added 9 regression cases: the original source fails all 6 new-format cases and passes the 3 existing date-time cases; with this change, all 350 tests in the Zod test file pass.
- 39 runtime assertions pass against generated schemas using Zod 3, Zod 4 and mini, covering local/UTC/offset timestamps, invalid strings and optional fields.
- [Fork validation passes](https://github.com/pj-workspace/orval/actions/runs/34359786074): frozen dependency installation with security scanning, build, `vp check`, packages/samples/snapshots lint, type checks, all package tests, snapshots, sample tests, and generated-code compilation. Source, security configuration and the validation lockfile remain unchanged throughout the run.

The validation runs on Ubuntu with Node 24 and Bun 1.4.0. At base `bc19a8e`, `packages/orval/package.json` requires `js-yaml 4.3.2` while `bun.lock` records `4.3.1`. The separate validation branch reconciles that existing mismatch, disables setup-vp's automatic install, and uses frozen installation with the repository's Socket scanner enabled. This contribution branch contains no lockfile or workflow changes. Windows/Node 22 has not been verified here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating local date-time values without timezone offsets.
  * Recognizes `date-time-local` as a predefined string format.

* **Bug Fixes**
  * Preserved timezone-offset validation for standard `date-time` values across supported Zod targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->