### PR TITLE
fix(orval): merge external refs into definitions for Swagger 2.0 (#2993)

### DIFF
--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -3221,6 +3221,12 @@ describe('normalizeNullableRefs', () => {
 });
 
 describe('dereferenceExternalRef — Swagger 2.0 documents', () => {
+  /** Just enough of a Swagger 2.0 path item to read the response schema back. */
+  type PathsWithResponseSchema = Record<
+    string,
+    { get: { responses: Record<string, { schema: unknown }> } }
+  >;
+
   it('does not inject a components key when nothing is merged', () => {
     // Strava's shape: the external document holds bare schemas at its root, so
     // the ref is inlined and no schema is merged. Creating the container
@@ -3247,12 +3253,15 @@ describe('dereferenceExternalRef — Swagger 2.0 documents', () => {
       },
     };
 
-    const result = dereferenceExternalRef(input) as Record<string, unknown>;
+    const result = dereferenceExternalRef(input) as {
+      paths: PathsWithResponseSchema;
+    };
 
     expect(result).not.toHaveProperty('components');
-    expect(
-      (result.paths as any)['/athlete'].get.responses['200'].schema,
-    ).toEqual({ type: 'object', properties: { id: { type: 'integer' } } });
+    expect(result.paths['/athlete'].get.responses['200'].schema).toEqual({
+      type: 'object',
+      properties: { id: { type: 'integer' } },
+    });
   });
 
   it('leaves an OpenAPI 3 document without merged schemas free of an empty container', () => {
@@ -3318,8 +3327,7 @@ describe('dereferenceExternalRef — Swagger 2.0 documents', () => {
 
     const result = dereferenceExternalRef(input) as {
       definitions: Record<string, unknown>;
-      components?: unknown;
-      paths: any;
+      paths: PathsWithResponseSchema;
     };
 
     expect(result).not.toHaveProperty('components');
@@ -3353,7 +3361,7 @@ describe('dereferenceExternalRef — Swagger 2.0 documents', () => {
     };
 
     const result = dereferenceExternalRef(input) as {
-      definitions: Record<string, any>;
+      definitions: { DetailedAthlete: { properties: { club: unknown } } };
     };
 
     expect(result.definitions.DetailedAthlete.properties.club).toEqual({

--- a/packages/orval/src/import-specs.test.ts
+++ b/packages/orval/src/import-specs.test.ts
@@ -2316,9 +2316,9 @@ describe('dereferenceExternalRefs', () => {
           url: 'https://opensource.org/licenses/MIT',
         },
       },
-      components: {
-        schemas: {},
-      },
+      // No `components`: the external schema is inlined, so nothing is merged
+      // and no container is created. The empty one this used to assert was
+      // residue that made Swagger 2.0 documents fail validation (#2993).
       paths: {
         '/points': {
           get: {
@@ -3217,5 +3217,171 @@ describe('normalizeNullableRefs', () => {
     expect(normalizeNullableRefs(null)).toBe(null);
     expect(normalizeNullableRefs(42)).toBe(42);
     expect(normalizeNullableRefs([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+});
+
+describe('dereferenceExternalRef — Swagger 2.0 documents', () => {
+  it('does not inject a components key when nothing is merged', () => {
+    // Strava's shape: the external document holds bare schemas at its root, so
+    // the ref is inlined and no schema is merged. Creating the container
+    // regardless left an empty `components` on a 2.0 document, which the
+    // validator rejects with "Property components is not expected to be here".
+    const input = {
+      swagger: '2.0',
+      paths: {
+        '/athlete': {
+          get: {
+            responses: {
+              '200': { schema: { $ref: '#/x-ext/athlete/DetailedAthlete' } },
+            },
+          },
+        },
+      },
+      'x-ext': {
+        athlete: {
+          DetailedAthlete: {
+            type: 'object',
+            properties: { id: { type: 'integer' } },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as Record<string, unknown>;
+
+    expect(result).not.toHaveProperty('components');
+    expect(
+      (result.paths as any)['/athlete'].get.responses['200'].schema,
+    ).toEqual({ type: 'object', properties: { id: { type: 'integer' } } });
+  });
+
+  it('leaves an OpenAPI 3 document without merged schemas free of an empty container', () => {
+    const input = {
+      openapi: '3.0.3',
+      paths: {
+        '/athlete': {
+          get: {
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/x-ext/athlete/DetailedAthlete' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      'x-ext': {
+        athlete: { DetailedAthlete: { type: 'object' } },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as Record<string, unknown>;
+
+    expect(result).not.toHaveProperty('components');
+  });
+
+  it('merges external schemas into definitions and rewrites refs accordingly', () => {
+    const input = {
+      swagger: '2.0',
+      definitions: {
+        Local: { type: 'string' },
+      },
+      paths: {
+        '/athlete': {
+          get: {
+            responses: {
+              '200': {
+                schema: {
+                  $ref: '#/x-ext/athlete/components/schemas/DetailedAthlete',
+                },
+              },
+            },
+          },
+        },
+      },
+      'x-ext': {
+        athlete: {
+          components: {
+            schemas: {
+              DetailedAthlete: {
+                type: 'object',
+                properties: { id: { type: 'integer' } },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as {
+      definitions: Record<string, unknown>;
+      components?: unknown;
+      paths: any;
+    };
+
+    expect(result).not.toHaveProperty('components');
+    expect(result.definitions.DetailedAthlete).toEqual({
+      type: 'object',
+      properties: { id: { type: 'integer' } },
+    });
+    expect(result.definitions.Local).toEqual({ type: 'string' });
+    expect(result.paths['/athlete'].get.responses['200'].schema).toEqual({
+      $ref: '#/definitions/DetailedAthlete',
+    });
+  });
+
+  it('rewrites a merged schema’s own internal refs to definitions', () => {
+    const input = {
+      swagger: '2.0',
+      paths: {},
+      'x-ext': {
+        athlete: {
+          components: {
+            schemas: {
+              DetailedAthlete: {
+                type: 'object',
+                properties: { club: { $ref: '#/components/schemas/Club' } },
+              },
+              Club: { type: 'object' },
+            },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as {
+      definitions: Record<string, any>;
+    };
+
+    expect(result.definitions.DetailedAthlete.properties.club).toEqual({
+      $ref: '#/definitions/Club',
+    });
+  });
+
+  it('keeps OpenAPI 3 documents merging into components.schemas', () => {
+    const input = {
+      openapi: '3.0.3',
+      paths: {},
+      'x-ext': {
+        athlete: {
+          components: {
+            schemas: { DetailedAthlete: { type: 'object' } },
+          },
+        },
+      },
+    };
+
+    const result = dereferenceExternalRef(input) as {
+      components: { schemas: Record<string, unknown> };
+      definitions?: unknown;
+    };
+
+    expect(result).not.toHaveProperty('definitions');
+    expect(result.components.schemas.DetailedAthlete).toEqual({
+      type: 'object',
+    });
   });
 });

--- a/packages/orval/src/import-specs.ts
+++ b/packages/orval/src/import-specs.ts
@@ -958,17 +958,27 @@ export function validateComponentKeys(data: Record<string, unknown>): void {
 }
 
 /**
+ * Where a document keeps its reusable schemas. Swagger 2.0 has no
+ * `components` — carrying one makes the document invalid ("Property components
+ * is not expected to be here"), so merged schemas have to land in
+ * `definitions` and be referenced as `#/definitions/...` instead (#2993).
+ */
+const schemaRefPrefix = (data: Record<string, unknown>): string =>
+  isSwagger2(data) ? '#/definitions/' : '#/components/schemas/';
+
+/**
  * The plugins from `@scalar/json-magic` does not dereference $ref.
  * Instead it fetches them and puts them under x-ext, and changes the $ref to point to #x-ext/<name>.
  * This function:
- * 1. Merges external schemas into main spec's components.schemas (with collision handling)
- * 2. Replaces x-ext refs with standard component refs or inlined content
+ * 1. Merges external schemas into the main spec's schema container (with collision handling)
+ * 2. Replaces x-ext refs with standard schema refs or inlined content
  */
 export function dereferenceExternalRef(
   data: Record<string, unknown>,
   strategy: ExternalRefNamingStrategy = 'default',
 ): Record<string, unknown> {
   const extensions = (data['x-ext'] ?? {}) as Record<string, unknown>;
+  const refPrefix = schemaRefPrefix(data);
 
   // Step 1: Merge external schemas into main spec with collision handling
   const schemaNameMappings = mergeExternalSchemas(data, extensions, strategy);
@@ -977,7 +987,12 @@ export function dereferenceExternalRef(
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
     if (key !== 'x-ext') {
-      result[key] = replaceXExtRefs(value, extensions, schemaNameMappings);
+      result[key] = replaceXExtRefs(
+        value,
+        extensions,
+        schemaNameMappings,
+        refPrefix,
+      );
     }
   }
 
@@ -997,10 +1012,28 @@ function mergeExternalSchemas(
 
   if (Object.keys(extensions).length === 0) return schemaNameMappings;
 
-  data.components ??= {};
-  const mainComponents = data.components as Record<string, unknown>;
-  mainComponents.schemas ??= {};
-  const mainSchemas = mainComponents.schemas as Record<string, unknown>;
+  const swagger2 = isSwagger2(data);
+
+  // Materialized on the first schema actually merged. An external document that
+  // contributes none — the common case, where it holds bare schemas at its root
+  // and the ref is inlined instead — must not leave an empty container behind:
+  // on a Swagger 2.0 document that stray `components` fails validation (#2993).
+  let mainSchemas: Record<string, unknown> | undefined;
+  const getMainSchemas = () => {
+    if (mainSchemas) return mainSchemas;
+
+    if (swagger2) {
+      data.definitions ??= {};
+      mainSchemas = data.definitions as Record<string, unknown>;
+      return mainSchemas;
+    }
+
+    data.components ??= {};
+    const mainComponents = data.components as Record<string, unknown>;
+    mainComponents.schemas ??= {};
+    mainSchemas = mainComponents.schemas as Record<string, unknown>;
+    return mainSchemas;
+  };
 
   // Merge schemas from each external doc. In default mode, preserve the
   // original name unless it is occupied by a different schema. In always mode,
@@ -1013,7 +1046,8 @@ function mergeExternalSchemas(
       if (isObject(extComponents) && 'schemas' in extComponents) {
         const extSchemas = extComponents.schemas as Record<string, unknown>;
         for (const [schemaName, schema] of Object.entries(extSchemas)) {
-          const existingSchema = mainSchemas[schemaName];
+          const targetSchemas = getMainSchemas();
+          const existingSchema = targetSchemas[schemaName];
           const existingRef =
             isObject(existingSchema) &&
             '$ref' in existingSchema &&
@@ -1034,14 +1068,14 @@ function mergeExternalSchemas(
 
           if (strategy === 'always') {
             finalSchemaName = `${schemaName}_${suffix}`;
-          } else if (schemaName in mainSchemas && !isMatchingXExtRef) {
+          } else if (schemaName in targetSchemas && !isMatchingXExtRef) {
             finalSchemaName = `${schemaName}_${suffix}`;
           }
 
           const isExistingPlaceholder =
             finalSchemaName === schemaName && isMatchingXExtRef;
           if (
-            Object.hasOwn(mainSchemas, finalSchemaName) &&
+            Object.hasOwn(targetSchemas, finalSchemaName) &&
             !isExistingPlaceholder
           ) {
             throw new Error(
@@ -1050,13 +1084,17 @@ function mergeExternalSchemas(
           }
 
           schemaNameMappings[extKey][schemaName] = finalSchemaName;
-          mainSchemas[finalSchemaName] = scrubUnwantedKeys(schema);
+          targetSchemas[finalSchemaName] = scrubUnwantedKeys(schema);
         }
       }
     }
   }
 
+  // Nothing was merged, so there is no container and no ref to rewrite.
+  if (!mainSchemas) return schemaNameMappings;
+
   // Apply internal ref updates to all schemas from external docs
+  const refPrefix = schemaRefPrefix(data);
   for (const [extKey, mapping] of Object.entries(schemaNameMappings)) {
     for (const [, finalName] of Object.entries(mapping)) {
       const schema = mainSchemas[finalName];
@@ -1065,6 +1103,7 @@ function mergeExternalSchemas(
           schema,
           extKey,
           schemaNameMappings,
+          refPrefix,
         ) as Record<string, unknown>;
       }
     }
@@ -1094,18 +1133,24 @@ function scrubUnwantedKeys(obj: unknown): unknown {
 }
 
 /**
- * Update internal refs within an external schema to use suffixed names
+ * Update internal refs within an external schema to use suffixed names.
+ *
+ * External documents are OpenAPI 3 shaped, so their own refs read
+ * `#/components/schemas/...`. `refPrefix` is where those schemas landed in the
+ * *main* document, which is `#/definitions/` when that document is Swagger 2.0
+ * (#2993).
  */
 function updateInternalRefs(
   obj: unknown,
   extKey: string,
   schemaNameMappings: Record<string, Record<string, string>>,
+  refPrefix: string,
 ): unknown {
   if (obj === null || obj === undefined) return obj;
 
   if (Array.isArray(obj)) {
     return obj.map((element) =>
-      updateInternalRefs(element, extKey, schemaNameMappings),
+      updateInternalRefs(element, extKey, schemaNameMappings, refPrefix),
     );
   }
 
@@ -1121,7 +1166,7 @@ function updateInternalRefs(
         const mappedName = schemaNameMappings[extKey][schemaName];
         if (mappedName) {
           return {
-            $ref: `#/components/schemas/${mappedName}`,
+            $ref: `${refPrefix}${mappedName}`,
           };
         }
       }
@@ -1130,7 +1175,12 @@ function updateInternalRefs(
     // Recursively process all properties
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(record)) {
-      result[key] = updateInternalRefs(value, extKey, schemaNameMappings);
+      result[key] = updateInternalRefs(
+        value,
+        extKey,
+        schemaNameMappings,
+        refPrefix,
+      );
     }
     return result;
   }
@@ -1167,13 +1217,20 @@ function replaceXExtRefs(
   obj: unknown,
   extensions: Record<string, unknown>,
   schemaNameMappings: Record<string, Record<string, string>>,
+  refPrefix: string,
   inliningRefs = new Set<string>(),
 ): unknown {
   if (isNullish(obj)) return obj;
 
   if (Array.isArray(obj)) {
     return obj.map((element) =>
-      replaceXExtRefs(element, extensions, schemaNameMappings, inliningRefs),
+      replaceXExtRefs(
+        element,
+        extensions,
+        schemaNameMappings,
+        refPrefix,
+        inliningRefs,
+      ),
     );
   }
 
@@ -1200,7 +1257,7 @@ function replaceXExtRefs(
             // Use the mapped name (which may include suffix for collisions)
             const finalName =
               schemaNameMappings[extKey][schemaName] || schemaName;
-            return { $ref: `#/components/schemas/${finalName}` };
+            return { $ref: `${refPrefix}${finalName}` };
           }
 
           // Otherwise inline the content; break cycles with `{}`.
@@ -1238,6 +1295,7 @@ function replaceXExtRefs(
               cleaned,
               extensions,
               schemaNameMappings,
+              refPrefix,
               nextInlining,
             );
           }
@@ -1252,6 +1310,7 @@ function replaceXExtRefs(
         value,
         extensions,
         schemaNameMappings,
+        refPrefix,
         inliningRefs,
       );
     }


### PR DESCRIPTION
Fixes the regression found while investigating #2993 — see [my analysis there](https://github.com/orval-labs/orval/issues/2993#issuecomment-5648252319). This does **not** close that issue (details at the bottom).

## The bug

Resolving *any* external `$ref` injects a `components` key into the document:

```ts
data.components ??= {};
const mainComponents = data.components as Record<string, unknown>;
mainComponents.schemas ??= {};
```

`components` is OpenAPI 3. A Swagger 2.0 document keeps its schemas in `definitions`, so every 2.0 spec with an external ref fails validation before a single file is emitted:

```
🛑 OpenAPI spec validation failed:
[ { "message": "Property components is not expected to be here", "path": "" } ]
```

Bisected across published versions with a minimal local repro (a 2.0 doc with one `$ref` into a sibling file):

| version | result |
|---|---|
| 8.4.0 | ✅ generates |
| **8.4.2** | ❌ `Property components is not expected to be here` |
| 8.32.0 | ❌ same |

Regression from #2944, first released in **v8.4.2**. Not zod- or client-specific — a plain `client: 'fetch'` with no `schemas` fails identically.

## The fix

Two separate things were wrong.

**1. The container was created eagerly.** It's built before we know whether any external document contributes a schema — and usually none does: the common shape (Strava's, and the one in the issue) has bare schemas at the external document's root, so the ref is *inlined*, nothing merges, and an empty `components: { schemas: {} }` is left behind. It's now materialized on the first schema actually merged.

**2. When schemas *are* merged, a 2.0 document needs `definitions`.** The container and the ref prefix (`#/definitions/` vs `#/components/schemas/`) are now chosen from the document version, threaded through `updateInternalRefs` and `replaceXExtRefs` so a merged schema's own internal refs are rewritten to match.

OpenAPI 3 documents are unaffected, except that they no longer receive an empty `components` when nothing merges.

I reused the existing `isSwagger2` helper in this file rather than adding a second version check.

## Verification

- 5 new tests covering: no container injected when nothing merges (2.0 and 3.0), merging into `definitions` with rewritten refs, a merged schema's internal refs rewritten, and a control that OpenAPI 3 still merges into `components.schemas`.
- One existing test updated: it asserted the empty `components: { schemas: {} }`. Its subject is inlining an external GeoJSON schema, its input has no `components` of its own, and that empty container was purely this bug's residue — so the expectation was encoding the defect.
- Package suites 372/372; snapshot suite 6970/6970; `tsc --noEmit` clean; regenerating the `tests/` corpus produced **no drift**.
- **End-to-end on the reporter's actual `strava-swagger.json`:** previously it died at validation. It now generates 75 model files. (It needs one unrelated patch to get there — `PUT /athlete` declares `weight` as `in: path` while the path has no `{weight}` segment. That's a defect in Strava's published spec, not ours.)

## Why this doesn't close #2993

With this fix the spec finally generates, which let me check the *original* symptom properly — and **it is still broken**. `tsc` on the generated Strava client:

```
strava.ts(49,3): error TS2724: '"./models"' has no exported member named 'GetClubAdminsById200Item'.
strava.ts(62,3): error TS2724: '"./models"' has no exported member named 'GetKudoersByActivityId200Item'.
strava.ts(68,3): error TS2724: '"./models"' has no exported member named 'GetLoggedInAthleteActivities200Item'.
strava.ts(71,3): error TS2724: '"./models"' has no exported member named 'GetLoggedInAthleteClubs200Item'.
```

Four of ten `*200Item` schemas are imported but never emitted. I have not isolated that trigger yet — it survives several obvious minimizations (a shared external schema across two array responses does emit both) — so it wants its own investigation rather than being bundled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved external schema reference handling for Swagger 2.0 documents.
  - External schemas are now merged into the correct `definitions` section, with references updated accordingly.
  - Internal references within merged schemas are updated to the appropriate Swagger 2.0 definitions paths.
  - Preserved OpenAPI 3 behavior by continuing to merge schemas into `components.schemas`.
  - Prevented empty schema containers from being added when no schemas are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->