### PR TITLE
fix(mock): reject or escape enum type-cast names in the faker generator (GHSA-w68h-2r38-4cqq)

### DIFF
--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1629,6 +1629,11 @@ describe('getMockScalar (enum type-cast name injection)', () => {
     expect(result.value).toBe(
       "faker.helpers.arrayElement(['A','B'] as MyEnum[])",
     );
+    // The imported type is `MyEnum`. `MyEnum[]` is an array of it, not a name
+    // anything exports, so importing that would leave the cast unresolved.
+    expect(result.imports).toContainEqual(
+      expect.objectContaining({ name: 'MyEnum' }),
+    );
   });
 
   // `parentReference` comes from resolved `$ref` names, which core sanitizes

--- a/packages/mock/src/faker/getters/scalar.test.ts
+++ b/packages/mock/src/faker/getters/scalar.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable unicorn/no-null */
 import type { ContextSpec, OpenApiSchemaObjectType } from '@orval/core';
-import { EnumGeneration } from '@orval/core';
+import { EnumGeneration, getKey } from '@orval/core';
+import ts from 'typescript';
 import { describe, expect, it } from 'vite-plus/test';
 
 import { createTestContextSpec } from '../../../../core/src/test-utils/context';
@@ -1482,5 +1483,172 @@ describe('getMockScalar (non-finite numeric constraints)', () => {
     });
 
     expect(result.value).toBe('faker.number.int({min: 1, max: 9})');
+  });
+});
+
+describe('getMockScalar (enum type-cast name injection)', () => {
+  const baseArg = {
+    imports: [],
+    operationId: 'test-operation',
+    tags: [],
+    splitMockImplementations: [],
+  };
+
+  /**
+   * The enum expression is emitted at the *value* side of a generated
+   * object-literal entry. Rebuild that entry and count what the TypeScript
+   * parser actually sees: one property means the value stayed contained, more
+   * than one means the name broke out of the cast and the enclosing call and
+   * introduced siblings — which is the whole exploit.
+   */
+  function propertyCount(key: string, value: string): number {
+    const source = ts.createSourceFile(
+      'mock.ts',
+      `const m = { ${getKey(key)}: ${value} };`,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    let count = -1;
+    const visit = (node: ts.Node) => {
+      if (ts.isObjectLiteralExpression(node) && count === -1) {
+        count = node.properties.length;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(source, visit);
+    return count;
+  }
+
+  // Regression for GHSA-w68h-2r38-4cqq. Under `enumGenerationType: 'enum'` the
+  // property name was spliced raw into the cast annotating the enum expression.
+  // `getKey` escapes the key side of the object-literal entry; the value side
+  // is this cast, and it was quoting the name by hand. A quote in the name
+  // closed the cast, then the call, and the remainder became sibling
+  // properties whose initializers run when the mock is constructed at test
+  // time.
+  const PAYLOAD =
+    "k'][]), __pwned: (globalThis.__x = 1), z: (0 as unknown as Parent['k";
+
+  it('escapes the property name in the parent indexed-access cast', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: ['A', 'B'],
+        name: PAYLOAD,
+        parentName: 'Parent',
+      } as never,
+      existingReferencedProperties: ['Parent'],
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).toBe(
+      String.raw`faker.helpers.arrayElement(['A','B'] as Parent['k\'][]), __pwned: (globalThis.__x = 1), z: (0 as unknown as Parent[\'k'][])`,
+    );
+    expect(propertyCount(PAYLOAD, result.value)).toBe(1);
+  });
+
+  it('leaves an ordinary property name byte-identical', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: ['A', 'B'],
+        name: 'status',
+        parentName: 'Parent',
+      } as never,
+      existingReferencedProperties: ['Parent'],
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).toBe(
+      "faker.helpers.arrayElement(['A','B'] as Parent['status'][])",
+    );
+  });
+
+  // The other sink: with no enclosing `$ref` the name goes into identifier
+  // position, where there is no quote to escape and nothing to escape it with.
+  // A name that is not a type reference names no importable type either, so
+  // the cast is dropped for the `as const` the other generation types emit.
+  const ROOT_PAYLOAD =
+    'Evil[]), __pwned: (globalThis.__y = 1), z: (0 as unknown as Evil';
+
+  it('does not emit a non-identifier schema name bare in the type cast', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: ['A', 'B'],
+        name: ROOT_PAYLOAD,
+      } as never,
+      existingReferencedProperties: [],
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).toBe("faker.helpers.arrayElement(['A','B'] as const)");
+    expect(propertyCount(ROOT_PAYLOAD, result.value)).toBe(1);
+    // No phantom import either — there is no type by that name to import.
+    expect(result.imports).not.toContainEqual(
+      expect.objectContaining({ name: ROOT_PAYLOAD }),
+    );
+  });
+
+  it('still casts to a valid identifier schema name', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: ['A', 'B'],
+        name: 'MyEnum',
+      } as never,
+      existingReferencedProperties: [],
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).toBe(
+      "faker.helpers.arrayElement(['A','B'] as MyEnum[])",
+    );
+    expect(result.imports).toContainEqual(
+      expect.objectContaining({ name: 'MyEnum' }),
+    );
+  });
+
+  it('keeps casting a name that already carries an array suffix', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: ['A', 'B'],
+        name: 'MyEnum[]',
+      } as never,
+      existingReferencedProperties: [],
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).toBe(
+      "faker.helpers.arrayElement(['A','B'] as MyEnum[])",
+    );
+  });
+
+  // `parentReference` comes from resolved `$ref` names, which core sanitizes
+  // in `getRefInfo`, so this is defense in depth rather than a demonstrated
+  // exploit — but it sits in the same identifier position as the sink above.
+  it('drops the cast when the parent reference is not an identifier', () => {
+    const result = getMockScalar({
+      ...baseArg,
+      item: {
+        type: 'string' as OpenApiSchemaObjectType,
+        enum: ['A', 'B'],
+        name: 'status',
+        parentName: 'x',
+      } as never,
+      existingReferencedProperties: [
+        "P'], __pwned: (globalThis.__z = 1), q: ['",
+      ],
+      context: scalarContext({ enumGenerationType: EnumGeneration.ENUM }),
+    });
+
+    expect(result.value).toBe("faker.helpers.arrayElement(['A','B'] as const)");
   });
 });

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -10,6 +10,7 @@ import {
   EnumGeneration,
   type GeneratorImport,
   getRefInfo,
+  getStringLiteralType,
   isBoolean,
   isNumber,
   isReference,
@@ -668,6 +669,24 @@ function formatEnumMember(value: unknown): string {
   return JSON.stringify(value);
 }
 
+/**
+ * Returns `name` when it is safe to emit as a type reference (optionally an
+ * array of one), `undefined` otherwise.
+ *
+ * The name lands in identifier position inside a cast, where there is no quote
+ * to escape and nothing to escape it with — the only safe handling is to reject
+ * it. Names here are OpenAPI property keys and schema names, neither of which
+ * is constrained to an identifier, and a name carrying `'` or `)` closed the
+ * cast and the enclosing call so the rest became sibling object-literal
+ * properties with live initializers (GHSA-w68h-2r38-4cqq).
+ *
+ * Same guard `getArrayItemFactory` applies before naming a type.
+ */
+function safeTypeReference(name: string): string | undefined {
+  const base = name.endsWith('[]') ? name.slice(0, -2) : name;
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(base) ? name : undefined;
+}
+
 function getEnum(
   item: MockSchemaObject,
   imports: GeneratorImport[],
@@ -692,19 +711,36 @@ function getEnum(
       existingReferencedProperties.length === 0 ||
       isRootSchema
     ) {
-      enumValue += ` as ${item.name}${item.name.endsWith('[]') ? '' : '[]'}`;
-      imports.push({ name: item.name });
+      // A name that is not a type reference cannot be cast to: there is no
+      // type by that name to import, and the cast would only carry the name's
+      // text into the expression. Fall back to the `as const` the other
+      // generation types emit, which is always well-formed.
+      const typeName = safeTypeReference(item.name);
+      if (typeName) {
+        enumValue += ` as ${typeName}${typeName.endsWith('[]') ? '' : '[]'}`;
+        imports.push({ name: item.name });
+      } else {
+        enumValue += ' as const';
+      }
     } else {
       const parentReference = existingReferencedProperties.at(-1);
       if (!parentReference) {
         return '';
       }
 
-      enumValue += ` as ${parentReference}['${item.name}']`;
-      if (!item.path?.endsWith('[]')) enumValue += '[]';
-      imports.push({
-        name: parentReference,
-      });
+      // The property name is an indexed-access key — a TS string literal type,
+      // so always quoted and therefore always escaped. `getKey` covers the key
+      // side of the object-literal entry this expression ends up in; the value
+      // side is this cast, and it was quoting the name by hand.
+      if (safeTypeReference(parentReference)) {
+        enumValue += ` as ${parentReference}[${getStringLiteralType(item.name)}]`;
+        if (!item.path?.endsWith('[]')) enumValue += '[]';
+        imports.push({
+          name: parentReference,
+        });
+      } else {
+        enumValue += ' as const';
+      }
     }
   } else {
     enumValue += ' as const';

--- a/packages/mock/src/faker/getters/scalar.ts
+++ b/packages/mock/src/faker/getters/scalar.ts
@@ -670,21 +670,25 @@ function formatEnumMember(value: unknown): string {
 }
 
 /**
- * Returns `name` when it is safe to emit as a type reference (optionally an
- * array of one), `undefined` otherwise.
+ * Returns the type identifier `name` refers to — `MyEnum` for both `MyEnum`
+ * and `MyEnum[]` — or `undefined` when it is not safe to emit as one.
  *
- * The name lands in identifier position inside a cast, where there is no quote
- * to escape and nothing to escape it with — the only safe handling is to reject
- * it. Names here are OpenAPI property keys and schema names, neither of which
- * is constrained to an identifier, and a name carrying `'` or `)` closed the
- * cast and the enclosing call so the rest became sibling object-literal
+ * The identifier lands in identifier position inside a cast, where there is no
+ * quote to escape and nothing to escape it with — the only safe handling is to
+ * reject it. Names here are OpenAPI property keys and schema names, neither of
+ * which is constrained to an identifier, and a name carrying `'` or `)` closed
+ * the cast and the enclosing call so the rest became sibling object-literal
  * properties with live initializers (GHSA-w68h-2r38-4cqq).
+ *
+ * The array suffix is stripped rather than carried along because callers need
+ * the identifier for both halves of the job: the cast reads `MyEnum[]`, but the
+ * import has to name the type itself.
  *
  * Same guard `getArrayItemFactory` applies before naming a type.
  */
-function safeTypeReference(name: string): string | undefined {
-  const base = name.endsWith('[]') ? name.slice(0, -2) : name;
-  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(base) ? name : undefined;
+function safeTypeIdentifier(name: string): string | undefined {
+  const identifier = name.endsWith('[]') ? name.slice(0, -2) : name;
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier) ? identifier : undefined;
 }
 
 function getEnum(
@@ -715,10 +719,14 @@ function getEnum(
       // type by that name to import, and the cast would only carry the name's
       // text into the expression. Fall back to the `as const` the other
       // generation types emit, which is always well-formed.
-      const typeName = safeTypeReference(item.name);
-      if (typeName) {
-        enumValue += ` as ${typeName}${typeName.endsWith('[]') ? '' : '[]'}`;
-        imports.push({ name: item.name });
+      const typeIdentifier = safeTypeIdentifier(item.name);
+      if (typeIdentifier) {
+        // Always an array of the element type — `item.name` arrives either
+        // bare or already carrying the suffix, and the identifier is the same
+        // either way. It is also what gets imported: the type is `MyEnum`,
+        // never `MyEnum[]`.
+        enumValue += ` as ${typeIdentifier}[]`;
+        imports.push({ name: typeIdentifier });
       } else {
         enumValue += ' as const';
       }
@@ -732,11 +740,12 @@ function getEnum(
       // so always quoted and therefore always escaped. `getKey` covers the key
       // side of the object-literal entry this expression ends up in; the value
       // side is this cast, and it was quoting the name by hand.
-      if (safeTypeReference(parentReference)) {
-        enumValue += ` as ${parentReference}[${getStringLiteralType(item.name)}]`;
+      const parentIdentifier = safeTypeIdentifier(parentReference);
+      if (parentIdentifier) {
+        enumValue += ` as ${parentIdentifier}[${getStringLiteralType(item.name)}]`;
         if (!item.path?.endsWith('[]')) enumValue += '[]';
         imports.push({
-          name: parentReference,
+          name: parentIdentifier,
         });
       } else {
         enumValue += ' as const';


### PR DESCRIPTION
Fixes the sinks reported in [GHSA-w68h-2r38-4cqq](https://github.com/orval-labs/orval/security/advisories/GHSA-w68h-2r38-4cqq) (critical, CWE-94).

## Analysis

Under `enumGenerationType: 'enum'`, `getEnum` in `packages/mock/src/faker/getters/scalar.ts` spliced an OpenAPI-supplied name raw into the cast that annotates the enum expression, in two positions:

```ts
enumValue += ` as ${item.name}${item.name.endsWith('[]') ? '' : '[]'}`;
...
enumValue += ` as ${parentReference}['${item.name}']`;
```

`item.name` is the raw property key — `getMockObject` passes `name: key` straight through from the spec. The resulting expression lands at the **value** side of a generated object-literal entry. `getKey` escapes the key side; nothing escaped the value side, so a quote in the name closes the cast, then the `arrayElement(...)` call, and the remainder is parsed as sibling object-literal properties whose initializers run when the mock object is constructed — i.e. on the developer or CI host as soon as the test suite builds the mock.

I reproduced both sinks before changing anything. The advisory's payload emitted verbatim:

```
faker.helpers.arrayElement(['A','B'] as Parent['k'][]), __pwned: (globalThis.__x = 1), z: (0 as unknown as Parent['k'][])
```

and the bare-identifier sink is equally live:

```
faker.helpers.arrayElement(['A','B'] as Evil[]), __pwned: (globalThis.__y = 1), z: (0 as unknown as Evil[])
```

Two notes where my reading is more specific than the advisory:

- The advisory presents both sinks as the same kind of problem. They are not, and they need different fixes — one is a string literal type (escape it), the other is an identifier (there is nothing to escape, so it has to be rejected).
- The advisory does not say whether `parentReference` is also hostile. I traced it: it only ever holds resolved `$ref` names, and `getRefInfo` runs those through `sanitize`, which strips quotes and brackets. So that one is **not** a demonstrated exploit. I guard it anyway, as defense in depth, and have labelled it as such rather than claiming a second exploit.

## Fix

**Indexed-access key** (`Parent['name']`) — this is a TS string literal type: always quoted, therefore always in need of escaping. Now goes through `getStringLiteralType`, the helper added for GHSA-6h9g-hcv4-66p6, which is exactly this position's parity partner and is already imported elsewhere in `@orval/mock`.

**Bare type name** (`as Name[]`) — identifier position, where there is no quote to escape and nothing to escape it with, so the only safe handling is to reject. Added `safeTypeReference`, applying the same identifier guard `getArrayItemFactory` already uses a few files over; a name that fails it drops the cast for the `as const` the other generation types emit.

That fallback is not a downgrade. A name that isn't an identifier never denoted an importable type in the first place — the old code emitted a cast to a phantom type *and* pushed a matching phantom import, producing source that could not compile. This replaces broken output with valid output.

## Verification

- Six new tests in `scalar.test.ts` cover both sinks, the `parentReference` guard, and the unchanged happy paths.
- Inertness is asserted structurally, not by string matching: the emitted value is placed back into an object-literal entry and parsed with the TypeScript compiler, asserting the literal has exactly **one** property. More than one is precisely the exploit.
- Confirmed 3 of the 6 fail on unpatched code and all pass after.
- `@orval/mock`: 397 tests pass. Full workspace suite: 125 files / 4493 tests, all green.
- `typecheck` clean; `lint --type-aware --type-check` reports nothing on the changed file.
- **No generated output changes.** Regenerating every fixture under `tests/` produces a zero-line diff, and the snapshot suite passes all 6970 assertions. The existing snapshots exercise both cast forms (`as DogGroup[]`, `as Bulldog['colour']`), and all of those names are identifiers, so they are emitted byte-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated enum mocks for schemas with special characters or otherwise unsafe names.
  - Prevented malformed type references and unintended property injection in generated TypeScript.
  - Preserved optimized enum casts for valid identifier names while safely falling back for unsupported names.
  - Correctly handles array-suffixed enum names without including the array notation in type imports.
  - Added support for safely processing root schemas and referenced schemas with varied naming patterns.
  - Expanded coverage for root schemas, referenced schemas, array-suffixed names, and malicious property names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->