### PR TITLE
feat(axios): generate status-discriminated responses

### DIFF
--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -2533,6 +2533,42 @@ See the [MCP guide](/docs/guides/mcp#custom-handler) for details on `fetcher` an
 
 ---
 
+## override.axios
+
+Axios client options:
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      override: {
+        axios: {
+          includeHttpResponseReturnType: true,
+        },
+      },
+    },
+  },
+});
+```
+
+### includeHttpResponseReturnType
+
+**Type:** `Boolean`
+**Default:** `false`
+
+Include the HTTP status in the return type and correlate it with the response
+data type. For example, an operation with a JSON `200` response and an empty
+`204` response returns a union that narrows `data` to the JSON body or `void`
+based on `status`.
+
+The built-in Axios client normalizes spec-declared empty responses to
+`undefined`. With a custom `mutator`, the option changes the generated type but
+not the runtime value because the mutator issues the request itself. The
+mutator must return a complete Axios response with the same status-correlated
+shape.
+
+---
+
 ## override.fetch
 
 Fetch client options:

--- a/packages/angular/src/base-url.test.ts
+++ b/packages/angular/src/base-url.test.ts
@@ -120,6 +120,9 @@ const createOutput = (
         useBrandedTypes: false,
         exactOptional: false,
       },
+      axios: {
+        includeHttpResponseReturnType: false,
+      },
       fetch: {
         includeHttpResponseReturnType: true,
         forceSuccessResponse: false,

--- a/packages/angular/src/http-client.test.ts
+++ b/packages/angular/src/http-client.test.ts
@@ -135,6 +135,9 @@ const createOutput = (
         useBrandedTypes: false,
         exactOptional: false,
       },
+      axios: {
+        includeHttpResponseReturnType: false,
+      },
       fetch: {
         includeHttpResponseReturnType: true,
         forceSuccessResponse: false,

--- a/packages/angular/src/http-resource.test.ts
+++ b/packages/angular/src/http-resource.test.ts
@@ -147,6 +147,9 @@ const createOutput = (
         useBrandedTypes: false,
         exactOptional: false,
       },
+      axios: {
+        includeHttpResponseReturnType: false,
+      },
       fetch: {
         includeHttpResponseReturnType: true,
         forceSuccessResponse: false,

--- a/packages/axios/src/index.test.ts
+++ b/packages/axios/src/index.test.ts
@@ -352,6 +352,65 @@ describe('Axios response types', () => {
     );
   });
 
+  it('gives exact responses precedence over wildcard responses', () => {
+    const result = generateAxios(
+      createVerbOptions({
+        response: {
+          ...responseWithMultipleSuccessStatuses,
+          types: {
+            success: [
+              responseWithMultipleSuccessStatuses.types.success[0],
+              {
+                ...responseWithMultipleSuccessStatuses.types.success[1],
+                key: '2XX',
+              },
+            ],
+            errors: [],
+          },
+        },
+        override: {
+          ...createVerbOptions().override,
+          axios: { includeHttpResponseReturnType: true },
+        },
+      }),
+      generatorOptions,
+    );
+
+    expect(result.returnType()).toContain(
+      'status: Exclude<HTTPStatusCode2xx, 200>',
+    );
+    expect(result.implementation).toContain(
+      'response.status >= 200 && response.status < 300 && response.status !== 200',
+    );
+  });
+
+  it('uses a default empty response only for undeclared statuses', () => {
+    const result = generateAxios(
+      createVerbOptions({
+        response: {
+          ...responseWithMultipleSuccessStatuses,
+          types: {
+            success: [
+              responseWithMultipleSuccessStatuses.types.success[0],
+              {
+                ...responseWithMultipleSuccessStatuses.types.success[1],
+                key: 'default',
+              },
+            ],
+            errors: [],
+          },
+        },
+        override: {
+          ...createVerbOptions().override,
+          axios: { includeHttpResponseReturnType: true },
+        },
+      }),
+      generatorOptions,
+    );
+
+    expect(result.implementation).toContain('!(response.status === 200)');
+  });
+
   it('declares the correlated response type for custom mutators', () => {
     const result = generateAxios(
       createVerbOptions({

--- a/packages/axios/src/index.test.ts
+++ b/packages/axios/src/index.test.ts
@@ -26,6 +26,26 @@ const response = {
   schemas: [],
 };
 
+const responseWithMultipleSuccessStatuses = {
+  ...response,
+  definition: { success: 'Pet | void', errors: 'unknown' },
+  types: {
+    success: [
+      {
+        key: '200',
+        contentType: 'application/json',
+        value: 'Pet',
+      },
+      {
+        key: '204',
+        contentType: '',
+        value: 'void',
+      },
+    ],
+    errors: [],
+  },
+} as unknown as GeneratorVerbOptions['response'];
+
 const createVerbOptions = (
   overrides: Partial<GeneratorVerbOptions> = {},
 ): GeneratorVerbOptions =>
@@ -293,6 +313,66 @@ describe('Axios URL helpers', () => {
   });
 });
 
+describe('Axios response types', () => {
+  it('preserves the existing return type by default', () => {
+    const result = generateAxios(createVerbOptions(), generatorOptions);
+
+    expect(result.implementation).toContain('Promise<AxiosResponse<Pet>>');
+    expect(result.returnType()).toBe(
+      'export type GetPetResult = AxiosResponse<Pet>',
+    );
+  });
+
+  it('correlates response data with each success status when enabled', () => {
+    const result = generateAxios(
+      createVerbOptions({
+        response: responseWithMultipleSuccessStatuses,
+        override: {
+          ...createVerbOptions().override,
+          axios: { includeHttpResponseReturnType: true },
+        },
+      }),
+      generatorOptions,
+    );
+
+    expect(result.implementation).toContain('Promise<getPetResponse>');
+    expect(result.implementation).toContain('response.status === 204');
+    expect(result.implementation).toContain('data: undefined');
+    expect(result.returnType()).toContain(
+      'export type getPetResponse200 = AxiosResponse<Pet> & {\n  status: 200',
+    );
+    expect(result.returnType()).toContain(
+      'export type getPetResponse204 = AxiosResponse<void> & {\n  status: 204',
+    );
+    expect(result.returnType()).toContain(
+      'export type getPetResponse = getPetResponse200 | getPetResponse204',
+    );
+    expect(result.returnType()).toContain(
+      'export type GetPetResult = getPetResponse',
+    );
+  });
+
+  it('declares the correlated response type for custom mutators', () => {
+    const result = generateAxios(
+      createVerbOptions({
+        response: responseWithMultipleSuccessStatuses,
+        mutator,
+        override: {
+          ...createVerbOptions().override,
+          axios: { includeHttpResponseReturnType: true },
+        },
+      }),
+      generatorOptions,
+    );
+
+    expect(result.implementation).toContain('as Promise<getPetResponse>');
+    expect(result.implementation).not.toContain('data: undefined');
+    expect(result.returnType()).toContain(
+      'export type GetPetResult = getPetResponse',
+    );
+  });
+});
+
 describe('getAxiosDependencies (axios-functions mode)', () => {
   it('should return axios runtime import when no global mutator', () => {
     const deps = getAxiosDependencies(false, false);
@@ -313,6 +393,28 @@ describe('getAxiosDependencies (axios-functions mode)', () => {
     const deps = getAxiosDependencies(true, false);
 
     expect(deps).toHaveLength(0);
+  });
+
+  it('imports AxiosResponse for status-aware mutator return types', () => {
+    const deps = getAxiosDependencies(
+      true,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      {
+        axios: { includeHttpResponseReturnType: true },
+        operations: {},
+        tags: {},
+      } as never,
+    );
+
+    expect(deps).toEqual([
+      {
+        exports: [{ name: 'AxiosResponse' }],
+        dependency: 'axios',
+      },
+    ]);
   });
 
   it('should include qs dependency when params serializer is enabled', () => {

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -15,8 +15,12 @@ import {
   type GeneratorOptions,
   type GeneratorVerbOptions,
   generateAxiosUrl,
+  getStatusCodeType,
+  HTTP_STATUS_CODE_SHARED_TYPES,
   isSyntheticDefaultImportsAllow,
   GetterPropType,
+  needsHttpStatusCodeTypes,
+  type NormalizedOverrideOutput,
   pascal,
   sanitize,
   toObjectString,
@@ -52,11 +56,32 @@ const PARAMS_SERIALIZER_DEPENDENCIES: GeneratorDependency[] = [
   },
 ];
 
+const hasHttpResponseReturnType = (override?: NormalizedOverrideOutput) =>
+  !!override &&
+  [
+    override,
+    ...Object.values(override.operations),
+    ...Object.values(override.tags),
+  ].some((entry) => entry?.axios?.includeHttpResponseReturnType);
+
 export const getAxiosDependencies: ClientDependenciesBuilder = (
   hasGlobalMutator,
   hasParamsSerializerOptions: boolean,
+  _packageJson,
+  _httpClient,
+  _hasTagsMutator,
+  override,
 ) => [
-  ...(hasGlobalMutator ? [] : AXIOS_DEPENDENCIES),
+  ...(hasGlobalMutator
+    ? hasHttpResponseReturnType(override)
+      ? [
+          {
+            exports: [{ name: 'AxiosResponse' }],
+            dependency: 'axios',
+          },
+        ]
+      : []
+    : AXIOS_DEPENDENCIES),
   ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
 ];
 
@@ -69,6 +94,7 @@ export const getAxiosFactoryDependencies: ClientDependenciesBuilder = (
   _packageJson,
   _httpClient,
   hasTagsMutator,
+  override,
 ) => [
   {
     exports: [
@@ -83,13 +109,93 @@ export const getAxiosFactoryDependencies: ClientDependenciesBuilder = (
         ? [{ name: 'AxiosInstance' }]
         : []),
       ...(hasGlobalMutator
-        ? []
+        ? hasHttpResponseReturnType(override)
+          ? [{ name: 'AxiosResponse' }]
+          : []
         : [{ name: 'AxiosRequestConfig' }, { name: 'AxiosResponse' }]),
     ],
     dependency: 'axios',
   },
   ...(hasParamsSerializerOptions ? PARAMS_SERIALIZER_DEPENDENCIES : []),
 ];
+
+const getAxiosResponseTypes = (
+  response: GeneratorVerbOptions['response'],
+  typeName: string,
+) => {
+  const responseTypeName = `${typeName}Response`;
+  const responses = response.types.success.length
+    ? response.types.success
+    : [
+        {
+          key: 'default',
+          contentType: '',
+          value: response.definition.success || 'unknown',
+        },
+      ];
+  const nonDefaultStatuses = responses
+    .filter(({ key }) => key !== 'default')
+    .map(({ key }) => getStatusCodeType(key));
+  const uniqueNonDefaultStatuses = [...new Set(nonDefaultStatuses)];
+  const types = responses.map((entry) => {
+    const hasDuplicateStatus =
+      responses.filter(({ key }) => key === entry.key).length > 1;
+    const name = `${responseTypeName}${pascal(entry.key)}${
+      hasDuplicateStatus ? pascal(entry.contentType) : ''
+    }`;
+    const status =
+      entry.key === 'default'
+        ? uniqueNonDefaultStatuses.length
+          ? `Exclude<HTTPStatusCodes, ${uniqueNonDefaultStatuses.join(' | ')}>`
+          : 'number'
+        : getStatusCodeType(entry.key);
+
+    return {
+      name,
+      value: `export type ${name} = AxiosResponse<${entry.value || 'unknown'}> & {
+  status: ${status}
+}`,
+    };
+  });
+
+  return {
+    name: responseTypeName,
+    value: `${types.map(({ value }) => value).join('\n\n')}
+
+export type ${responseTypeName} = ${types.map(({ name }) => name).join(' | ')}`,
+  };
+};
+
+const getEmptyResponseStatusCondition = (
+  response: GeneratorVerbOptions['response'],
+) => {
+  const statuses = new Set(response.types.success.map(({ key }) => key));
+
+  return [...statuses]
+    .filter((key) =>
+      response.types.success
+        .filter((entry) => entry.key === key)
+        .every(({ value }) => value === 'void'),
+    )
+    .map((key) => {
+      if (key === 'default') return 'true';
+      if (/^[1-5]XX$/i.test(key)) {
+        const start = Number(key[0]) * 100;
+        return `(response.status >= ${start} && response.status < ${start + 100})`;
+      }
+      return `response.status === ${key}`;
+    })
+    .join(' || ');
+};
+
+const normalizeEmptyAxiosResponse = (condition: string) =>
+  condition
+    ? `.then((response) =>
+      ${condition}
+        ? { ...response, data: undefined }
+        : response,
+    )`
+    : '';
 
 const generateAxiosImplementation = (
   {
@@ -112,6 +218,12 @@ const generateAxiosImplementation = (
   isFactoryMode = false,
 ) => {
   const isRequestOptions = override.requestOptions !== false;
+  const includeHttpResponseReturnType =
+    override.axios?.includeHttpResponseReturnType;
+  const axiosResponse = getAxiosResponseTypes(response, typeName);
+  const emptyResponseNormalization = normalizeEmptyAxiosResponse(
+    getEmptyResponseStatusCondition(response),
+  );
   const isFormData = !override.formData.disabled;
   const isFormUrlEncoded = override.formUrlEncoded !== false;
   const isExactOptionalPropertyTypes =
@@ -151,11 +263,15 @@ const generateAxiosImplementation = (
       : '';
 
     const returnType = (title?: string) =>
-      `export type ${pascal(typeName)}Result = NonNullable<Awaited<ReturnType<${
-        title
-          ? `ReturnType<typeof ${title}>['${operationName}']`
-          : `typeof ${operationName}`
-      }>>>`;
+      includeHttpResponseReturnType
+        ? `${axiosResponse.value}
+
+export type ${pascal(typeName)}Result = ${axiosResponse.name}`
+        : `export type ${pascal(typeName)}Result = NonNullable<Awaited<ReturnType<${
+            title
+              ? `ReturnType<typeof ${title}>['${operationName}']`
+              : `typeof ${operationName}`
+          }>>>`;
 
     const propsImplementation =
       mutator.bodyTypeName && body.definition
@@ -173,7 +289,7 @@ const generateAxiosImplementation = (
       }) => {${bodyForm}
       return ${mutator.name}<${response.definition.success || 'unknown'}>(
       ${mutatorConfig},
-      ${requestOptions});
+      ${requestOptions})${includeHttpResponseReturnType ? ` as Promise<${axiosResponse.name}>` : ''};
     }
   `,
       returnType,
@@ -197,9 +313,13 @@ const generateAxiosImplementation = (
   });
 
   const returnType = () =>
-    `export type ${pascal(typeName)}Result = AxiosResponse<${
-      response.definition.success || 'unknown'
-    }>`;
+    includeHttpResponseReturnType
+      ? `${axiosResponse.value}
+
+export type ${pascal(typeName)}Result = ${axiosResponse.name}`
+      : `export type ${pascal(typeName)}Result = AxiosResponse<${
+          response.definition.success || 'unknown'
+        }>`;
 
   // In factory mode, use the axiosInstance parameter
   // In functions mode with global import, .default may be needed based on tsconfig
@@ -228,8 +348,8 @@ const generateAxiosImplementation = (
       isRequestOptions
         ? `options${context.output.optionsParamRequired ? '' : '?'}: AxiosRequestConfig\n`
         : ''
-    } ): Promise<AxiosResponse<${response.definition.success || 'unknown'}>> => {${bodyForm}
-    return ${axiosRef}.${verb}(${options});
+    } ): Promise<${includeHttpResponseReturnType ? axiosResponse.name : `AxiosResponse<${response.definition.success || 'unknown'}>`}> => {${bodyForm}
+    return ${axiosRef}.${verb}(${options})${includeHttpResponseReturnType ? emptyResponseNormalization + ` as Promise<${axiosResponse.name}>` : ''};
   }
 ${isFactoryMode ? urlImplementation.replace(/^export /, '') : urlImplementation}`,
     returnType,
@@ -264,13 +384,27 @@ export const generateAxiosHeader: ClientHeaderBuilder = ({
     isGlobalMutator ||
     Object.values(verbOptions).some((verbOption) => !!verbOption.mutator);
 
-  return `
+  const implementation = `
 ${
   isRequestOptions && isMutator
     ? `type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];\n\n`
     : ''
 }
   ${noFunction ? '' : hasAnyMutator ? `export const ${title} = () => {\n` : `export const ${title} = (axiosInstance: AxiosInstance = ${axiosDefault}) => {\n`}`;
+  const hasStatusCodeTypes = Object.values(verbOptions).some(
+    (verbOption) =>
+      verbOption.override?.axios?.includeHttpResponseReturnType &&
+      needsHttpStatusCodeTypes(
+        getAxiosResponseTypes(verbOption.response, verbOption.typeName).value,
+      ),
+  );
+
+  return hasStatusCodeTypes
+    ? {
+        implementation,
+        sharedTypes: HTTP_STATUS_CODE_SHARED_TYPES,
+      }
+    : implementation;
 };
 
 export const generateAxiosFooter: ClientFooterBuilder = ({

--- a/packages/axios/src/index.ts
+++ b/packages/axios/src/index.ts
@@ -133,9 +133,10 @@ const getAxiosResponseTypes = (
           value: response.definition.success || 'unknown',
         },
       ];
+  const responseKeys = responses.map(({ key }) => key);
   const nonDefaultStatuses = responses
     .filter(({ key }) => key !== 'default')
-    .map(({ key }) => getStatusCodeType(key));
+    .map(({ key }) => getStatusCodeType(key, responseKeys));
   const uniqueNonDefaultStatuses = [...new Set(nonDefaultStatuses)];
   const types = responses.map((entry) => {
     const hasDuplicateStatus =
@@ -148,7 +149,7 @@ const getAxiosResponseTypes = (
         ? uniqueNonDefaultStatuses.length
           ? `Exclude<HTTPStatusCodes, ${uniqueNonDefaultStatuses.join(' | ')}>`
           : 'number'
-        : getStatusCodeType(entry.key);
+        : getStatusCodeType(entry.key, responseKeys);
 
     return {
       name,
@@ -170,6 +171,21 @@ const getEmptyResponseStatusCondition = (
   response: GeneratorVerbOptions['response'],
 ) => {
   const statuses = new Set(response.types.success.map(({ key }) => key));
+  const exactStatuses = [...statuses].filter((key) => /^[1-5]\d{2}$/.test(key));
+
+  const conditionFor = (key: string) => {
+    if (/^[1-5]XX$/i.test(key)) {
+      const start = Number(key[0]) * 100;
+      const exclusions = exactStatuses
+        .filter((status) => status[0] === key[0])
+        .map((status) => `response.status !== ${status}`)
+        .join(' && ');
+      return `response.status >= ${start} && response.status < ${start + 100}${
+        exclusions ? ` && ${exclusions}` : ''
+      }`;
+    }
+    return `response.status === ${key}`;
+  };
 
   return [...statuses]
     .filter((key) =>
@@ -178,12 +194,15 @@ const getEmptyResponseStatusCondition = (
         .every(({ value }) => value === 'void'),
     )
     .map((key) => {
-      if (key === 'default') return 'true';
-      if (/^[1-5]XX$/i.test(key)) {
-        const start = Number(key[0]) * 100;
-        return `(response.status >= ${start} && response.status < ${start + 100})`;
+      if (key === 'default') {
+        const declaredConditions = [...statuses]
+          .filter((status) => status !== 'default')
+          .map(conditionFor);
+        return declaredConditions.length
+          ? `!(${declaredConditions.join(' || ')})`
+          : 'true';
       }
-      return `response.status === ${key}`;
+      return `(${conditionFor(key)})`;
     })
     .join(' || ');
 };

--- a/packages/core/src/test-utils/context.ts
+++ b/packages/core/src/test-utils/context.ts
@@ -159,6 +159,9 @@ export function createTestContextSpec({
         useBrandedTypes: false,
         exactOptional: false,
       },
+      axios: {
+        includeHttpResponseReturnType: false,
+      },
       fetch: {
         includeHttpResponseReturnType: false,
         forceSuccessResponse: false,

--- a/packages/core/src/test-utils/split-modes.ts
+++ b/packages/core/src/test-utils/split-modes.ts
@@ -100,6 +100,7 @@ export const createSplitModeOutput = (
       swr: {},
       zod: {},
       effect: {},
+      axios: {},
       fetch: {},
     },
     ...overrides,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -172,6 +172,7 @@ export interface NormalizedOverrideOutput {
   swr: SwrOptions;
   zod: NormalizedZodOptions;
   effect: NormalizedEffectOptions;
+  axios: NormalizedAxiosOptions;
   fetch: NormalizedFetchOptions;
   operationName?: (
     operation: OpenApiOperationObject,
@@ -263,6 +264,7 @@ export interface NormalizedOperationOptions {
     route: string,
     verb: Verbs,
   ) => string | [string, string];
+  axios?: AxiosOptions;
   fetch?: FetchOptions;
   formData?: NormalizedFormDataType<NormalizedMutator>;
   formUrlEncoded?: boolean | NormalizedMutator;
@@ -872,6 +874,7 @@ export interface OverrideOutput {
     route: string,
     verb: Verbs,
   ) => string | [string, string];
+  axios?: AxiosOptions;
   fetch?: FetchOptions;
 
   requestOptions?: Record<string, unknown> | boolean;
@@ -1466,6 +1469,20 @@ export interface SwrOptions {
   swrInfiniteOptions?: unknown;
 }
 
+export interface NormalizedAxiosOptions {
+  includeHttpResponseReturnType: boolean;
+}
+
+export interface AxiosOptions {
+  /**
+   * Include the HTTP status in the return type so it discriminates the
+   * response data type.
+   *
+   * @default false
+   */
+  includeHttpResponseReturnType?: boolean;
+}
+
 export interface NormalizedFetchOptions {
   includeHttpResponseReturnType: boolean;
   forceSuccessResponse: boolean;
@@ -1537,6 +1554,7 @@ export interface OperationOptions {
     route: string,
     verb: Verbs,
   ) => string | [string, string];
+  axios?: AxiosOptions;
   fetch?: FetchOptions;
   formData?: boolean | Mutator | FormDataType<Mutator>;
   formUrlEncoded?: boolean | Mutator;

--- a/packages/core/src/utils/http-status.ts
+++ b/packages/core/src/utils/http-status.ts
@@ -1,0 +1,46 @@
+import type { SharedTypeDeclaration } from '../types';
+
+const WILDCARD_STATUS_CODE_REGEX = /^[1-5]XX$/i;
+
+export const getStatusCodeType = (key: string) => {
+  if (WILDCARD_STATUS_CODE_REGEX.test(key)) {
+    return `HTTPStatusCode${key[0]}xx`;
+  }
+  return key;
+};
+
+export const HTTP_STATUS_CODE_SHARED_TYPES: SharedTypeDeclaration[] = [
+  {
+    name: 'HTTPStatusCode1xx',
+    exported: true,
+    code: 'type HTTPStatusCode1xx = 100 | 101 | 102 | 103;',
+  },
+  {
+    name: 'HTTPStatusCode2xx',
+    exported: true,
+    code: 'type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;',
+  },
+  {
+    name: 'HTTPStatusCode3xx',
+    exported: true,
+    code: 'type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;',
+  },
+  {
+    name: 'HTTPStatusCode4xx',
+    exported: true,
+    code: 'type HTTPStatusCode4xx = 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 419 | 420 | 421 | 422 | 423 | 424 | 426 | 428 | 429 | 431 | 451;',
+  },
+  {
+    name: 'HTTPStatusCode5xx',
+    exported: true,
+    code: 'type HTTPStatusCode5xx = 500 | 501 | 502 | 503 | 504 | 505 | 507 | 511;',
+  },
+  {
+    name: 'HTTPStatusCodes',
+    exported: true,
+    code: 'type HTTPStatusCodes = HTTPStatusCode1xx | HTTPStatusCode2xx | HTTPStatusCode3xx | HTTPStatusCode4xx | HTTPStatusCode5xx;',
+  },
+];
+
+export const needsHttpStatusCodeTypes = (implementation: string) =>
+  /HTTPStatusCode[1-5]xx|<HTTPStatusCodes,/.test(implementation);

--- a/packages/core/src/utils/http-status.ts
+++ b/packages/core/src/utils/http-status.ts
@@ -1,10 +1,24 @@
 import type { SharedTypeDeclaration } from '../types';
 
 const WILDCARD_STATUS_CODE_REGEX = /^[1-5]XX$/i;
+const EXACT_STATUS_CODE_REGEX = /^[1-5]\d{2}$/;
 
-export const getStatusCodeType = (key: string) => {
+export const getStatusCodeType = (key: string, responseKeys: string[] = []) => {
   if (WILDCARD_STATUS_CODE_REGEX.test(key)) {
-    return `HTTPStatusCode${key[0]}xx`;
+    const wildcardType = `HTTPStatusCode${key[0]}xx`;
+    const exactStatuses = [
+      ...new Set(
+        responseKeys.filter(
+          (responseKey) =>
+            EXACT_STATUS_CODE_REGEX.test(responseKey) &&
+            responseKey[0] === key[0],
+        ),
+      ),
+    ];
+
+    return exactStatuses.length
+      ? `Exclude<${wildcardType}, ${exactStatuses.join(' | ')}>`
+      : wildcardType;
   }
   return key;
 };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './extension';
 export * from './file';
 export * from './file-extensions';
 export * from './get-property-safe';
+export * from './http-status';
 export * from './is-body-verb';
 export * from './logger';
 export * from './merge-deep';

--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -157,6 +157,9 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         useBrandedTypes: false,
         exactOptional: false,
       },
+      axios: {
+        includeHttpResponseReturnType: false,
+      },
       fetch: {
         includeHttpResponseReturnType: false,
         forceSuccessResponse: false,

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -8,9 +8,11 @@ import {
   generateFormDataAndUrlEncodedFunction,
   generateVerbImports,
   type GeneratorDependency,
+  getStatusCodeType,
   getSchemaOutputTypeRef,
   getSchemaValueRef,
   hasSchemaImport,
+  HTTP_STATUS_CODE_SHARED_TYPES,
   isPrimitiveResponseType,
   jsStringLiteralEscape,
   rewriteImportsForResponseValidation,
@@ -20,18 +22,17 @@ import {
   GetterPropType,
   isObject,
   makeRouteSafe,
+  needsHttpStatusCodeTypes,
   type OpenApiParameterObject,
   type OpenApiPathItemObject,
   type OpenApiReferenceObject,
   type OpenApiSchemaObject,
   pascal,
   resolveRef,
-  type SharedTypeDeclaration,
   stringify,
   toObjectString,
 } from '@orval/core';
 
-const WILDCARD_STATUS_CODE_REGEX = /^[1-5]XX$/i;
 const resolveSchemaRef = (
   schema: OpenApiSchemaObject | OpenApiReferenceObject,
   context: GeneratorOptions['context'],
@@ -39,14 +40,6 @@ const resolveSchemaRef = (
   resolveRef(schema, context) as {
     schema: OpenApiSchemaObject;
   };
-
-const getStatusCodeType = (key: string): string => {
-  if (WILDCARD_STATUS_CODE_REGEX.test(key)) {
-    const prefix = key[0];
-    return `HTTPStatusCode${prefix}xx`;
-  }
-  return key;
-};
 
 const FETCH_DEPENDENCIES: GeneratorDependency[] = [
   {
@@ -913,47 +906,11 @@ export const generateClient: ClientBuilder = (verbOptions, options) => {
   };
 };
 
-const HTTP_STATUS_CODE_SHARED_TYPES: SharedTypeDeclaration[] = [
-  {
-    name: 'HTTPStatusCode1xx',
-    exported: true,
-    code: 'type HTTPStatusCode1xx = 100 | 101 | 102 | 103;',
-  },
-  {
-    name: 'HTTPStatusCode2xx',
-    exported: true,
-    code: 'type HTTPStatusCode2xx = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207;',
-  },
-  {
-    name: 'HTTPStatusCode3xx',
-    exported: true,
-    code: 'type HTTPStatusCode3xx = 300 | 301 | 302 | 303 | 304 | 305 | 307 | 308;',
-  },
-  {
-    name: 'HTTPStatusCode4xx',
-    exported: true,
-    code: 'type HTTPStatusCode4xx = 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 419 | 420 | 421 | 422 | 423 | 424 | 426 | 428 | 429 | 431 | 451;',
-  },
-  {
-    name: 'HTTPStatusCode5xx',
-    exported: true,
-    code: 'type HTTPStatusCode5xx = 500 | 501 | 502 | 503 | 504 | 505 | 507 | 511;',
-  },
-  {
-    name: 'HTTPStatusCodes',
-    exported: true,
-    code: 'type HTTPStatusCodes = HTTPStatusCode1xx | HTTPStatusCode2xx | HTTPStatusCode3xx | HTTPStatusCode4xx | HTTPStatusCode5xx;',
-  },
-];
-
 /** Emits HTTP status-code union types at the top of the generated file when they are needed. */
 export const generateFetchHeader: ClientHeaderBuilder = ({
   clientImplementation,
 }) => {
-  const needsStatusCodeTypes = /HTTPStatusCode[1-5]xx|<HTTPStatusCodes,/.test(
-    clientImplementation,
-  );
-  if (!needsStatusCodeTypes) return '';
+  if (!needsHttpStatusCodeTypes(clientImplementation)) return '';
 
   return {
     implementation: '',

--- a/packages/mock/src/faker/getters/combine.test.ts
+++ b/packages/mock/src/faker/getters/combine.test.ts
@@ -156,6 +156,9 @@ function createMockContext(): ContextSpec {
           useBrandedTypes: false,
           exactOptional: false,
         },
+        axios: {
+          includeHttpResponseReturnType: false,
+        },
         fetch: {
           includeHttpResponseReturnType: false,
           forceSuccessResponse: false,

--- a/packages/orval/src/utils/options.test.ts
+++ b/packages/orval/src/utils/options.test.ts
@@ -2695,7 +2695,7 @@ describe('normalizeOptions', () => {
     }
   });
 
-  it('keeps fetch boolean defaults when the user passes them as undefined', async () => {
+  it('keeps client boolean defaults when the user passes them as undefined', async () => {
     const workspace = await createTempWorkspace();
 
     try {
@@ -2711,6 +2711,9 @@ describe('normalizeOptions', () => {
           output: {
             target: './generated.ts',
             override: {
+              axios: {
+                includeHttpResponseReturnType: undefined,
+              },
               fetch: {
                 serializeResponseHeaders: undefined,
                 includeHttpResponseReturnType: undefined,
@@ -2727,6 +2730,9 @@ describe('normalizeOptions', () => {
         includeHttpResponseReturnType: true,
         forceSuccessResponse: false,
       });
+      expect(
+        normalized.output.override.axios.includeHttpResponseReturnType,
+      ).toBe(false);
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }

--- a/packages/orval/src/utils/options.ts
+++ b/packages/orval/src/utils/options.ts
@@ -945,6 +945,11 @@ export async function normalizeOptions(
               }
             : {}),
         },
+        axios: {
+          includeHttpResponseReturnType:
+            outputOptions.override?.axios?.includeHttpResponseReturnType ??
+            false,
+        },
         fetch: {
           // Spread first so an explicit `undefined` cannot erase a default below.
           ...outputOptions.override?.fetch,

--- a/packages/solid-start/src/index.test.ts
+++ b/packages/solid-start/src/index.test.ts
@@ -159,6 +159,9 @@ function makeOutput(useDates = false): ContextSpec['output'] {
         useBrandedTypes: false,
         exactOptional: false,
       },
+      axios: {
+        includeHttpResponseReturnType: false,
+      },
       fetch: {
         includeHttpResponseReturnType: false,
         forceSuccessResponse: false,


### PR DESCRIPTION
Adds opt-in `override.axios.includeHttpResponseReturnType` support. When enabled, Axios operations return a union of full `AxiosResponse` values whose literal `status` discriminates the corresponding `data` type. Spec-declared empty responses are normalized to `undefined`. Existing Axios output remains unchanged by default.

The implementation follows the existing Fetch client's `includeHttpResponseReturnType` behavior and status-code handling as closely as the Axios response shape permits. The shared HTTP status helpers were moved to core so Axios and Fetch use the same handling for exact, wildcard, and default response statuses without duplicating that logic.

Custom mutators retain control of runtime response handling and must return the documented full Axios response shape.

Validation:
- `bun x vp check` (one pre-existing warning in a generated Angular Query fixture)
- `bun x vp test` (125 files, 4,479 tests)
- `bun x vp run -F './packages/*' typecheck`

This change was implemented with the assistance of an AI coding agent; the author reviewed the full diff and verification results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Axios configuration option to include HTTP status codes in generated response types.
  * Generated response types can narrow response data based on status, including empty responses.
  * Added support for status-aware response types with custom Axios mutators.
  * Exact status responses now take precedence over wildcard and default responses.

* **Documentation**
  * Documented the Axios response-type configuration, including custom mutators and empty responses.

* **Tests**
  * Added coverage for status-aware responses, empty responses, dependencies, and default configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->