### PR TITLE
fix(fetch): preserve response status precedence

### DIFF
--- a/packages/fetch/src/index.test.ts
+++ b/packages/fetch/src/index.test.ts
@@ -627,6 +627,40 @@ describe('generateRequestFunction — zod runtimeValidation response typing (#39
   });
 });
 
+describe('generateRequestFunction — response status precedence', () => {
+  it('excludes exact responses from matching wildcard responses', () => {
+    const response = {
+      definition: { success: 'Pet | void', errors: '' },
+      imports: [],
+      types: {
+        success: [
+          {
+            key: '200',
+            contentType: 'application/json',
+            value: 'Pet',
+          },
+          { key: '2XX', contentType: '', value: 'void' },
+        ],
+        errors: [],
+      },
+      contentTypes: ['application/json'],
+      schemas: [],
+      isBlob: false,
+    } as unknown as GeneratorVerbOptions['response'];
+    const verbOptions = makeVerbOptions({ response });
+    (
+      verbOptions.override.fetch as { includeHttpResponseReturnType: boolean }
+    ).includeHttpResponseReturnType = true;
+
+    const implementation = generateRequestFunction(
+      verbOptions,
+      makeOptions(makeContext()),
+    );
+
+    expect(implementation).toContain('status: Exclude<HTTPStatusCode2xx, 200>');
+  });
+});
+
 describe('generateRequestFunction — Content-Type header escaping', () => {
   it('escapes single quotes in the request body media type key', () => {
     const verbOptions = makeVerbOptions({

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -480,9 +480,10 @@ ${deepObjectParameters.length > 0 ? '  const deepObjectEntries: string[] = [];\n
       dependencies: [],
     });
   }
+  const responseKeys = allResponses.map(({ key }) => key);
   const nonDefaultStatuses = allResponses
     .filter((r) => r.key !== 'default')
-    .map((r) => getStatusCodeType(r.key));
+    .map((r) => getStatusCodeType(r.key, responseKeys));
   const uniqueNonDefaultStatuses = [...new Set(nonDefaultStatuses)];
   const responseDataTypes = allResponses
     .map((r) =>
@@ -517,7 +518,7 @@ ${deepObjectParameters.length > 0 ? '  const deepObjectEntries: string[] = [];\n
       ? uniqueNonDefaultStatuses.length > 0
         ? `Exclude<HTTPStatusCodes, ${uniqueNonDefaultStatuses.join(' | ')}>`
         : 'number'
-      : getStatusCodeType(r.key)
+      : getStatusCodeType(r.key, responseKeys)
   }
 }`,
       };

--- a/tests/__snapshots__/fetch/wildcard-responses/endpoints.ts
+++ b/tests/__snapshots__/fetch/wildcard-responses/endpoints.ts
@@ -171,7 +171,7 @@ export type getMixedResponsesResponse200 = {
 
 export type getMixedResponsesResponse2xx = {
   data: GenericSuccessDto;
-  status: HTTPStatusCode2xx;
+  status: Exclude<HTTPStatusCode2xx, 200>;
 };
 
 export type getMixedResponsesResponse400 = {
@@ -181,7 +181,7 @@ export type getMixedResponsesResponse400 = {
 
 export type getMixedResponsesResponse4xx = {
   data: ErrorDto;
-  status: HTTPStatusCode4xx;
+  status: Exclude<HTTPStatusCode4xx, 400>;
 };
 
 export type getMixedResponsesResponseSuccess = (


### PR DESCRIPTION
While implementing the Axios equivalent of Fetch's status-aware response types in https://github.com/orval-labs/orval/pull/4076, we found that Fetch response unions do not preserve OpenAPI response precedence when an exact status and a wildcard overlap.

For example, when both `200` and `2XX` are declared, the generated wildcard member also includes `200`, so `status` cannot reliably discriminate the corresponding data type. This applies the same precedence correction to the existing Fetch implementation by excluding explicitly declared statuses from matching wildcard members.

The change includes one focused regression test for the overlapping exact and wildcard case.

Validation:
- `vp test packages/fetch/src/index.test.ts`
- `vp run -F @orval/fetch typecheck`

Prepared with AI assistance and reviewed against the OpenAPI response precedence rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved generated fetch client types for response status handling.
- Wildcard HTTP status types now exclude explicitly defined exact statuses, preventing overlapping or ambiguous response types.
- For example, a `2XX` response type no longer includes status `200` when `200` is defined separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->