### PR TITLE
test(pinia-colada): bound temporary workspace cleanup

### DIFF
--- a/packages/orval/src/pinia-colada.test.ts
+++ b/packages/orval/src/pinia-colada.test.ts
@@ -1,5 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdtemp, readFile, rm, rmdir } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 
@@ -8,7 +7,9 @@ import { normalizeOptions } from './utils/options';
 
 describe('pinia-colada generation', () => {
   it('does not restrict the HTTP client of other generators', async () => {
-    const workspace = await mkdtemp(path.join(tmpdir(), 'orval-angular-'));
+    const workspace = await mkdtemp(
+      path.join(import.meta.dirname, '.orval-angular-'),
+    );
     try {
       const options = await normalizeOptions(
         {
@@ -25,14 +26,17 @@ describe('pinia-colada generation', () => {
       expect(source).toContain('HttpClient');
       expect(source).not.toContain('useColadaQuery');
     } finally {
-      await rm(workspace, { recursive: true, force: true });
+      await rm(path.join(workspace, 'client.ts'), { force: true });
+      await rmdir(workspace);
     }
   });
 
   it.each(['fetch', 'axios'] as const)(
     'generates queries and mutations with %s',
     async (httpClient) => {
-      const workspace = await mkdtemp(path.join(tmpdir(), 'orval-colada-'));
+      const workspace = await mkdtemp(
+        path.join(import.meta.dirname, '.orval-colada-'),
+      );
       try {
         const options = await normalizeOptions(
           {
@@ -64,7 +68,8 @@ describe('pinia-colada generation', () => {
         expect(source).not.toContain('staleTime: 60_000');
         if (httpClient === 'fetch') expect(source).toContain('!res.ok');
       } finally {
-        await rm(workspace, { recursive: true, force: true });
+        await rm(path.join(workspace, 'client.ts'), { force: true });
+        await rmdir(workspace);
       }
     },
   );


### PR DESCRIPTION
Follow-up to the [cleanup review on #4067](https://github.com/orval-labs/orval/pull/4067#discussion_r3982307963).

Create each test workspace under the test directory using `import.meta.dirname`, rather than the system temporary directory. Cleanup removes only the expected `client.ts` file, then uses non-recursive `rmdir` on the empty workspace. Unexpected files, subdirectories, or a directory at the output path cause cleanup to fail instead of recursively deleting them. The missing-file case remains safe if generation fails before writing output.

Only `packages/orval/src/pinia-colada.test.ts` changes; generation behavior is unchanged.

Validation: [Ubuntu and Windows passed](https://github.com/pj-workspace/orval/actions/runs/34553865469) with repository security scanning, package builds, all three Angular/Fetch/Axios generation tests, package type checks and targeted lint. Four filesystem cases verified normal cleanup, a missing output file, preservation of unexpected files, and refusal to recursively remove a directory at the output path. No temporary test workspaces remained. The validation workflow and boundary-check script are confined to the Fork validation branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated temporary workspace handling and cleanup in automated tests.
  * Test cleanup now explicitly removes generated files before deleting temporary directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->