### PR TITLE
fix(core): escape schema names in emitted TS string literal types (GHSA-6h9g-hcv4-66p6)

### DIFF
--- a/packages/core/src/getters/combine.test.ts
+++ b/packages/core/src/getters/combine.test.ts
@@ -1,3 +1,4 @@
+import ts from 'typescript';
 import { describe, expect, it } from 'vite-plus/test';
 
 import type { ContextSpec, OpenApiSchemaObject } from '../types';
@@ -1939,5 +1940,127 @@ describe('combineSchemas (allOf required handling)', () => {
     });
 
     expect(resultA.value).toBe(resultB.value);
+  });
+});
+
+describe('combineSchemas — GHSA-6h9g-hcv4-66p6: type-literal injection via schema names', () => {
+  // Schema-derived names land in the key position of `Pick`/`Extract`, which is
+  // a TS *string literal type* — always quoted, so always in need of escaping.
+  // Emitted raw, a `'` in a name closed the literal and the rest was written as
+  // sibling top-level source in `export type X = …;`. A value statement there
+  // survives type erasure and runs when the module is imported.
+  const payload =
+    "id'>>>;\nexport const pwned=(()=>{globalThis.__PWNED=1;})();\ntype _Dummy = Array<Array<Array<'id";
+
+  // The property that actually matters: whatever the name contains, the emitted
+  // type must stay a single `export type X = …;` statement. A breakout shows up
+  // as a second top-level statement, which is what carried the payload. Parsing
+  // with TypeScript checks that directly rather than pattern-matching source —
+  // the escaped payload legitimately still contains the text `export const`
+  // *inside* a string literal, where it is inert.
+  const expectSingleStatement = (value: string) => {
+    const source = ts.createSourceFile(
+      'evil.ts',
+      `export type Evil = ${value};`,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    expect(
+      source.statements.map((statement) => statement.getText(source)),
+    ).toHaveLength(1);
+    expect(source.statements[0].kind).toBe(ts.SyntaxKind.TypeAliasDeclaration);
+  };
+
+  const contextWithEvilBase = {
+    ...context,
+    spec: {
+      components: {
+        schemas: {
+          ...context.spec.components!.schemas,
+          // Owns the property but does not require it, so the parent's
+          // `required` drives the Pick/Extract emission.
+          EvilBase: {
+            type: 'object',
+            properties: { [payload]: { type: 'string' } },
+          },
+        },
+      },
+    },
+  } as unknown as ContextSpec;
+
+  it('escapes the name in the Extract<keyof …> branch', () => {
+    // The required name is not a known member key, so it takes the
+    // Extract-guarded path — reachable under default config.
+    const result = combineSchemas({
+      schema: {
+        required: [payload],
+        allOf: [{ $ref: '#/components/schemas/Base' }],
+      } as OpenApiSchemaObject,
+      name: 'Evil',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('Extract<keyof (Base)');
+    expectSingleStatement(result.value);
+  });
+
+  it('escapes the name in the Required<Pick<…>> branch', () => {
+    // Same name is a real member key here, so it is pickable directly.
+    const result = combineSchemas({
+      schema: {
+        required: [payload],
+        allOf: [{ $ref: '#/components/schemas/EvilBase' }],
+      } as OpenApiSchemaObject,
+      name: 'Evil',
+      separator: 'allOf',
+      context: contextWithEvilBase,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('Required<Pick<EvilBase,');
+    expect(result.value).not.toContain('Extract<');
+    expectSingleStatement(result.value);
+  });
+
+  it('escapes the name in the unionAddMissingProperties `?: never` keys', () => {
+    const contextWithUnionFill = {
+      ...context,
+      output: { ...context.output, unionAddMissingProperties: true },
+    } as unknown as ContextSpec;
+
+    const result = combineSchemas({
+      schema: {
+        oneOf: [
+          { type: 'object', properties: { [payload]: { type: 'string' } } },
+          { type: 'object', properties: { other: { type: 'string' } } },
+        ],
+      } as OpenApiSchemaObject,
+      name: 'Evil',
+      separator: 'oneOf',
+      context: contextWithUnionFill,
+      nullable: '',
+    });
+
+    expect(result.value).toContain('?: never');
+    expectSingleStatement(result.value);
+  });
+
+  it('leaves ordinary names byte-identical', () => {
+    // The escaper must be a no-op for every name that does not need it, so no
+    // generated output churns.
+    const result = combineSchemas({
+      schema: {
+        required: ['baseProp'],
+        allOf: [{ $ref: '#/components/schemas/Base' }],
+      } as OpenApiSchemaObject,
+      name: 'Plain',
+      separator: 'allOf',
+      context,
+      nullable: '',
+    });
+
+    expect(result.value).toBe("Base & Required<Pick<Base, 'baseProp'>>");
   });
 });

--- a/packages/core/src/getters/combine.ts
+++ b/packages/core/src/getters/combine.ts
@@ -21,6 +21,7 @@ import {
 } from '../utils';
 import { getCombinedEnumValue, hasEnumMetadata, getEnumMembers } from './enum';
 import { getAliasedImports, getImportAliasForRefOrValue } from './imports';
+import { getKey, getStringLiteralTypeUnion } from './keys';
 import type { FormDataContext } from './object';
 import { getRefInfo, isComponentRef } from './ref';
 import { getScalar } from './scalar';
@@ -570,7 +571,13 @@ function combineValues({
         },
       ) as OpenApiSchemaObject[];
       if (discriminatedPropertySchemas.length > 0) {
-        resolvedDataValue = `Omit<${resolvedDataValue}, '${discriminatedPropertySchemas.map((s) => (s.discriminator as Discriminator | undefined)?.propertyName).join("' | '")}'>`;
+        resolvedDataValue = `Omit<${resolvedDataValue}, ${getStringLiteralTypeUnion(
+          discriminatedPropertySchemas.map(
+            (s) =>
+              (s.discriminator as Discriminator | undefined)?.propertyName ??
+              '',
+          ),
+        )}>`;
       }
     }
     // Also wrap resolvedValue if it contains union (sibling pattern: allOf + oneOf at same level)
@@ -647,13 +654,13 @@ function combineValues({
       );
     let result = joined;
     if (pickableRequiredProperties.length > 0) {
-      result = `${result} & Required<Pick<${joined}, '${pickableRequiredProperties.join("' | '")}'>>`;
+      result = `${result} & Required<Pick<${joined}, ${getStringLiteralTypeUnion(pickableRequiredProperties)}>>`;
     }
     if (unresolvedRequiredProperties.length > 0) {
-      result = `${result} & Required<Pick<${joined}, Extract<keyof (${joined}), '${unresolvedRequiredProperties.join("' | '")}'>>>`;
+      result = `${result} & Required<Pick<${joined}, Extract<keyof (${joined}), ${getStringLiteralTypeUnion(unresolvedRequiredProperties)}>>>`;
     }
     if (nullableParentRequiredProperties.length > 0) {
-      result = `${result} & (Required<Pick<NonNullable<${joined}>, '${nullableParentRequiredProperties.join("' | '")}'>> | null)`;
+      result = `${result} & (Required<Pick<NonNullable<${joined}>, ${getStringLiteralTypeUnion(nullableParentRequiredProperties)}>> | null)`;
     }
     if (
       pickableRequiredProperties.length > 0 ||
@@ -684,7 +691,7 @@ function combineValues({
       values.push(
         `${resolvedData.values[i]}${
           missingProperties.length > 0
-            ? ` & {${missingProperties.map((p) => `${p}?: never`).join('; ')}}`
+            ? ` & {${missingProperties.map((p) => `${getKey(p)}?: never`).join('; ')}}`
             : ''
         }`,
       );

--- a/packages/core/src/getters/keys.test.ts
+++ b/packages/core/src/getters/keys.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { getKey, getPropertyAccessor } from './keys';
+import {
+  getKey,
+  getPropertyAccessor,
+  getStringLiteralType,
+  getStringLiteralTypeUnion,
+} from './keys';
 
 describe('getKey', () => {
   it('leaves a valid identifier name unchanged', () => {
@@ -39,5 +44,44 @@ describe('getPropertyAccessor', () => {
 
   it('escapes quotes inside a bracket-access name', () => {
     expect(getPropertyAccessor("it's")).toBe(String.raw`['it\'s']`);
+  });
+});
+
+describe('getStringLiteralType', () => {
+  it('quotes a plain name', () => {
+    expect(getStringLiteralType('petId')).toBe("'petId'");
+  });
+
+  it('quotes a valid identifier too, unlike getKey', () => {
+    // A string literal type has no bare form: `Extract<keyof T, petId>` would
+    // be a type reference, not the literal `'petId'`.
+    expect(getKey('petId')).toBe('petId');
+    expect(getStringLiteralType('petId')).toBe("'petId'");
+  });
+
+  it('escapes a quote so the name cannot close the literal', () => {
+    expect(getStringLiteralType("id'>>>;type X = '")).toBe(
+      String.raw`'id\'>>>;type X = \''`,
+    );
+  });
+
+  it('escapes newlines so a name cannot open a new statement line', () => {
+    expect(getStringLiteralType('a\nb')).toBe(String.raw`'a\nb'`);
+  });
+});
+
+describe('getStringLiteralTypeUnion', () => {
+  it('joins names as a union of literal types', () => {
+    expect(getStringLiteralTypeUnion(['a', 'b'])).toBe("'a' | 'b'");
+  });
+
+  it('escapes every member', () => {
+    expect(getStringLiteralTypeUnion(["a'", "b'"])).toBe(
+      String.raw`'a\'' | 'b\''`,
+    );
+  });
+
+  it('returns an empty string for no names', () => {
+    expect(getStringLiteralTypeUnion([])).toBe('');
   });
 });

--- a/packages/core/src/getters/keys.ts
+++ b/packages/core/src/getters/keys.ts
@@ -9,6 +9,31 @@ export function getKey(key: string) {
 }
 
 /**
+ * Emits a schema-derived name as a TypeScript *string literal type*
+ * (`'petId'`), for the key positions of `Pick`, `Omit` and `Extract`.
+ *
+ * The sibling {@link getKey} covers the property-key position, where a valid
+ * identifier may be emitted bare. A string literal type has no bare form —
+ * `Extract<keyof T, petId>` is a type *reference*, not the literal `'petId'` —
+ * so the name is always quoted, and therefore always has to be escaped. Left
+ * unescaped, a `'` in a schema name closes the literal and the rest of the
+ * name is emitted as sibling top-level source in `export type X = …;`, which
+ * survives type erasure and runs when the generated module is imported
+ * (GHSA-6h9g-hcv4-66p6).
+ */
+export function getStringLiteralType(name: string) {
+  return `'${jsStringLiteralEscape(name)}'`;
+}
+
+/**
+ * Joins schema-derived names into a union of string literal types
+ * (`'a' | 'b'`). See {@link getStringLiteralType}.
+ */
+export function getStringLiteralTypeUnion(names: readonly string[]) {
+  return names.map((name) => getStringLiteralType(name)).join(' | ');
+}
+
+/**
  * Emits a property access for a possibly non-identifier name: dot access for
  * valid identifier names (`.petId`), quoted bracket access otherwise
  * (`['scope.id']`).

--- a/packages/mock/src/faker/resolvers/value.ts
+++ b/packages/mock/src/faker/resolvers/value.ts
@@ -3,6 +3,7 @@ import {
   type GeneratorImport,
   getRefInfo,
   getRequiredKeys,
+  getStringLiteralType,
   isFunction,
   isReference,
   type MockOptions,
@@ -494,7 +495,9 @@ export function resolveMockValue({
 
         let overrideType = `Partial<${newSchema.name}>`;
         if (discriminatedProperty) {
-          overrideType = `Omit<${overrideType}, '${discriminatedProperty}'>`;
+          overrideType = `Omit<${overrideType}, ${getStringLiteralType(
+            discriminatedProperty,
+          )}>`;
         }
 
         const { param, returnType, returnCast } = getMockFactorySignatureParts(


### PR DESCRIPTION
Fixes GHSA-6h9g-hcv4-66p6 (CWE-94, CVSS 9.6). Reported by @manus-use.

## The bug

`combineValues` joined schema-derived names — `required[]` entries and property names — raw into the key position of `Pick`, `Omit` and `Extract`. That position is a TypeScript **string literal type**: always quoted, so always in need of escaping. Emitted raw, a `'` in a name closed the literal and the rest of the name was written as sibling top-level source in `export type X = …;`.

Reproduced end-to-end on this repo at `d69250dc7`, default config (`client: 'fetch'`, single mode, no `unsafeDisableValidation`). Spec:

```yaml
Evil:
  allOf: [ { $ref: '#/components/schemas/Base' } ]
  required:
    - "id'>>>;\nexport const pwned=(()=>{globalThis.__PWNED=1;})();\ntype _Dummy = Array<Array<Array<'id"
```

Generated `api.ts`:

```ts
export type Evil = Base & Required<Pick<Base, Extract<keyof (Base), 'id'>>>;
export const pwned=(()=>{globalThis.__PWNED=1;})();
type _Dummy = Array<Array<Array<'id'>>>;
```

Line 2 is a value statement, so it is **not** removed with the types. `tsc --noEmit` exits 0, and importing the generated client runs it — on the build host and in every downstream consumer. Confirmed: `__PWNED` is `1` after `import { getX } from './api.ts'`.

`validateComponentKeys` does not help — it checks the keys of `components.<section>`, never the names inside a schema.

After the fix the same spec emits the payload inert, all of it inside one literal:

```ts
export type Evil = Base & Required<Pick<Base, Extract<keyof (Base), 'id\'>>>;\nexport const pwned=…\'id'>>>;
```

`__PWNED` is `undefined` after import, `tsc` still exits 0, and the client imports normally.

## The fix

- **`packages/core/src/getters/keys.ts`** — new `getStringLiteralType` / `getStringLiteralTypeUnion`, placed next to `getKey`, the parity partner that already got this right for the property-key position. The two differ deliberately: `getKey` may emit a valid identifier bare, whereas a string literal type has no bare form — `Extract<keyof T, petId>` is a type *reference*, not the literal `'petId'` — so it always quotes and therefore always escapes.
- **`packages/core/src/getters/combine.ts`** — the four literal-type sinks use it, and the `unionAddMissingProperties` `?: never` keys now go through `getKey` like every other property-key emission.
- **`packages/mock/src/faker/resolvers/value.ts`** — the same pattern in the mock discriminator `Omit<Partial<X>, '…'>`.

I also checked `quoteKeys` in `packages/query/src/query-options.ts`, which looks similar but takes hardcoded framework-adapter constants (`solid.ts`), not spec input — left alone.

## Reachability, stated exactly

The `Extract<keyof …>`, `Required<Pick<…>>` and `?: never` sinks are reachable, and each has a test that fails without this change. The two **discriminator** sinks are *not* provably reachable with a hostile name: the guard upstream of them matches the raw `propertyName` against emitted source that would already have quoted it, so a name containing `'` never gets that far. Those are escaped as defense in depth, not on a demonstrated exploit — flagging it so the fix isn't read as broader than what's proven.

## Verification

- 3 new injection tests fail on the unpatched source (verified by reverting) and pass with it. They assert the real property via the TypeScript parser: `export type Evil = <value>;` must parse to exactly one `TypeAliasDeclaration`. Pattern-matching the source would be wrong here — the escaped payload legitimately still contains the text `export const` *inside* a string literal, where it is inert.
- A byte-identical test pins that ordinary names are unaffected.
- Full suite green — 4,384 tests across 12 packages; typecheck and format clean.
- Full snapshot suite regenerated and unchanged: no generated output churns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated TypeScript types for schemas with names containing quotes, newlines, or other special characters.
  - Prevented schema-derived names from breaking generated type declarations or introducing invalid code.
  - Improved generated types for combined and discriminated responses, including property omission and required-property handling.
  - Ensured mock response types correctly handle discriminator property names.
  - Preserved byte-identical output for ordinary schema names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->