### PR TITLE
fix(query): warn when an explicit infinite opt-in is silently suppressed (#4025)

### DIFF
--- a/packages/query/src/query-generator.test.ts
+++ b/packages/query/src/query-generator.test.ts
@@ -14,6 +14,7 @@ import {
   getMutationInvalidatesConflictWarning,
   getQueryFnProperty,
   getQueryKeyVerbPrefix,
+  getSuppressedInfiniteQueryWarning,
   hasQueryParam,
   makeOptionalParam,
   resolveInfiniteQueryParam,
@@ -313,6 +314,87 @@ describe('resolveInfiniteQueryParam', () => {
     expect(
       resolveInfiniteQueryParam(undefined, ['page', 'cursor.marker']),
     ).toStrictEqual({ queryParam: undefined, infiniteHookAllowed: false });
+  });
+});
+
+describe('getSuppressedInfiniteQueryWarning', () => {
+  const paramsWith = (...paramNames: string[]) => ({
+    schema: { name: 'ElementFilterParams', model: '', imports: [] },
+    deps: [],
+    isOptional: true,
+    paramNames,
+  });
+
+  const base = {
+    operationName: 'searchPageableElementsByFilter',
+    infiniteHookAllowed: false,
+    configuredInfiniteQueryParam: 'offset',
+    queryParams: undefined,
+  };
+
+  it('returns undefined when the infinite hook was not suppressed', () => {
+    expect(
+      getSuppressedInfiniteQueryWarning({
+        ...base,
+        infiniteHookAllowed: true,
+        operationUseInfinite: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the operation did not opt in explicitly', () => {
+    expect(getSuppressedInfiniteQueryWarning(base)).toBeUndefined();
+  });
+
+  it('returns undefined when the operation opted out explicitly', () => {
+    expect(
+      getSuppressedInfiniteQueryWarning({
+        ...base,
+        operationUseInfinite: false,
+        operationUseSuspenseInfiniteQuery: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('warns when an explicit useInfinite opt-in was suppressed', () => {
+    const warning = getSuppressedInfiniteQueryWarning({
+      ...base,
+      operationUseInfinite: true,
+    });
+
+    expect(warning).toContain("'searchPageableElementsByFilter'");
+    expect(warning).toContain("'offset'");
+    expect(warning).toContain('declares no query parameters');
+  });
+
+  it('warns for an explicit useSuspenseInfiniteQuery opt-in too', () => {
+    expect(
+      getSuppressedInfiniteQueryWarning({
+        ...base,
+        operationUseSuspenseInfiniteQuery: true,
+      }),
+    ).toContain("'searchPageableElementsByFilter'");
+  });
+
+  it('lists the query parameters the operation does declare', () => {
+    const warning = getSuppressedInfiniteQueryWarning({
+      ...base,
+      operationUseInfinite: true,
+      queryParams: paramsWith('limit', 'sort'),
+    });
+
+    expect(warning).toContain("'limit', 'sort'");
+    expect(warning).not.toContain('declares no query parameters');
+  });
+
+  it('lists every configured candidate', () => {
+    const warning = getSuppressedInfiniteQueryWarning({
+      ...base,
+      operationUseInfinite: true,
+      configuredInfiniteQueryParam: ['offset', 'cursor'],
+    });
+
+    expect(warning).toContain("'offset', 'cursor'");
   });
 });
 

--- a/packages/query/src/query-generator.ts
+++ b/packages/query/src/query-generator.ts
@@ -119,6 +119,71 @@ export const resolveInfiniteQueryParam = (
   return { queryParam, infiniteHookAllowed: queryParam !== undefined };
 };
 
+const quoteList = (values: readonly string[]) =>
+  values.map((value) => `'${value}'`).join(', ');
+
+/**
+ * `resolveInfiniteQueryParam` suppresses the infinite hook when none of the
+ * configured `useInfiniteQueryParam` candidates is one of the operation's
+ * query parameters, so a *global* `useInfinite: true` does not emit a useless
+ * infinite hook for every non-paginated `GET` (#3101). That suppression is
+ * right, but it leaves no trace: an operation that opts in explicitly and
+ * paginates through its request body instead — the common `POST` + filter-body
+ * shape — simply gets no infinite hook and no diagnostic, which reads as orval
+ * ignoring the config (#4025).
+ *
+ * Warn only for the explicit per-operation opt-in. There the user named both
+ * the operation and the page param, so the message is actionable and cannot
+ * become per-`GET` noise the way a warning on the global flag would.
+ */
+export const getSuppressedInfiniteQueryWarning = ({
+  operationName,
+  infiniteHookAllowed,
+  operationUseInfinite,
+  operationUseSuspenseInfiniteQuery,
+  configuredInfiniteQueryParam,
+  queryParams,
+}: {
+  operationName: string;
+  infiniteHookAllowed: boolean;
+  operationUseInfinite?: boolean;
+  operationUseSuspenseInfiniteQuery?: boolean;
+  configuredInfiniteQueryParam: string | string[] | undefined;
+  queryParams: GetterQueryParam | undefined;
+}): string | undefined => {
+  if (infiniteHookAllowed) return undefined;
+
+  const requested = [
+    operationUseInfinite === true ? 'useInfinite' : undefined,
+    operationUseSuspenseInfiniteQuery === true
+      ? 'useSuspenseInfiniteQuery'
+      : undefined,
+  ].filter((flag): flag is string => !!flag);
+  if (requested.length === 0) return undefined;
+
+  const candidates = (
+    Array.isArray(configuredInfiniteQueryParam)
+      ? configuredInfiniteQueryParam
+      : [configuredInfiniteQueryParam]
+  ).filter((name): name is string => !!name);
+
+  const declared = queryParams?.paramNames ?? [];
+  const declaredText =
+    declared.length > 0
+      ? `only declares ${quoteList(declared)}`
+      : 'declares no query parameters';
+
+  return (
+    `'${operationName}' sets ${quoteList(requested)}, but its ` +
+    `useInfiniteQueryParam (${quoteList(candidates)}) is not one of its query ` +
+    `parameters — the operation ${declaredText}, so no infinite hook was ` +
+    `generated. orval can only page through a URL query parameter; a page ` +
+    `param that lives in the request body is not supported yet (#4025). ` +
+    `Either declare it as a query parameter, or drop the infinite options for ` +
+    `this operation.`
+  );
+};
+
 const escapeRegExpMetaChars = (value: string): string =>
   value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 
@@ -1153,6 +1218,19 @@ export const generateQueryHook = async (
         override.query.useSuspenseInfiniteQuery,
       )) &&
     infiniteHookAllowed;
+
+  const suppressedInfiniteWarning = getSuppressedInfiniteQueryWarning({
+    operationName,
+    infiniteHookAllowed,
+    operationUseInfinite: operationQueryOptions?.useInfinite,
+    operationUseSuspenseInfiniteQuery:
+      operationQueryOptions?.useSuspenseInfiniteQuery,
+    configuredInfiniteQueryParam,
+    queryParams,
+  });
+  if (suppressedInfiniteWarning) {
+    logger.warn(suppressedInfiniteWarning);
+  }
 
   let isQuery =
     effectiveUseQuery ||


### PR DESCRIPTION
Partially addresses #4025.

## What this does *not* do

It does not implement body-based page params. That's the actual feature request and it's a larger change with a design decision attached — see my [analysis on the issue](https://github.com/orval-labs/orval/issues/4025).

## What it does

Today, when an operation explicitly opts into an infinite hook but its configured `useInfiniteQueryParam` isn't one of its OpenAPI query parameters, orval generates **nothing** and says **nothing**:

```ts
operations: {
  searchPageableElementsByFilter: {
    query: { useQuery: true, useInfinite: true, useInfiniteQueryParam: 'offset' },
  },
}
```

→ plain Query hook generated, infinite hook silently dropped, exit code 0, no diagnostic. The issue reporter spent time writing a custom PreGen transformer to inject a synthetic query parameter before working out why.

`resolveInfiniteQueryParam` suppresses the hook on purpose — that's what keeps a global `useInfinite: true` from emitting a useless infinite hook for every non-paginated GET (#3101). The suppression is right; the silence isn't.

After:

```
⚠️  'searchPageableElementsByFilter' sets 'useInfinite', but its useInfiniteQueryParam
('offset') is not one of its query parameters — the operation declares no query
parameters, so no infinite hook was generated. orval can only page through a URL query
parameter; a page param that lives in the request body is not supported yet (#4025).
Either declare it as a query parameter, or drop the infinite options for this operation.
```

## Scoping

The warning fires **only** for the explicit per-operation opt-in (`override.operations[id].query.useInfinite` / `useSuspenseInfiniteQuery` set to `true`). A global `useInfinite: true` stays silent, so this cannot become per-GET noise — that's the whole point of #3101's suppression.

Verified both ways:

| config | warns? |
|---|---|
| per-operation `useInfinite: true`, param absent | ✅ yes |
| per-operation `useInfinite: true`, param present | no |
| global `useInfinite: true` only, param absent | no |
| per-operation `useInfinite: false` | no |

The message names the operation, every configured candidate, and the query parameters the operation *does* declare, so it's actionable without opening the spec.

## Verification

- 7 new unit tests for `getSuppressedInfiniteQueryWarning`; `@orval/query` suite 231/231 green.
- Full package suites: 367/367 green.
- `tsc --noEmit` clean.
- Regenerated the whole `tests/` corpus: **no generated-output drift** (`git status` shows only the two source files) and **no new warnings anywhere** across the existing specs — confirming the scoping holds in practice.

Generated output is unchanged by this PR; it only adds a diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear warning when an explicitly requested infinite query hook cannot be generated because the configured pagination parameter is not declared by the operation.
  * Warning messages identify the affected operation and configured parameter, helping explain why the infinite hook was suppressed.

* **Tests**
  * Added coverage for supported and suppressed infinite-query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->