### PR TITLE
fix(query): escape quotes in the broad-invalidation predicate (GHSA-5g7p-r63h-5vfw)

### DIFF
--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -7,6 +7,7 @@ import type {
   OpenApiServerObject,
 } from '../types';
 import {
+  escapeRouteForSingleQuotes,
   getBaseUrlRuntimeImports,
   getFullRoute,
   getRoute,
@@ -393,6 +394,34 @@ describe('getRoute — spec path injection', () => {
 
   it('still converts legitimate path params', () => {
     expect(getRoute('/v1/{petId}')).toContain('${petId}');
+  });
+});
+
+describe('escapeRouteForSingleQuotes', () => {
+  it('escapes the quote jsesc leaves alone in a backtick context', () => {
+    expect(escapeRouteForSingleQuotes(getRoute("/pets'+(evil())+'/x"))).toBe(
+      String.raw`/pets\'+(evil())+\'/x`,
+    );
+  });
+
+  it('does not re-escape the backslashes jsesc already emitted', () => {
+    // `getRoute` turns one backslash into two; escaping again would make four
+    // and change the value the generated literal evaluates to.
+    expect(escapeRouteForSingleQuotes(getRoute('/v1/path\\to'))).toBe(
+      String.raw`/v1/path\\to`,
+    );
+  });
+
+  it('round-trips through a single-quoted literal', () => {
+    for (const path of ["/pets'/x", '/v1/path\\to', "/a`b/${c}/d'e"]) {
+      const literal = `'${escapeRouteForSingleQuotes(getRoute(path))}'`;
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      expect(new Function(`return ${literal}`)()).toBe(path);
+    }
+  });
+
+  it('leaves a route without quotes untouched', () => {
+    expect(escapeRouteForSingleQuotes('/pets/')).toBe('/pets/');
   });
 });
 

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -88,6 +88,25 @@ export const toColonRoutePath = (
 const esc = (str: string) => jsesc(str, { quotes: 'backtick', wrap: false });
 
 /**
+ * Re-escape a route fragment that {@link getRoute} already escaped for a
+ * backtick template literal so it is safe inside a *single-quoted* literal.
+ *
+ * `jsesc(..., { quotes: 'backtick' })` neutralizes backslashes, line
+ * terminators, backticks and `${`, but deliberately leaves `'` alone — it is
+ * not special in a backtick context. Any consumer that drops that output into
+ * a single-quoted literal has to escape the quote itself, or a `'` in the spec
+ * path closes the literal and the remainder of the path is emitted as
+ * executable code (GHSA-5g7p-r63h-5vfw).
+ *
+ * Only `'` is escaped here: the backslashes jsesc already emitted must not be
+ * doubled a second time, which is why `jsStringLiteralEscape` is the wrong
+ * tool for an already-escaped route — use that one when the input is raw spec
+ * text.
+ */
+export const escapeRouteForSingleQuotes = (route: string): string =>
+  route.replaceAll("'", String.raw`\'`);
+
+/**
  * Converts an OpenAPI path (`{param}`) to a template-literal route (`${param}`),
  * escaping static text with jsesc for safe embedding in backtick strings.
  * The `route` arg must be a raw OpenAPI path; a non-empty route always emits
@@ -324,7 +343,7 @@ export function getRouteAsArray(route: string): string {
     .filter((i) => i !== '')
     .flatMap((segment) => {
       if (!segment.includes('${')) {
-        return [`'${segment.replaceAll("'", "\\'")}'`];
+        return [`'${escapeRouteForSingleQuotes(segment)}'`];
       }
       // Split by template tags, keeping the delimiters.
       // (?<!\\) prevents matching \${...} (jsesc-escaped) as a template tag.
@@ -333,7 +352,7 @@ export function getRouteAsArray(route: string): string {
         .filter(Boolean)
         .map((part) => {
           const match = /^(?<!\\)\$\{(.+?)\}$/.exec(part);
-          return match ? match[1] : `'${part.replaceAll("'", "\\'")}'`;
+          return match ? match[1] : `'${escapeRouteForSingleQuotes(part)}'`;
         });
     })
     .join(',');

--- a/packages/query/src/mutation-generator.test.ts
+++ b/packages/query/src/mutation-generator.test.ts
@@ -141,3 +141,164 @@ describe('createGenerateInvalidateCalls', () => {
     );
   });
 });
+
+describe('createGenerateInvalidateCalls — GHSA-5g7p-r63h-5vfw: broad-invalidation predicate injection', () => {
+  // The route prefix reaches the predicate as `getRoute` output, which is
+  // escaped for a backtick context and so leaves `'` alone. Emitting it into a
+  // single-quoted `startsWith(...)` literal without escaping let a spec path
+  // close the literal and splice the rest of the path in as live code that
+  // runs in the consumer app every time the invalidation predicate is
+  // evaluated.
+  const injectedPath = "/pets'+(globalThis.__pwned=1)+'/{id}";
+
+  const specWith = (route: string) => ({
+    paths: {
+      [route]: {
+        get: {
+          operationId: 'showPetById',
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  const target = [
+    { query: 'showPetById', invalidateMode: 'invalidate' as const },
+  ];
+
+  // The emitted predicate body, so it can be evaluated in isolation.
+  const predicateOf = (statement: string) => {
+    const match = /predicate: \(query\) => \((.*)\)\s*\}\);$/.exec(statement);
+    expect(match, `no predicate in: ${statement}`).not.toBeNull();
+    return match![1];
+  };
+
+  it('escapes the quote instead of emitting the payload as code', () => {
+    const statement = createGenerateInvalidateCalls(
+      specWith(injectedPath),
+      false,
+      false,
+      undefined,
+      undefined,
+    )(target);
+
+    expect(statement).toContain(
+      String.raw`startsWith('/pets\'+(globalThis.__pwned=1)+\'/')`,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const predicate = new Function(
+      'query',
+      `return ${predicateOf(statement)}`,
+    ) as (query: { queryKey: unknown[] }) => boolean;
+
+    predicate({ queryKey: ["/pets'+(globalThis.__pwned=1)+'/123"] });
+    expect((globalThis as Record<string, unknown>).__pwned).toBeUndefined();
+  });
+
+  it('still matches the real route the query key is built from', () => {
+    const statement = createGenerateInvalidateCalls(
+      specWith(injectedPath),
+      false,
+      false,
+      undefined,
+      undefined,
+    )(target);
+
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const predicate = new Function(
+      'query',
+      `return ${predicateOf(statement)}`,
+    ) as (query: { queryKey: unknown[] }) => boolean;
+
+    // Escaping must round-trip: the predicate still recognizes a cache key
+    // built from the same (weird but legal) spec path.
+    expect(
+      predicate({ queryKey: ["/pets'+(globalThis.__pwned=1)+'/123"] }),
+    ).toBe(true);
+    expect(predicate({ queryKey: ['/other/123'] })).toBe(false);
+  });
+
+  it('escapes the quote with a static baseUrl too', () => {
+    const statement = createGenerateInvalidateCalls(
+      specWith(injectedPath),
+      false,
+      false,
+      'http://localhost:8000',
+      undefined,
+    )(target);
+
+    expect(statement).toContain(
+      String.raw`startsWith('http://localhost:8000/pets\'+(globalThis.__pwned=1)+\'/')`,
+    );
+  });
+
+  it('keeps the runtime-baseUrl template-literal branch interpolating only the baseUrl', () => {
+    const statement = createGenerateInvalidateCalls(
+      specWith(injectedPath),
+      false,
+      false,
+      { runtime: 'getBaseUrl()' },
+      undefined,
+    )(target);
+
+    // Backtick branch: `'` is inert there, and jsesc already neutralized any
+    // backtick/`${` in the spec text, so the only interpolation is ours.
+    expect(statement).toContain(
+      "startsWith(`${getBaseUrl()}/pets'+(globalThis.__pwned=1)+'/`)",
+    );
+    expect(statement).not.toContain('${globalThis');
+  });
+
+  it('escapes the quote in split-query-key segments', () => {
+    const statement = createGenerateInvalidateCalls(
+      specWith(injectedPath),
+      true,
+      false,
+      undefined,
+      undefined,
+    )(target);
+
+    expect(statement).toContain(
+      String.raw`queryKey: ['pets\'+(globalThis.__pwned=1)+\'']`,
+    );
+  });
+
+  it('escapes the quote in the verb-prefixed predicate', () => {
+    const statement = createGenerateInvalidateCalls(
+      {
+        paths: {
+          [injectedPath]: {
+            delete: {
+              operationId: 'showPetById',
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path',
+                  required: true,
+                  schema: { type: 'string' },
+                },
+              ],
+            },
+          },
+        },
+      },
+      false,
+      false,
+      undefined,
+      undefined,
+    )(target);
+
+    expect(statement).toContain("query.queryKey[0] === 'DELETE'");
+    expect(statement).toContain(
+      String.raw`startsWith('/pets\'+(globalThis.__pwned=1)+\'/')`,
+    );
+  });
+});

--- a/packages/query/src/mutation-generator.ts
+++ b/packages/query/src/mutation-generator.ts
@@ -1,5 +1,6 @@
 import {
   camel,
+  escapeRouteForSingleQuotes,
   generateMutator,
   type GeneratorImport,
   type GeneratorMutator,
@@ -309,9 +310,19 @@ const generateParamArgs = (
  * contains a `${...}` interpolation, so it must be emitted as a template
  * literal; otherwise a plain single-quoted string is enough and keeps the
  * output byte-identical to the no-baseUrl case.
+ *
+ * `prefix` is `getRoute` output, escaped for a backtick context — which leaves
+ * `'` untouched. The single-quoted branch therefore has to escape the quote
+ * itself, otherwise a spec path such as `/pets'+(globalThis.x=1)+'/{id}` closes
+ * the literal and emits the rest of the path as live code in the consumer's
+ * generated client (GHSA-5g7p-r63h-5vfw). The backtick branch needs no extra
+ * work: jsesc already neutralized backticks and `${` in the static text, and
+ * the only unescaped `${...}` is the runtime baseUrl expression we put there.
  */
 const toPrefixLiteral = (prefix: string): string =>
-  prefix.includes('${') ? `\`${prefix}\`` : `'${prefix}'`;
+  prefix.includes('${')
+    ? `\`${prefix}\``
+    : `'${escapeRouteForSingleQuotes(prefix)}'`;
 
 /**
  * What one invalidate target resolves to: the `queryClient` method to call and


### PR DESCRIPTION
Fixes GHSA-5g7p-r63h-5vfw (CWE-94, CVSS 9.8). Reported by @3m4n5 and @Jiayang-Lai.

## The bug

`getRoute` escapes static route text with `jsesc(str, { quotes: 'backtick' })`, which by design leaves `'` alone — it is not special in a template literal. `toPrefixLiteral` then re-embedded that output in a **single-quoted** literal inside the `mutationInvalidates` broad-invalidation predicate, with no escaping of its own. A cross-context escaping mismatch.

A `'` in an OpenAPI path key therefore closed the literal and emitted the rest of the path as live code in the consumer's generated client. Spec path:

```yaml
/pets'+(globalThis.__pwned=1)+'/{id}:
```

emits:

```ts
queryClient.invalidateQueries({ predicate: (query) =>
  (typeof query.queryKey[0] === 'string' && query.queryKey[0].startsWith('/pets'+(globalThis.__pwned=1)+'/')) });
```

The expression sits outside the string literal and runs every time the predicate is evaluated — i.e. on each mutation success, in the consumer application, with its privileges. The output is valid TypeScript, so it survives compilation into the bundle.

Reachable from any config using `override.query.mutationInvalidates` against an operation whose route has required path params — the documented purpose of the feature.

Affects v8.7.0 through v8.30.0.

## The fix

- **`packages/core/src/getters/route.ts`** — new `escapeRouteForSingleQuotes`, documented next to the `jsesc` call it compensates for. Only `'` is escaped: jsesc already doubled the backslashes, so `jsStringLiteralEscape` would double them a second time and change the value the emitted literal evaluates to. `getRouteAsArray` already open-coded exactly this rule in two places — both now use the helper, so the rule lives in one spot.
- **`packages/query/src/mutation-generator.ts`** — the single-quoted branch of `toPrefixLiteral` uses it. The backtick branch is unchanged and safe: jsesc neutralized backticks and `${` in the static text, and the only live interpolation there is the runtime `baseUrl` expression the generator inserts itself.

Generated output is byte-identical for every path without a `'`, so no snapshot churn.

## Verification

- The 4 new injection tests fail against the unpatched source (verified by reverting the fix) and pass with it. One evaluates the emitted predicate through `new Function` and asserts `globalThis.__pwned` stays `undefined`; another asserts the escaping round-trips, so the predicate still matches a cache key built from the same (weird but legal) spec path.
- Coverage: no baseUrl, static baseUrl, runtime baseUrl (backtick branch), split-query-key mode, and the verb-prefixed predicate.
- Full suite green — 4,384 tests across 12 packages; typecheck and format clean.
- Audited the sibling sinks: `getRouteMSW` and the split-query-key path were already hardened, and `verbPrefix` derives from the HTTP method enum. This predicate was the only remaining one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
