### PR TITLE
feat(zod): support single-file schema output

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -142,6 +142,7 @@ export default defineConfig({
 | `importPath`  | `string`  | Optional package import specifier (see below)   |
 | `splitByTags` | `boolean` | Organize schemas into per-tag subdirectories (default `false`, see below) |
 | `routes`      | `object`  | Route enums separately from other schemas |
+| `mode`        | `'split' \| 'single'` | Zod schema file layout (default `'split'`) |
 
 `routes.default` is required and route values are relative directories under
 `schemas.path`. `routes.enum` is optional; without it, enums use the default
@@ -178,6 +179,28 @@ When `splitByTags` is also enabled, tag directories are nested under their
 route. Schemas used by multiple tags (or by no operation) are placed under
 `<route>/shared`, for example `schemas/models/pets`,
 `schemas/models/shared`, and `schemas/types/pets`.
+
+### Single-file Zod schemas
+
+Set `schemas.mode: 'single'` to write component and operation schemas into
+`<schemas.path>/index.zod.ts`. The API client stays in its own output file and
+imports the schemas and their derived TypeScript types from this module.
+
+```ts
+output: {
+  target: './api/client.ts',
+  client: 'react-query',
+  httpClient: 'fetch',
+  schemas: { path: './api/model', type: 'zod', mode: 'single' },
+}
+```
+
+`path` remains a directory. The filename uses `schemaFileExtension` (default
+`.zod.ts`). No additional barrel is generated, regardless of `indexFiles`.
+`importPath`, when provided, must resolve to the single module.
+This mode cannot be combined with `splitByTags`, `routes`, `operationSchemas`,
+mock generators, or `factoryMethods`.
+Omitting `mode` preserves the existing split-file output.
 
 ### importPath
 

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -200,7 +200,8 @@ output: {
 `importPath`, when provided, must resolve to the single module.
 This mode cannot be combined with `splitByTags`, `routes`, `operationSchemas`,
 mock generators, or `factoryMethods`.
-Omitting `mode` preserves the existing split-file output.
+Omitting `schemas.mode` preserves the existing split-file schema output.
+`output.mode` independently controls how API client files are organized.
 
 ### importPath
 
@@ -278,7 +279,7 @@ subdirectories instead of a single flat directory. Schemas referenced by
 only one tag go in that tag's directory; schemas referenced by multiple
 tags (or not referenced by any operation) go in `shared`. If an operation has
 multiple tags, Orval uses its first tag, matching the existing Orval routing
-behavior. Works with any `mode` (`single`, `split`, `tags`, `tags-split`).
+behavior. Works with any `output.mode` (`single`, `split`, `tags`, `tags-split`).
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -318,7 +319,9 @@ import type { Error } from '../shared/error';
 
 **Requirements:**
 
-- Works with any `mode` (`single`, `split`, `tags`, `tags-split`).
+- Works with any `output.mode` (`single`, `split`, `tags`, `tags-split`).
+- Incompatible with `schemas.mode: 'single'`, which writes all Zod schemas
+  into one file instead of per-tag directories.
 - Can be combined with `schemas.routes`; tag directories are nested under the
   selected route, while shared schemas are nested under `<route>/shared`.
 - Incompatible with `operationSchemas` — operation-derived types are placed

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -391,6 +391,8 @@ export interface NormalizedFactoryMethodsOptions {
 
 export interface SchemaOptions {
   path: string;
+  /** Write Zod schemas to one index file instead of separate schema files. */
+  mode?: 'split' | 'single';
   type?: SchemaGenerationType;
   importPath?: string;
   routes?: SchemaRouteOptions;
@@ -411,6 +413,7 @@ export interface SchemaRouteOptions {
 
 export interface NormalizedSchemaOptions {
   path: string;
+  mode?: 'split' | 'single';
   type: SchemaGenerationType;
   importPath?: string;
   splitByTags: boolean;

--- a/packages/core/src/utils/schema-import-path.test.ts
+++ b/packages/core/src/utils/schema-import-path.test.ts
@@ -308,3 +308,57 @@ describe('resolveSchemaImportDependencies', () => {
     });
   });
 });
+
+describe('single-file Zod schema imports', () => {
+  it.each([true, false])(
+    'uses the single module with indexFiles=%s',
+    (indexFiles) => {
+      const output = createOutput({
+        indexFiles,
+        schemas: {
+          path: '/models',
+          type: 'zod',
+          mode: 'single',
+          splitByTags: false,
+        },
+      });
+      expect(
+        resolve(output, '../models', [PET, ERROR], { isZod: true }),
+      ).toEqual(['../models/index.zod']);
+    },
+  );
+
+  it('honors the schema extension and NodeNext module resolution', () => {
+    const output = createOutput({
+      schemaFileExtension: '.schema.ts',
+      schemas: {
+        path: '/models',
+        type: 'zod',
+        mode: 'single',
+        splitByTags: false,
+      },
+      tsconfig: {
+        compilerOptions: { module: 'NodeNext', moduleResolution: 'NodeNext' },
+      },
+    });
+    expect(resolve(output, '../models', [PET], { isZod: true })).toEqual([
+      '../models/index.schema.js',
+    ]);
+  });
+
+  it('keeps an explicit package import path unchanged', () => {
+    const output = createOutput({
+      indexFiles: false,
+      schemas: {
+        path: '/models',
+        type: 'zod',
+        mode: 'single',
+        splitByTags: false,
+        importPath: '@acme/models',
+      },
+    });
+    expect(resolve(output, '@acme/models', [PET], { isZod: true })).toEqual([
+      '@acme/models',
+    ]);
+  });
+});

--- a/packages/core/src/utils/schema-import-path.ts
+++ b/packages/core/src/utils/schema-import-path.ts
@@ -71,6 +71,24 @@ export function resolveSchemaImportDependencies(
   const schemasImportPath = getSchemasImportPath(output.schemas);
   const isPackageImport = !!schemasImportPath;
 
+  if (
+    output.schemas &&
+    typeof output.schemas === 'object' &&
+    output.schemas.mode === 'single'
+  ) {
+    return [
+      {
+        exports: dedupeSchemaImports(resolved),
+        dependency:
+          schemasImportPath ??
+          upath.joinSafe(
+            relativeSchemasPath,
+            `index${getImportExtension(output.schemaFileExtension, output.tsconfig)}`,
+          ),
+      },
+    ];
+  }
+
   // A root barrel makes every schema available from one module.
   if (output.indexFiles) {
     return [

--- a/packages/orval/src/generate-spec.test.ts
+++ b/packages/orval/src/generate-spec.test.ts
@@ -3370,3 +3370,175 @@ describe('generateSpec - clean scopes to the configured schemas directory', () =
     }
   });
 });
+
+describe('generateSpec - single-file Zod schemas', () => {
+  it.each([
+    {
+      variant: 'classic' as const,
+      version: 3 as const,
+      reusable: false,
+      indexFiles: true,
+    },
+    {
+      variant: 'classic' as const,
+      version: 4 as const,
+      reusable: false,
+      indexFiles: false,
+    },
+    {
+      variant: 'classic' as const,
+      version: 4 as const,
+      reusable: true,
+      indexFiles: true,
+    },
+    {
+      variant: 'mini' as const,
+      version: 4 as const,
+      reusable: true,
+      indexFiles: false,
+    },
+  ])(
+    'writes one schema module for $variant v$version, reusable=$reusable, indexFiles=$indexFiles',
+    async ({ variant, version, reusable, indexFiles }) => {
+      const workspace = await createTempWorkspace();
+      const spec: OpenApiDocument = {
+        ...PETSTORE_SPEC,
+        paths: {
+          '/pets': {
+            post: {
+              operationId: 'createPet',
+              parameters: [
+                { name: 'limit', in: 'query', schema: { type: 'integer' } },
+              ],
+              requestBody: {
+                required: true,
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { pet: { $ref: '#/components/schemas/Pet' } },
+                    },
+                  },
+                },
+              },
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/Pet' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      try {
+        const options = await normalizeOptions(
+          {
+            input: { target: spec },
+            output: {
+              target: './client.ts',
+              client: 'react-query',
+              httpClient: 'fetch',
+              mode: 'single',
+              indexFiles,
+              schemas: { path: './model', type: 'zod', mode: 'single' },
+              override: {
+                zod: { variant, version, generateReusableSchemas: reusable },
+              },
+            },
+          },
+          workspace,
+        );
+        await generateSpec(workspace, options);
+        expect(await readdir(path.join(workspace, 'model'))).toEqual([
+          'index.zod.ts',
+        ]);
+        const schemas = await fs.readFile(
+          path.join(workspace, 'model/index.zod.ts'),
+          'utf8',
+        );
+        const client = await fs.readFile(
+          path.join(workspace, 'client.ts'),
+          'utf8',
+        );
+        expect(schemas).toMatch(/export const Pet =/);
+        expect(schemas).toMatch(/export type Pet = zod.input<typeof Pet>/);
+        expect(schemas).toMatch(
+          /export type PetOutput = zod.output<typeof Pet>/,
+        );
+        expect(schemas).toMatch(/export const CreatePetBody =/);
+        expect(schemas).toMatch(/export const CreatePetParams =/);
+        expect(schemas.match(/import \* as zod from/g)).toHaveLength(1);
+        expect(schemas).not.toMatch(/from ['"]\.\//);
+        expect(schemas).not.toContain('__REF_');
+        expect(client).toContain("from './model/index.zod'");
+        if (reusable) {
+          expect(schemas.indexOf('export const Pet =')).toBeLessThan(
+            schemas.indexOf('export const CreatePetBody ='),
+          );
+        }
+        const before = schemas;
+        await generateSpec(workspace, options);
+        expect(
+          await fs.readFile(path.join(workspace, 'model/index.zod.ts'), 'utf8'),
+        ).toBe(before);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('preserves recursive component references in one file', async () => {
+    const workspace = await createTempWorkspace();
+    try {
+      const options = await normalizeOptions(
+        {
+          input: {
+            target: {
+              openapi: '3.1.0',
+              info: { title: 'Recursive', version: '1.0' },
+              paths: {},
+              components: {
+                schemas: {
+                  Tree: {
+                    type: 'object',
+                    properties: {
+                      children: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/Tree' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          output: {
+            target: './client.ts',
+            client: 'fetch',
+            schemas: { path: './model', type: 'zod', mode: 'single' },
+            override: { zod: { version: 4, generateReusableSchemas: true } },
+          },
+        },
+        workspace,
+      );
+      await generateSpec(workspace, options);
+      expect(await readdir(path.join(workspace, 'model'))).toEqual([
+        'index.zod.ts',
+      ]);
+      const content = await fs.readFile(
+        path.join(workspace, 'model/index.zod.ts'),
+        'utf8',
+      );
+      expect(content).toContain('zod.lazy(() => Tree)');
+      expect(content).not.toContain('__REF_');
+      expect(content).not.toMatch(/from ['"]\.\//);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -2945,3 +2945,58 @@ describe('normalizeOptions', () => {
     }
   });
 });
+
+describe('single-file Zod schema options', () => {
+  it.each([
+    {
+      schemas: {
+        path: './model',
+        mode: 'single' as const,
+        type: 'typescript' as const,
+      },
+      error: 'requires schemas.type "zod"',
+    },
+    {
+      schemas: {
+        path: './model',
+        mode: 'single' as const,
+        type: 'zod' as const,
+        splitByTags: true,
+      },
+      error: 'cannot be combined',
+    },
+    {
+      schemas: {
+        path: './model',
+        mode: 'single' as const,
+        type: 'zod' as const,
+        routes: { default: 'models' },
+      },
+      error: 'cannot be combined',
+    },
+  ])(
+    'rejects incompatible schema layout $schemas',
+    async ({ schemas, error }) => {
+      const workspace = await createTempWorkspace();
+      try {
+        await expect(
+          normalizeOptions(
+            {
+              input: {
+                target: {
+                  openapi: '3.1.0',
+                  info: { title: 'Test', version: '1.0' },
+                  paths: {},
+                },
+              },
+              output: { target: './client.ts', schemas },
+            },
+            workspace,
+          ),
+        ).rejects.toThrow(error);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -3000,3 +3000,36 @@ describe('single-file Zod schema options', () => {
     },
   );
 });
+
+describe('single-file Zod schema output combinations', () => {
+  it.each([
+    { operationSchemas: './operations' },
+    { mock: true },
+    { factoryMethods: { outputDirectory: './factories' } },
+  ])('rejects unsupported output $0 before writing files', async (output) => {
+    const workspace = await createTempWorkspace();
+    try {
+      await expect(
+        normalizeOptions(
+          {
+            input: {
+              target: {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0' },
+                paths: {},
+              },
+            },
+            output: {
+              target: './client.ts',
+              schemas: { path: './model', type: 'zod', mode: 'single' },
+              ...output,
+            },
+          },
+          workspace,
+        ),
+      ).rejects.toThrow('schemas.mode "single" cannot be combined');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -174,6 +174,24 @@ function normalizeSchemasOption(
     );
   }
 
+  if (
+    schemas.mode !== undefined &&
+    schemas.mode !== 'split' &&
+    schemas.mode !== 'single'
+  ) {
+    throw new Error('schemas.mode must be "split" or "single".');
+  }
+  if (schemas.mode === 'single') {
+    if (schemas.type !== 'zod') {
+      throw new Error('schemas.mode "single" requires schemas.type "zod".');
+    }
+    if (schemas.splitByTags || schemas.routes) {
+      throw new Error(
+        'schemas.mode "single" cannot be combined with schemas.splitByTags or schemas.routes.',
+      );
+    }
+  }
+
   assertSchemasPathIsDirectory(schemas.path, 'schemas.path');
   validatePackageSpecifier(schemas.importPath, 'schemas.importPath');
 
@@ -186,6 +204,7 @@ function normalizeSchemasOption(
     type: schemas.type ?? 'typescript',
     importPath: schemas.importPath,
     splitByTags: schemas.splitByTags ?? false,
+    ...(schemas.mode === undefined ? {} : { mode: schemas.mode }),
     routes,
   };
 }
@@ -258,7 +277,19 @@ function validateSchemaRoute(value: string, fieldName: string): string {
 /** Rejects schema-routing combinations that are unsupported by generation. */
 function validateSchemaRoutes(output: NormalizedOutputOptions): void {
   const schemas = output.schemas;
-  if (!schemas || isString(schemas) || !schemas.routes) return;
+  if (!schemas || isString(schemas)) return;
+  if (schemas.mode === 'single') {
+    if (
+      output.operationSchemas ||
+      output.mock.generators.length > 0 ||
+      output.factoryMethods
+    ) {
+      throw new Error(
+        'schemas.mode "single" cannot be combined with operationSchemas, mock generators, or factoryMethods.',
+      );
+    }
+  }
+  if (!schemas.routes) return;
 
   if (output.operationSchemas) {
     throw new Error(

--- a/packages/orval/src/write-specs.ts
+++ b/packages/orval/src/write-specs.ts
@@ -57,6 +57,7 @@ import {
 import {
   generateZodSchemasInline,
   writeZodSchemas,
+  writeZodSchemasSingle,
   writeZodSchemasFromVerbs,
   writeZodSchemaRoutesBarrel,
   writeZodSchemaTagsSplitBarrel,
@@ -590,6 +591,8 @@ async function writeSpecsInternal(
         output.client === 'zod' &&
         output.override.zod.generateReusableSchemas);
 
+    const singleZodFile =
+      isObject(output.schemas) && output.schemas.mode === 'single';
     if (shouldSplitSchemasByTags && output.operationSchemas) {
       throw new Error(
         'schemas.splitByTags cannot be used with output.operationSchemas. ' +
@@ -616,7 +619,18 @@ async function writeSpecsInternal(
           })
         : undefined;
 
-      if (shouldSplitSchemasByTags) {
+      if (singleZodFile) {
+        await writeZodSchemasSingle(
+          builder,
+          builder.verbOptions,
+          schemasPath,
+          fileExtension,
+          header,
+          output,
+          { spec: builder.spec, target: builder.target, workspace, output },
+          schemasParamsMutator,
+        );
+      } else if (shouldSplitSchemasByTags) {
         const componentDirs = await writeZodSchemas(
           builder,
           schemasPath,

--- a/packages/orval/src/write-zod-specs.ts
+++ b/packages/orval/src/write-zod-specs.ts
@@ -1198,23 +1198,22 @@ async function writeZodSchemasReusable(
   return new Map([[ROOT_DIR, rewritten.map((e) => e.name)]]);
 }
 
-/** Writes operation-derived Zod schemas using the selected route layout. */
-export async function writeZodSchemasFromVerbs(
+/** Builds operation schemas for either single-file or split-file output. */
+function generateZodSchemasFromVerbs(
   verbOptions: WriteZodSchemasFromVerbsInput,
   schemasPath: string,
   fileExtension: string,
-  header: string,
   output: WriteZodOutputOptions,
   context: WriteZodSchemasFromVerbsContext,
   schemaTagMap?: SchemaTagMap,
   schemaOutputPlan?: SchemaOutputPlan,
-): Promise<WrittenSchemaInfo> {
+) {
   const isSplit = !!schemaTagMap;
   const zodContext = context as unknown as ContextSpec;
   const verbOptionsArray = Object.values(verbOptions);
 
   if (verbOptionsArray.length === 0) {
-    return new Map();
+    return { schemasToWrite: [], uniqueVerbsSchemas: [] };
   }
 
   const isZodV4 = resolveIsZodV4(
@@ -1581,6 +1580,33 @@ export async function writeZodSchemasFromVerbs(
     });
   }
 
+  return { schemasToWrite, uniqueVerbsSchemas };
+}
+
+export async function writeZodSchemasFromVerbs(
+  verbOptions: WriteZodSchemasFromVerbsInput,
+  schemasPath: string,
+  fileExtension: string,
+  header: string,
+  output: WriteZodOutputOptions,
+  context: WriteZodSchemasFromVerbsContext,
+  schemaTagMap?: SchemaTagMap,
+  schemaOutputPlan?: SchemaOutputPlan,
+): Promise<WrittenSchemaInfo> {
+  const isSplit = !!schemaTagMap;
+  const useReusableSchemas =
+    output.override.zod.generateReusableSchemas === true;
+  const { schemasToWrite, uniqueVerbsSchemas } = generateZodSchemasFromVerbs(
+    verbOptions,
+    schemasPath,
+    fileExtension,
+    output,
+    context,
+    schemaTagMap,
+    schemaOutputPlan,
+  );
+  if (Object.keys(verbOptions).length === 0) return new Map();
+
   const groupedSchemasToWrite = groupSchemasByFilePath(schemasToWrite);
 
   for (const schemaGroup of groupedSchemasToWrite) {
@@ -1636,4 +1662,49 @@ export async function writeZodSchemasFromVerbs(
   }
 
   return new Map([[ROOT_DIR, writtenSchemaNames]]);
+}
+
+/** Writes component and operation schemas to one module, preserving dependency order. */
+export async function writeZodSchemasSingle(
+  builder: WriteZodSchemasInput,
+  verbOptions: WriteZodSchemasFromVerbsInput,
+  schemasPath: string,
+  fileExtension: string,
+  header: string,
+  output: WriteZodOutputOptions,
+  context: WriteZodSchemasFromVerbsContext,
+  paramsMutator?: GeneratorMutator,
+): Promise<void> {
+  const { schemasToWrite } = generateZodSchemasFromVerbs(
+    verbOptions,
+    schemasPath,
+    fileExtension,
+    output,
+    context,
+  );
+  const operationNames = new Set(
+    schemasToWrite.map((entry) => entry.schemaName),
+  );
+  const components = generateZodSchemasInline(
+    {
+      ...builder,
+      schemas: builder.schemas.filter(
+        (schema) => !operationNames.has(schema.name),
+      ),
+    },
+    output,
+    false,
+    paramsMutator,
+    true,
+  );
+  const operations = generateZodSchemaFileContent(
+    '',
+    schemasToWrite.map((entry) => ({ ...entry, importStatements: undefined })),
+    output.override.zod.variant,
+    false,
+  );
+  await writeGeneratedFile(
+    path.join(schemasPath, `index${fileExtension}`),
+    `${header}${getZodSchemaImportStatement(output.override.zod.variant)}\n\n${components}${operations}`,
+  );
 }


### PR DESCRIPTION
Closes #4042.

Add opt-in `schemas.mode: 'single'` for Zod schemas. Component and operation schemas are written to `<schemas.path>/index<schemaFileExtension>` (default `index.zod.ts`), and generated clients import the schemas and their derived TypeScript types from that module. Existing split-file output remains the default.

```ts
schemas: { path: './model', type: 'zod', mode: 'single' }
```

The implementation reuses the existing inline component renderer, including reusable and recursive schemas, and shares operation-schema generation with the split writer. `indexFiles` does not add a barrel in this mode; an explicit `importPath` still resolves to the configured package module.

For this initial implementation, incompatible layouts (`splitByTags`, `routes`, `operationSchemas`) and mock/factory generators are rejected during configuration normalization.

Validation on [the isolated fork workflow](https://github.com/pj-workspace/orval/actions/runs/34429909938) (Ubuntu / Node 24):

- 207 focused tests pass; all five new generation tests fail against the upstream implementation.
- Six Zod 3/4/mini generation configurations compile and pass 54 runtime/output assertions, including reusable and recursive schemas.
- Repository checks, package lint/typecheck/tests, existing snapshots, sample tests, and generated-code build pass.
- Regenerated tracked sample differences match the upstream baseline byte-for-byte.

The validation branch separately normalizes the existing js-yaml lockfile mismatch; no lockfile or CI changes are part of this feature. Windows / Node 22 has not been run in this fork validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single-file output mode for Zod schemas.
  * Schemas can be generated in one `index` file while preserving split-file output by default.
  * Added support for custom schema file extensions and package import paths in single-file mode.

* **Bug Fixes**
  * Improved schema imports to avoid duplicate dependencies and preserve recursive references.
  * Added validation for incompatible single-file schema configurations.

* **Documentation**
  * Documented single-file Zod schema configuration and compatibility restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->