### PR TITLE
fix(docs): correct the transposed locale in the zh MCP guide link

### DIFF
--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -2300,7 +2300,7 @@ export const customHandler = async (
 };
 ```
 
-关于 `fetcher` 和 `ctx` 的详细说明，请参阅 [MCP 指南](/docs/zh/guides/mcp)。
+关于 `fetcher` 和 `ctx` 的详细说明，请参阅 [MCP 指南](/zh/docs/guides/mcp#custom-handler自定义-handler)。
 
 ---
 


### PR DESCRIPTION
Fixes the failing [Deploy Docs](https://github.com/orval-labs/orval/actions/runs/34487706130) action on `master`.

## The bug

One internal link in the zh docs had its locale and `docs` segments transposed:

```
docs/content/docs/zh/reference/configuration/output.mdx:2303
-  [MCP 指南](/docs/zh/guides/mcp)
+  [MCP 指南](/zh/docs/guides/mcp#custom-handler自定义-handler)
```

The zh route is `/$locale/docs/$`, so the real path is `/zh/docs/guides/mcp`. Every other internal link in the zh content already uses that shape — this was the only one that didn't:

```
2  ](/zh/docs/guides/msw)
2  ](/zh/docs/guides/faker)
1  ](/zh/docs/guides/solid-start)
…
1  ](/docs/zh/guides/mcp)      ← the outlier
```

TanStack Start prerenders by crawling links, so a single bad href fails the whole build:

```
Error: Failed to fetch /docs/zh/guides/mcp: Not Found
    at @tanstack/start-plugin-core/dist/esm/prerender.js:137:19
error: script "build" exited with code 1
error: script "deploy" exited with code 1
```

`deploy` is `bun run build && wrangler deploy`, so the build failure took the deploy with it. Nothing was actually missing — both `docs/content/docs/zh/guides/mcp.mdx` and the `mcp` entry in `zh/guides/meta.json` are present and correct.

## Verification

- Reproduced locally on `master` at `61d10cae9`: `bun run build` fails with the exact error above.
- With the fix: exits 0. Prerender crawls 161 pages, including `/zh/docs/guides/mcp` → `200 OK`.
- `bun run i18n:check` → "All zh documentation files are present."
- Grepped for the same transposition elsewhere in `docs/content/` — this was the only instance.

## One note on the anchor

I also added the section anchor the English link already carries (`/docs/guides/mcp#custom-handler`). The zh heading is `## Custom Handler（自定义 Handler）`, so its slug is `custom-handler自定义-handler`, **not** `custom-handler` — I took that from the prerendered HTML rather than guessing, and confirmed prerender resolves it (`/zh/docs/guides/mcp#custom-handler%E8%87%AA%E5%AE%9A%E4%B9%89-handler` → `200 OK`). Happy to drop it and keep this to the bare path fix if you'd rather not encode a heading-derived slug in a link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Chinese MCP guide link for custom handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->