### PR TITLE
feat(orval): support JSON5 package manifests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -236,6 +236,7 @@
         "fs-extra": "^11.3.2",
         "get-tsconfig": "^4.14.0",
         "jiti": "^2.6.1",
+        "json5": "^2.2.3",
         "js-yaml": "4.3.2",
         "remeda": "^2.33.6",
         "string-argv": "^0.3.2",

--- a/packages/orval/package.json
+++ b/packages/orval/package.json
@@ -79,6 +79,7 @@
     "get-tsconfig": "^4.14.0",
     "jiti": "^2.6.1",
     "js-yaml": "4.3.2",
+    "json5": "^2.2.3",
     "remeda": "^2.33.6",
     "string-argv": "^0.3.2",
     "typedoc": "^0.28.19",

--- a/packages/orval/src/utils/package-json.test.ts
+++ b/packages/orval/src/utils/package-json.test.ts
@@ -89,6 +89,34 @@ const mockReadFile = (value: string) => {
   ).mockResolvedValue(Buffer.from(value));
 };
 
+describe('loadPackageJson - configured package manifest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('loads a JSON5 package manifest', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    mockReadFile(`{
+      // JSON5 syntax is valid for configured package manifests.
+      dependencies: {
+        react: '^19.0.0',
+      },
+    }`);
+
+    const result = await loadPackageJson('/workspace/package.json5');
+
+    expect(result?.dependencies?.react).toBe('^19.0.0');
+    expect(fs.readFile).toHaveBeenCalledWith(
+      '/workspace/package.json5',
+      'utf8',
+    );
+  });
+});
+
 describe('loadPackageJson - catalog resolution', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/orval/src/utils/package-json.test.ts
+++ b/packages/orval/src/utils/package-json.test.ts
@@ -115,6 +115,34 @@ describe('loadPackageJson - configured package manifest', () => {
       'utf8',
     );
   });
+
+  it('includes the manifest path and parse error as the cause', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    mockReadFile('{ invalid: }');
+
+    const result = loadPackageJson('/workspace/package.json5');
+
+    await expect(result).rejects.toThrow(
+      'Oups... 🍺. Path: /workspace/package.json5',
+    );
+    await expect(result).rejects.toHaveProperty(
+      'cause',
+      expect.any(SyntaxError),
+    );
+  });
+
+  it('includes the manifest path and read error as the cause', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const readError = new Error('EACCES');
+    vi.mocked(fs.readFile).mockRejectedValue(readError);
+
+    const result = loadPackageJson('/workspace/package.json5');
+
+    await expect(result).rejects.toThrow(
+      'Oups... 🍺. Path: /workspace/package.json5 => Error: EACCES',
+    );
+    await expect(result).rejects.toHaveProperty('cause', readError);
+  });
 });
 
 describe('loadPackageJson - catalog resolution', () => {

--- a/packages/orval/src/utils/package-json.ts
+++ b/packages/orval/src/utils/package-json.ts
@@ -41,9 +41,15 @@ export const loadPackageJson = async (
 
   const normalizedPath = normalizePath(packageJson, workspace);
   if (fs.existsSync(normalizedPath)) {
-    const pkg = JSON5.parse(
-      await fs.readFile(normalizedPath, 'utf8'),
-    ) as unknown;
+    let pkg: unknown;
+    try {
+      pkg = JSON5.parse(await fs.readFile(normalizedPath, 'utf8')) as unknown;
+    } catch (error) {
+      throw new Error(
+        `Oups... 🍺. Path: ${normalizedPath} => ${String(error)}`,
+        { cause: error },
+      );
+    }
 
     if (isPackageJson(pkg)) {
       return resolveAndAttachVersions(

--- a/packages/orval/src/utils/package-json.ts
+++ b/packages/orval/src/utils/package-json.ts
@@ -9,6 +9,7 @@ import {
 } from '@orval/core';
 import { findUp, findUpMultiple } from 'find-up';
 import fs from 'fs-extra';
+import JSON5 from 'json5';
 import yaml from 'js-yaml';
 
 import { logger } from '../logger';
@@ -40,7 +41,9 @@ export const loadPackageJson = async (
 
   const normalizedPath = normalizePath(packageJson, workspace);
   if (fs.existsSync(normalizedPath)) {
-    const pkg = await dynamicImport<unknown>(normalizedPath);
+    const pkg = JSON5.parse(
+      await fs.readFile(normalizedPath, 'utf8'),
+    ) as unknown;
 
     if (isPackageJson(pkg)) {
       return resolveAndAttachVersions(


### PR DESCRIPTION
Closes #4071

Parse configured `output.packageJson` files with JSON5 so manifests with comments, unquoted keys, and trailing commas work while standard JSON remains supported. Includes a focused regression test.

Validation: focused tests (21 passed), formatting, type-aware lint, package build, and typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading package manifests written in JSON5 format.
  - Dependency information can now be read from manifests containing comments and trailing commas.
  - Improved support for UTF-8 encoded package manifest files.

- **Bug Fixes**
  - Errors encountered while reading or parsing manifests now include the affected file path and preserve the original error details.

- **Tests**
  - Added coverage for JSON5 parsing, dependency extraction, UTF-8 file support, and path-aware error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->