### PR TITLE
docs()Expand Client and Configuration Documentation

### DIFF
--- a/docs/content/docs/guides/fetch-client.mdx
+++ b/docs/content/docs/guides/fetch-client.mdx
@@ -96,6 +96,29 @@ export const listPets = async (
 };
 ```
 
+## Exact and wildcard response statuses
+
+When `includeHttpResponseReturnType` is enabled and an operation declares both
+an exact status and a matching wildcard status, the exact status is removed
+from the wildcard type. This keeps the generated response union
+discriminated:
+
+```ts
+export type getMixedResponsesResponse200 = {
+  data: SuccessDto;
+  status: 200;
+};
+
+export type getMixedResponsesResponse2xx = {
+  data: GenericSuccessDto;
+  status: Exclude<HTTPStatusCode2xx, 200>;
+};
+```
+
+Narrow the generated response by checking `status`; this behavior affects the
+generated TypeScript types and does not change how the server selects a
+response.
+
 ## Custom Fetch Client
 
 Use a mutator for custom fetch implementations:

--- a/docs/content/docs/guides/pinia-colada.mdx
+++ b/docs/content/docs/guides/pinia-colada.mdx
@@ -196,7 +196,9 @@ export async function customFetch<T>(
 ): Promise<T> {
   const response = await fetch(url, options);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  return response.status === 204 ? (undefined as T) : response.json();
+  return response.status === 204 || response.status === 205
+    ? (undefined as T)
+    : response.json();
 }
 ```
 

--- a/docs/content/docs/guides/pinia-colada.mdx
+++ b/docs/content/docs/guides/pinia-colada.mdx
@@ -7,7 +7,11 @@ Set `client: 'pinia-colada'` to generate request functions, query keys,
 query/mutation options and Vue composables. Install `@pinia/colada` 1.x (1.4.4 or
 later) and its Vue/Pinia peer dependencies in your application.
 
+## Configuration
+
 ```ts
+import { defineConfig } from 'orval';
+
 export default defineConfig({
   pets: {
     input: './openapi.json',
@@ -24,17 +28,53 @@ export default defineConfig({
 Register Pinia and the `PiniaColada` plugin in your Vue application.
 GET and HEAD operations generate queries; other methods generate mutations.
 
+```ts
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import { PiniaColada } from '@pinia/colada';
+import App from './App.vue';
+
+createApp(App).use(createPinia()).use(PiniaColada).mount('#app');
+```
+
+## Generated output
+
+For an operation named `getPet`, the client generates the request function,
+`getGetPetQueryKey`, `getGetPetQueryOptions`, and `useGetPet`. For a mutation
+named `createPet`, it generates `createPet`, `CreatePetMutationVariables`,
+`getCreatePetMutationOptions`, and `useCreatePet`.
+
+Query options factories can be used without creating a composable:
+
+```ts
+const key = getGetPetQueryKey(1);
+const options = getGetPetQueryOptions(1, {
+  query: { staleTime: 30_000 },
+});
+```
+
 ## Queries
 
-Query parameters accept plain values, refs and getters. Generated query keys
+Operation inputs accept plain values, refs and getters. Generated query keys
 include the HTTP method, route and operation arguments. Colada receives matching
 key/request values when reactive arguments change.
 
 ```ts
+import { ref } from 'vue';
+
 const petId = ref(1);
 const pet = useGetPet(petId, { query: { staleTime: 30_000 } });
 const key = getGetPetQueryKey(1);
 const options = getGetPetQueryOptions(1);
+```
+
+Each reactive input is typed as `MaybeRefOrGetter<T>`, so a path or query input
+can be a value, a Vue ref, or a getter:
+
+```ts
+useGetPet(petId.value);
+useGetPet(petId);
+useGetPet(() => petId.value);
 ```
 
 Use `options.query` for Colada options, including a custom key, and
@@ -83,6 +123,56 @@ The generator does not guess which queries a mutation invalidates. Choose the
 affected keys in application code. `getCreatePetMutationOptions()` also exposes
 reusable options without creating a composable.
 
+Mutation variables keep the generated operation argument types. The same types
+are used by `mutate` and `mutateAsync`, and lifecycle callbacks receive typed
+data, variables, and context:
+
+```ts
+const createPet = useCreatePet({
+  mutation: {
+    onMutate: () => ({ previousName: 'Milo' }),
+    onSuccess(data, variables, context) {
+      console.log(data.id, variables.createPetBody.name, context.previousName);
+    },
+  },
+});
+
+createPet.mutate({ createPetBody: { name: 'Milo' } });
+await createPet.mutateAsync({ createPetBody: { name: 'Luna' } });
+```
+
+## Request and query options
+
+Colada options are passed inside `options.query`, while Fetch or Axios request
+options are passed inside `options.request`:
+
+```ts
+useGetPet(petId, {
+  query: { enabled: true, staleTime: 30_000 },
+  request: { headers: { 'x-client': 'web' } },
+});
+```
+
+For reactive options, pass a getter so the query key and options are resolved
+together:
+
+```ts
+const isReady = ref(true);
+
+useGetPet(petId, () => ({
+  query: { enabled: isReady.value },
+  request: { headers: { 'x-client': 'web' } },
+}));
+```
+
+When `requestOptions: false` is configured, the generated operation does not
+accept request options and the generated Colada wrapper does not expose
+`options.request`. When request options are enabled together with
+`optionsParamRequired: true`, the request options argument is required for
+operations that support it. `useNamedParameters` changes the generated
+operation argument shape; the Pinia Colada wrapper follows that generated
+shape.
+
 ## Compatibility
 
 The client uses Orval's existing Fetch/Axios serializers and supports plain
@@ -90,7 +180,52 @@ function mutators. Custom mutators must reject failed requests themselves.
 Hook mutators are not supported. JSON, multipart and URL-encoded bodies follow
 the request generator's existing configuration.
 
-Use the generated options and keys with Colada's cache APIs. Dedicated infinite
-query helpers and Nuxt integration are not generated. The sample at
+The built-in Fetch transport is configured to reject failed HTTP responses so
+that Colada receives them through its error state. Axios keeps its normal
+response shape. A plain Fetch mutator should reject failed responses itself,
+and a plain Axios mutator should return the value expected by the generated
+request function.
+
+For example, a plain Fetch mutator can preserve the generated request contract
+while rejecting failed responses:
+
+```ts
+export async function customFetch<T>(
+  url: string,
+  options?: RequestInit,
+): Promise<T> {
+  const response = await fetch(url, options);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.status === 204 ? (undefined as T) : response.json();
+}
+```
+
+An Axios mutator can return the response data directly when that is the shape
+expected by the generated operation:
+
+```ts
+import axios, { type AxiosRequestConfig } from 'axios';
+
+export const customAxios = <T>(
+  config: AxiosRequestConfig,
+  options?: AxiosRequestConfig,
+): Promise<T> =>
+  axios({ ...config, ...options }).then((response) => response.data);
+```
+
+The generated query function forwards Colada's `AbortSignal` to the request
+when request options are available. If a reactive query input changes while a
+request is pending, the previous request can be cancelled by the query
+library.
+
+The client works with the `single`, `split`, `tags`, and `tags-split` output
+modes. It does not generate dedicated infinite-query helpers or Nuxt
+integration, and hook mutators are not supported.
+
+Use the generated options and keys with Colada's cache APIs. The sample at
 `samples/pinia-colada` demonstrates queries, CRUD mutations, cache invalidation,
 and error recovery in English.
+
+## Full Example
+
+See the [complete Pinia Colada example](https://github.com/orval-labs/orval/tree/master/samples/pinia-colada) for Fetch and Axios output, custom mutators, payload serialization, type checks, and browser tests.

--- a/docs/content/docs/guides/zod.mdx
+++ b/docs/content/docs/guides/zod.mdx
@@ -82,6 +82,25 @@ With Zod Mini + pure annotations, the unused schema can disappear entirely:
 
 In large generated clients this can remove unused schema initializers from the final bundle. In real builds this can mean hundreds of kilobytes less generated validation code loaded at startup.
 
+## Array response items
+
+Inline array response items can use OpenAPI compositions such as `allOf`,
+`oneOf`, or `anyOf`. Orval generates a schema for the item type, for example:
+
+```ts
+export const ListAllOf200Item = zod.object({
+  id: zod.int().optional(),
+}).and(
+  zod.object({
+    extra: zod.string().optional(),
+  }),
+);
+```
+
+The generated client can then use `ListAllOf200Item[]` for the response. When
+an array item is a component `$ref`, the component schema writer owns that
+schema and the operation does not generate a duplicate item schema.
+
 ## Zod version
 
 Orval uses **Zod 4** as its output baseline (`z.strictObject`, `z.looseObject`, `z.iso.datetime()`, `.meta()`, …), while projects still on Zod 3 are fully supported. The emitted syntax follows whichever `zod` major your project resolves.

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -25,7 +25,10 @@ export default defineConfig({
 
 **Type:** `String | Function`
 **Default:** `'axios-functions'`
-**Options:** `angular`, `angular-query`, `axios`, `axios-functions`, `react-query`, `solid-start`, `solid-query`, `svelte-query`, `vue-query`, `swr`, `zod`, `effect`, `hono`, `fetch`, `mcp`
+**Options:** `angular`, `angular-query`, `axios`, `axios-functions`, `react-query`, `solid-start`, `solid-query`, `svelte-query`, `vue-query`, `pinia-colada`, `swr`, `zod`, `effect`, `hono`, `fetch`, `mcp`
+
+See the [Pinia Colada guide](/docs/guides/pinia-colada) for generated Vue
+queries, mutations, query keys, and options.
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -444,7 +447,7 @@ export default defineConfig({
 
 ## mode
 
-**Type:** `'single' | 'split' | 'tags' | 'tags-split'`
+**Type:** `'single' | 'split' | 'tags' | 'tags-split' | 'tags-operations' | 'tags-operations-split'`
 **Default:** `'single'`
 
 ### single
@@ -521,6 +524,47 @@ my-app/src/
 └── users/
     └── users.ts
 ```
+
+### tags-operations
+
+Generate one implementation file per operation inside a directory for each
+OpenAPI tag. When `indexFiles` is enabled (the default), a per-tag `index.ts`
+re-exports the operation files:
+
+```
+my-app/src/
+└── pets/
+    ├── get-pet.ts
+    ├── list-pets.ts
+    └── index.ts
+```
+
+The operation file contains that operation's types and runtime implementation.
+With `indexFiles: false`, import the operation files directly.
+This mode is supported for the `react-query`, `svelte-query`, `vue-query`,
+`swr`, and `fetch` clients.
+
+### tags-operations-split
+
+Generate one implementation file and one `.schemas.ts` file per operation,
+nested under the operation's tag directory. When `indexFiles` is enabled (the
+default), a per-tag `index.ts` re-exports both files:
+
+```
+my-app/src/
+└── pets/
+    ├── get-pet.ts
+    ├── get-pet.schemas.ts
+    ├── list-pets.ts
+    ├── list-pets.schemas.ts
+    └── index.ts
+```
+
+This mode uses the same supported clients as `tags-operations`. With
+`indexFiles: false`, import the operation and schema files directly. Component
+schemas referenced by an operation are emitted into that operation's schema
+file; schemas configured through `output.schemas` continue to use that output
+location.
 
 ## baseUrl
 
@@ -808,11 +852,11 @@ Generate `index.ts` files for schemas.
 
 In `tags-split` mode, extract shared infrastructure types (e.g. `HTTPStatusCode*` emitted by the fetch client) into a single `common-types.ts` file and generate a barrel `index.ts` at the target root.
 
-When enabled alongside [`indexFiles: true`](#indexfiles):
+Deduplication and [`indexFiles`](#indexfiles) control separate behaviors:
 
 - Shared types that would otherwise be duplicated across per-tag files are collected and written once to `[commonTypesFileName].ts`
 - Each per-tag file imports shared types from the common file instead of declaring them inline
-- A barrel `index.ts` is generated with named re-exports for public shared types plus `export *` re-exports for each per-tag implementation file
+- When `indexFiles: true`, a barrel `index.ts` is generated with named re-exports for public shared types plus `export *` re-exports for each per-tag implementation file
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -841,7 +885,9 @@ src/api/
     └── health.ts             ← import type { ... } from '../common-types'
 ```
 
-When disabled (default), shared types are inlined per-tag and no barrel is generated — identical to previous behavior.
+When `tagsSplitDeduplication` is disabled (default), shared types are inlined
+per tag. When `indexFiles` is `false`, the shared types file can still be
+generated, but the root barrel is not generated.
 
 Suppressed when [`workspace`](#workspace) is set (the workspace barrel handles aggregation).
 
@@ -1752,6 +1798,10 @@ Override SWR hook options.
 
 Zod schema generation options:
 
+For inline array responses, item schemas using `allOf`, `oneOf`, or `anyOf` are
+also emitted as operation item schemas. Array items that are component
+`$ref`s continue to use the component schema writer. See the [Zod guide](/docs/guides/zod#array-response-items) for an example.
+
 ```ts title="orval.config.ts"
 export default defineConfig({
   petstore: {
@@ -2598,7 +2648,10 @@ export default defineConfig({
 **Type:** `Boolean`
 **Default:** `true`
 
-Include HTTP status in return type. Set to `false` to return data directly.
+Include HTTP status in return type. Set to `false` to return data directly. When
+an exact response status and a matching wildcard are both declared, the exact
+status takes precedence in the generated type. For example, `200` and `2XX`
+produce `status: 200` and `status: Exclude<HTTPStatusCode2xx, 200>`.
 
 ### forceSuccessResponse
 
@@ -3002,6 +3055,31 @@ export default defineConfig({
 ```
 
 ---
+
+The default suffix is `''` for schemas, `'Response'` for responses,
+`'Parameter'` for parameters, and `'Body'` for request bodies. Set a suffix to
+`''` explicitly to disable it.
+
+For array schemas, `schemas.itemSuffix` controls the suffix of the generated
+item type. It defaults to `'Item'` and applies only to `components.schemas`:
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      override: {
+        components: {
+          schemas: { itemSuffix: 'Element' },
+        },
+      },
+    },
+  },
+});
+```
+
+An inline array response can consequently produce an item type such as
+`ListPets200Element`. The item suffix names the generated element type; it does
+not change the component schema's structure.
 
 ## Type Generation Options
 

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -1190,6 +1190,8 @@ Pass `false` to omit the comment block, or a function to replace it. Passing
 `true` produces the same output as omitting the option, since any value that is
 neither `false` nor a function falls back to the built-in header.
 
+The callback receives the OpenAPI [`Info Object`](https://spec.openapis.org/oas/v3.1.1#info-object) as `info`. `title` and `version` are required by the OpenAPI specification. `summary`, `description`, `termsOfService`, `contact`, and `license` are optional, so check them before using them. Specification extensions such as `x-*` may also be present. Return either one string, which is used verbatim, or an array of strings, which is rendered one line per string.
+
 ```ts title="orval.config.ts"
 export default defineConfig({
   petstore: {
@@ -2955,6 +2957,11 @@ Override by OpenAPI tag (same options as `operations`).
 **Type:** `Function`
 
 Custom function to override generated operation names.
+
+The callback receives `(operation, route, verb)`, where `operation` is the OpenAPI
+Operation Object, `route` is the operation's route string, and `verb` is Orval's
+HTTP verb value. Return a string to set both the method name and the type-name base,
+or return `[methodName, typeNameBase]` to control them independently.
 
 **Return `string`** to control both the method name and the type-name base together:
 

--- a/docs/content/docs/reference/configuration/output.mdx
+++ b/docs/content/docs/reference/configuration/output.mdx
@@ -850,7 +850,7 @@ Generate `index.ts` files for schemas.
 **Type:** `Boolean`
 **Default:** `false`
 
-In `tags-split` mode, extract shared infrastructure types (e.g. `HTTPStatusCode*` emitted by the fetch client) into a single `common-types.ts` file and generate a barrel `index.ts` at the target root.
+In `tags-split` mode, when `tagsSplitDeduplication` is enabled and `workspace` is not set, shared infrastructure types (e.g. `HTTPStatusCode*` emitted by the fetch client) can be extracted into a single `common-types.ts` file. A shared-types file is generated only when there are shared types to extract; `indexFiles` independently controls whether a root `index.ts` barrel is generated.
 
 Deduplication and [`indexFiles`](#indexfiles) control separate behaviors:
 
@@ -886,10 +886,13 @@ src/api/
 ```
 
 When `tagsSplitDeduplication` is disabled (default), shared types are inlined
-per tag. When `indexFiles` is `false`, the shared types file can still be
-generated, but the root barrel is not generated.
+per tag. Shared-type extraction is only available when
+`tagsSplitDeduplication` is enabled and `workspace` is not set. With that
+condition satisfied, the shared types file can still be generated when
+`indexFiles` is `false`, but the root barrel is not generated.
 
-Suppressed when [`workspace`](#workspace) is set (the workspace barrel handles aggregation).
+Shared-type extraction is suppressed when [`workspace`](#workspace) is set; the
+workspace barrel handles aggregation instead.
 
 ## commonTypesFileName
 

--- a/docs/content/docs/zh/guides/fetch-client.mdx
+++ b/docs/content/docs/zh/guides/fetch-client.mdx
@@ -96,6 +96,24 @@ export const listPets = async (
 };
 ```
 
+## 精确和 wildcard response status
+
+启用 `includeHttpResponseReturnType` 后，如果 operation 同时声明精确 status 和匹配的 wildcard status，精确 status 会从 wildcard 类型中排除：
+
+```ts
+export type getMixedResponsesResponse200 = {
+  data: SuccessDto;
+  status: 200;
+};
+
+export type getMixedResponsesResponse2xx = {
+  data: GenericSuccessDto;
+  status: Exclude<HTTPStatusCode2xx, 200>;
+};
+```
+
+这样可以通过检查 `status` 缩小生成的 response union。该行为影响生成的 TypeScript 类型，不改变服务器选择 response 的方式。
+
 ## Custom Fetch Client（自定义 Fetch 客户端）
 
 使用 mutator 接入自定义 Fetch 实现：

--- a/docs/content/docs/zh/guides/meta.json
+++ b/docs/content/docs/zh/guides/meta.json
@@ -11,6 +11,7 @@
     "---数据获取---",
     "react-query",
     "vue-query",
+    "pinia-colada",
     "svelte-query",
     "solid-query",
     "angular-query",

--- a/docs/content/docs/zh/guides/pinia-colada.mdx
+++ b/docs/content/docs/zh/guides/pinia-colada.mdx
@@ -155,7 +155,9 @@ export async function customFetch<T>(
 ): Promise<T> {
   const response = await fetch(url, options);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  return response.status === 204 ? (undefined as T) : response.json();
+  return response.status === 204 || response.status === 205
+    ? (undefined as T)
+    : response.json();
 }
 ```
 

--- a/docs/content/docs/zh/guides/pinia-colada.mdx
+++ b/docs/content/docs/zh/guides/pinia-colada.mdx
@@ -1,0 +1,182 @@
+---
+title: Pinia Colada
+description: 使用 Pinia Colada 生成 Vue 查询和 mutation。
+---
+
+将 `client` 设置为 `'pinia-colada'`，即可生成请求函数、query key、query/mutation options 和 Vue composables。请在应用中安装 `@pinia/colada` 1.x（1.4.4 或更高版本）以及 Vue/Pinia peer dependencies。
+
+## 配置
+
+```ts
+import { defineConfig } from 'orval';
+
+export default defineConfig({
+  pets: {
+    input: './openapi.json',
+    output: {
+      target: './src/api/pets.ts',
+      client: 'pinia-colada',
+      httpClient: 'fetch', // 或 'axios'
+      override: { fetch: { includeHttpResponseReturnType: false } },
+    },
+  },
+});
+```
+
+在 Vue 应用中注册 Pinia 和 `PiniaColada` 插件。GET 与 HEAD 操作会生成 query，其他 HTTP 方法会生成 mutation：
+
+```ts
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import { PiniaColada } from '@pinia/colada';
+import App from './App.vue';
+
+createApp(App).use(createPinia()).use(PiniaColada).mount('#app');
+```
+
+## 生成的结果
+
+对于名为 `getPet` 的操作，生成 `getPet`、`getGetPetQueryKey`、`getGetPetQueryOptions` 和 `useGetPet`。对于名为 `createPet` 的 mutation，生成 `createPet`、`CreatePetMutationVariables`、`getCreatePetMutationOptions` 和 `useCreatePet`。
+
+```ts
+const key = getGetPetQueryKey(1);
+const options = getGetPetQueryOptions(1, {
+  query: { staleTime: 30_000 },
+});
+```
+
+## Queries
+
+操作输入可以是普通值、ref 或 getter。生成的 query key 包含 HTTP method、route 和操作参数；当响应式输入变化时，Colada 会获得匹配的 key 和 request 值。
+
+```ts
+import { ref } from 'vue';
+
+const petId = ref(1);
+const pet = useGetPet(petId, { query: { staleTime: 30_000 } });
+useGetPet(petId.value);
+useGetPet(petId);
+useGetPet(() => petId.value);
+```
+
+使用 `options.query` 传递 Colada 选项，使用 `options.request` 传递 Fetch/Axios 请求选项。响应式选项应使用 getter：
+
+```ts
+const isReady = ref(true);
+
+useGetPet(petId, () => ({
+  query: { enabled: isReady.value },
+  request: { headers: { 'x-client': 'web' } },
+}));
+```
+
+生成的 query 函数会在可用时转发 Colada 的 `AbortSignal`。内置 Fetch transport 会拒绝 HTTP 失败，使 Colada 进入 error state；Axios 保留其正常的 response shape。
+
+自定义 `query.key` 时，必须包含所有会影响响应的变量。响应式输入应在同一个 options getter 中返回 key：
+
+```ts
+useGetPet(petId, () => ({
+  query: { key: ['pets', petId.value] },
+}));
+```
+
+不同 pet ID 共用固定 key 会复用同一个 cache entry。使用相同的 key factory 使自定义 key 失效；`getGetPetQueryKey()` 仍然返回默认 key。详见 [Colada query key 指南](https://pinia-colada.esm.dev/guide/query-keys.html)。
+
+## Mutations
+
+Mutation variables 包含操作的 path、query、header 和 body 参数，并保留生成的名称和类型。通过 `options.mutation` 传递 Colada 生命周期回调：
+
+```ts
+const cache = useQueryCache();
+const createPet = useCreatePet({
+  mutation: {
+    onSuccess: () =>
+      cache.invalidateQueries({
+        key: getListPetsQueryKey().slice(0, 2),
+      }),
+  },
+});
+
+await createPet.mutateAsync({ createPetBody: { name: 'Milo' } });
+```
+
+生成器不会猜测 mutation 应该使哪些 query 失效，应在应用代码中选择对应的 key。`getCreatePetMutationOptions()` 可以在不创建 composable 的情况下提供可复用 options。
+
+`mutate` 和 `mutateAsync` 使用生成的 operation argument 类型，生命周期回调也会获得类型化的 data、variables 和 context：
+
+```ts
+const createPet = useCreatePet({
+  mutation: {
+    onMutate: () => ({ previousName: 'Milo' }),
+    onSuccess(data, variables, context) {
+      console.log(data.id, variables.createPetBody.name, context.previousName);
+    },
+  },
+});
+
+createPet.mutate({ createPetBody: { name: 'Milo' } });
+await createPet.mutateAsync({ createPetBody: { name: 'Luna' } });
+```
+
+## Request and query options
+
+Colada 选项放在 `options.query` 中，Fetch 或 Axios 请求选项放在 `options.request` 中：
+
+```ts
+useGetPet(petId, {
+  query: { enabled: true, staleTime: 30_000 },
+  request: { headers: { 'x-client': 'web' } },
+});
+```
+
+对于响应式选项，使用 getter，使 query key 和 options 一起解析：
+
+```ts
+const isReady = ref(true);
+
+useGetPet(petId, () => ({
+  query: { enabled: isReady.value },
+  request: { headers: { 'x-client': 'web' } },
+}));
+```
+
+## Compatibility
+
+该 client 使用 Orval 现有的 Fetch/Axios serializer，并支持普通函数形式的 mutator。自定义 mutator 必须自行拒绝失败请求；不支持 hook mutator。JSON、multipart 和 URL-encoded body 遵循请求生成器已有的配置。
+
+内置 Fetch transport 会拒绝失败的 HTTP 响应，使 Colada 能通过 error state 接收失败。Axios 保留其正常的 response shape。普通 Fetch mutator 应自行拒绝失败响应，普通 Axios mutator 则应返回生成 operation 所期望的值。
+
+例如，普通 Fetch mutator 可以在保留生成请求契约的同时拒绝失败响应：
+
+```ts
+export async function customFetch<T>(
+  url: string,
+  options?: RequestInit,
+): Promise<T> {
+  const response = await fetch(url, options);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.status === 204 ? (undefined as T) : response.json();
+}
+```
+
+如果生成的 operation 需要直接获得 response data，Axios mutator 可以返回该数据：
+
+```ts
+import axios, { type AxiosRequestConfig } from 'axios';
+
+export const customAxios = <T>(
+  config: AxiosRequestConfig,
+  options?: AxiosRequestConfig,
+): Promise<T> =>
+  axios({ ...config, ...options }).then((response) => response.data);
+```
+
+`requestOptions: false` 时不会生成 `options.request`。与 `optionsParamRequired: true` 一起使用时，支持 request options 的操作会要求该参数。`useNamedParameters` 会改变生成的操作参数形式，Pinia Colada wrapper 会遵循该形式。
+
+该 client 支持 `single`、`split`、`tags` 和 `tags-split` mode。不会生成专用的 infinite query helper，也不会生成 Nuxt 集成。生成的 query 会在可用时转发 AbortSignal，因此响应式输入变化时，之前的请求可能被 query library 取消。
+
+请将生成的 options 和 key 与 Colada cache API 一起使用。`samples/pinia-colada` 展示了 query、CRUD mutation、cache invalidation、Fetch/Axios transport、错误恢复和类型检查。
+
+## Full Example
+
+完整示例请参阅 [Pinia Colada sample](https://github.com/orval-labs/orval/tree/master/samples/pinia-colada)，其中包含 Fetch 和 Axios 输出、自定义 mutator、body 序列化、类型检查和浏览器测试。

--- a/docs/content/docs/zh/guides/zod.mdx
+++ b/docs/content/docs/zh/guides/zod.mdx
@@ -82,6 +82,22 @@ object({
 
 在大型生成客户端中，这可以从最终 bundle 中移除未使用的 schema 初始化代码。在真实构建里，这可能意味着启动时少加载数百 KB 的验证代码。
 
+## 数组响应元素
+
+内联数组响应的元素可以使用 `allOf`、`oneOf` 或 `anyOf` 等 OpenAPI composition。Orval 会为元素类型生成 schema，例如：
+
+```ts
+export const ListAllOf200Item = zod.object({
+  id: zod.int().optional(),
+}).and(
+  zod.object({
+    extra: zod.string().optional(),
+  }),
+);
+```
+
+生成的 client 可以使用 `ListAllOf200Item[]` 作为响应类型。如果数组元素是 component `$ref`，则由 component schema writer 负责，不会生成重复的 operation item schema。
+
 ## Zod version
 
 Orval 以 **Zod 4** 作为输出基线（`z.strictObject`、`z.looseObject`、`z.iso.datetime()`、`.meta()` 等），但也完全支持仍在使用 Zod 3 的项目。最终输出的语法会跟随你的项目实际解析到的 `zod` 主版本。

--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -27,7 +27,9 @@ export default defineConfig({
 
 **类型：** `String | Function`
 **默认值：** `'axios-functions'`
-**可选值：** `angular`、`angular-query`、`axios`、`axios-functions`、`react-query`、`solid-start`、`solid-query`、`svelte-query`、`vue-query`、`swr`、`zod`、`effect`、`hono`、`fetch`、`mcp`
+**可选值：** `angular`、`angular-query`、`axios`、`axios-functions`、`react-query`、`solid-start`、`solid-query`、`svelte-query`、`vue-query`、`pinia-colada`、`swr`、`zod`、`effect`、`hono`、`fetch`、`mcp`
+
+关于生成 Vue query、mutation、query key 和 options 的说明，请参阅 [Pinia Colada 指南](/zh/docs/guides/pinia-colada)。
 
 指定生成客户端类型。
 
@@ -368,7 +370,7 @@ export default defineConfig({
 
 ## mode
 
-**类型：** `'single' | 'split' | 'tags' | 'tags-split'`
+**类型：** `'single' | 'split' | 'tags' | 'tags-split' | 'tags-operations' | 'tags-operations-split'`
 **默认值：** `'single'`
 
 ### single
@@ -445,6 +447,36 @@ my-app/src/
 └── users/
     └── users.ts
 ```
+
+### tags-operations
+
+在每个 OpenAPI tag 目录下为每个 operation 生成一个实现文件。启用 `indexFiles`（默认）时，会生成按 tag 聚合的 `index.ts`：
+
+```
+my-app/src/
+└── pets/
+    ├── get-pet.ts
+    ├── list-pets.ts
+    └── index.ts
+```
+
+实现文件同时包含该 operation 的类型和运行时实现。设置 `indexFiles: false` 时，请直接导入 operation 文件。该模式支持 `react-query`、`svelte-query`、`vue-query`、`swr` 和 `fetch` client。
+
+### tags-operations-split
+
+在每个 tag 目录下为每个 operation 生成实现文件和 `.schemas.ts` 文件。启用 `indexFiles`（默认）时，tag 的 `index.ts` 会重新导出这两个文件：
+
+```
+my-app/src/
+└── pets/
+    ├── get-pet.ts
+    ├── get-pet.schemas.ts
+    ├── list-pets.ts
+    ├── list-pets.schemas.ts
+    └── index.ts
+```
+
+设置 `indexFiles: false` 时，请直接导入 operation 和 schema 文件。该模式使用与 `tags-operations` 相同的 client 支持范围。
 
 ## baseUrl
 
@@ -722,11 +754,11 @@ import { getPetMock } from '@acme/data-layer/sdk/fakers';
 
 在 `tags-split` 模式下，将共享的基础设施类型（例如 fetch client 生成的 `HTTPStatusCode*`）提取到单独的 `common-types.ts` 文件中，并在 target 根目录生成一个 barrel `index.ts`。
 
-当它与 [`indexFiles: true`](#indexfiles) 一起启用时：
+该选项与 [`indexFiles`](#indexfiles) 控制不同的行为：
 
 - 原本会在每个 tag 文件中重复出现的共享类型，会被统一收集并写入一次 `[commonTypesFileName].ts`
 - 每个 tag 文件都会从该公共文件导入共享类型，而不是内联声明
-- 会生成一个 barrel `index.ts`，其中包含对公共共享类型的具名 re-export，以及对每个 tag 实现文件的 `export *` re-export
+- 当 `indexFiles: true` 时，会生成一个 barrel `index.ts`，其中包含对公共共享类型的具名 re-export，以及对每个 tag 实现文件的 `export *` re-export
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -755,7 +787,7 @@ src/api/
     └── health.ts             ← import type { ... } from '../common-types'
 ```
 
-禁用时（默认），共享类型会继续按 tag 内联，也不会生成该 barrel，这与旧行为完全一致。
+禁用 `tagsSplitDeduplication` 时（默认），共享类型会继续按 tag 内联。设置 `indexFiles: false` 时，仍然可以生成共享类型文件，但不会生成根 barrel。
 
 当设置了 [`workspace`](#workspace) 时，此选项会被抑制（workspace 自己的 barrel 会处理聚合）。
 
@@ -1202,6 +1234,17 @@ Query keys 通过前缀匹配，因此 query params 和 body 参数会被放宽�
 
 生成类型安全的 `getQueryData` helpers。
 
+### useSkipToken
+
+**类型：** `Boolean`
+**默认值：** `false`
+
+当 query 参数尚未解析时，使用 [`skipToken`](https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken) 暂停 query，而不是使用生成的 `enabled` guard。
+
+与 `enabled` 不同，该选项也会覆盖 `refetch()`：参数未解析时不会发送请求，query 会改为因 `Missing queryFn` 而拒绝（TanStack 在开发环境中也会记录 console error）。同时，调用方仍可自由使用 `enabled`，因为调用方的 `...queryOptions` 会最后展开，否则可能覆盖生成的参数检查。
+
+仅适用于 React Query v5。Suspense queries 不受影响——TanStack 不会在其 `queryFn` 中使用 `SkipToken`。
+
 ### mutationInvalidates
 
 **类型：** `Array`
@@ -1594,6 +1637,8 @@ export default defineConfig({
 ## override.zod
 
 Zod schema 生成选项：
+
+对于内联数组响应，使用 `allOf`、`oneOf` 或 `anyOf` 的元素 schema 也会作为 operation item schema 输出。作为 component `$ref` 的数组元素仍由 component schema writer 负责。示例请参阅 [Zod 指南](/zh/docs/guides/zod#数组响应元素)。
 
 ```ts title="orval.config.ts"
 export default defineConfig({
@@ -2304,6 +2349,35 @@ export const customHandler = async (
 
 ---
 
+## override.axios
+
+Axios client 选项：
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      override: {
+        axios: {
+          includeHttpResponseReturnType: true,
+        },
+      },
+    },
+  },
+});
+```
+
+### includeHttpResponseReturnType
+
+**类型：** `Boolean`
+**默认值：** `false`
+
+在返回类型中包含 HTTP 状态，并将其与 response data 类型关联。例如，JSON `200` response 和空的 `204` response 会根据 `status` 将 `data` 收窄为 JSON body 或 `void`。
+
+内置 Axios client 会将规范中声明的空 response 规范化为 `undefined`。使用自定义 `mutator` 时，该选项只会改变生成的类型，不会改变运行时值，因为请求由 mutator 自行发出。mutator 必须返回具有相同 status 关联结构的完整 Axios response。
+
+---
+
 ## override.fetch
 
 Fetch client 选项：
@@ -2328,7 +2402,7 @@ export default defineConfig({
 **类型：** `Boolean`
 **默认值：** `true`
 
-在返回类型中包含 HTTP 状态。设为 `false` 时，直接返回数据。
+在返回类型中包含 HTTP 状态。设为 `false` 时，直接返回数据。当 operation 同时声明精确状态和匹配的 wildcard 状态时，生成的类型会优先使用精确状态。例如 `200` 和 `2XX` 会生成 `status: 200` 与 `status: Exclude<HTTPStatusCode2xx, 200>`。
 
 ### forceSuccessResponse
 
@@ -2700,6 +2774,24 @@ export default defineConfig({
           responses: { suffix: 'Response' },
           parameters: { suffix: 'Params' },
           requestBodies: { suffix: 'Bodies' },
+        },
+      },
+    },
+  },
+});
+```
+
+schema 的默认后缀为 `''`，response 为 `'Response'`，parameter 为 `'Parameter'`，request body 为 `'Body'`。显式设置后缀为 `''` 可以禁用后缀。
+
+对于数组 schema，`schemas.itemSuffix` 控制生成的元素类型后缀，默认值为 `'Item'`，且只适用于 `components.schemas`：
+
+```ts title="orval.config.ts"
+export default defineConfig({
+  petstore: {
+    output: {
+      override: {
+        components: {
+          schemas: { itemSuffix: 'Element' },
         },
       },
     },

--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -752,7 +752,7 @@ import { getPetMock } from '@acme/data-layer/sdk/fakers';
 **类型：** `Boolean`
 **默认值：** `false`
 
-在 `tags-split` 模式下，将共享的基础设施类型（例如 fetch client 生成的 `HTTPStatusCode*`）提取到单独的 `common-types.ts` 文件中，并在 target 根目录生成一个 barrel `index.ts`。
+在 `tags-split` 模式下，只有启用 `tagsSplitDeduplication` 且未设置 `workspace` 时，才可以将共享的基础设施类型（例如 fetch client 生成的 `HTTPStatusCode*`）提取到单独的 `common-types.ts` 文件中。只有存在需要提取的共享类型时，才会生成共享类型文件；`indexFiles` 独立控制是否生成根目录的 `index.ts` barrel。
 
 该选项与 [`indexFiles`](#indexfiles) 控制不同的行为：
 
@@ -787,9 +787,9 @@ src/api/
     └── health.ts             ← import type { ... } from '../common-types'
 ```
 
-禁用 `tagsSplitDeduplication` 时（默认），共享类型会继续按 tag 内联。设置 `indexFiles: false` 时，仍然可以生成共享类型文件，但不会生成根 barrel。
+禁用 `tagsSplitDeduplication` 时（默认），共享类型会继续按 tag 内联。只有在启用 `tagsSplitDeduplication` 且未设置 `workspace` 时，才可以提取共享类型。满足该条件时，即使 `indexFiles: false`，共享类型文件仍然可以生成，但不会生成根 barrel。
 
-当设置了 [`workspace`](#workspace) 时，此选项会被抑制（workspace 自己的 barrel 会处理聚合）。
+当设置了 [`workspace`](#workspace) 时，共享类型提取会被抑制，由 workspace 自己的 barrel 负责聚合。
 
 ## commonTypesFileName
 

--- a/docs/content/docs/zh/reference/configuration/output.mdx
+++ b/docs/content/docs/zh/reference/configuration/output.mdx
@@ -1083,6 +1083,8 @@ export default defineConfig({
 
 传入 `false` 可以省略该注释块，传入函数则可替换它。传入 `true` 的效果与省略该选项相同，因为只要值既不是 `false` 也不是函数，就会回退到内置 header。
 
+该回调接收 OpenAPI [`Info Object`](https://spec.openapis.org/oas/v3.1.1#info-object) 作为 `info`。根据 OpenAPI 规范，`title` 和 `version` 是必填字段；`summary`、`description`、`termsOfService`、`contact` 和 `license` 是可选字段，使用前应先进行检查。对象中也可能包含 `x-*` 等规范扩展。回调可以返回一个字符串（按原样使用），也可以返回字符串数组（每个字符串渲染为一行）。
+
 ```ts title="orval.config.ts"
 export default defineConfig({
   petstore: {
@@ -2701,6 +2703,8 @@ export default defineConfig({
 **类型：** `Function`
 
 用于覆盖生成的 operation 名称的自定义函数。
+
+该回调接收 `(operation, route, verb)`：`operation` 是 OpenAPI Operation Object，`route` 是 operation 的 route 字符串，`verb` 是 Orval 的 HTTP verb 值。返回字符串时会同时设置方法名和类型名基底；返回 `[methodName, typeNameBase]` 时可以分别控制两者。
 
 **返回 `string`** 时，会同时控制方法名和类型名基底：
 


### PR DESCRIPTION
## Summary
Updates Orval’s documentation to better reflect the current public configuration API and generated behavior. It adds missing documentation
  for supported clients, output modes, recent Fetch and Zod changes, Pinia Colada, schema naming options, and configuration callback parameters.

  The documentation is synchronized between English and Chinese without documenting the unresolved override.mock.data runtime issue.

  ## Changes

  - Added comprehensive Pinia Colada documentation.
  - Added Chinese documentation for Pinia Colada.
  - Documented tags-operations and tags-operations-split.
  - Documented Fetch response precedence for exact and wildcard statuses.
  - Documented Zod composed inline array response items.
  - Documented schema suffixes and components.schemas.itemSuffix.
  - Clarified tagsSplitDeduplication and indexFiles.
  - Added details for override.header callback parameters.
  - Added details for override.operationName callback parameters and return values.
  - Added missing Chinese sections for override.axios and useSkipToken.
  - Updated Chinese navigation and cross-references.
  - Removed documentation referring to the unresolved override.mock.data callback behavior.
  - Preserved the existing documentation for mock.data and mock.properties.

---
- Closes #4091
- Related to #3786 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese guides for Pinia Colada, covering setup, generated APIs, reactive usage, mutations, options, cancellation, and custom mutators.
  * Documented exact-versus-wildcard HTTP status typing for improved response narrowing.
  * Added guidance for Zod schemas representing composed inline array items.
  * Expanded output configuration references with Pinia Colada support, additional generation modes, override options, deduplication behavior, schema naming, Axios response types, and React Query options.
  * Added Pinia Colada to Chinese guide navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->